### PR TITLE
fix: enable SELECT on streaming sources

### DIFF
--- a/crates/laminar-db/src/handle.rs
+++ b/crates/laminar-db/src/handle.rs
@@ -247,7 +247,7 @@ impl<T: Record> SourceHandle<T> {
     #[allow(clippy::needless_pass_by_value)]
     pub fn push(&self, record: T) -> Result<(), laminar_core::streaming::StreamingError> {
         let batch = record.to_record_batch();
-        self.entry.source.push_arrow(batch)
+        self.entry.push_and_buffer(batch)
     }
 
     /// Push a batch of records.
@@ -279,6 +279,9 @@ impl<T: Record> SourceHandle<T> {
 
     /// Push a raw `RecordBatch`.
     ///
+    /// The batch is sent to the SPSC channel for pipeline processing and
+    /// also buffered for ad-hoc `SELECT` snapshot queries.
+    ///
     /// # Errors
     ///
     /// Returns `StreamingError` if the channel is full or closed.
@@ -286,7 +289,7 @@ impl<T: Record> SourceHandle<T> {
         &self,
         batch: RecordBatch,
     ) -> Result<(), laminar_core::streaming::StreamingError> {
-        self.entry.source.push_arrow(batch)
+        self.entry.push_and_buffer(batch)
     }
 
     /// Emit a watermark.
@@ -367,6 +370,9 @@ impl UntypedSourceHandle {
 
     /// Push a `RecordBatch`.
     ///
+    /// The batch is sent to the SPSC channel for pipeline processing and
+    /// also buffered for ad-hoc `SELECT` snapshot queries.
+    ///
     /// # Errors
     ///
     /// Returns `StreamingError` if the channel is full or closed.
@@ -374,7 +380,7 @@ impl UntypedSourceHandle {
         &self,
         batch: RecordBatch,
     ) -> Result<(), laminar_core::streaming::StreamingError> {
-        self.entry.source.push_arrow(batch)
+        self.entry.push_and_buffer(batch)
     }
 
     /// Emit a watermark.


### PR DESCRIPTION
## Summary

Fixes #2. `SELECT * FROM source` failed with "table not found" because `CREATE SOURCE` only registered in `SourceCatalog`, not in DataFusion's `SessionContext`.

- Added a bounded snapshot buffer to `SourceEntry` that captures batches on every push
- Added `SourceSnapshotProvider` (implements `TableProvider`) that serves point-in-time snapshots via `MemTable`
- `CREATE SOURCE` now registers the provider in DataFusion; `DROP SOURCE` deregisters it
- All push paths (`SourceHandle`, `UntypedSourceHandle`, `INSERT INTO`) route through `push_and_buffer()` for dual-write to both SPSC channel and snapshot buffer

Follows the RisingWave/Materialize model: `SELECT * FROM source` returns a bounded snapshot of buffered data and terminates.

## Performance

| Aspect | Impact |
|--------|--------|
| Ring 0 hot path | **Zero** — buffer is on push side (Ring 1/2), not poll side |
| Push overhead | ~15ns per batch (uncontended Mutex + VecDeque append) |
| Memory | Bounded by configurable capacity (defaults to channel buffer_size) |

## Test plan

- [x] `cargo build` compiles
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo doc --no-deps` clean
- [x] All 315 existing tests pass
- [x] New test: `CREATE SOURCE → INSERT INTO → SELECT * FROM source` returns rows
- [x] New test: `DROP SOURCE → SELECT` fails
- [x] New test: `CREATE OR REPLACE SOURCE` clears old buffer
- [x] New test: buffer capacity exceeded drops oldest batches