### PR TITLE
fix: wire manual checkpoint() to disk persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/crates/laminar-core/src/streaming/mod.rs
+++ b/crates/laminar-core/src/streaming/mod.rs
@@ -123,9 +123,7 @@ pub mod subscription;
 
 // Re-export key types
 pub use channel::{channel, channel_with_config, ChannelMode, Consumer, Producer};
-pub use checkpoint::{
-    CheckpointError, StreamCheckpoint, StreamCheckpointConfig, StreamCheckpointManager, WalMode,
-};
+pub use checkpoint::{CheckpointError, StreamCheckpoint, StreamCheckpointConfig, WalMode};
 pub use config::{
     BackpressureStrategy, ChannelConfig, ChannelStats, SinkConfig, SourceConfig, WaitStrategy,
 };

--- a/crates/laminar-db/tests/checkpoint_disk_persistence.rs
+++ b/crates/laminar-db/tests/checkpoint_disk_persistence.rs
@@ -1,0 +1,96 @@
+//! Integration test: verify that `db.checkpoint()` persists to disk.
+//!
+//! Reproduces the scenario from laminardb/laminardb-python#4 where
+//! `checkpoint()` returned a valid ID but wrote nothing to disk.
+
+use laminar_core::streaming::StreamCheckpointConfig;
+use laminar_db::{LaminarConfig, LaminarDB};
+use laminar_storage::checkpoint_store::{CheckpointStore, FileSystemCheckpointStore};
+
+/// Build a `LaminarConfig` with checkpoint enabled and `storage_dir`
+/// pointed at the given directory.
+fn config_with_storage(dir: &std::path::Path) -> LaminarConfig {
+    LaminarConfig {
+        storage_dir: Some(dir.to_path_buf()),
+        checkpoint: Some(StreamCheckpointConfig {
+            interval_ms: None, // manual only
+            ..StreamCheckpointConfig::default()
+        }),
+        ..LaminarConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn test_manual_checkpoint_writes_to_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = dir.path().to_path_buf();
+
+    let db = LaminarDB::open_with_config(config_with_storage(&storage)).unwrap();
+
+    db.execute("CREATE SOURCE sensors (ts BIGINT, device VARCHAR, value DOUBLE)")
+        .await
+        .unwrap();
+    db.execute(
+        "CREATE STREAM avg_val AS SELECT device, AVG(value) AS avg_v FROM sensors GROUP BY device",
+    )
+    .await
+    .unwrap();
+    db.execute("CREATE SINK out FROM avg_val").await.unwrap();
+
+    db.start().await.unwrap();
+
+    // Insert some data
+    let source = db.source_untyped("sensors").unwrap();
+    let schema = source.schema();
+    let batch = arrow::array::RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            std::sync::Arc::new(arrow::array::Int64Array::from(vec![1, 2, 3])),
+            std::sync::Arc::new(arrow::array::StringArray::from(vec!["a", "b", "a"])),
+            std::sync::Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0])),
+        ],
+    )
+    .unwrap();
+    source.push_arrow(batch).unwrap();
+
+    // Manual checkpoint — this should persist to disk
+    let result = db.checkpoint().await.unwrap();
+    assert!(result.success, "checkpoint should succeed");
+    assert_eq!(result.checkpoint_id, 1);
+
+    // Verify files exist on disk
+    let checkpoint_dir = storage.join("checkpoints");
+    assert!(
+        checkpoint_dir.exists(),
+        "checkpoints directory should be created at {checkpoint_dir:?}"
+    );
+
+    // Verify the store can load the manifest
+    let store = FileSystemCheckpointStore::new(&storage, 3);
+    let manifest = store.load_latest().unwrap();
+    assert!(manifest.is_some(), "manifest should be loadable from disk");
+
+    let manifest = manifest.unwrap();
+    assert_eq!(manifest.checkpoint_id, 1);
+    assert_eq!(manifest.epoch, 1);
+
+    db.close();
+}
+
+#[tokio::test]
+async fn test_checkpoint_errors_when_not_enabled() {
+    let db = LaminarDB::open().unwrap(); // default config, no checkpoint
+
+    let err = db.checkpoint().await;
+    assert!(err.is_err(), "checkpoint should fail when not enabled");
+}
+
+#[tokio::test]
+async fn test_checkpoint_errors_before_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = LaminarDB::open_with_config(config_with_storage(dir.path())).unwrap();
+
+    // checkpoint enabled but start() not called — coordinator not initialized
+    let err = db.checkpoint().await;
+    assert!(err.is_err(), "checkpoint should fail before start()");
+}

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -475,8 +475,8 @@ async fn run_tui_loop<D: PipelineDataSource>(
                             app.set_or_toggle_view(ViewMode::Dag);
                         }
                         KeyCode::Char('c') => {
-                            if let Ok(Some(epoch)) = db.checkpoint() {
-                                app.record_checkpoint(epoch);
+                            if let Ok(result) = db.checkpoint().await {
+                                app.record_checkpoint(result.epoch);
                             }
                         }
                         _ => {}


### PR DESCRIPTION
## Summary

- `db.checkpoint()` was silently returning a valid checkpoint ID without writing anything to disk — the `StreamCheckpointManager` (in-memory) and `CheckpointCoordinator` (persists to disk) were two independent systems that were never wired together
- Replace the dual system with a single `CheckpointCoordinator` stored on the `LaminarDB` struct, so manual `checkpoint()` calls go through the full two-phase commit protocol (source snapshot → sink pre-commit → manifest persist → sink commit)
- Remove `StreamCheckpointManager` from `LaminarDB` and public exports, remove `restore_checkpoint()`, simplify `is_checkpoint_enabled()`
- `checkpoint()` is now `async` — `Connection` API bridges it with the same `thread::scope` pattern used by `execute()` and `start()`
- Bump workspace version to 0.13.1

Ref: laminardb/laminardb-python#4

## Test plan

- [x] `cargo build` — passes
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test --all --lib` — 158 tests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo doc --no-deps` — no warnings