### PR TITLE
refactor: remove ~460 lines of boilerplate via macros and dead code deletion

### DIFF
--- a/crates/laminar-connectors/src/config.rs
+++ b/crates/laminar-connectors/src/config.rs
@@ -155,6 +155,20 @@ impl ConnectorConfig {
     }
 }
 
+/// Validates that a string field is non-empty.
+///
+/// # Errors
+///
+/// Returns `ConnectorError::ConfigurationError` if the value is empty.
+pub fn require_non_empty(value: &str, field_name: &str) -> Result<(), ConnectorError> {
+    if value.is_empty() {
+        return Err(ConnectorError::ConfigurationError(format!(
+            "{field_name} must not be empty",
+        )));
+    }
+    Ok(())
+}
+
 /// Specification for a configuration key.
 ///
 /// Used by connectors to declare their expected configuration.

--- a/crates/laminar-connectors/src/kafka/config.rs
+++ b/crates/laminar-connectors/src/kafka/config.rs
@@ -57,21 +57,12 @@ impl SecurityProtocol {
     }
 }
 
-impl std::str::FromStr for SecurityProtocol {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('-', "_").as_str() {
-            "plaintext" => Ok(SecurityProtocol::Plaintext),
-            "ssl" => Ok(SecurityProtocol::Ssl),
-            "sasl_plaintext" => Ok(SecurityProtocol::SaslPlaintext),
-            "sasl_ssl" => Ok(SecurityProtocol::SaslSsl),
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid security.protocol: '{other}' (expected plaintext/ssl/sasl_plaintext/sasl_ssl)"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr SecurityProtocol, lowercase, ConnectorError, "invalid security.protocol",
+    Plaintext => "plaintext";
+    Ssl => "ssl";
+    SaslPlaintext => "sasl_plaintext";
+    SaslSsl => "sasl_ssl"
+);
 
 impl std::fmt::Display for SecurityProtocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -118,22 +109,13 @@ impl SaslMechanism {
     }
 }
 
-impl std::str::FromStr for SaslMechanism {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_uppercase().replace('-', "_").as_str() {
-            "PLAIN" => Ok(SaslMechanism::Plain),
-            "SCRAM_SHA_256" | "SCRAM_SHA256" => Ok(SaslMechanism::ScramSha256),
-            "SCRAM_SHA_512" | "SCRAM_SHA512" => Ok(SaslMechanism::ScramSha512),
-            "GSSAPI" | "KERBEROS" => Ok(SaslMechanism::Gssapi),
-            "OAUTHBEARER" | "OAUTH" => Ok(SaslMechanism::Oauthbearer),
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid sasl.mechanism: '{other}' (expected PLAIN/SCRAM-SHA-256/SCRAM-SHA-512/GSSAPI/OAUTHBEARER)"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr SaslMechanism, uppercase, ConnectorError, "invalid sasl.mechanism",
+    Plain => "PLAIN";
+    ScramSha256 => "SCRAM_SHA_256", "SCRAM_SHA256";
+    ScramSha512 => "SCRAM_SHA_512", "SCRAM_SHA512";
+    Gssapi => "GSSAPI", "KERBEROS";
+    Oauthbearer => "OAUTHBEARER", "OAUTH"
+);
 
 impl std::fmt::Display for SaslMechanism {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -164,19 +146,10 @@ impl IsolationLevel {
     }
 }
 
-impl std::str::FromStr for IsolationLevel {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('-', "_").as_str() {
-            "read_uncommitted" => Ok(IsolationLevel::ReadUncommitted),
-            "read_committed" => Ok(IsolationLevel::ReadCommitted),
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid isolation.level: '{other}' (expected read_uncommitted/read_committed)"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr IsolationLevel, lowercase, ConnectorError, "invalid isolation.level",
+    ReadUncommitted => "read_uncommitted";
+    ReadCommitted => "read_committed"
+);
 
 impl std::fmt::Display for IsolationLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -318,20 +291,11 @@ impl OffsetReset {
     }
 }
 
-impl std::str::FromStr for OffsetReset {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "earliest" | "beginning" => Ok(OffsetReset::Earliest),
-            "latest" | "end" => Ok(OffsetReset::Latest),
-            "none" | "error" => Ok(OffsetReset::None),
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid auto.offset.reset: '{other}' (expected earliest/latest/none)"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr OffsetReset, lowercase_nodash, ConnectorError, "invalid auto.offset.reset",
+    Earliest => "earliest", "beginning";
+    Latest => "latest", "end";
+    None => "none", "error"
+);
 
 /// Kafka partition assignment strategy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -356,22 +320,12 @@ impl AssignmentStrategy {
     }
 }
 
