### PR TITLE
🧹 replace production eprintln! with tracing macros

### DIFF
--- a/crates/laminar-core/src/io_uring/buffer_pool.rs
+++ b/crates/laminar-core/src/io_uring/buffer_pool.rs
@@ -381,7 +381,7 @@ mod tests {
         let mut ring = match create_test_ring() {
             Some(r) => r,
             None => {
-                eprintln!("io_uring not available, skipping test");
+                tracing::warn!("io_uring not available, skipping test");
                 return;
             }
         };
@@ -395,7 +395,7 @@ mod tests {
                 assert_eq!(p.acquired_count(), 0);
             }
             Err(e) => {
-                eprintln!("Buffer registration failed: {e}");
+                tracing::warn!("Buffer registration failed: {e}");
             }
         }
     }

--- a/crates/laminar-core/src/io_uring/manager.rs
+++ b/crates/laminar-core/src/io_uring/manager.rs
@@ -767,7 +767,7 @@ mod tests {
                 assert_eq!(m.mode(), RingMode::Standard);
             }
             Err(e) => {
-                eprintln!("io_uring not available: {e}");
+                tracing::error!("io_uring not available: {e}");
             }
         }
     }
@@ -788,7 +788,7 @@ mod tests {
                 manager.release_buffer(idx);
             }
             Err(e) => {
-                eprintln!("Buffer acquire failed: {e}");
+                tracing::error!("Buffer acquire failed: {e}");
             }
         }
     }
@@ -900,13 +900,13 @@ mod tests {
                 // In some CI environments, io_uring operations may fail
                 // (e.g., containers without proper io_uring support)
                 if !completion.is_success() {
-                    eprintln!("Write completion failed (possibly unsupported environment)");
+                    tracing::error!("Write completion failed (possibly unsupported environment)");
                     return;
                 }
                 assert_eq!(completion.kind(), CompletionKind::Write);
             }
             Err(e) => {
-                eprintln!("Wait failed: {e}");
+                tracing::error!("Wait failed: {e}");
                 return;
             }
         }

--- a/crates/laminar-core/src/io_uring/three_ring/reactor.rs
+++ b/crates/laminar-core/src/io_uring/three_ring/reactor.rs
@@ -800,7 +800,7 @@ mod tests {
                 assert_eq!(r.router().pending_count(), 0);
             }
             Err(e) => {
-                eprintln!("io_uring not available: {e}");
+                tracing::error!("io_uring not available: {e}");
             }
         }
     }
@@ -818,7 +818,7 @@ mod tests {
             }
             Err(e) => {
                 // May fail if IOPOLL not available
-                eprintln!("Poll ring not available: {e}");
+                tracing::error!("Poll ring not available: {e}");
             }
         }
     }

--- a/crates/laminar-core/src/reactor/mod.rs
+++ b/crates/laminar-core/src/reactor/mod.rs
@@ -441,7 +441,7 @@ impl Reactor {
 
             #[cfg(not(any(target_os = "linux", target_os = "windows")))]
             {
-                eprintln!("Warning: CPU affinity is not implemented for this platform");
+                tracing::warn!("CPU affinity is not implemented for this platform");
             }
         }
         Ok(())
@@ -463,7 +463,7 @@ impl Reactor {
             if !outputs.is_empty() {
                 if let Some(sink) = &mut self.sink {
                     if let Err(e) = sink.write(outputs) {
-                        eprintln!("Failed to write to sink: {e}");
+                        tracing::error!("Failed to write to sink: {e}");
                         // Continue processing even if sink fails
                     }
                 }
@@ -483,7 +483,7 @@ impl Reactor {
         // Flush sink before shutdown
         if let Some(sink) = &mut self.sink {
             if let Err(e) = sink.flush() {
-                eprintln!("Failed to flush sink during shutdown: {e}");
+                tracing::error!("Failed to flush sink during shutdown: {e}");
             }
         }
 
@@ -507,7 +507,7 @@ impl Reactor {
             if !outputs.is_empty() {
                 if let Some(sink) = &mut self.sink {
                     if let Err(e) = sink.write(outputs) {
-                        eprintln!("Failed to write final outputs during shutdown: {e}");
+                        tracing::error!("Failed to write final outputs during shutdown: {e}");
                     }
                 }
             }
@@ -516,7 +516,7 @@ impl Reactor {
         // Final flush
         if let Some(sink) = &mut self.sink {
             if let Err(e) = sink.flush() {
-                eprintln!("Failed to flush sink during shutdown: {e}");
+                tracing::error!("Failed to flush sink during shutdown: {e}");
             }
         }
 

--- a/crates/laminar-core/src/tpc/core_handle.rs
+++ b/crates/laminar-core/src/tpc/core_handle.rs
@@ -548,7 +548,7 @@ fn init_core_thread(
         match CoreRingManager::new(ctx.core_id, io_uring_config) {
             Ok(manager) => Some(manager),
             Err(e) => {
-                eprintln!(
+                tracing::error!(
                     "Core {}: Failed to initialize io_uring ring: {e}. Falling back to standard I/O.",
                     ctx.core_id
                 );
@@ -607,7 +607,7 @@ fn core_thread_main(
             match message {
                 CoreMessage::Event(event) => {
                     if let Err(e) = reactor.submit(event) {
-                        eprintln!("Core {}: Failed to submit event: {e}", ctx.core_id);
+                        tracing::error!("Core {}: Failed to submit event: {e}", ctx.core_id);
                     }
                     messages_processed += 1;
                     had_work = true;


### PR DESCRIPTION
Replaced `eprintln!` with `tracing::warn!` and `tracing::error!` across several files in `laminar-core` to improve observability. This includes both production code and test utilities for better consistency.

---
*PR created automatically by Jules for task [17015277023350027455](https://jules.google.com/task/17015277023350027455) started by @sujitn*