### PR TITLE
fix(ci): add swap space and limit build jobs to prevent OOM kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   # Disable incremental compilation in CI to reduce disk usage
   CARGO_INCREMENTAL: 0
+  # Limit parallel compiler jobs to avoid OOM on GitHub Actions runners (7 GB RAM)
+  CARGO_BUILD_JOBS: 2
 
 jobs:
   # ============================================
@@ -50,6 +52,10 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           df -h /
+      - name: Set swap space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -81,6 +87,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           df -h /
+      - name: Set swap space (Linux)
+        if: runner.os == 'Linux'
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -127,6 +138,10 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
           df -h /
+      - name: Set swap space
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Limit parallel compiler jobs to avoid OOM on GitHub Actions runners (7 GB RAM)
+  CARGO_BUILD_JOBS: 2
 
 jobs:
   # ============================================
@@ -114,6 +116,12 @@ jobs:
 
           echo "Workspace version:"
           grep '^version' Cargo.toml
+
+      - name: Set swap space (Linux)
+        if: runner.os == 'Linux'
+        uses: pierotofy/set-swap-space@v1.0
+        with:
+          swap-size-gb: 10
 
       - name: Install system dependencies (Linux native)
         if: runner.os == 'Linux' && !matrix.cross


### PR DESCRIPTION
## Summary
- Add 10GB swap via `pierotofy/set-swap-space@v1.0` action on all Linux CI/release build jobs
- Set `CARGO_BUILD_JOBS: 2` globally in both `ci.yml` and `release.yml` to halve peak memory usage
- Fixes release builds failing after ~25min with exit code 143 (SIGTERM from OOM killer)

## Test plan
- [ ] Trigger a release build and verify it completes without OOM
- [ ] Verify CI jobs (clippy, build-and-test, release-build) pass with the new swap/job limits