-impl std::str::FromStr for AssignmentStrategy {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "range" => Ok(AssignmentStrategy::Range),
-            "roundrobin" | "round-robin" | "round_robin" => Ok(AssignmentStrategy::RoundRobin),
-            "cooperative-sticky" | "cooperative_sticky" => {
-                Ok(AssignmentStrategy::CooperativeSticky)
-            }
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid partition.assignment.strategy: '{other}'"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr AssignmentStrategy, lowercase_nodash, ConnectorError,
+    "invalid partition.assignment.strategy",
+    Range => "range";
+    RoundRobin => "roundrobin", "round-robin", "round_robin";
+    CooperativeSticky => "cooperative-sticky", "cooperative_sticky"
+);
 
 /// Schema Registry compatibility level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -408,24 +362,15 @@ impl CompatibilityLevel {
     }
 }
 
-impl std::str::FromStr for CompatibilityLevel {
-    type Err = ConnectorError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_uppercase().as_str() {
-            "BACKWARD" => Ok(CompatibilityLevel::Backward),
-            "BACKWARD_TRANSITIVE" => Ok(CompatibilityLevel::BackwardTransitive),
-            "FORWARD" => Ok(CompatibilityLevel::Forward),
-            "FORWARD_TRANSITIVE" => Ok(CompatibilityLevel::ForwardTransitive),
-            "FULL" => Ok(CompatibilityLevel::Full),
-            "FULL_TRANSITIVE" => Ok(CompatibilityLevel::FullTransitive),
-            "NONE" => Ok(CompatibilityLevel::None),
-            other => Err(ConnectorError::ConfigurationError(format!(
-                "invalid schema.compatibility: '{other}'"
-            ))),
-        }
-    }
-}
+str_enum!(fromstr CompatibilityLevel, uppercase, ConnectorError, "invalid schema.compatibility",
+    Backward => "BACKWARD";
+    BackwardTransitive => "BACKWARD_TRANSITIVE";
+    Forward => "FORWARD";
+    ForwardTransitive => "FORWARD_TRANSITIVE";
+    Full => "FULL";
+    FullTransitive => "FULL_TRANSITIVE";
+    None => "NONE"
+);
 
 impl std::fmt::Display for CompatibilityLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/laminar-connectors/src/kafka/sink_config.rs
+++ b/crates/laminar-connectors/src/kafka/sink_config.rs
@@ -415,26 +415,10 @@ pub enum DeliveryGuarantee {
     ExactlyOnce,
 }
 
-impl std::str::FromStr for DeliveryGuarantee {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('_', "-").as_str() {
-            "at-least-once" | "atleastonce" => Ok(Self::AtLeastOnce),
-            "exactly-once" | "exactlyonce" => Ok(Self::ExactlyOnce),
-            other => Err(format!("unknown delivery guarantee: '{other}'")),
-        }
-    }
-}
-
-impl std::fmt::Display for DeliveryGuarantee {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::AtLeastOnce => write!(f, "at-least-once"),
-            Self::ExactlyOnce => write!(f, "exactly-once"),
-        }
-    }
-}
+str_enum!(DeliveryGuarantee, lowercase_udash, String, "unknown delivery guarantee",
+    AtLeastOnce => "at-least-once", "atleastonce";
+    ExactlyOnce => "exactly-once", "exactlyonce"
+);
 
 /// Partitioning strategy for distributing records across Kafka partitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -447,28 +431,11 @@ pub enum PartitionStrategy {
     Sticky,
 }
 
