### PR TITLE
Fix NumaAllocator::dealloc hardcoded alignment vulnerability

### DIFF
--- a/crates/laminar-core/src/numa/mod.rs
+++ b/crates/laminar-core/src/numa/mod.rs
@@ -40,7 +40,7 @@
 //! let ptr = allocator.alloc_on_node(0, 4096, 64)?;
 //!
 //! // Free when done
-//! unsafe { allocator.dealloc(ptr, 4096); }
+//! unsafe { allocator.dealloc(ptr, 4096, 64); }
 //! ```
 //!
 //! ## Platform Support
@@ -83,7 +83,7 @@ mod tests {
         assert!(!ptr.is_null());
 
         // Free
-        unsafe { allocator.dealloc(ptr, 4096) };
+        unsafe { allocator.dealloc(ptr, 4096, 64) };
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
         assert!(!ptr.is_null());
 
         // Free
-        unsafe { allocator.dealloc(ptr, 4096) };
+        unsafe { allocator.dealloc(ptr, 4096, 64) };
     }
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
         assert!(!ptr.is_null());
 
         // Free
-        unsafe { allocator.dealloc(ptr, 64 * 1024) };
+        unsafe { allocator.dealloc(ptr, 64 * 1024, 64) };
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses a security vulnerability in `NumaAllocator::dealloc` where alignment was hardcoded to 64 bytes. This could lead to undefined behavior on non-Linux platforms if memory was allocated with a different alignment.

The fix involves:
1.  Updating `NumaAllocator::dealloc` to require an `align` parameter.
2.  Updating all usages of `dealloc` to pass the correct alignment.
3.  Deprecating `dealloc_with_align` as it is now redundant.
4.  Adding a test case to verify correct handling of custom alignments.

This change is a breaking change for the `NumaAllocator::dealloc` API but is necessary for safety.

---
*PR created automatically by Jules for task [16577444047769418851](https://jules.google.com/task/16577444047769418851) started by @sujitn*