### PR TITLE
fix: register empty tables for missing sources, auto-checkpoint in Do…

### DIFF
--- a/examples/demo/docker-compose.yml
+++ b/examples/demo/docker-compose.yml
@@ -96,5 +96,11 @@ services:
       DEMO_MODE: kafka
       KAFKA_BROKERS: redpanda:9092
       GROUP_ID: laminardb-demo
+      CHECKPOINT_DIR: /data/checkpoints
+    volumes:
+      - demo-checkpoints:/data/checkpoints
     stdin_open: true
     tty: true
+
+volumes:
+  demo-checkpoints:

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -255,7 +255,7 @@ async fn run_embedded_mode() -> Result<(), Box<dyn std::error::Error>> {
         .buffer_size(65536)
         .checkpoint(StreamCheckpointConfig {
             data_dir: Some(ckpt_dir),
-            interval_ms: None, // manual only via [c]
+            interval_ms: Some(30_000),
             max_retained: Some(5),
             ..StreamCheckpointConfig::default()
         })
@@ -318,7 +318,9 @@ async fn run_kafka_mode() -> Result<(), Box<dyn std::error::Error>> {
     let group_id = std::env::var("GROUP_ID").unwrap_or_else(|_| "laminardb-demo".into());
 
     // -- Build LaminarDB with Kafka config --
-    let ckpt_dir = std::env::temp_dir().join("laminardb-demo-kafka-ckpt");
+    let ckpt_dir = std::env::var("CHECKPOINT_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("laminardb-demo-kafka-ckpt"));
     let db = LaminarDB::builder()
         .config_var("KAFKA_BROKERS", &brokers)
         .config_var("GROUP_ID", &group_id)
@@ -326,7 +328,7 @@ async fn run_kafka_mode() -> Result<(), Box<dyn std::error::Error>> {
         .buffer_size(65536)
         .checkpoint(StreamCheckpointConfig {
             data_dir: Some(ckpt_dir),
-            interval_ms: None,
+            interval_ms: Some(30_000),
             max_retained: Some(5),
             ..StreamCheckpointConfig::default()
         })


### PR DESCRIPTION
…cker

StreamExecutor now pre-registers source schemas and creates empty MemTables for sources with no data in a given cycle, preventing DataFusion "table not found" errors when sources produce at different rates.

- stream_executor: add source_schemas map, register empty placeholder tables for known sources missing from source_batches
- db: register all catalog source schemas on executor at pipeline start
- demo: enable 30s auto-checkpoint (was manual-only), add CHECKPOINT_DIR env var, mount named volume in Docker Compose for persistence
- Dockerfile: use debian:trixie-slim runtime to match rust:1.93 glibc