-impl std::str::FromStr for PartitionStrategy {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('_', "-").as_str() {
-            "key-hash" | "keyhash" | "hash" => Ok(Self::KeyHash),
-            "round-robin" | "roundrobin" => Ok(Self::RoundRobin),
-            "sticky" => Ok(Self::Sticky),
-            other => Err(format!("unknown partition strategy: '{other}'")),
-        }
-    }
-}
-
-impl std::fmt::Display for PartitionStrategy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::KeyHash => write!(f, "key-hash"),
-            Self::RoundRobin => write!(f, "round-robin"),
-            Self::Sticky => write!(f, "sticky"),
-        }
-    }
-}
+str_enum!(PartitionStrategy, lowercase_udash, String, "unknown partition strategy",
+    KeyHash => "key-hash", "keyhash", "hash";
+    RoundRobin => "round-robin", "roundrobin";
+    Sticky => "sticky"
+);
 
 /// Compression type for produced Kafka messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -499,20 +466,13 @@ impl CompressionType {
     }
 }
 
-impl std::str::FromStr for CompressionType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "none" => Ok(Self::None),
-            "gzip" => Ok(Self::Gzip),
-            "snappy" => Ok(Self::Snappy),
-            "lz4" => Ok(Self::Lz4),
-            "zstd" | "zstandard" => Ok(Self::Zstd),
-            other => Err(format!("unknown compression type: '{other}'")),
-        }
-    }
-}
+str_enum!(fromstr CompressionType, lowercase_nodash, String, "unknown compression type",
+    None => "none";
+    Gzip => "gzip";
+    Snappy => "snappy";
+    Lz4 => "lz4";
+    Zstd => "zstd", "zstandard"
+);
 
 impl std::fmt::Display for CompressionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -543,18 +503,11 @@ impl Acks {
     }
 }
 
-impl std::str::FromStr for Acks {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "0" | "none" => Ok(Self::None),
-            "1" | "leader" => Ok(Self::Leader),
-            "-1" | "all" => Ok(Self::All),
-            other => Err(format!("unknown acks value: '{other}'")),
-        }
-    }
-}
+str_enum!(fromstr Acks, lowercase_nodash, String, "unknown acks value",
+    None => "0", "none";
+    Leader => "1", "leader";
+    All => "-1", "all"
+);
 
 impl std::fmt::Display for Acks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/laminar-connectors/src/kafka/watermarks.rs
+++ b/crates/laminar-connectors/src/kafka/watermarks.rs
@@ -390,28 +390,11 @@ pub enum KafkaAlignmentMode {
     DropExcess,
 }
 
-impl std::fmt::Display for KafkaAlignmentMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pause => write!(f, "pause"),
-            Self::WarnOnly => write!(f, "warn-only"),
-            Self::DropExcess => write!(f, "drop-excess"),
-        }
-    }
-}
-
-impl std::str::FromStr for KafkaAlignmentMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('_', "-").as_str() {
-            "pause" => Ok(Self::Pause),
-            "warn-only" | "warnonly" | "warn" => Ok(Self::WarnOnly),
-            "drop-excess" | "dropexcess" | "drop" => Ok(Self::DropExcess),
-            other => Err(format!("invalid alignment mode: '{other}'")),
-        }
-    }
-}
+str_enum!(KafkaAlignmentMode, lowercase_udash, String, "invalid alignment mode",
+    Pause => "pause";
+    WarnOnly => "warn-only", "warnonly", "warn";
+    DropExcess => "drop-excess", "dropexcess", "drop"
+);
 
 /// Configuration for Kafka source watermark alignment.
 ///

--- a/crates/laminar-connectors/src/lib.rs
+++ b/crates/laminar-connectors/src/lib.rs
@@ -52,6 +52,9 @@
 /// Connector error types.
 pub mod error;
 
+#[macro_use]
+mod macros;
+
 /// Connector configuration types.
 pub mod config;
 

--- a/crates/laminar-connectors/src/lookup/postgres_source.rs
+++ b/crates/laminar-connectors/src/lookup/postgres_source.rs
@@ -313,8 +313,8 @@ pub fn build_query(
     };
 
     // WHERE clause parts
-    let mut where_parts: Vec<String> = Vec::new();
-    let mut params: Vec<String> = Vec::new();
+    let mut where_parts = Vec::new();
+    let mut params = Vec::new();
 
     // Key lookup clause
     if !keys.is_empty() && !pk_columns.is_empty() {

--- a/crates/laminar-connectors/src/macros.rs
+++ b/crates/laminar-connectors/src/macros.rs
@@ -1,0 +1,81 @@
+/// Generates `FromStr` and optionally `Display` impls for simple string enums.
+///
+/// # Forms
+///
+/// - `str_enum!(Enum, norm, ErrType, "msg", ...)` — both `Display` + `FromStr`
+/// - `str_enum!(fromstr Enum, norm, ErrType, "msg", ...)` — `FromStr` only
+///
+/// # Normalization modes
+///
+/// - `lowercase`: `to_lowercase().replace('-', "_")`
+/// - `uppercase`: `to_uppercase().replace('-', "_")`
+/// - `lowercase_nodash`: `to_lowercase()`
+/// - `lowercase_udash`: `to_lowercase().replace('_', "-")`
+#[allow(unused_macros)]
+macro_rules! str_enum {
+    // ── Full form: Display + FromStr ──
+    ($enum_name:ident, $norm:ident, $err_kind:ident, $err_msg:literal,
+        $( $variant:ident => $display:literal $(, $alias:literal)* );+ $(;)?
+    ) => {
+        impl std::fmt::Display for $enum_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let s = match self {
+                    $( Self::$variant => $display, )+
+                };
+                f.write_str(s)
+            }
+        }
+        str_enum!(fromstr $enum_name, $norm, $err_kind, $err_msg,
+            $( $variant => $display $(, $alias)* );+);
+    };
+
+    // ── FromStr-only form ──
+    (fromstr $enum_name:ident, $norm:ident, $err_kind:ident, $err_msg:literal,
+        $( $variant:ident => $canonical:literal $(, $alias:literal)* );+ $(;)?
+    ) => {
+        str_enum!(@fromstr_impl $enum_name, $norm, $err_kind, $err_msg,
+            $( $variant => $canonical $(, $alias)* );+);
+    };
+
+    // ── Internal: ConnectorError variant ──
+    (@fromstr_impl $enum_name:ident, $norm:ident, ConnectorError, $err_msg:literal,
+        $( $variant:ident => $canonical:literal $(, $alias:literal)* );+ $(;)?
+    ) => {
+        impl std::str::FromStr for $enum_name {
+            type Err = crate::error::ConnectorError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let normalized = str_enum!(@normalize $norm s);
+                match normalized.as_str() {
+                    $( $canonical $(| $alias)* => Ok(Self::$variant), )+
+                    other => Err(crate::error::ConnectorError::ConfigurationError(
+                        format!("{}: '{}'", $err_msg, other),
+                    )),
+                }
+            }
+        }
+    };
+
+    // ── Internal: String variant ──
+    (@fromstr_impl $enum_name:ident, $norm:ident, String, $err_msg:literal,
+        $( $variant:ident => $canonical:literal $(, $alias:literal)* );+ $(;)?
+    ) => {
+        impl std::str::FromStr for $enum_name {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                let normalized = str_enum!(@normalize $norm s);
+                match normalized.as_str() {
+                    $( $canonical $(| $alias)* => Ok(Self::$variant), )+
+                    other => Err(format!("{}: '{}'", $err_msg, other)),
+                }
+            }
+        }
+    };
+
+    // ── Normalization helpers ──
+    (@normalize lowercase $s:ident) => { $s.to_lowercase().replace('-', "_") };
+    (@normalize uppercase $s:ident) => { $s.to_uppercase().replace('-', "_") };
+    (@normalize lowercase_nodash $s:ident) => { $s.to_lowercase() };
+    (@normalize lowercase_udash $s:ident) => { $s.to_lowercase().replace('_', "-") };
+}

--- a/crates/laminar-connectors/src/postgres/sink_config.rs
+++ b/crates/laminar-connectors/src/postgres/sink_config.rs
@@ -3,8 +3,6 @@
 //! [`PostgresSinkConfig`] encapsulates all settings for writing Arrow
 //! `RecordBatch` data to `PostgreSQL`, parsed from SQL `WITH (...)` clauses.
 
-use std::fmt;
-use std::str::FromStr;
 use std::time::Duration;
 
 use crate::config::ConnectorConfig;
@@ -256,26 +254,10 @@ pub enum WriteMode {
     Upsert,
 }
 
-impl FromStr for WriteMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "append" | "copy" => Ok(Self::Append),
-            "upsert" | "insert" => Ok(Self::Upsert),
-            other => Err(format!("unknown write mode: '{other}'")),
-        }
-    }
-}
-
-impl fmt::Display for WriteMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Append => write!(f, "append"),
-            Self::Upsert => write!(f, "upsert"),
-        }
-    }
-}
+str_enum!(WriteMode, lowercase_nodash, String, "unknown write mode",
+    Append => "append", "copy";
+    Upsert => "upsert", "insert"
+);
 
 /// Delivery guarantee for the `PostgreSQL` sink.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -286,26 +268,10 @@ pub enum DeliveryGuarantee {
     ExactlyOnce,
 }
 
-impl FromStr for DeliveryGuarantee {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('-', "_").as_str() {
-            "at_least_once" | "atleastonce" => Ok(Self::AtLeastOnce),
-            "exactly_once" | "exactlyonce" => Ok(Self::ExactlyOnce),
-            other => Err(format!("unknown delivery guarantee: '{other}'")),
-        }
-    }
-}
-
-impl fmt::Display for DeliveryGuarantee {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::AtLeastOnce => write!(f, "at_least_once"),
-            Self::ExactlyOnce => write!(f, "exactly_once"),
-        }
-    }
-}
+str_enum!(DeliveryGuarantee, lowercase_nodash, String, "unknown delivery guarantee",
+    AtLeastOnce => "at_least_once", "at-least-once", "atleastonce";
+    ExactlyOnce => "exactly_once", "exactly-once", "exactlyonce"
+);
 
 /// SSL mode for `PostgreSQL` connections.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -322,32 +288,13 @@ pub enum SslMode {
     VerifyFull,
 }
 
-impl FromStr for SslMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().replace('-', "_").as_str() {
-            "disable" | "off" => Ok(Self::Disable),
-            "prefer" => Ok(Self::Prefer),
-            "require" => Ok(Self::Require),
-            "verify_ca" | "verifyca" => Ok(Self::VerifyCa),
-            "verify_full" | "verifyfull" => Ok(Self::VerifyFull),
-            other => Err(format!("unknown SSL mode: '{other}'")),
-        }
-    }
-}
-
-impl fmt::Display for SslMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Disable => write!(f, "disable"),
-            Self::Prefer => write!(f, "prefer"),
-            Self::Require => write!(f, "require"),
-            Self::VerifyCa => write!(f, "verify-ca"),
-            Self::VerifyFull => write!(f, "verify-full"),
-        }
-    }
-}
+str_enum!(SslMode, lowercase_nodash, String, "unknown SSL mode",
+    Disable => "disable", "off";
+    Prefer => "prefer";
+    Require => "require";
+    VerifyCa => "verify-ca", "verify_ca", "verifyca";
+    VerifyFull => "verify-full", "verify_full", "verifyfull"
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/laminar-connectors/src/schema/evolution.rs
+++ b/crates/laminar-connectors/src/schema/evolution.rs
@@ -308,7 +308,7 @@ pub fn apply_changes(old: &SchemaRef, changes: &[SchemaChange]) -> SchemaResult<
     let mut old_index_map: Vec<Option<usize>> = (0..fields.len()).map(Some).collect();
 
     // Collect indices of columns to remove.
-    let mut remove_indices: Vec<usize> = Vec::new();
+    let mut remove_indices = Vec::new();
 
     for change in changes {
         match change {

--- a/crates/laminar-connectors/src/schema/inference.rs
+++ b/crates/laminar-connectors/src/schema/inference.rs
@@ -170,8 +170,8 @@ impl FormatInference for JsonFormatInference {
         let samples = &samples[..limit];
 
         let mut field_types: HashMap<String, Vec<InferredType>> = HashMap::new();
-        let mut field_order: Vec<String> = Vec::new();
-        let mut warnings: Vec<InferenceWarning> = Vec::new();
+        let mut field_order = Vec::new();
+        let mut warnings = Vec::new();
 
         for (i, record) in samples.iter().enumerate() {
             let value: serde_json::Value = serde_json::from_slice(&record.value).map_err(|e| {
@@ -196,8 +196,8 @@ impl FormatInference for JsonFormatInference {
         }
 
         let total = samples.len();
-        let mut fields: Vec<Field> = Vec::new();
-        let mut details: Vec<FieldInferenceDetail> = Vec::new();
+        let mut fields = Vec::new();
+        let mut details = Vec::new();
 
         for name in &field_order {
             let types = &field_types[name];

--- a/crates/laminar-storage/src/incremental/mod.rs
+++ b/crates/laminar-storage/src/incremental/mod.rs
@@ -68,7 +68,7 @@ mod error;
 mod manager;
 mod recovery;
 
-pub use changelog::{ChangelogEntryBuilder, StateChangelogBuffer, StateChangelogEntry, StateOp};
+pub use changelog::{StateChangelogBuffer, StateChangelogEntry, StateOp};
 pub use error::IncrementalCheckpointError;
 pub use manager::{CheckpointConfig, IncrementalCheckpointManager, IncrementalCheckpointMetadata};
 pub use recovery::{

--- a/crates/laminar-storage/src/lib.rs
+++ b/crates/laminar-storage/src/lib.rs
@@ -66,10 +66,9 @@ pub use wal_state_store::WalStateStore;
 
 // Re-export incremental checkpoint types
 pub use incremental::{
-    validate_checkpoint, wal_size, ChangelogEntryBuilder, CheckpointConfig,
-    IncrementalCheckpointError, IncrementalCheckpointManager, IncrementalCheckpointMetadata,
-    RecoveredState, RecoveryConfig, RecoveryManager, StateChangelogBuffer, StateChangelogEntry,
-    StateOp,
+    validate_checkpoint, wal_size, CheckpointConfig, IncrementalCheckpointError,
+    IncrementalCheckpointManager, IncrementalCheckpointMetadata, RecoveredState, RecoveryConfig,
+    RecoveryManager, StateChangelogBuffer, StateChangelogEntry, StateOp,
 };
 
 // Re-export per-core WAL types


### PR DESCRIPTION
## Summary

- **str_enum! macro**: Replaces 17 hand-written `Display`/`FromStr` impls across 6 connector files with a single declarative macro supporting 4 normalization modes and 2 error types
- **CDC config simplification**: Adds `require_non_empty()` helper and converts manual `parse().map_err()` chains to `get_parsed::<T>()` in both Postgres and MySQL CDC configs
- **ApiError constructor macros**: Introduces `api_error_msg!` and `api_error_fixed!` macros replacing 10 repetitive constructor methods
- **Dead code deletion**: Removes unused `PacketBuilder` (header.rs) and `ChangelogEntryBuilder` (changelog.rs) along with their tests and re-exports
- **Type annotation cleanup**: Removes redundant `Vec<T>` annotations where type is obvious from context

Net: **280 added, 652 removed** across 17 files.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (0 failures)
- [x] No new `unsafe` code introduced