### PR TITLE
docs: comprehensive documentation sync with current implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ cargo test --all
 cargo test -p laminar-core
 
 # With feature flags
-cargo test --all --features kafka,postgres-cdc,mysql-cdc,rocksdb
+cargo test --all --features kafka,postgres-cdc,mysql-cdc,delta-lake
 
 # Run benchmarks
 cargo bench
@@ -115,15 +115,21 @@ Many features are optional to keep compile times manageable:
 | Flag | Crate | Purpose |
 |------|-------|---------|
 | `jit` | laminar-core, laminar-db | Cranelift JIT compilation |
-| `kafka` | laminar-connectors | Kafka source/sink, Avro serde |
-| `postgres-cdc` | laminar-connectors | PostgreSQL CDC source |
-| `postgres-sink` | laminar-connectors | PostgreSQL sink |
+| `kafka` | laminar-connectors, laminar-db | Kafka source/sink, Avro serde |
+| `postgres-cdc` | laminar-connectors, laminar-db | PostgreSQL CDC source |
+| `postgres-sink` | laminar-connectors, laminar-db | PostgreSQL sink |
 | `mysql-cdc` | laminar-connectors | MySQL CDC source |
-| `rocksdb` | laminar-storage, laminar-db | RocksDB-backed state store |
-| `delta-lake` | laminar-connectors | Delta Lake sink |
+| `delta-lake` | laminar-connectors, laminar-db | Delta Lake sink and source |
+| `delta-lake-s3` | laminar-connectors | S3 storage backend for Delta Lake |
+| `websocket` | laminar-connectors | WebSocket source and sink |
 | `ffi` | laminar-db | C FFI layer |
+| `api` | laminar-db | FFI-friendly API module |
+| `delta` | laminar-core, laminar-db | Distributed delta mode |
 | `allocation-tracking` | laminar-core | Panic on hot-path allocation |
 | `io-uring` | laminar-core | Linux io_uring integration |
+| `hwloc` | laminar-core | Enhanced NUMA topology |
+| `xdp` | laminar-core | Linux eBPF/XDP |
+| `parquet-lookup` | laminar-connectors | Parquet file lookup source |
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaminarDB
 
-**Ultra-low latency embedded streaming SQL database written in Rust.**
+**Embedded streaming SQL database written in Rust.**
 
 [![CI](https://github.com/laminardb/laminardb/actions/workflows/ci.yml/badge.svg)](https://github.com/laminardb/laminardb/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/laminar-db.svg)](https://crates.io/crates/laminar-db)
@@ -8,46 +8,36 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange)](https://www.rust-lang.org)
 
-Think "SQLite for stream processing." LaminarDB is an embedded streaming database that lets you run continuous SQL queries over real-time data with sub-microsecond latency. No cluster, no JVM, no external dependencies -- just link it as a Rust library or use the Python bindings.
+Think "SQLite for stream processing." LaminarDB is an embedded streaming database that lets you run continuous SQL queries over real-time data with sub-microsecond latency. No cluster, no JVM, no external dependencies -- just link it as a Rust library.
 
 Built on [Apache Arrow](https://arrow.apache.org/) and [DataFusion](https://datafusion.apache.org/), LaminarDB targets use cases like financial market data, IoT edge analytics, and real-time application state where every microsecond counts.
 
-## Install
+---
 
-### Rust (crates.io)
+## Getting Started
+
+### 1. Add the dependency
 
 ```bash
 cargo add laminar-db
 ```
 
-LaminarDB is published to [crates.io](https://crates.io/crates/laminar-db) as six workspace crates:
+Or in your `Cargo.toml`:
 
-| Crate | Description |
-|-------|-------------|
-| [`laminar-db`](https://crates.io/crates/laminar-db) | Unified database facade (start here) |
-| [`laminar-core`](https://crates.io/crates/laminar-core) | Reactor, operators, state stores, windows, joins |
-| [`laminar-sql`](https://crates.io/crates/laminar-sql) | DataFusion integration, streaming SQL parser |
-| [`laminar-storage`](https://crates.io/crates/laminar-storage) | WAL, checkpointing, RocksDB backend |
-| [`laminar-connectors`](https://crates.io/crates/laminar-connectors) | Kafka, PostgreSQL CDC, MySQL CDC, Delta Lake |
-| [`laminar-derive`](https://crates.io/crates/laminar-derive) | `#[derive(Record, FromRecordBatch)]` macros |
-
-### Python (PyPI)
-
-```bash
-pip install laminardb
+```toml
+[dependencies]
+laminar-db = "0.15"
+tokio = { version = "1", features = ["full"] }
 ```
 
-See the [laminardb-python](https://github.com/laminardb/laminardb-python) repository for the full Python API.
-
-## Quick Start
-
-### Rust
+### 2. Write your first streaming query
 
 ```rust
 use laminar_db::LaminarDB;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Open an in-memory database
     let db = LaminarDB::open()?;
 
     // Create a streaming source
@@ -60,158 +50,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Define a continuous aggregation with a tumbling window
     db.execute("CREATE STREAM vwap AS
-        SELECT symbol, SUM(price * volume) / SUM(volume) AS vwap, COUNT(*) AS trades
+        SELECT symbol,
+               SUM(price * CAST(volume AS DOUBLE)) / SUM(CAST(volume AS DOUBLE)) AS vwap,
+               COUNT(*) AS trades
         FROM trades
         GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
     ").await?;
 
-    // Push data and subscribe to results
+    // Get a handle to push data
     let source = db.source_untyped("trades")?;
-    // source.push(batch);
 
     // Start the streaming pipeline
     db.start().await?;
 
+    // Push data via source.push(record_batch)
+    // Subscribe to results via db.subscribe::<T>("vwap")
+
+    db.shutdown().await?;
     Ok(())
 }
 ```
 
-### Python
-
-```python
-import laminardb
-
-db = laminardb.open(":memory:")
-
-db.execute("CREATE SOURCE sensors (device_id VARCHAR, temp DOUBLE, ts BIGINT)")
-db.execute("""
-    CREATE STREAM avg_temp AS
-    SELECT device_id, AVG(temp) AS avg_temp, COUNT(*) AS readings
-    FROM sensors
-    GROUP BY device_id, tumble(ts, INTERVAL '10' SECOND)
-""")
-
-db.insert("sensors", {"device_id": "a1", "temp": 22.5, "ts": 1700000000000})
-db.start()
-```
-
-### Standalone Server
+### 3. Build and run
 
 ```bash
-cargo run --release --bin laminardb
+cargo build --release
+cargo run
 ```
 
-## Key Features
+---
 
-- **Streaming SQL** -- Tumbling, sliding, hopping, and session windows with standard SQL syntax
-- **Sub-microsecond latency** -- Three-ring architecture with zero allocations on the hot path
-- **Embedded-first** -- Link as a Rust library, no external dependencies
-- **Apache DataFusion** -- Full SQL support via DataFusion, including joins, aggregations, and UDFs
-- **Arrow-native** -- Zero-copy data flow with Apache Arrow RecordBatch at every boundary
-- **Exactly-once semantics** -- WAL, incremental checkpointing, and two-phase commit
-- **Thread-per-core** -- Linear scaling with CPU cores, NUMA-aware memory allocation
-- **Connectors** -- Kafka, PostgreSQL CDC, MySQL CDC, Delta Lake, with a connector SDK
-- **JIT compilation** -- Optional Cranelift-based query compilation for Ring 0 execution
-- **Python bindings** -- Full-featured Python API with PyArrow zero-copy interop
+## Feature Overview
 
-## Architecture
+### Streaming SQL
 
-LaminarDB uses a three-ring architecture to separate latency-critical event processing from background I/O and control plane operations:
+LaminarDB extends standard SQL with streaming primitives. All window types, join types, and EMIT strategies listed below are implemented and tested.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        RING 0: HOT PATH                         │
-│  Zero allocations, no locks, < 1us latency                      │
-│  ┌─────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐         │
-│  │ Reactor │─>│ Operators│─>│  State   │─>│   Emit   │         │
-│  │  Loop   │  │ (window, │  │  Store   │  │ (output) │         │
-│  │         │  │  join,   │  │ (mmap/   │  │          │         │
-│  │         │  │  filter) │  │  fxhash) │  │          │         │
-│  └─────────┘  └──────────┘  └──────────┘  └──────────┘         │
-│       |                                                         │
-│       | SPSC queues (lock-free)                                 │
-│       v                                                         │
-├─────────────────────────────────────────────────────────────────┤
-│                     RING 1: BACKGROUND                          │
-│  Async I/O, can allocate, bounded latency impact                │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐        │
-│  │Checkpoint│  │   WAL    │  │Compaction│  │  Timer   │        │
-│  │ Manager  │  │  Writer  │  │  Thread  │  │  Wheel   │        │
-│  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
-│       |                                                         │
-│       | Channels (bounded)                                      │
-│       v                                                         │
-├─────────────────────────────────────────────────────────────────┤
-│                     RING 2: CONTROL PLANE                       │
-│  No latency requirements, full flexibility                      │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐        │
-│  │  Admin   │  │ Metrics  │  │   Auth   │  │  Config  │        │
-│  │   API    │  │  Export  │  │  Engine  │  │ Manager  │        │
-│  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
-└─────────────────────────────────────────────────────────────────┘
-```
+#### Window Types
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
-
-## Performance Targets
-
-| Metric | Target | Benchmark |
-|--------|--------|-----------|
-| State lookup | < 500ns p99 | `cargo bench --bench state_bench` |
-| Throughput/core | 500K events/sec | `cargo bench --bench throughput_bench` |
-| p99 latency | < 10us | `cargo bench --bench latency_bench` |
-| Checkpoint recovery | < 10s | Integration tests |
-| Window trigger | < 10us | `cargo bench --bench window_bench` |
-
-Run all benchmarks:
-
-```bash
-cargo bench
-```
-
-## Windows
-
-LaminarDB supports four window types for time-based aggregation over streaming data.
-
-### Tumbling Windows
-
-Fixed-size, non-overlapping windows. Each event belongs to exactly one window.
+| Window | Syntax | Description |
+|--------|--------|-------------|
+| Tumbling | `tumble(ts, INTERVAL '1' MINUTE)` | Fixed-size, non-overlapping windows |
+| Sliding | `slide(ts, INTERVAL '5' MINUTE, INTERVAL '1' MINUTE)` | Overlapping windows with configurable slide |
+| Hopping | `hop(ts, INTERVAL '10' SECOND, INTERVAL '5' SECOND)` | Alias for sliding windows |
+| Session | `session(ts, INTERVAL '30' SECOND)` | Gap-based dynamic windows with merge support |
 
 ```sql
-CREATE STREAM trades_1m AS
-SELECT symbol, SUM(volume) AS total_volume, COUNT(*) AS trade_count
+-- Tumbling window: 1-minute OHLC bars
+CREATE STREAM ohlc_1m AS
+SELECT symbol,
+       CAST(tumble(ts, INTERVAL '1' MINUTE) AS BIGINT) AS window_start,
+       first_value(price) AS open,
+       MAX(price) AS high,
+       MIN(price) AS low,
+       last_value(price) AS close,
+       SUM(volume) AS volume
 FROM trades
 GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
 EMIT ON WINDOW CLOSE;
-```
 
-### Sliding Windows
-
-Overlapping windows with configurable size and slide interval. An event may appear in multiple windows.
-
-```sql
-CREATE STREAM moving_avg AS
-SELECT symbol, AVG(price) AS avg_price
-FROM trades
-GROUP BY symbol, slide(ts, INTERVAL '5' MINUTE, INTERVAL '1' MINUTE)
-EMIT ON WINDOW CLOSE;
-```
-
-### Hopping Windows
-
-Alias for sliding windows -- size and hop interval define how windows overlap.
-
-```sql
-SELECT sensor_id, MAX(temp) AS peak_temp
-FROM readings
-GROUP BY sensor_id, hop(ts, INTERVAL '10' SECOND, INTERVAL '5' SECOND);
-```
-
-### Session Windows
-
-Dynamic windows that close after a configurable gap of inactivity. Events within the gap are grouped into the same session.
-
-```sql
+-- Session window: detect activity bursts
 CREATE STREAM user_sessions AS
 SELECT user_id,
        COUNT(*) AS clicks,
@@ -221,129 +119,123 @@ GROUP BY user_id, session(ts, INTERVAL '30' SECOND)
 EMIT ON WINDOW CLOSE;
 ```
 
-Session windows support:
-- **Merging**: overlapping sessions merge into a single window
-- **Per-key state**: each key maintains its own session independently
-- **Watermark closure**: sessions close when the watermark passes the gap threshold
+#### Join Types
 
-## EMIT Strategies
+| Join | Description |
+|------|-------------|
+| Stream-Stream | Time-bounded inner/outer joins between two streams |
+| ASOF | Point-in-time lookups (match closest preceding row) |
+| Temporal | Versioned joins with time-validity semantics |
+| Lookup | Enrichment joins against reference/lookup tables |
 
-The `EMIT` clause controls when window results are produced downstream.
+```sql
+-- Stream-stream join with time window
+CREATE STREAM enriched_orders AS
+SELECT o.order_id, o.symbol, t.price AS market_price
+FROM orders o
+INNER JOIN trades t ON o.symbol = t.symbol
+    AND t.ts BETWEEN o.ts - 10000 AND o.ts + 10000;
+
+-- ASOF join for point-in-time lookup
+SELECT o.*, t.price AS last_trade_price
+FROM orders o
+ASOF JOIN trades t ON o.symbol = t.symbol AND o.ts >= t.ts;
+
+-- Lookup join against a reference table
+CREATE LOOKUP TABLE instruments FROM POSTGRES (
+    hostname = 'db.example.com', port = '5432',
+    database = 'market', query = 'SELECT * FROM instruments'
+);
+
+SELECT t.symbol, t.price, i.sector, i.exchange
+FROM trades t
+JOIN instruments i ON t.symbol = i.symbol;
+```
+
+#### EMIT Strategies
 
 | Strategy | Behavior | Use Case |
 |----------|----------|----------|
 | `EMIT ON WINDOW CLOSE` | Emit once when the window closes | Final aggregates (OHLC bars, billing) |
 | `EMIT CHANGES` | Emit insert/retract pairs on every update | Live dashboards, cascading MVs |
-| `EMIT FINAL` | Emit only the final value when the window closes | Same as ON WINDOW CLOSE (explicit alias) |
+| `EMIT FINAL` | Alias for ON WINDOW CLOSE | Explicit final-only output |
+
+`EMIT CHANGES` uses the **Z-set changelog model** (DBSP/Feldera-inspired): each update produces a `+1` insert for the new value and a `-1` retraction for the previous value, enabling correct incremental computation and cascading materialized views.
+
+#### Analytics Functions
 
 ```sql
--- Emit running updates as a changelog (insert + retract pairs)
-CREATE STREAM live_totals AS
-SELECT symbol, SUM(volume) AS running_volume
-FROM trades
-GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
-EMIT CHANGES;
+-- LAG/LEAD
+SELECT symbol, price,
+       LAG(price, 1) OVER (PARTITION BY symbol ORDER BY ts) AS prev_price,
+       price - LAG(price, 1) OVER (PARTITION BY symbol ORDER BY ts) AS delta
+FROM trades;
 
--- Emit only the final bar when the window closes
-CREATE STREAM ohlc_1m AS
+-- Ranking
+SELECT symbol, price,
+       ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY price DESC) AS rank
+FROM trades;
+
+-- Cascading materialized views (MV reading from MV)
+CREATE MATERIALIZED VIEW ohlc_1h AS
 SELECT symbol,
-       FIRST(price) AS open, MAX(price) AS high,
-       MIN(price) AS low, LAST(price) AS close,
-       SUM(volume) AS volume
-FROM trades
-GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
-EMIT ON WINDOW CLOSE;
+       first_value(open) AS open, MAX(high) AS high,
+       MIN(low) AS low, last_value(close) AS close
+FROM ohlc_1m
+GROUP BY symbol, tumble(window_start, INTERVAL '1' HOUR);
 ```
 
-`EMIT CHANGES` uses the **Z-set changelog model** (DBSP/Feldera-inspired): each update produces a `+1` insert for the new value and a `-1` retraction for the previous value, enabling correct incremental downstream computation including cascading materialized views.
+See [docs/SQL_REFERENCE.md](docs/SQL_REFERENCE.md) for the complete SQL dialect reference, including gotchas and tested patterns.
 
-## Watermarks and Event Time
+### Watermarks and Event Time
 
 LaminarDB uses event-time processing with watermarks to handle out-of-order data.
-
-### Watermarks
-
-Watermarks declare "all events with timestamp <= W have arrived." Windows close when the watermark passes their end boundary.
 
 ```sql
 -- Bounded out-of-orderness: allow up to 5 seconds of late data
 CREATE SOURCE trades (
-    symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT
-) WITH (
-    watermark = 'ts',
-    allowed_lateness = INTERVAL '5' SECOND
+    symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT,
+    WATERMARK FOR ts AS ts - INTERVAL '5' SECOND
 );
 ```
 
-### Watermark Granularity
+Watermark types:
+- **Per-partition** -- independent watermark per source partition
+- **Per-key** -- independent watermark per key (e.g., per symbol)
+- **Alignment groups** -- synchronized watermarks across related sources for join correctness
 
-| Type | Description |
-|------|-------------|
-| **Per-partition** | Independent watermark per source partition -- one slow partition doesn't block others |
-| **Per-key** | Independent watermark per key (e.g., per symbol) for heterogeneous data rates |
-| **Alignment groups** | Synchronized watermarks across related sources for join correctness |
+Late data can be dropped (default) or redirected to a side output.
 
-### Late Data Handling
-
-Events arriving after the watermark passes can be:
-- **Dropped** (default) -- silently discarded
-- **Redirected to a side output** -- captured for reprocessing or alerting
-
-```sql
--- Allow 10 seconds of late data before dropping
-CREATE STREAM results AS
-SELECT symbol, COUNT(*) AS cnt
-FROM trades
-GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
-WITH (allowed_lateness = INTERVAL '10' SECOND);
-```
-
-## Checkpointing and Recovery
-
-LaminarDB provides exactly-once semantics through a coordinated checkpointing system.
-
-### How It Works
-
-1. **Ring 0 Changelog**: Every state mutation is captured in a zero-allocation changelog (~2-5ns overhead per mutation) via `ChangelogAwareStore`
-2. **Per-Core WAL**: Each CPU core writes to its own WAL segment -- no locks, no contention, epoch-ordered
-3. **Incremental Checkpoints**: Only changed state is written, backed by RocksDB for efficient delta snapshots
-4. **Checkpoint Coordinator**: Orchestrates consistent snapshots across all operators, sinks, and connectors using Chandy-Lamport barriers
-5. **Two-Phase Commit**: Sinks (Kafka, PostgreSQL, Delta Lake) participate in the checkpoint protocol with pre-commit/commit phases
-
-### Recovery
-
-On restart, the `RecoveryManager` restores the last consistent checkpoint:
-- Loads the `CheckpointManifest` (operator states, connector offsets, sink positions)
-- Restores state stores from the incremental RocksDB snapshot
-- Replays WAL entries written after the checkpoint
-- Resumes connectors from their checkpointed offsets -- no duplicate processing
-
-```rust
-// Enable checkpointing with 30-second intervals
-let db = LaminarDB::builder()
-    .storage_dir("./data")
-    .checkpoint(CheckpointConfig {
-        interval: Duration::from_secs(30),
-        ..Default::default()
-    })
-    .build().await?;
-```
-
-### Exactly-Once Sinks
-
-Sinks participate in the checkpoint protocol to guarantee exactly-once delivery:
-
-| Sink | Mechanism |
-|------|-----------|
-| **Kafka** | Kafka transactions -- begin on epoch start, commit on checkpoint |
-| **PostgreSQL** | Co-transactional -- sink writes + offset update in the same DB transaction |
-| **Delta Lake** | Epoch-aligned Parquet file commits with atomic manifest updates |
+---
 
 ## Connectors
 
-### Kafka Source
+LaminarDB connects to external systems via feature-gated connectors. Each connector implements the `SourceConnector` or `SinkConnector` trait with exactly-once semantics via two-phase commit.
 
-Consume from Kafka topics with consumer group management, backpressure, and Schema Registry integration.
+### Source Connectors
+
+| Connector | Feature Flag | Description | Status |
+|-----------|-------------|-------------|--------|
+| **Kafka** | `kafka` | Consumer group, backpressure, Schema Registry | Implemented |
+| **PostgreSQL CDC** | `postgres-cdc` | Logical replication (pgoutput), Z-set changelog | Implemented |
+| **MySQL CDC** | `mysql-cdc` | Binlog decoding, GTID position tracking | Implemented |
+| **WebSocket Client** | `websocket` | Connect to external WebSocket servers | Implemented |
+| **WebSocket Server** | `websocket` | Accept incoming WebSocket connections | Implemented |
+| **Delta Lake** | `delta-lake` | Read from Delta Lake tables (version polling) | Implemented |
+| MongoDB CDC | -- | -- | Planned |
+
+### Sink Connectors
+
+| Connector | Feature Flag | Description | Status |
+|-----------|-------------|-------------|--------|
+| **Kafka** | `kafka` | Exactly-once transactions, configurable partitioning | Implemented |
+| **PostgreSQL** | `postgres-sink` | COPY BINARY, upsert, co-transactional exactly-once | Implemented |
+| **Delta Lake** | `delta-lake` | S3/Azure/GCS, epoch-aligned Parquet commits | Implemented |
+| **Apache Iceberg** | -- | Buffering, epoch, partition transforms | Implemented (business logic; I/O integration planned) |
+| **WebSocket Server** | `websocket` | Fan-out results to connected subscribers | Implemented |
+| **WebSocket Client** | `websocket` | Push results to external WebSocket server | Implemented |
+
+### Kafka Source Example
 
 ```sql
 CREATE SOURCE trades (
@@ -359,34 +251,7 @@ CREATE SOURCE trades (
 
 Supported formats: `json`, `csv`, `avro` (with Schema Registry), `raw` (bytes), `debezium` (CDC envelope).
 
-Avro with Schema Registry:
-
-```sql
-CREATE SOURCE events (...) FROM KAFKA (
-    brokers = '${KAFKA_BROKERS}',
-    topic = 'events',
-    format = 'avro',
-    schema.registry.url = 'http://schema-registry:8081'
-);
-```
-
-### Kafka Sink
-
-Produce to Kafka topics with exactly-once transactions, configurable partitioning, and compression.
-
-```sql
-CREATE SINK output INTO KAFKA (
-    brokers = '${KAFKA_BROKERS}',
-    topic = 'trade-summaries',
-    format = 'json',
-    delivery.guarantee = 'exactly-once',
-    compression.type = 'snappy'
-) AS SELECT * FROM trade_summary;
-```
-
-### PostgreSQL CDC
-
-Capture real-time changes from PostgreSQL using logical replication (pgoutput protocol). Changes are emitted as a Z-set changelog with `_op` column (`I`=insert, `U`=update, `D`=delete).
+### PostgreSQL CDC Example
 
 ```sql
 CREATE SOURCE orders_cdc (
@@ -398,23 +263,11 @@ CREATE SOURCE orders_cdc (
     slot.name = 'laminar_orders',
     publication = 'laminar_pub'
 );
-
--- Aggregate CDC changes
-CREATE STREAM customer_totals AS
-SELECT customer_id, COUNT(*) AS total_orders, SUM(amount) AS total_spent
-FROM orders_cdc
-WHERE _op IN ('I', 'U')
-GROUP BY customer_id
-EMIT CHANGES;
 ```
 
-### PostgreSQL Sink
+CDC events are emitted as a Z-set changelog with `_op` column (`I`=insert, `U`=update, `D`=delete).
 
-Write results to PostgreSQL using COPY BINARY protocol with upsert support and co-transactional exactly-once delivery.
-
-### MySQL CDC
-
-Capture changes from MySQL using binlog decoding with GTID-based position tracking. Emits the same Z-set changelog format as PostgreSQL CDC.
+### MySQL CDC Example
 
 ```sql
 CREATE SOURCE products_cdc (
@@ -428,95 +281,240 @@ CREATE SOURCE products_cdc (
 );
 ```
 
-### Delta Lake Sink
-
-Write streaming results to Delta Lake tables on S3, Azure ADLS, or GCS with exactly-once epoch-aligned commits.
+### Delta Lake Sink Example
 
 ```sql
 CREATE SINK lake INTO DELTA_LAKE (
     path = 's3://my-bucket/trade_summary',
-    write_mode = 'append'
+    write_mode = 'append',
+    delivery.guarantee = 'exactly-once'
 ) AS SELECT * FROM trade_summary;
 ```
 
+Cloud storage backends: S3 (`delta-lake-s3`), Azure ADLS (`delta-lake-azure`), GCS (`delta-lake-gcs`). Supports Glue and Unity catalogs.
+
 ### Connector SDK
 
-Build custom connectors using the built-in SDK with retry policies, circuit breakers, rate limiting, and a test harness:
+Build custom connectors using the SDK with operational resilience built in:
 
 ```rust
+use laminar_connectors::connector::{SourceConnector, SinkConnector};
 use laminar_connectors::sdk::{RetryPolicy, CircuitBreaker, RateLimiter};
 ```
 
-## Streaming SQL
+The SDK provides retry policies with exponential backoff, circuit breakers, rate limiters, and a test harness for connector development.
 
-LaminarDB extends standard SQL with streaming primitives:
+---
 
-```sql
--- Tumbling window aggregation
-CREATE STREAM ohlc_1min AS
-SELECT symbol,
-       MIN(price) AS low, MAX(price) AS high,
-       SUM(volume) AS total_volume
-FROM trades
-GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE);
+## Schema Framework
 
--- Session windows (gap-based)
-CREATE STREAM user_sessions AS
-SELECT user_id, COUNT(*) AS clicks, MAX(ts) - MIN(ts) AS duration
-FROM clickstream
-GROUP BY user_id, session(ts, INTERVAL '30' SECOND);
+LaminarDB includes a pluggable schema framework for format decoding, schema inference, and schema evolution.
 
--- Stream-to-stream joins
-CREATE STREAM enriched_orders AS
-SELECT o.order_id, o.symbol, t.price AS market_price
-FROM orders o
-JOIN trades t ON o.symbol = t.symbol
-    AND t.ts BETWEEN o.ts - INTERVAL '5' SECOND AND o.ts;
+### Format Decoders
 
--- ASOF joins for point-in-time lookups
-SELECT o.*, t.price AS last_trade_price
-FROM orders o
-ASOF JOIN trades t MATCH_CONDITION(o.ts >= t.ts) ON o.symbol = t.symbol;
+| Format | Inference | Description |
+|--------|-----------|-------------|
+| JSON | Yes | Type inference, nested object/array support |
+| CSV | Yes | Header-based inference, type sampling |
+| Avro | Yes | Schema Registry integration |
+| Parquet | Yes | Metadata-driven schema |
+| Protobuf | -- | Planned |
 
--- Cascading materialized views (MV reading from MV)
-CREATE MATERIALIZED VIEW ohlc_1h AS
-SELECT symbol,
-       FIRST(open) AS open, MAX(high) AS high,
-       MIN(low) AS low, LAST(close) AS close
-FROM ohlc_1min
-GROUP BY symbol, tumble(bar_start, INTERVAL '1' HOUR);
+### Additional Capabilities
 
--- LAG/LEAD window functions
-SELECT symbol, price,
-       LAG(price, 1) OVER (PARTITION BY symbol ORDER BY ts) AS prev_price,
-       price - LAG(price, 1) OVER (PARTITION BY symbol ORDER BY ts) AS delta
-FROM trades;
+- **Schema Evolution** -- additive column changes with backward/forward compatibility
+- **Dead Letter Queue** -- malformed records routed to DLQ for inspection
+- **Schema Hints** -- partial schema specification with wildcard inference for the rest
+- **JSON Functions** -- PostgreSQL-compatible JSON extraction, table-valued functions, LaminarDB extensions
+- **Array/Struct/Map Functions** -- complex type manipulation in SQL
 
--- Ranking functions
-SELECT symbol, price,
-       ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY price DESC) AS rank
-FROM trades;
+---
+
+## Architecture
+
+LaminarDB uses a three-ring architecture to separate latency-critical event processing from background I/O and control plane operations:
+
+```
++------------------------------------------------------------------+
+|                        RING 0: HOT PATH                          |
+|  Zero allocations, no locks, < 1us latency                      |
+|  +---------+  +----------+  +----------+  +----------+          |
+|  | Reactor |->| Operators|->|  State   |->|   Emit   |          |
+|  |  Loop   |  | (window, |  |  Store   |  | (output) |          |
+|  |         |  |  join,   |  | (ahash/  |  |          |          |
+|  |         |  |  filter) |  |  fxhash) |  |          |          |
+|  +---------+  +----------+  +----------+  +----------+          |
+|       |                                                          |
+|       | SPSC queues (lock-free)                                  |
+|       v                                                          |
++------------------------------------------------------------------+
+|                     RING 1: BACKGROUND                           |
+|  Async I/O, can allocate, bounded latency impact                 |
+|  +----------+  +----------+  +----------+  +----------+         |
+|  |Checkpoint|  |   WAL    |  |Compaction|  |  Timer   |         |
+|  | Manager  |  |  Writer  |  |  Thread  |  |  Wheel   |         |
+|  +----------+  +----------+  +----------+  +----------+         |
+|       |                                                          |
+|       | Channels (bounded)                                       |
+|       v                                                          |
++------------------------------------------------------------------+
+|                     RING 2: CONTROL PLANE                        |
+|  No latency requirements, full flexibility                       |
+|  +----------+  +----------+  +----------+  +----------+         |
+|  |  Admin   |  | Metrics  |  |   Auth   |  |  Config  |         |
+|  |   API    |  |  Export  |  |  Engine  |  | Manager  |         |
+|  +----------+  +----------+  +----------+  +----------+         |
++------------------------------------------------------------------+
 ```
 
-### SQL Extensions Summary
+- **Ring 0** -- CPU-pinned reactor loop, zero heap allocations, SPSC queues, optional Cranelift JIT compilation
+- **Ring 1** -- Tokio async runtime for WAL, checkpointing, connectors, changelog draining
+- **Ring 2** -- Admin API, metrics, auth, configuration (planned; crate stubs exist)
 
-| Extension | Description |
-|-----------|-------------|
-| `tumble(ts, interval)` | Fixed-size non-overlapping windows |
-| `slide(ts, size, slide)` | Overlapping windows with configurable slide |
-| `hop(ts, size, hop)` | Alias for sliding windows |
-| `session(ts, gap)` | Gap-based dynamic windows |
-| `EMIT ON WINDOW CLOSE` | Emit results when window closes |
-| `EMIT CHANGES` | Emit changelog (insert/retract pairs) |
-| `ASOF JOIN ... MATCH_CONDITION` | Point-in-time lookups |
-| `FIRST(col)` / `LAST(col)` | First/last value aggregates (retractable) |
-| `CREATE SOURCE ... FROM KAFKA(...)` | Kafka source DDL |
-| `CREATE SOURCE ... FROM POSTGRES_CDC(...)` | PostgreSQL CDC DDL |
-| `CREATE SOURCE ... FROM MYSQL_CDC(...)` | MySQL CDC DDL |
-| `CREATE SINK ... INTO KAFKA(...)` | Kafka sink DDL |
-| `CREATE SINK ... INTO DELTA_LAKE(...)` | Delta Lake sink DDL |
-| `WITH (allowed_lateness = ...)` | Late data handling |
-| `${VAR}` in SQL strings | Config variable substitution |
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
+
+---
+
+## Checkpointing and Recovery
+
+LaminarDB provides exactly-once semantics through a coordinated checkpointing system:
+
+1. **Ring 0 Changelog** -- Every state mutation is captured by `ChangelogAwareStore` (~2-5ns overhead per mutation)
+2. **Per-Core WAL** -- Each CPU core writes to its own WAL segment with CRC32C checksums and torn write detection
+3. **Incremental Checkpoints** -- Only changed state is written; backed by directory-based delta snapshots
+4. **Checkpoint Coordinator** -- Orchestrates consistent snapshots across all operators and sinks using Chandy-Lamport barriers
+5. **Two-Phase Commit** -- Sinks participate in the checkpoint protocol with pre-commit/commit phases
+6. **Recovery** -- `RecoveryManager` restores from the latest checkpoint manifest, replays WAL, resumes connectors from committed offsets
+
+```rust
+use laminar_db::LaminarDB;
+
+let db = LaminarDB::builder()
+    .storage_dir("./data")
+    .checkpoint(laminar_core::streaming::StreamCheckpointConfig {
+        interval: std::time::Duration::from_secs(30),
+        ..Default::default()
+    })
+    .build()
+    .await?;
+```
+
+---
+
+## JIT Compilation
+
+LaminarDB optionally compiles DataFusion logical plans into native machine code via Cranelift for Ring 0 execution. Enable with the `jit` feature flag.
+
+The `AdaptiveQueryRunner` runs queries interpreted first, compiles in the background, and hot-swaps to compiled execution when ready -- zero downtime during compilation.
+
+```toml
+[dependencies]
+laminar-db = { version = "0.15", features = ["jit"] }
+```
+
+---
+
+## Derive Macros
+
+The `laminar-derive` crate provides procedural macros to eliminate boilerplate:
+
+```rust
+use laminar_derive::{Record, FromRow, ConnectorConfig};
+
+// Typed data ingestion
+#[derive(Record)]
+struct Trade {
+    symbol: String,
+    price: f64,
+    volume: i64,
+    #[event_time]
+    ts: i64,
+}
+
+// Typed result consumption
+#[derive(FromRow)]
+struct OhlcBar {
+    symbol: String,
+    window_start: i64,
+    open: f64,
+    high: f64,
+    low: f64,
+    close: f64,
+}
+
+// Connector configuration parsing
+#[derive(ConnectorConfig)]
+struct MySourceConfig {
+    #[config(key = "bootstrap.servers", required)]
+    bootstrap_servers: String,
+
+    #[config(key = "batch.size", default = "1000")]
+    batch_size: usize,
+
+    #[config(key = "timeout.ms", default = "30000", duration_ms)]
+    timeout: std::time::Duration,
+}
+```
+
+---
+
+## Distributed Mode (Delta Architecture)
+
+LaminarDB extends from single-process to multi-node via the Delta architecture. Enable with the `delta` feature flag.
+
+Implemented:
+- Gossip-based node discovery (chitchat)
+- Raft metadata consensus (openraft)
+- Partition ownership with epoch fencing
+- Cross-node gRPC RPC (tonic)
+- Distributed checkpoint coordination
+- Partitioned lookups and cross-node aggregation
+
+```toml
+[dependencies]
+laminar-db = { version = "0.15", features = ["delta"] }
+```
+
+---
+
+## Performance Targets
+
+| Metric | Target | Benchmark |
+|--------|--------|-----------|
+| State lookup | < 500ns p99 | `cargo bench --bench state_bench` |
+| Throughput/core | 500K events/sec | `cargo bench --bench throughput_bench` |
+| p99 latency | < 10us | `cargo bench --bench latency_bench` |
+| Checkpoint recovery | < 10s | Integration tests |
+| Window trigger | < 10us | `cargo bench --bench window_bench` |
+| Changelog overhead | ~2-5ns/mutation | `ChangelogAwareStore` wrapper |
+
+Run all benchmarks:
+
+```bash
+cargo bench
+```
+
+Available benchmark suites (17 in laminar-core, 2 in laminar-storage):
+
+```bash
+cargo bench --bench state_bench          # State lookup latency
+cargo bench --bench throughput_bench     # Throughput per core
+cargo bench --bench latency_bench        # p99 latency
+cargo bench --bench window_bench         # Window operations
+cargo bench --bench join_bench           # Join throughput
+cargo bench --bench dag_bench            # DAG pipeline
+cargo bench --bench lookup_join_bench    # Lookup join throughput
+cargo bench --bench cache_bench          # foyer cache hit/miss
+cargo bench --bench compiler_bench       # JIT compilation
+cargo bench --bench streaming_bench      # Streaming channels
+cargo bench --bench subscription_bench   # Subscription dispatch
+cargo bench --bench reactor_bench        # Reactor loop
+cargo bench --bench tpc_bench            # Thread-per-core
+cargo bench --bench checkpoint_bench     # Checkpoint cycle
+cargo bench --bench wal_bench            # WAL write throughput
+```
+
+---
 
 ## Comparison
 
@@ -524,44 +522,97 @@ FROM trades;
 |---------|-----------|--------------|---------------|------------|-------------|
 | Deployment | Embedded | Distributed | Embedded | Distributed | Distributed |
 | Latency | < 1us | ~10ms | ~1ms | ~10ms | ~10ms |
-| SQL support | Full | Limited | None | Full | Full |
+| SQL support | Full (DataFusion) | Limited | None | Full | Full |
 | Exactly-once | Yes | Yes | Yes | Yes | Yes |
 | No JVM | Yes | No | No | Yes | Yes |
 | Windows | Tumble/Slide/Session/Hop | All | Tumble/Slide/Session | Tumble/Hop | N/A |
 | CDC sources | PostgreSQL, MySQL | Many | Debezium only | PostgreSQL, MySQL | PostgreSQL |
 | Lakehouse sinks | Delta Lake, Iceberg | Limited | No | Delta Lake, Iceberg | No |
-| Language bindings | Rust, Python, C | Java | Java | SQL only | SQL only |
+| JIT compilation | Yes (Cranelift) | No | No | No | No |
 | License | Apache-2.0 | Apache-2.0 | Apache-2.0 | Apache-2.0 | BSL |
+
+---
 
 ## Project Structure
 
 ```
 crates/
-├── laminar-core/        Core engine: reactor, operators, state, windows, joins
-├── laminar-sql/         SQL layer: DataFusion integration, streaming SQL parser
-├── laminar-storage/     Durability: WAL, checkpointing, RocksDB, Delta Lake
-├── laminar-connectors/  Connectors: Kafka, PostgreSQL CDC, MySQL CDC, Delta Lake
-├── laminar-db/          Unified database facade and FFI API
-├── laminar-auth/        Authentication and authorization (JWT, RBAC, ABAC)
-├── laminar-admin/       Admin REST API (Axum, Swagger UI)
-├── laminar-observe/     Observability: Prometheus metrics, OpenTelemetry tracing
-├── laminar-derive/      Derive macros for Record and FromRecordBatch traits
-└── laminar-server/      Standalone server binary
+  laminar-core/        Core engine: reactor, operators, state, windows, joins, JIT compiler
+  laminar-sql/         SQL layer: DataFusion integration, streaming SQL parser
+  laminar-storage/     Durability: WAL, checkpointing, per-core WAL, recovery
+  laminar-connectors/  Connectors: Kafka, CDC, WebSocket, Delta Lake, Iceberg, SDK
+  laminar-db/          Unified database facade, checkpoint coordination, FFI API
+  laminar-auth/        Authentication and authorization (planned -- stubs only)
+  laminar-admin/       Admin REST API (planned -- stubs only)
+  laminar-observe/     Observability: metrics, tracing (planned -- stubs only)
+  laminar-derive/      Derive macros: Record, FromRecordBatch, FromRow, ConnectorConfig
+  laminar-server/      Standalone server binary (skeleton)
 examples/
-└── demo/                Market data TUI demo with Ratatui
+  demo/                Market data TUI demo with Ratatui
 ```
 
-## Language Bindings
+### Crate Dependency Graph
 
-| Language | Package | Status |
-|----------|---------|--------|
-| **Rust** | [`laminar-db`](https://crates.io/crates/laminar-db) | Primary |
-| **Python** | [`laminardb`](https://pypi.org/project/laminardb/) | Implemented |
-| C/C++ | Via FFI (`--features ffi`) | Implemented |
-| Java | laminardb-java | Planned |
-| Node.js | @laminardb/node | Planned |
+```
+laminar-db  (facade)
+  |-- laminar-core        (Ring 0 engine)
+  |-- laminar-sql         (SQL parsing + DataFusion)
+  |-- laminar-storage     (WAL + checkpointing)
+  |-- laminar-connectors  (external connectors)
+        |-- laminar-core
+        |-- laminar-storage
 
-The Python bindings use [PyO3](https://pyo3.rs/) with [pyo3-arrow](https://crates.io/crates/pyo3-arrow) for zero-copy Arrow interop. See [laminardb-python](https://github.com/laminardb/laminardb-python) for the full API.
+laminar-derive            (proc macros, no internal deps)
+laminar-server            (binary: laminar-db + laminar-admin + laminar-auth + laminar-observe)
+```
+
+---
+
+## Project Status
+
+LaminarDB is in active development. Here is the current phase progress:
+
+| Phase | Description | Features | Status |
+|-------|-------------|----------|--------|
+| Phase 1 | Core Engine | 12/12 | Complete |
+| Phase 1.5 | Production SQL Parser | 1/1 | Complete |
+| Phase 2 | Production Hardening | 38/38 | Complete |
+| Phase 2.5 | JIT Compiler | 12/12 | Complete |
+| Phase 3 | Connectors & Integration | 81/93 | 87% complete |
+| Phase 4 | Enterprise Security | 0/11 | Planned (stubs exist) |
+| Phase 5 | Admin & Observability | 0/10 | Planned (stubs exist) |
+| Phase 6a | Delta Partition-Parallel | 27/29 | 93% complete |
+| Phase 6b | Delta Foundation | 14/14 | Complete |
+| Phase 6c | Delta Production Hardening | 0/10 | Planned |
+| **Total** | | **185/242** | **76%** |
+
+See [docs/features/INDEX.md](docs/features/INDEX.md) for the full feature tracking breakdown and [docs/ROADMAP.md](docs/ROADMAP.md) for the phase timeline.
+
+---
+
+## Feature Flags
+
+| Flag | Crate | Description |
+|------|-------|-------------|
+| `kafka` | laminar-db, laminar-connectors | Kafka source/sink, Avro serde, Schema Registry |
+| `postgres-cdc` | laminar-db, laminar-connectors | PostgreSQL CDC source via logical replication |
+| `postgres-sink` | laminar-db, laminar-connectors | PostgreSQL sink via COPY BINARY |
+| `mysql-cdc` | laminar-connectors | MySQL CDC source via binlog (not re-exported by laminar-db) |
+| `delta-lake` | laminar-db, laminar-connectors | Delta Lake sink and source |
+| `delta-lake-s3` | laminar-connectors | S3 storage backend for Delta Lake |
+| `delta-lake-azure` | laminar-connectors | Azure storage backend for Delta Lake |
+| `delta-lake-gcs` | laminar-connectors | GCS storage backend for Delta Lake |
+| `websocket` | laminar-connectors | WebSocket source and sink connectors |
+| `jit` | laminar-db, laminar-core | Cranelift JIT query compilation |
+| `ffi` | laminar-db | C FFI with Arrow C Data Interface |
+| `api` | laminar-db | FFI-friendly API module for language bindings |
+| `delta` | laminar-db, laminar-core | Distributed delta mode (gossip, Raft, gRPC) |
+| `allocation-tracking` | laminar-core | Panic on hot-path allocation |
+| `io-uring` | laminar-core | Linux 5.10+ io_uring integration |
+| `hwloc` | laminar-core | Enhanced NUMA topology discovery |
+| `xdp` | laminar-core | Linux eBPF/XDP network optimization |
+
+---
 
 ## Building from Source
 
@@ -583,38 +634,49 @@ cargo test --all --features kafka,postgres-cdc,mysql-cdc
 # Lint
 cargo clippy --all -- -D warnings
 
+# Format check
+cargo fmt --all -- --check
+
 # Generate API docs
 cargo doc --no-deps --open
 
 # Run the market data demo
 cargo run -p laminardb-demo
+
+# Run benchmarks
+cargo bench
 ```
 
-### Feature Flags
+---
 
-| Flag | Crate | Description |
-|------|-------|-------------|
-| `kafka` | laminar-db | Kafka source/sink, Avro serde, Schema Registry |
-| `postgres-cdc` | laminar-db | PostgreSQL CDC source via logical replication |
-| `postgres-sink` | laminar-db | PostgreSQL sink via COPY BINARY |
-| `mysql-cdc` | laminar-db | MySQL CDC source via binlog |
-| `delta-lake` | laminar-db | Delta Lake sink (S3/Azure/GCS) |
-| `rocksdb` | laminar-db | RocksDB-backed persistent table store |
-| `jit` | laminar-db | Cranelift JIT query compilation |
-| `ffi` | laminar-db | C FFI with Arrow C Data Interface |
+## Language Bindings
+
+| Language | Package | Status |
+|----------|---------|--------|
+| **Rust** | [`laminar-db`](https://crates.io/crates/laminar-db) | Primary API |
+| **Python** | [`laminardb`](https://pypi.org/project/laminardb/) | Via [laminardb-python](https://github.com/laminardb/laminardb-python) |
+| C/C++ | Via FFI (`--features ffi`) | Implemented (Arrow C Data Interface) |
+| Java | laminardb-java | Planned |
+| Node.js | @laminardb/node | Planned |
+
+---
 
 ## Documentation
 
 - [Architecture Guide](docs/ARCHITECTURE.md) -- Three-ring design, data flow, state management
+- [SQL Reference](docs/SQL_REFERENCE.md) -- Streaming SQL dialect, gotchas, tested patterns
 - [Development Roadmap](docs/ROADMAP.md) -- Phases, milestones, and feature status
-- [Feature Index](docs/features/INDEX.md) -- All 160 features with specifications
+- [Feature Index](docs/features/INDEX.md) -- All 242 features with specifications
 - [Contributing Guide](CONTRIBUTING.md) -- How to build, test, and submit PRs
 - [API Reference](https://docs.rs/laminar-db) -- Rustdoc API documentation
-- [Python Bindings](https://github.com/laminardb/laminardb-python) -- Python API and docs
+
+---
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style guidelines, and the pull request process.
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style guidelines, Ring 0 rules, and the pull request process.
+
+---
 
 ## License
 

--- a/crates/laminar-admin/README.md
+++ b/crates/laminar-admin/README.md
@@ -2,17 +2,25 @@
 
 Administration interface for LaminarDB.
 
-## Overview
+## Status: Planned (Phase 5)
 
-Ring 2 crate providing a REST API for pipeline management, built on Axum with auto-generated OpenAPI documentation via utoipa/Swagger UI.
+This crate exists as a workspace member with module stubs, but **no implementation exists yet**. The source files (`api.rs`, `dashboard.rs`, `cli.rs`) contain only module-level doc comments.
 
-## Key Components
+Implementation is planned for Phase 5 (Admin & Observability). See the [Feature Index](../../docs/features/INDEX.md) for details on features F046-F055.
 
-- **REST API** -- Pipeline management endpoints (Axum 0.8)
-- **Swagger UI** -- Interactive API documentation (utoipa-swagger-ui)
+## Planned Components
+
+- **Admin REST API** (F046) -- Pipeline management endpoints via Axum
+- **Web Dashboard** (F047) -- Browser-based admin dashboard
+- **SQL Query Console** (F049) -- Interactive SQL console
+- **CLI Tools** (F055) -- Command-line administration
+
+## Architecture
+
+This crate operates in **Ring 2 (Control Plane)** with no latency requirements.
 
 ## Related Crates
 
 - [`laminar-auth`](../laminar-auth) -- Authentication and authorization
 - [`laminar-observe`](../laminar-observe) -- Metrics and health endpoints
-- [`laminar-server`](../laminar-server) -- Server binary that mounts the admin API
+- [`laminar-server`](../laminar-server) -- Server binary that will mount the admin API

--- a/crates/laminar-auth/README.md
+++ b/crates/laminar-auth/README.md
@@ -2,18 +2,30 @@
 
 Authentication and authorization for LaminarDB.
 
-## Overview
+## Status: Planned (Phase 4)
 
-Ring 2 crate providing security infrastructure. Handles JWT-based authentication and policy-based authorization (RBAC and ABAC).
+This crate exists as a workspace member with module stubs, but **no implementation exists yet**. The source files (`authn.rs`, `authz.rs`, `rls.rs`) contain only module-level doc comments.
 
-## Key Components
+Implementation is planned for Phase 4 (Enterprise & Security). See the [Feature Index](../../docs/features/INDEX.md) for details on features F035-F045.
 
-- **JWT Authentication** -- Token validation and claims extraction via `jsonwebtoken`
-- **RBAC** -- Role-based access control with role hierarchies
-- **ABAC** -- Attribute-based access control with policy evaluation
-- **Row-Level Security** -- Per-user data filtering (planned)
+## Planned Components
+
+- **JWT Authentication** (F036) -- Token validation and claims extraction
+- **mTLS Authentication** (F037) -- Mutual TLS client certificate auth
+- **LDAP Integration** (F038) -- Directory-based authentication
+- **RBAC** (F039) -- Role-based access control with role hierarchies
+- **ABAC** (F040) -- Attribute-based access control with policy evaluation
+- **Row-Level Security** (F041) -- Per-user data filtering
+- **Column-Level Security** (F042) -- Per-user column masking
+- **Audit Logging** (F043) -- Tamper-evident audit trail
+- **Encryption at Rest** (F044) -- State store and WAL encryption
+- **Key Management** (F045) -- Key rotation and vault integration
+
+## Architecture
+
+This crate operates in **Ring 2 (Control Plane)** with no latency requirements.
 
 ## Related Crates
 
-- [`laminar-admin`](../laminar-admin) -- REST API that uses auth for endpoint protection
-- [`laminar-server`](../laminar-server) -- Server binary that configures auth
+- [`laminar-admin`](../laminar-admin) -- REST API that will use auth for endpoint protection
+- [`laminar-server`](../laminar-server) -- Server binary that will configure auth

--- a/crates/laminar-connectors/README.md
+++ b/crates/laminar-connectors/README.md
@@ -1,38 +1,109 @@
 # laminar-connectors
 
-External system connectors for LaminarDB -- Kafka, CDC, lookup tables, and lakehouse sinks.
+External system connectors for LaminarDB -- Kafka, CDC, WebSocket, lakehouse sinks, and the Connector SDK.
 
 ## Overview
 
 Provides source and sink connectors for integrating LaminarDB with external systems. Each connector implements the `SourceConnector` or `SinkConnector` trait and supports exactly-once semantics via two-phase commit.
 
+## Connectors
+
+### Source Connectors
+
+| Connector | Feature Flag | Protocol | Status |
+|-----------|-------------|----------|--------|
+| Kafka | `kafka` | rdkafka consumer groups, Schema Registry | Implemented |
+| PostgreSQL CDC | `postgres-cdc` | pgoutput logical replication | Implemented |
+| MySQL CDC | `mysql-cdc` | Binlog decoding, GTID position tracking | Implemented |
+| WebSocket Client | `websocket` | tokio-tungstenite | Implemented |
+| WebSocket Server | `websocket` | tokio-tungstenite listener | Implemented |
+| Delta Lake Source | `delta-lake` | Version polling via deltalake crate | Implemented |
+
+### Sink Connectors
+
+| Connector | Feature Flag | Protocol | Status |
+|-----------|-------------|----------|--------|
+| Kafka | `kafka` | rdkafka transactions | Implemented |
+| PostgreSQL | `postgres-sink` | COPY BINARY, upsert, co-transactional | Implemented |
+| Delta Lake | `delta-lake` | Epoch-aligned Parquet commits | Implemented |
+| Apache Iceberg | -- | Buffering, partition transforms | Implemented (business logic) |
+| WebSocket Server | `websocket` | Fan-out to connected subscribers | Implemented |
+| WebSocket Client | `websocket` | Push to external server | Implemented |
+
 ## Key Modules
 
 | Module | Purpose |
 |--------|---------|
+| `connector` | Core traits: `SourceConnector`, `SinkConnector`, `SourceBatch`, `WriteResult` |
 | `kafka` | Kafka source/sink, Avro serde, schema registry, partitioner, backpressure |
 | `postgres` | PostgreSQL sink (COPY BINARY, upsert, exactly-once) |
 | `cdc/postgres` | PostgreSQL CDC source (pgoutput decoder, Z-set changelog, replication I/O) |
 | `cdc/mysql` | MySQL CDC source (binlog decoder, GTID, Z-set changelog) |
+| `websocket` | WebSocket source/sink (client, server, fan-out, backpressure, reconnect) |
 | `lakehouse` | Delta Lake and Iceberg sinks (buffering, epoch, changelog) |
 | `storage` | Cloud storage: provider detection, credential resolver, config validation, secret masking |
 | `bridge` | DAG-to-connector bridge (source/sink bridges, runtime orchestration) |
-| `sdk` | Connector SDK: retry, rate limiting, circuit breaker, test harness, schema discovery |
+| `sdk` | Connector SDK: retry policies, rate limiting, circuit breaker, test harness |
 | `serde` | Format implementations: JSON, CSV, raw, Debezium, Avro |
-| `registry` | `ConnectorRegistry` for registering and looking up connectors |
+| `schema` | Schema framework: inference, resolution, evolution, decoders (JSON/CSV/Avro/Parquet), DLQ |
+| `registry` | `ConnectorRegistry` for registering and looking up connectors by name |
+| `lookup` | Lookup table support for enrichment joins |
+| `reference` | Reference table source trait and refresh modes |
+| `error_handling` | Dead letter queue and error routing for malformed records |
+
+## Schema Framework
+
+The schema module provides a pluggable framework for format decoding and schema management:
+
+| Sub-module | Description |
+|------------|-------------|
+| `schema::traits` | `SchemaProvider`, `SchemaInferable`, `SchemaRegistryAware`, `SchemaEvolvable` traits |
+| `schema::resolver` | Schema resolution and merge engine |
+| `schema::inference` | Format inference registry |
+| `schema::json` | JSON format decoder with type inference |
+| `schema::csv` | CSV format decoder with header/type sampling |
+| `schema::avro` | Avro decoder with Schema Registry integration |
+| `schema::parquet` | Parquet metadata-driven decoder |
+| `schema::evolution` | Schema evolution engine (additive columns) |
+| `schema::bridge` | Format bridge functions (JSON-to-Avro, etc.) |
 
 ## Feature Flags
 
 | Flag | Purpose |
 |------|---------|
-| `kafka` | rdkafka, Avro serde, schema registry |
+| `kafka` | rdkafka, Avro serde, schema registry (reqwest) |
 | `postgres-cdc` | PostgreSQL CDC via pgwire-replication |
 | `postgres-sink` | PostgreSQL sink via tokio-postgres |
-| `mysql-cdc` | MySQL CDC via mysql_async |
-| `delta-lake` | Delta Lake sink via deltalake crate |
+| `mysql-cdc` | MySQL CDC via mysql_async (rustls, no OpenSSL) |
+| `delta-lake` | Delta Lake sink/source via deltalake crate |
 | `delta-lake-s3` | S3 storage backend for Delta Lake |
 | `delta-lake-azure` | Azure storage backend for Delta Lake |
 | `delta-lake-gcs` | GCS storage backend for Delta Lake |
+| `delta-lake-unity` | Databricks Unity catalog for Delta Lake |
+| `delta-lake-glue` | AWS Glue catalog for Delta Lake |
+| `parquet-lookup` | Parquet file lookup source |
+| `websocket` | WebSocket source and sink (tokio-tungstenite) |
+| `kafka-discovery` | Kafka-based discovery for delta mode |
+
+## Connector SDK
+
+Build custom connectors with operational resilience:
+
+```rust
+use laminar_connectors::connector::{SourceConnector, SinkConnector};
+use laminar_connectors::sdk::{RetryPolicy, CircuitBreaker, RateLimiter};
+use laminar_connectors::registry::ConnectorRegistry;
+
+// Register a custom source
+let registry = ConnectorRegistry::new();
+registry.register_source("my-source", info, factory_fn);
+```
+
+The SDK provides:
+- **RetryPolicy** -- configurable retry with exponential backoff
+- **CircuitBreaker** -- fail-fast when downstream is unavailable
+- **RateLimiter** -- rate-limit source polling or sink writes
+- **Test Harness** -- mock connectors for unit testing
 
 ## Related Crates
 

--- a/crates/laminar-core/README.md
+++ b/crates/laminar-core/README.md
@@ -12,7 +12,7 @@ This is the Ring 0 crate containing all latency-critical components. Everything 
 |--------|---------|
 | `reactor` | Single-threaded event loop, CPU-pinned |
 | `operator` | Windows (tumbling, sliding, hopping, session), joins (stream, ASOF, temporal, lookup), changelog, lag/lead, ranking |
-| `state` | `StateStore` trait, `InMemoryStateStore` (FxHashMap), `ChangelogAwareStore` wrapper |
+| `state` | `StateStore` trait, `InMemoryStateStore` (AHashMap), `ChangelogAwareStore` wrapper |
 | `time` | Event time processing, watermarks (partitioned, keyed, alignment groups) |
 | `streaming` | Ring buffer, SPSC/MPSC channels, source/sink abstractions, checkpoint manager |
 | `dag` | DAG pipeline topology, multicast routing, executor, checkpointing |
@@ -25,6 +25,13 @@ This is the Ring 0 crate containing all latency-critical components. Everything 
 | `numa` | NUMA-aware memory allocation |
 | `io_uring` | io_uring integration, three-ring I/O architecture |
 | `budget` | Task budget enforcement |
+| `checkpoint` | Distributed checkpoint barrier protocol, barrier alignment |
+| `lookup` | Lookup table trait, predicate types, foyer caches (memory + hybrid), CDC-to-cache adapter |
+| `index` | redb secondary indexes for non-primary-key lookups |
+| `aggregation` | Cross-partition lock-free HashMap (papaya) |
+| `detect` | Platform detection utilities |
+| `xdp` | Linux eBPF/XDP network optimization |
+| `delta` | Distributed mode: discovery (gossip, Kafka), Raft consensus, partition ownership, gRPC RPC |
 
 ## Feature Flags
 
@@ -33,8 +40,10 @@ This is the Ring 0 crate containing all latency-critical components. Everything 
 | `jit` | Cranelift JIT compilation for Ring 0 query execution |
 | `allocation-tracking` | Panic on heap allocation in marked sections |
 | `io-uring` | Linux 5.10+ io_uring integration |
-| `hwloc` | Enhanced NUMA topology discovery |
-| `xdp` | Linux eBPF/XDP network optimization |
+| `hwloc` | Enhanced NUMA topology discovery (hwlocality) |
+| `xdp` | Linux eBPF/XDP network optimization (libbpf-rs) |
+| `dag-metrics` | Per-event DAG executor metrics (adds ~5-10ns/event overhead) |
+| `delta` | Distributed mode (tonic, openraft, chitchat, prost) |
 
 ## Ring Placement
 
@@ -43,6 +52,31 @@ This crate operates in **Ring 0 (Hot Path)**. All code must:
 - Use no locks (SPSC queues for communication)
 - Avoid system calls on the fast path
 - Stay within task budget limits
+
+## Key Abstractions
+
+### StateStore Trait
+
+```rust
+pub trait StateStore: Send {
+    fn get(&self, key: &[u8]) -> Option<&[u8]>;
+    fn put(&mut self, key: &[u8], value: &[u8]);
+    fn delete(&mut self, key: &[u8]);
+    fn prefix_scan(&self, prefix: &[u8]) -> impl Iterator<Item = (&[u8], &[u8])>;
+}
+```
+
+### Reactor
+
+Single-threaded event loop that pulls batches from sources, runs them through the operator DAG, and emits results. CPU-pinned via the thread-per-core runtime.
+
+### Operator Types
+
+- **Stateless**: map, filter, project
+- **Windowed**: tumbling, sliding, hopping, session (with merge detection)
+- **Join**: stream-stream (time-bounded), ASOF (point-in-time), temporal, lookup
+- **Analytics**: LAG/LEAD, ROW_NUMBER/RANK/DENSE_RANK
+- **Changelog**: Z-set retraction (+1 insert, -1 retract)
 
 ## Benchmarks
 
@@ -53,4 +87,21 @@ cargo bench -p laminar-core --bench latency_bench      # p99 latency
 cargo bench -p laminar-core --bench window_bench       # Window operations
 cargo bench -p laminar-core --bench dag_bench          # DAG pipeline
 cargo bench -p laminar-core --bench join_bench         # Join throughput
+cargo bench -p laminar-core --bench lookup_join_bench  # Lookup join throughput
+cargo bench -p laminar-core --bench cache_bench        # foyer cache hit/miss
+cargo bench -p laminar-core --bench compiler_bench     # JIT compilation
+cargo bench -p laminar-core --bench streaming_bench    # Streaming channels
+cargo bench -p laminar-core --bench subscription_bench # Subscription dispatch
+cargo bench -p laminar-core --bench reactor_bench      # Reactor loop
+cargo bench -p laminar-core --bench tpc_bench          # Thread-per-core
+cargo bench -p laminar-core --bench checkpoint_bench   # Checkpoint cycle
+cargo bench -p laminar-core --bench delta_checkpoint_bench  # Delta checkpoint
+cargo bench -p laminar-core --bench io_uring_bench     # io_uring operations
+cargo bench -p laminar-core --bench dag_stress         # DAG stress test
 ```
+
+## Related Crates
+
+- [`laminar-sql`](../laminar-sql) -- SQL parser that produces operator configurations
+- [`laminar-storage`](../laminar-storage) -- WAL and checkpointing that consumes changelog entries
+- [`laminar-db`](../laminar-db) -- Database facade that orchestrates the reactor

--- a/crates/laminar-derive/README.md
+++ b/crates/laminar-derive/README.md
@@ -1,28 +1,102 @@
 # laminar-derive
 
-Derive macros for LaminarDB `Record` and `FromRecordBatch` traits.
+Derive macros for LaminarDB -- `Record`, `FromRecordBatch`, `FromRow`, and `ConnectorConfig`.
 
 ## Overview
 
-Provides procedural macros that automatically generate Arrow RecordBatch conversion code for Rust structs, enabling zero-boilerplate typed data ingestion and result consumption.
+Provides procedural macros that automatically generate Arrow RecordBatch conversion code and connector configuration parsing, eliminating boilerplate in typed data ingestion, result consumption, and connector development.
 
-## Usage
+## Macros
+
+### `#[derive(Record)]`
+
+Generates `Record::schema()`, `Record::to_record_batch()`, and `Record::event_time()` for typed data ingestion.
+
+```rust
+use laminar_derive::Record;
+
+#[derive(Record)]
+struct Trade {
+    symbol: String,
+    price: f64,
+    volume: i64,
+    #[event_time]
+    ts: i64,
+}
+```
+
+**Attributes:**
+- `#[event_time]` -- marks a field as the event time column
+- `#[column("name")]` -- overrides the Arrow column name
+- `#[nullable]` -- marks a non-Option field as nullable in the schema
+
+**Supported types:** `bool`, `i8`-`i64`, `u8`-`u64`, `f32`, `f64`, `String`, `Vec<u8>`, `Option<T>`
+
+### `#[derive(FromRecordBatch)]`
+
+Generates `from_batch()` and `from_batch_all()` for deserializing Arrow RecordBatches into typed structs. Fields are matched by name.
 
 ```rust
 use laminar_derive::FromRecordBatch;
 
 #[derive(FromRecordBatch)]
-struct Trade {
+struct OhlcBar {
     symbol: String,
-    price: f64,
-    volume: i64,
-    ts: i64,
+    open: f64,
+    high: f64,
+    low: f64,
+    close: f64,
 }
 ```
 
-The `FromRecordBatch` derive generates `from_batch()` and `from_batch_all()` methods that convert Arrow RecordBatches into typed Rust structs. Used with `LaminarDB::subscribe::<Trade>("stream_name")` for typed result consumption.
+### `#[derive(FromRow)]`
+
+Like `FromRecordBatch`, but also implements `laminar_db::FromBatch`. Fields are matched by **position** (column order in SELECT), not by name.
+
+```rust
+use laminar_derive::FromRow;
+
+#[derive(FromRow)]
+struct Result {
+    symbol: String,    // 1st SELECT column
+    total: i64,        // 2nd SELECT column
+    avg_price: f64,    // 3rd SELECT column
+}
+```
+
+### `#[derive(ConnectorConfig)]`
+
+Generates `from_config()`, `validate()`, and `config_keys()` for connector configuration parsing.
+
+```rust
+use laminar_derive::ConnectorConfig;
+
+#[derive(ConnectorConfig)]
+struct MySourceConfig {
+    #[config(key = "bootstrap.servers", required, description = "Kafka brokers")]
+    bootstrap_servers: String,
+
+    #[config(key = "batch.size", default = "1000")]
+    batch_size: usize,
+
+    #[config(key = "timeout.ms", default = "30000", duration_ms)]
+    timeout: std::time::Duration,
+
+    #[config(key = "api.key", env = "MY_API_KEY")]
+    api_key: Option<String>,
+}
+```
+
+**Attributes:**
+- `#[config(key = "...")]` -- config key name
+- `#[config(required)]` -- field is required
+- `#[config(default = "...")]` -- default value
+- `#[config(env = "...")]` -- environment variable fallback
+- `#[config(description = "...")]` -- documentation for the key
+- `#[config(duration_ms)]` -- parse as `Duration` from milliseconds
 
 ## Related Crates
 
 - [`laminar-core`](../laminar-core) -- `Record` trait definition
 - [`laminar-db`](../laminar-db) -- `TypedSubscription<T>` and `SourceHandle<T>` that use derived traits
+- [`laminar-connectors`](../laminar-connectors) -- Connector SDK that uses `ConnectorConfig`

--- a/crates/laminar-observe/README.md
+++ b/crates/laminar-observe/README.md
@@ -2,24 +2,26 @@
 
 Observability for LaminarDB -- metrics, tracing, and health checks.
 
-## Overview
+## Status: Planned (Phase 5)
 
-Ring 2 crate providing production observability. Exports metrics via Prometheus and traces via OpenTelemetry.
+This crate exists as a workspace member with module stubs, but **no implementation exists yet**. The source files (`metrics.rs`, `tracing.rs`, `health.rs`) contain only module-level doc comments.
 
-## Key Components
+Implementation is planned for Phase 5 (Admin & Observability). See the [Feature Index](../../docs/features/INDEX.md) for details on features F048-F054.
 
-- **Prometheus Metrics** -- Pipeline throughput, latency histograms, state store sizes
-- **OpenTelemetry Tracing** -- Distributed trace spans for query execution
-- **Health Checks** -- Liveness and readiness endpoints
+Note: LaminarDB already has internal pipeline observability via `PipelineMetrics` and `PipelineCounters` in `laminar-db`. This crate will add external export capabilities (Prometheus, OpenTelemetry).
 
-## Dependencies
+## Planned Components
 
-- `prometheus` 0.14
-- `opentelemetry` 0.31
-- `tracing` + `tracing-opentelemetry`
-- `axum` 0.8 (health/metrics endpoints)
+- **Real-Time Metrics** (F048) -- Pipeline throughput, latency histograms, state store sizes
+- **Prometheus Export** (F050) -- `/metrics` endpoint in Prometheus exposition format
+- **OpenTelemetry Tracing** (F051) -- Distributed trace spans for query execution
+- **Health Check Endpoints** (F052) -- Liveness and readiness probes
+
+## Architecture
+
+This crate operates in **Ring 2 (Control Plane)** with no latency requirements.
 
 ## Related Crates
 
-- [`laminar-admin`](../laminar-admin) -- Mounts metrics and health endpoints
+- [`laminar-admin`](../laminar-admin) -- Will mount metrics and health endpoints
 - [`laminar-core`](../laminar-core) -- Pipeline counters and metrics sources

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -2,38 +2,43 @@
 
 Standalone server binary for LaminarDB.
 
-## Overview
+## Status: Skeleton
 
-Provides the `laminardb` binary that runs LaminarDB as a standalone server process. Combines all crates (core, SQL, storage, connectors, auth, admin, observe) into a single deployable binary.
+The server binary exists with CLI argument parsing and logging initialization, but the core server logic (configuration loading, reactor initialization, admin API mounting) is not yet implemented. The `main.rs` contains TODO comments for Phase 5 features.
+
+## What Works
+
+- CLI argument parsing via clap (`--config`, `--log-level`, `--admin-bind`)
+- Tracing/logging initialization via tracing-subscriber
+- Prints version and config file path
+
+## What is Planned (Phase 6c)
+
+- **TOML Configuration** (F-SERVER-001) -- Load pipeline definitions from TOML
+- **Engine Construction** (F-SERVER-002) -- Initialize reactor from config
+- **HTTP API** (F-SERVER-003) -- Admin and query endpoints
+- **Hot Reload** (F-SERVER-004) -- Reload config without restart
+- **Delta Server Mode** (F-SERVER-005) -- Multi-node distributed operation
+- **Graceful Rolling Restart** (F-SERVER-006) -- Zero-downtime upgrades
 
 ## Running
 
 ```bash
-# Build and run
+# Build and run (currently just prints startup info)
 cargo run --release --bin laminardb
 
 # With configuration file
 cargo run --release --bin laminardb -- --config config.toml
+
+# Custom log level and bind address
+cargo run --release --bin laminardb -- --log-level debug --admin-bind 0.0.0.0:8080
 ```
-
-## Configuration
-
-Configuration is loaded from (in order of precedence):
-1. CLI arguments (via clap)
-2. Environment variables
-3. Configuration file (TOML)
-4. Default values
-
-## Binary
-
-- **Name**: `laminardb`
-- **Entry point**: `src/main.rs`
 
 ## Related Crates
 
-This crate depends on all other LaminarDB crates and serves as the integration point:
+This crate will depend on all other LaminarDB crates and serve as the integration point:
 
 - [`laminar-db`](../laminar-db) -- Database facade
-- [`laminar-admin`](../laminar-admin) -- REST API
-- [`laminar-observe`](../laminar-observe) -- Metrics and health endpoints
-- [`laminar-auth`](../laminar-auth) -- Authentication
+- [`laminar-admin`](../laminar-admin) -- REST API (planned)
+- [`laminar-observe`](../laminar-observe) -- Metrics and health endpoints (planned)
+- [`laminar-auth`](../laminar-auth) -- Authentication (planned)

--- a/crates/laminar-sql/README.md
+++ b/crates/laminar-sql/README.md
@@ -10,10 +10,11 @@ Extends standard SQL (via sqlparser-rs) with streaming constructs like tumbling 
 
 | Module | Purpose |
 |--------|---------|
-| `parser` | Streaming SQL parser: windows, emit, late data, joins, aggregation, analytics, ranking |
+| `parser` | Streaming SQL parser: windows, emit, late data, joins, aggregation, analytics, ranking, DDL (CREATE SOURCE/STREAM/SINK/LOOKUP TABLE) |
 | `planner` | `StreamingPlanner` converts parsed SQL into `StreamingPlan` / `QueryPlan` |
-| `translator` | Operator config builders: window, join, analytic, order, having, DDL |
-| `datafusion` | DataFusion integration: custom UDFs, aggregate bridge, `execute_streaming_sql` |
+| `translator` | Operator config builders: window, join, analytic, order, having, DDL, ASOF join |
+| `datafusion` | DataFusion integration: custom UDFs (tumble, hop, session, slide, first_value, last_value), aggregate bridge, `execute_streaming_sql` |
+| `error` | User-friendly DataFusion error translation |
 
 ## Streaming SQL Extensions
 
@@ -24,6 +25,9 @@ SELECT ... FROM source GROUP BY tumble(ts, INTERVAL '1' MINUTE)
 -- Sliding windows
 SELECT ... FROM source GROUP BY slide(ts, INTERVAL '5' MINUTE, INTERVAL '1' MINUTE)
 
+-- Hopping windows
+SELECT ... FROM source GROUP BY hop(ts, INTERVAL '10' SECOND, INTERVAL '5' SECOND)
+
 -- Session windows
 SELECT ... FROM source GROUP BY session(ts, INTERVAL '30' SECOND)
 
@@ -32,12 +36,58 @@ CREATE SOURCE events (..., WATERMARK FOR ts AS ts - INTERVAL '5' SECOND)
 
 -- EMIT clause
 SELECT ... EMIT ON WINDOW CLOSE
+SELECT ... EMIT CHANGES
+SELECT ... EMIT FINAL
 
 -- ASOF JOIN
-SELECT ... FROM orders ASOF JOIN trades MATCH_CONDITION(o.ts >= t.ts) ON o.symbol = t.symbol
+SELECT ... FROM orders ASOF JOIN trades ON o.symbol = t.symbol AND o.ts >= t.ts
+
+-- Lookup tables
+CREATE LOOKUP TABLE instruments FROM POSTGRES (...)
 
 -- Late data handling
 SELECT ... ALLOWED_LATENESS INTERVAL '10' SECOND
+
+-- Window functions
+SELECT ..., LAG(price, 1) OVER (PARTITION BY symbol ORDER BY ts) FROM trades
+SELECT ..., ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY price DESC) FROM trades
+
+-- Window frames
+SELECT ..., SUM(vol) OVER (PARTITION BY sym ORDER BY ts ROWS BETWEEN 5 PRECEDING AND CURRENT ROW)
+
+-- Connector DDL
+CREATE SOURCE ... FROM KAFKA (brokers = '...', topic = '...', format = 'json')
+CREATE SOURCE ... FROM POSTGRES_CDC (hostname = '...', database = '...')
+CREATE SOURCE ... FROM MYSQL_CDC (hostname = '...', database = '...')
+CREATE SINK ... INTO KAFKA (brokers = '...', topic = '...')
+CREATE SINK ... INTO DELTA_LAKE (path = '...')
+```
+
+## Custom UDFs Registered with DataFusion
+
+| Function | Description |
+|----------|-------------|
+| `tumble(ts, interval)` | Tumbling window assignment |
+| `hop(ts, slide, size)` | Hopping/sliding window assignment |
+| `session(ts, gap)` | Session window assignment |
+| `slide(ts, size, slide)` | Alias for hop |
+| `first_value(col)` | First value in window (retractable) |
+| `last_value(col)` | Last value in window (retractable) |
+
+## Public API
+
+```rust
+use laminar_sql::{parse_streaming_sql, StreamingPlanner, execute_streaming_sql};
+
+// Parse streaming SQL
+let statements = parse_streaming_sql("CREATE SOURCE trades (...)")?;
+
+// Plan a query
+let planner = StreamingPlanner::new();
+let plan = planner.plan(&statement)?;
+
+// Execute via DataFusion
+let result = execute_streaming_sql(&ctx, sql).await?;
 ```
 
 ## Related Crates

--- a/crates/laminar-storage/README.md
+++ b/crates/laminar-storage/README.md
@@ -1,29 +1,65 @@
 # laminar-storage
 
-Storage layer for LaminarDB -- WAL, checkpointing, and lakehouse integration.
+Storage layer for LaminarDB -- WAL, checkpointing, and recovery.
 
 ## Overview
 
-Ring 1 crate handling all durability concerns. Provides write-ahead logging with per-core segments, incremental checkpointing with RocksDB, and Delta Lake/Iceberg sink backends. Designed to never block Ring 0 operations.
+Ring 1 crate handling all durability concerns. Provides write-ahead logging with per-core segments, incremental checkpointing with directory-based snapshots, and checkpoint manifests. Designed to never block Ring 0 operations.
+
+Note: Lakehouse sinks (Delta Lake, Iceberg) are in `laminar-connectors`, not here. This crate handles LaminarDB's internal durability.
 
 ## Key Modules
 
 | Module | Purpose |
 |--------|---------|
 | `wal` | Write-ahead log with CRC32C checksums, torn write detection, fdatasync |
-| `per_core_wal` | Per-core WAL segments for lock-free per-core writers |
-| `incremental` | Incremental checkpointing with RocksDB backend |
+| `per_core_wal` | Per-core WAL segments for lock-free per-core writers, epoch ordering |
+| `incremental` | Incremental checkpointing with directory-based delta snapshots |
+| `checkpoint` | Checkpoint manager, object-store checkpointer, checkpoint layout |
 | `checkpoint_manifest` | `CheckpointManifest`, `ConnectorCheckpoint`, `OperatorCheckpoint` |
 | `checkpoint_store` | `CheckpointStore` trait, `FileSystemCheckpointStore` (atomic writes) |
 | `changelog_drainer` | Ring 1 SPSC changelog consumer |
+| `wal_state_store` | Combines state store with WAL for durability |
+| `io_uring_wal` | io_uring-backed WAL for Linux 5.10+ (feature-gated) |
 
-## Feature Flags
+## Key Types
 
-| Flag | Purpose |
-|------|---------|
-| `rocksdb` (default) | RocksDB-backed incremental checkpointing |
-| `delta` | Delta Lake integration via delta_kernel |
-| `io-uring` | Forwards to laminar-core io_uring support |
+- **`WriteAheadLog`** -- Core WAL with CRC32C checksums and torn write detection
+- **`PerCoreWalManager`** / **`CoreWalWriter`** -- Per-core WAL segments (one per CPU core)
+- **`IncrementalCheckpointManager`** -- Directory-based incremental checkpointing
+- **`ObjectStoreCheckpointer`** -- Cloud object store checkpoint backend
+- **`CheckpointManifest`** -- Serializable snapshot of all operator and connector state
+- **`RecoveryManager`** -- Restores state from checkpoint + WAL replay
+- **`ChangelogDrainer`** -- Consumes Ring 0 changelog entries via SPSC queues
+- **`CheckpointCoordinator`** -- Coordinates per-core WAL checkpoint epochs
+
+## Checkpoint Architecture
+
+```
+Ring 0                          Ring 1
++------------------+            +------------------+
+| ChangelogAware   |  SPSC -->  | Changelog        |
+| StateStore       |            | Drainer          |
++------------------+            +--------+---------+
+                                         |
+                                         v
+                                +--------+---------+
+                                | Per-Core WAL     |
+                                | (CRC32C, epoch)  |
+                                +--------+---------+
+                                         |
+                                         v
+                                +--------+---------+
+                                | Incremental      |
+                                | Checkpoint Mgr   |
+                                +--------+---------+
+                                         |
+                                         v
+                                +--------+---------+
+                                | Checkpoint Store  |
+                                | (FS / Object)    |
+                                +------------------+
+```
 
 ## Benchmarks
 
@@ -31,6 +67,12 @@ Ring 1 crate handling all durability concerns. Provides write-ahead logging with
 cargo bench -p laminar-storage --bench wal_bench          # WAL write throughput
 cargo bench -p laminar-storage --bench checkpoint_bench   # Checkpoint/recovery time
 ```
+
+## Feature Flags
+
+| Flag | Purpose |
+|------|---------|
+| `io-uring` | io_uring-backed WAL (Linux 5.10+ only) |
 
 ## Related Crates
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,177 +2,257 @@
 
 ## Overview
 
-LaminarDB development is organized into 5 phases, each building on the previous.
+LaminarDB development is organized into phases, each building on the previous. Development has progressed significantly beyond the original 5-phase plan, with two additional major phases (2.5 and 6) added.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Development Phases                        │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  Phase 1        Phase 2        Phase 3        Phase 4    Phase 5│
-│  ┌──────┐       ┌──────┐       ┌──────┐       ┌──────┐  ┌──────┐│
-│  │ Core │──────▶│Harden│──────▶│Connect│─────▶│Secure│─▶│Admin ││
-│  │Engine│       │ ing  │       │ ors  │       │      │  │      ││
-│  └──────┘       └──────┘       └──────┘       └──────┘  └──────┘│
-│                                                                 │
-│  Reactor        Thread/Core    Kafka          RBAC      Dashboard│
-│  State          Windows        CDC            ABAC      Metrics │
-│  Windows        Exactly-Once   Lakehouse      Audit     Console │
-│  DataFusion     Joins                         RLS       Health  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
++------------------------------------------------------------------+
+|                        Development Phases                        |
++------------------------------------------------------------------+
+|                                                                  |
+|  Phase 1       Phase 1.5    Phase 2       Phase 2.5    Phase 3  |
+|  +------+      +------+    +------+      +------+    +------+  |
+|  | Core |----->| SQL  |--->|Harden|--->  | JIT  |--->|Connect|  |
+|  |Engine|      |Parser|    | ing  |      |Compil|    | ors  |  |
+|  +------+      +------+    +------+      +------+    +------+  |
+|  DONE          DONE        DONE          DONE        87%       |
+|                                                                  |
+|  Phase 4       Phase 5     Phase 6a      Phase 6b    Phase 6c  |
+|  +------+      +------+    +------+      +------+    +------+  |
+|  |Secure|      |Admin |    |Partit|      |Delta |    | Prod |  |
+|  |      |      |      |    |  ion |      |Found |    |Harden|  |
+|  +------+      +------+    +------+      +------+    +------+  |
+|  Planned       Planned     93%           DONE        Planned   |
+|                                                                  |
++------------------------------------------------------------------+
 ```
 
 ---
 
-## Phase 1: Core Engine
+## Phase 1: Core Engine -- COMPLETE
 
 **Goal**: Build the foundational streaming engine with basic functionality.
 
-**Success Criteria**:
-- [ ] 500K events/sec/core throughput
-- [ ] < 500ns state lookup p99
-- [ ] Tumbling windows operational
-- [ ] Basic WAL and checkpointing
-
-### Features
-
-| ID | Feature | Priority | Status |
-|----|---------|----------|--------|
-| F001 | Core Reactor Event Loop | P0 | 📝 Draft |
-| F002 | Memory-Mapped State Store | P0 | 📝 Draft |
-| F003 | State Store Interface | P0 | 📝 Draft |
-| F004 | Tumbling Windows | P0 | 📝 Draft |
-| F005 | DataFusion Integration | P0 | 📝 Draft |
-| F006 | Basic SQL Parser | P0 | 📝 Draft |
-| F007 | Write-Ahead Log | P1 | 📝 Draft |
-| F008 | Basic Checkpointing | P1 | 📝 Draft |
-| F009 | Event Time Processing | P1 | 📝 Draft |
-| F010 | Watermarks | P1 | 📝 Draft |
-| F011 | EMIT Clause | P2 | 📝 Draft |
-| F012 | Late Data Handling | P2 | 📝 Draft |
+**Completed Features (12/12):**
+- F001: Core Reactor Event Loop
+- F002: Memory-Mapped State Store
+- F003: State Store Interface
+- F004: Tumbling Windows
+- F005: DataFusion Integration
+- F006: Basic SQL Parser
+- F007: Write-Ahead Log (with CRC32C, torn write detection, fdatasync)
+- F008: Basic Checkpointing
+- F009: Event Time Processing
+- F010: Watermarks
+- F011: EMIT Clause
+- F012: Late Data Handling
 
 ---
 
-## Phase 2: Production Hardening
+## Phase 1.5: Production SQL Parser -- COMPLETE
+
+**Completed Features (1/1):**
+- F006B: Production SQL Parser (129 tests)
+
+---
+
+## Phase 2: Production Hardening -- COMPLETE
 
 **Goal**: Make the engine production-ready with advanced features.
 
-**Success Criteria**:
-- [ ] Thread-per-core architecture operational
-- [ ] Sliding and session windows working
-- [ ] Exactly-once semantics verified
-- [ ] < 10 second checkpoint recovery
-
-### Features
-
-| ID | Feature | Priority | Status |
-|----|---------|----------|--------|
-| F013 | Thread-Per-Core Architecture | P0 | 📝 Draft |
-| F014 | SPSC Queue Communication | P0 | 📝 Draft |
-| F015 | CPU Pinning | P1 | 📝 Draft |
-| F016 | Sliding Windows | P0 | 📝 Draft |
-| F017 | Session Windows | P1 | 📝 Draft |
-| F018 | Hopping Windows | P1 | 📝 Draft |
-| F019 | Stream-Stream Joins | P0 | 📝 Draft |
-| F020 | Lookup Joins | P0 | 📝 Draft |
-| F021 | Temporal Joins | P2 | 📝 Draft |
-| F022 | Incremental Checkpointing | P1 | 📝 Draft |
-| F023 | Exactly-Once Sinks | P0 | 📝 Draft |
-| F024 | Two-Phase Commit | P1 | 📝 Draft |
+**Completed Features (38/38):**
+- Thread-per-core architecture with CPU pinning (F013-F015)
+- Sliding, hopping, and session windows with merge support (F016-F018)
+- Stream-stream, lookup, temporal, and ASOF joins (F019-F021, F056-F057)
+- Incremental checkpointing and per-core WAL (F022, F062)
+- Exactly-once sinks with two-phase commit (F023-F024)
+- FIRST/LAST aggregates, cascading materialized views (F059-F060)
+- EMIT clause extension, changelog/retraction Z-sets (F011B, F063)
+- Per-partition, keyed, and alignment group watermarks (F064-F066)
+- io_uring optimization, NUMA-aware memory (F067-F068)
+- Three-ring I/O architecture, task budget enforcement (F069-F070)
+- Zero-allocation enforcement, zero-allocation polling (F071, F073)
+- XDP/eBPF network optimization (F072)
+- Advanced DataFusion integration, composite aggregator (F005B, F074-F077)
 
 ---
 
-## Phase 3: Connectors & Integration
+## Phase 2.5: JIT Compiler -- COMPLETE
+
+**Goal**: Compile DataFusion logical plans into zero-allocation JIT functions for Ring 0.
+
+**Completed Features (12/12):**
+- Event Row Format (F078)
+- Compiled Expression Evaluator (F079)
+- Plan Compiler Core (F080)
+- Ring 0/Ring 1 Pipeline Bridge (F081)
+- Streaming Query Lifecycle (F082)
+- Batch Row Reader (F083)
+- SQL Compiler Orchestrator (F084)
+- LaminarDB JIT Query Execution (F085)
+- Adaptive Compilation Warmup (F086)
+- Compiled Stateful Pipeline Bridge (F087)
+- Schema-Aware Event Time Extraction (F088)
+- Compilation Metrics & Observability (F089)
+
+---
+
+## Phase 3: Connectors & Integration -- 87% COMPLETE (81/93)
 
 **Goal**: Connect to external systems for real-world data pipelines.
 
-**Success Criteria**:
-- [ ] Kafka source/sink operational
-- [ ] PostgreSQL CDC working
-- [ ] Delta Lake/Iceberg integration complete
+**Completed:**
+- Streaming API (ring buffer, SPSC/MPSC channels, source/sink abstractions, broadcast, checkpointing) -- 9/9
+- DAG pipeline (topology, multicast, executor, checkpointing, SQL/MV integration, connector bridge) -- 7/7
+- Reactive subscriptions (change events, notification slot, registry, dispatcher, push/callback/stream subscriptions, backpressure) -- 8/8
+- Cloud storage infrastructure (credentials, validation, secret masking) -- 3/3
+- External connectors: Kafka source/sink, PostgreSQL CDC/sink, MySQL CDC, Delta Lake sink/source, Iceberg sink, Connector SDK -- 14/19
+- SQL extensions: ASOF JOIN, LAG/LEAD, ROW_NUMBER/RANK/DENSE_RANK, HAVING, multi-way JOINs, window frames, multi-partition scans -- 7/7
+- Connector infrastructure: checkpoint recovery, reference tables, partial cache, RocksDB table store, Avro hardening -- 6/6
+- Pipeline observability -- 1/1
+- Demo application (market data pipeline, Ratatui TUI, Kafka mode, DAG visualization) -- 6/6
+- Unified checkpoint system (manifest, 2PC, coordinator, operator state, changelog, WAL coordination, recovery, observability) -- 9/9
+- FFI & language bindings (API module, C headers, Arrow C Data Interface, async callbacks) -- 4/4
+- Schema framework (trait architecture, resolver, inference registry, JSON/CSV/Avro/Parquet decoders, evolution, DLQ, JSON functions, array/struct/map functions, format bridges, schema hints) -- 15/16
 
-### Features
-
-| ID | Feature | Priority | Status |
-|----|---------|----------|--------|
-| F025 | Kafka Source Connector | P0 | 📝 Draft |
-| F026 | Kafka Sink Connector | P0 | 📝 Draft |
-| F027 | PostgreSQL CDC Source | P0 | 📝 Draft |
-| F027B | PostgreSQL Sink | P0 | 📝 Draft |
-| F028 | MySQL CDC Source | P1 | 📝 Draft |
-| F029 | MongoDB CDC Source | P2 | 📝 Draft |
-| F030 | Redis Lookup Table | P1 | 📝 Draft |
-| F031 | Delta Lake Sink | P0 | 📝 Draft |
-| F032 | Iceberg Sink | P1 | 📝 Draft |
-| F033 | Parquet File Source | P2 | 📝 Draft |
-| F034 | Connector SDK | P1 | 📝 Draft |
+**Remaining (12 features, all Draft status):**
+- MongoDB CDC Source (F029)
+- Redis Lookup Table (F030)
+- Delta Lake Recovery, Compaction, Schema Evolution (F031B-D)
+- Iceberg I/O Integration (F032A) -- blocked by iceberg-datafusion compatibility
+- Parquet File Source (F033)
+- Async State Access (F058)
+- Historical Backfill (F061)
+- Protobuf Format Decoder (F-SCHEMA-008)
 
 ---
 
-## Phase 4: Enterprise & Security
+## Phase 4: Enterprise & Security -- PLANNED (0/11)
 
 **Goal**: Add enterprise security features for production deployments.
 
-**Success Criteria**:
-- [ ] RBAC fully implemented
-- [ ] ABAC policies working
-- [ ] Row-level security operational
-- [ ] Audit logging complete
+Crate stubs exist (`laminar-auth/`) but source files contain only doc comments.
 
-### Features
-
-| ID | Feature | Priority | Status |
-|----|---------|----------|--------|
-| F035 | Authentication Framework | P0 | 📝 Draft |
-| F036 | JWT Authentication | P0 | 📝 Draft |
-| F037 | mTLS Authentication | P1 | 📝 Draft |
-| F038 | LDAP Integration | P2 | 📝 Draft |
-| F039 | Role-Based Access Control | P0 | 📝 Draft |
-| F040 | Attribute-Based Access Control | P1 | 📝 Draft |
-| F041 | Row-Level Security | P0 | 📝 Draft |
-| F042 | Column-Level Security | P2 | 📝 Draft |
-| F043 | Audit Logging | P0 | 📝 Draft |
-| F044 | Encryption at Rest | P1 | 📝 Draft |
-| F045 | Key Management | P1 | 📝 Draft |
+**Planned Features:**
+- F035: Authentication Framework
+- F036: JWT Authentication
+- F037: mTLS Authentication
+- F038: LDAP Integration
+- F039: Role-Based Access Control (RBAC)
+- F040: Attribute-Based Access Control (ABAC)
+- F041: Row-Level Security
+- F042: Column-Level Security
+- F043: Audit Logging
+- F044: Encryption at Rest
+- F045: Key Management
 
 ---
 
-## Phase 5: Admin & Observability
+## Phase 5: Admin & Observability -- PLANNED (0/10)
 
 **Goal**: Provide operational tools for managing LaminarDB.
 
-**Success Criteria**:
-- [ ] Admin dashboard deployed
-- [ ] Real-time metrics working
-- [ ] Query console functional
-- [ ] Health checks operational
+Crate stubs exist (`laminar-admin/`, `laminar-observe/`) but source files contain only doc comments.
 
-### Features
-
-| ID | Feature | Priority | Status |
-|----|---------|----------|--------|
-| F046 | Admin REST API | P0 | 📝 Draft |
-| F047 | Web Dashboard | P0 | 📝 Draft |
-| F048 | Real-Time Metrics | P0 | 📝 Draft |
-| F049 | SQL Query Console | P0 | 📝 Draft |
-| F050 | Prometheus Export | P1 | 📝 Draft |
-| F051 | OpenTelemetry Tracing | P1 | 📝 Draft |
-| F052 | Health Check Endpoints | P0 | 📝 Draft |
-| F053 | Alerting Integration | P2 | 📝 Draft |
-| F054 | Configuration Management | P1 | 📝 Draft |
-| F055 | CLI Tools | P1 | 📝 Draft |
+**Planned Features:**
+- F046: Admin REST API
+- F047: Web Dashboard
+- F048: Real-Time Metrics
+- F049: SQL Query Console
+- F050: Prometheus Export
+- F051: OpenTelemetry Tracing
+- F052: Health Check Endpoints
+- F053: Alerting Integration
+- F054: Configuration Management
+- F055: CLI Tools
 
 ---
 
-## Timeline (Estimated)
+## Phase 6a: Partition-Parallel Embedded -- 93% COMPLETE (27/29)
 
-| Phase | Duration | Dependencies |
-|-------|----------|--------------|
-| Phase 1 | 8-10 weeks | None |
-| Phase 2 | 6-8 weeks | Phase 1 |
-| Phase 3 | 6-8 weeks | Phase 2 |
-| Phase 4 | 4-6 weeks | Phase 1 |
-| Phase 5 | 4-6 weeks | Phase 1 |
+**Goal**: State store infrastructure, checkpoint barriers, lookup tables with foyer caching, SQL integration, baseline benchmarks.
 
-**Note**: Phases 4 and 5 can be developed in parallel with Phases 2-3 since they build on Phase 1 independently.
+**Completed:**
+- State store architecture (revised trait, InMemoryStateStore) -- 2/2 (2 superseded)
+- Distributed checkpoint barriers and alignment -- 5/5
+- Lookup tables (trait, sources, predicates, foyer caches, CDC adapter, Postgres/Parquet sources, RocksDB removal) -- 9/9
+- Secondary indexes (redb) -- 1/1
+- Deployment profiles -- 1/1
+- Cross-partition lock-free HashMap -- 1/1
+- Source offset checkpoint -- 1/1
+- SQL integration (CREATE LOOKUP TABLE DDL, lookup join plan node, predicate pushdown) -- 3/3
+- Performance benchmarks (state store, cache, checkpoint, lookup join) -- 4/4
+
+---
+
+## Phase 6b: Delta Foundation -- COMPLETE (14/14)
+
+**Goal**: Multi-node discovery, Raft-based metadata consensus, partition ownership, distributed checkpointing, inter-node RPC.
+
+**Completed:**
+- Discovery (static, gossip/chitchat, Kafka group) -- 3/3
+- Coordination (Raft metadata consensus, delta orchestration) -- 2/2
+- Partition ownership (epoch fencing, assignment algorithm, reassignment protocol) -- 3/3
+- Distributed checkpoint coordination -- 1/1
+- Partitioned lookup strategy -- 1/1
+- Cross-node aggregation (gossip partial, gRPC fan-out) -- 2/2
+- Inter-node RPC (gRPC services, remote lookup, barrier forwarding) -- 3/3
+- Delta checkpoint benchmark -- 1/1
+
+---
+
+## Phase 6c: Delta Production Hardening -- PLANNED (0/10)
+
+**Goal**: Unaligned checkpoints, exactly-once sinks, laminardb-server binary with TOML config, HTTP API, hot reload, rolling restarts.
+
+**Planned Features:**
+- Unaligned Checkpoints (F-DCKP-006)
+- Transactional Sink 2PC (F-E2E-002)
+- Idempotent Sink (F-E2E-003)
+- TOML Configuration (F-SERVER-001)
+- Engine Construction (F-SERVER-002)
+- HTTP API (F-SERVER-003)
+- Hot Reload (F-SERVER-004)
+- Delta Server Mode (F-SERVER-005)
+- Graceful Rolling Restart (F-SERVER-006)
+
+(1 feature superseded: Incremental Mmap Checkpoints)
+
+---
+
+## Performance Optimization -- PLANNED (0/12)
+
+Architectural performance improvements identified by audit. All actionable local fixes (40+ findings) have been implemented.
+
+- Zero-Copy Prefix Scan (F-POPT-001)
+- Monomorphized Reactor Dispatch (F-POPT-002)
+- AHashMapStore Key Deduplication (F-POPT-003)
+- MmapStateStore Compaction (F-POPT-004)
+- Zero-Copy Join Row Encoding (F-POPT-005)
+- Pooled Arrow Builders (F-POPT-006)
+- LogicalPlan Passthrough (F-POPT-007)
+- Binary JSON (JSONB) (F-POPT-008)
+- SQL Plan Cache (F-POPT-009)
+- MVCC TableStore (F-POPT-010)
+- WAL Scatter-Gather Writes (F-POPT-011)
+- Avro Decoder Reuse (F-POPT-012)
+
+---
+
+## Summary
+
+| Phase | Features | Complete | Status |
+|-------|----------|----------|--------|
+| Phase 1: Core Engine | 12 | 12 | COMPLETE |
+| Phase 1.5: SQL Parser | 1 | 1 | COMPLETE |
+| Phase 2: Hardening | 38 | 38 | COMPLETE |
+| Phase 2.5: JIT Compiler | 12 | 12 | COMPLETE |
+| Phase 3: Connectors | 93 | 81 | 87% |
+| Phase 4: Security | 11 | 0 | Planned |
+| Phase 5: Admin | 10 | 0 | Planned |
+| Phase 6a: Partition-Parallel | 29 | 27 | 93% |
+| Phase 6b: Delta Foundation | 14 | 14 | COMPLETE |
+| Phase 6c: Delta Hardening | 10 | 0 | Planned |
+| Perf Optimization | 12 | 0 | Planned |
+| **Total** | **242** | **185** | **76%** |
+
+Note: Phases 4 and 5 can be developed in parallel with Phase 3 completion and Phase 6c since they build on Phase 1 independently.

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -355,4 +355,4 @@ The following patterns are confirmed working in LaminarDB embedded mode (tested 
 
 ---
 
-*This reference is based on LaminarDB v0.1.x with DataFusion 57.x. Contributions and corrections welcome — please open an issue or PR.*
+*This reference is based on LaminarDB v0.15.x with DataFusion 52.x and Arrow 57.x. Contributions and corrections welcome -- please open an issue or PR.*

--- a/docs/STEERING.md
+++ b/docs/STEERING.md
@@ -1,69 +1,65 @@
 # Steering Document
 
-> Last Updated: January 2026
+> Last Updated: February 2026
 
 ## Current Focus
 
-**Phase 2 Production Hardening** - ✅ **COMPLETE** (29/29 features)
+**Phase 3 Connectors & Integration** -- 87% complete (81/93 features)
 
-### Sprint Priority: Phase 3 - Connectors & Integration
+### Active Work
 
-Phase 2 Production Hardening is complete with all 29 features implemented.
+Phase 3 is nearly complete. The remaining 12 features are all in Draft status:
 
-**Phase 2 Completed**: F013 (Thread-Per-Core), F014 (SPSC), F015 (CPU Pinning), F016 (Sliding Windows), F017 (Session Windows), F018 (Hopping), F019 (Stream-Stream Joins), F020 (Lookup Joins), F021 (Temporal Joins), F067 (io_uring), F068 (NUMA), F071 (Zero-Alloc), F011B (EMIT Extension), F063 (Changelog/Retraction), F059 (FIRST/LAST), F023 (Exactly-Once Sinks), F022 (Incremental Checkpointing), F062 (Per-Core WAL), F069 (Three-Ring I/O), F070 (Task Budget), F073 (Zero-Alloc Polling), F060 (Cascading MVs), F056 (ASOF Joins), F064 (Per-Partition Watermarks), F065 (Keyed Watermarks), F024 (Two-Phase Commit), F066 (Watermark Alignment Groups), F072 (XDP/eBPF)
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| MongoDB CDC Source (F029) | P2 | Not started |
+| Redis Lookup Table (F030) | P1 | Not started |
+| Delta Lake Recovery (F031B) | P1 | Spec written |
+| Delta Lake Compaction (F031C) | P1 | Spec written |
+| Delta Lake Schema Evolution (F031D) | P1 | Spec written |
+| Iceberg I/O Integration (F032A) | P1 | Blocked by iceberg-datafusion DF 52.0 compat |
+| Parquet File Source (F033) | P2 | Not started |
+| Async State Access (F058) | P2 | Not started |
+| Historical Backfill (F061) | P2 | Not started |
+| Protobuf Format Decoder (F-SCHEMA-008) | P2 | Spec written |
+| WebSocket connector improvements | -- | Recently merged (PR #103) |
+| Schema inference framework | -- | Recently merged (PR #104) |
 
-**Next Priority** (updated based on research reviews):
+### Phase 6 Status
 
-**Thread-Per-Core Optimizations**:
-1. ~~**F071 (Zero-Allocation Enforcement)**~~ - ✅ COMPLETE
-2. ~~**F067 (io_uring Advanced)**~~ - ✅ COMPLETE
-3. ~~**F068 (NUMA-Aware Memory)**~~ - ✅ COMPLETE
-4. ~~**F070 (Task Budget Enforcement)**~~ - ✅ COMPLETE - latency SLA guarantees
-5. ~~**F069 (Three-Ring I/O)**~~ - ✅ COMPLETE - latency/main/poll ring separation
+- **Phase 6a** (Partition-Parallel Embedded): 27/29 features complete (93%)
+- **Phase 6b** (Delta Foundation): 14/14 features complete (100%)
+- **Phase 6c** (Delta Production Hardening): 0/10 features (planned)
 
-**Emit & Checkpoint**:
-6. ~~**F011B (EMIT Clause Extension)**~~ - ✅ COMPLETE - OnWindowClose/Changelog/Final
-7. ~~**F063 (Changelog/Retraction)**~~ - ✅ COMPLETE - Z-set foundation, unblocks F023, F060
-8. ~~**F059 (FIRST/LAST Value Aggregates)**~~ - ✅ COMPLETE - Essential for OHLC, unblocks F060
-9. ~~**F023 (Exactly-Once Sinks)**~~ - ✅ COMPLETE - Transactional + idempotent sinks
-10. ~~**F022 (Incremental Checkpointing)**~~ - ✅ COMPLETE - RocksDB backend, SPSC changelog
-11. ~~**F062 (Per-Core WAL)**~~ - ✅ COMPLETE - lock-free per-core writers, epoch ordering
+### Next Priorities
 
-### Phase 1 Hardening (Complete)
+1. Complete remaining Phase 3 P1 features (Delta Lake advanced, Redis lookup)
+2. Begin Phase 6c server infrastructure (TOML config, engine construction, HTTP API)
+3. Phase 4/5 security and admin features can begin in parallel
 
-Phase 1 features are functionally complete. A comprehensive audit against 2025-2026 best practices identified critical gaps that have been fixed.
+---
 
-#### P0 - Must Fix Before Phase 2
+## Completed Phases
 
-| # | Issue | Feature | Effort | Impact |
-|---|-------|---------|--------|--------|
-| 1 | **WAL uses fsync not fdatasync** | F007 | 1 hour | 50-100μs/sync wasted on metadata |
-| 2 | **No CRC32 checksum in WAL** | F007 | 4 hours | Cannot detect corruption |
-| 3 | **No torn write detection** | F007 | 4 hours | Crash recovery may fail |
-| 4 | **Watermark not persisted in WAL** | F010 | 4 hours | Recovery loses watermark progress |
-| 5 | **No recovery integration test** | F007/F008 | 1 day | Untested critical path |
+### Phase 1: Core Engine -- COMPLETE (12/12)
 
-#### P1 - Early Phase 2
+Reactor, state stores, tumbling windows, DataFusion integration, WAL, checkpointing, event time processing, watermarks, EMIT clause, late data handling.
 
-| # | Issue | Feature | Effort | Status | Impact |
-|---|-------|---------|--------|--------|--------|
-| 6 | Per-core WAL segments | **F062** | 3-5 days | ✅ Done | Required for F013 (thread-per-core) |
-| 7 | Async checkpointing | **F022** | 1-2 weeks | ✅ Done | Blocks Ring 0 currently |
-| 8 | MAP_PRIVATE for checkpoints | F002 | 2-3 days | 📝 Draft | CoW isolation for snapshots |
-| 9 | io_uring integration | F001/F007 | 3-5 days | ✅ Done | Blocking I/O on hot path |
+### Phase 1.5: Production SQL Parser -- COMPLETE (1/1)
 
-**New ADR**: [ADR-004: Checkpoint Strategy](adr/ADR-004-checkpoint-strategy.md) documents the three-tier checkpoint architecture decision.
+129 parser tests covering all streaming SQL extensions.
 
-### Audit Summary
+### Phase 2: Production Hardening -- COMPLETE (38/38)
 
-| Category | Status |
-|----------|--------|
-| Features Audited | 12 |
-| Fully Implemented | 5 |
-| Partial (gaps found) | 6 |
-| Needs Work | 1 |
+Thread-per-core, all window types, all join types, exactly-once sinks, two-phase commit, per-core WAL, incremental checkpointing, NUMA, io_uring, Z-set changelog, cascading MVs, watermark variants, JIT groundwork.
 
-**Full audit report**: All P0 items resolved.
+### Phase 2.5: JIT Compiler -- COMPLETE (12/12)
+
+Cranelift JIT compilation, adaptive compilation warmup, compiled stateful pipeline bridge.
+
+### Phase 6b: Delta Foundation -- COMPLETE (14/14)
+
+Gossip discovery, Raft consensus, partition ownership, distributed checkpoints, gRPC services, cross-node aggregation.
 
 ---
 
@@ -73,79 +69,53 @@ Phase 1 features are functionally complete. A comprehensive audit against 2025-2
 
 | Decision | Choice | Rationale | ADR |
 |----------|--------|-----------|-----|
-| Hash map implementation | FxHashMap | Faster than std HashMap for small keys | ADR-001 |
+| Hash map implementation | AHashMap (Ring 0), FxHashMap (general) | Faster for small keys, DoS-resistant | ADR-001 |
 | Serialization format | rkyv | Zero-copy deserialization, ~1.2ns access | ADR-002 |
 | SQL parser strategy | Extend sqlparser-rs | DataFusion compatible, streaming extensions | ADR-003 |
-| Checkpoint strategy | Three-tier hybrid | Ring 0 changelog, Ring 1 WAL+RocksDB | ADR-004 |
-| Async runtime | tokio (Ring 1 only) | Industry standard, not on hot path | - |
-| WAL format | Custom (keep) | Simpler than RocksDB WAL, add checksums | - |
-
-### Pending
-
-| Decision | Options | Deadline | Owner |
-|----------|---------|----------|-------|
-| io_uring crate | tokio-uring vs io_uring | Phase 2 | TBD |
-| NUMA crate | libc vs numa crate | Phase 2 | TBD |
-| ~~Retraction model~~ | ~~Z-set vs Flink changelog~~ | ~~Phase 2 Week 2~~ | ✅ **Decided: Z-set** (F063) |
-
-**Notes**:
-- Retraction model decided: DBSP/Feldera Z-sets chosen for mathematical foundation. See [F063: Changelog/Retraction](features/phase-2/F063-changelog-retraction.md).
-- io_uring and NUMA implementation details specified in [F067](features/phase-2/F067-io-uring-optimization.md) and [F068](features/phase-2/F068-numa-aware-memory.md) respectively.
-
----
-
-## Blocked Items
-
-| Item | Blocker | Unblock Action |
-|------|---------|----------------|
-| ~~Phase 2 Start~~ | ~~P0 hardening fixes~~ | ✅ Complete - 5 critical items done |
-| Benchmarking | CI setup | Set up benchmark CI |
-| Performance validation | No benchmarks exist | Add criterion benchmarks |
-
----
-
-## Technical Debt
-
-### Critical (P0) - ✅ ALL COMPLETE
-
-- [x] ~~Phase 1 features complete~~
-- [x] ~~WAL durability fixes~~ - fdatasync, CRC32C, torn write detection
-- [x] ~~Watermark persistence~~ - In WAL commits and checkpoint metadata
-- [x] ~~Recovery integration test~~ - 6 comprehensive tests in wal_state_store.rs
-
-### High (P0/P1) - Thread-Per-Core Research Gaps
-
-- [ ] **Zero-allocation enforcement** - See [F071: Zero-Allocation Enforcement](features/phase-2/F071-zero-allocation-enforcement.md)
-- [ ] **io_uring advanced** - See [F067: io_uring Advanced Optimization](features/phase-2/F067-io-uring-optimization.md)
-- [ ] **NUMA awareness** - See [F068: NUMA-Aware Memory Allocation](features/phase-2/F068-numa-aware-memory.md)
-- [ ] **Task budgeting** - See [F070: Task Budget Enforcement](features/phase-2/F070-task-budget-enforcement.md)
-- [ ] **Three-ring I/O** - See [F069: Three-Ring I/O Architecture](features/phase-2/F069-three-ring-io.md)
-
-### High (P1)
-
-- [ ] **Production SQL Parser** - Current F006 is POC only (see ADR-003, F006B spec)
-- [ ] **Async checkpointing** - See [F022: Incremental Checkpointing](features/phase-2/F022-incremental-checkpointing.md)
-- [ ] **Per-core WAL** - See [F062: Per-Core WAL Segments](features/phase-2/F062-per-core-wal.md)
-
-### Medium (P2)
-
-- [ ] Add property-based tests for serialization
-- [ ] Document unsafe blocks in core crate
-- [ ] Add tracing spans for debugging
-- [ ] Prefix scan optimization (currently O(n))
-- [ ] madvise hints for mmap
-- [ ] Huge page support for large state
+| Checkpoint strategy | Three-tier hybrid | Ring 0 changelog, Ring 1 WAL + directory snapshots | ADR-004 |
+| Async runtime | tokio (Ring 1 only) | Industry standard, not on hot path | -- |
+| WAL format | Custom (keep) | Simpler than RocksDB WAL, CRC32C checksums | -- |
+| Retraction model | Z-sets (DBSP/Feldera) | Mathematical foundation for correctness | F063 |
+| Schema trait architecture | Extensible connector traits | Pluggable format decoders, schema inference | ADR-006 |
+| Distributed coordination | openraft + chitchat | Proven Raft for consensus, gossip for discovery | -- |
+| Cache implementation | foyer | S3-FIFO eviction, serde for HybridCache | -- |
+| Secondary indexes | redb | Embedded B-tree, no external dependencies | -- |
+| Concurrent HashMap | papaya | Lock-free, better than dashmap for cross-partition | -- |
 
 ---
 
 ## Performance Validation Status
 
-| Metric | Target | Verified | Action |
-|--------|--------|----------|--------|
-| State lookup | < 500ns | ⚠️ Claimed | Add benchmark |
-| Throughput/core | 500K/sec | ❌ Not tested | Add benchmark |
-| p99 latency | < 10μs | ❌ Not tested | Add histogram |
-| Checkpoint recovery | < 10s | ❌ Not tested | Add benchmark |
+| Metric | Target | Validated | Benchmark |
+|--------|--------|-----------|-----------|
+| State lookup | < 500ns | Benchmarks exist | `state_bench` |
+| Throughput/core | 500K/sec | Benchmarks exist | `throughput_bench` |
+| p99 latency | < 10us | Benchmarks exist | `latency_bench` |
+| Checkpoint recovery | < 10s | Integration tests | `checkpoint_bench` |
+| Window trigger | < 10us | Benchmarks exist | `window_bench` |
+| Join throughput | -- | Benchmarks exist | `join_bench`, `lookup_join_bench` |
+| Cache performance | -- | Benchmarks exist | `cache_bench` |
+| JIT compilation | -- | Benchmarks exist | `compiler_bench` |
+
+17 benchmark suites exist in `laminar-core`, 2 in `laminar-storage`.
+
+---
+
+## Technical Debt
+
+### Resolved (P0)
+
+All Phase 1 P0 issues resolved:
+- WAL durability fixes (fdatasync, CRC32C, torn write detection)
+- Watermark persistence in WAL commits and checkpoint metadata
+- Recovery integration tests (6 comprehensive tests)
+
+### Remaining
+
+- [ ] Phase 4/5 crate stubs are empty (auth, admin, observe) -- implementation planned
+- [ ] Server binary is skeleton only -- Phase 6c will implement
+- [ ] Iceberg I/O integration blocked by iceberg-datafusion compatibility
+- [ ] Performance optimization features (12 identified, all planned)
 
 ---
 
@@ -167,19 +137,17 @@ Phase 1 features are functionally complete. A comprehensive audit against 2025-2
 
 ---
 
-## Upcoming Milestones
+## Milestones
 
 | Milestone | Target Date | Status |
 |-----------|-------------|--------|
-| Phase 1 Features Complete | 2026-01-24 | ✅ Done |
-| Phase 1 P0 Hardening Complete | 2026-01-24 | ✅ Done |
-| Phase 2 Start | 2026-01-24 | ✅ Started (7/28 features complete) |
-| Phase 2 P0 Features | TBD | 🚧 In Progress |
-| First public demo | TBD | 📋 Planned |
-
----
-
-## Communication
-
-- **Weekly**: Update STEERING.md priorities
-- **Phase End**: Full retrospective and planning
+| Phase 1 Complete | 2026-01-24 | Done |
+| Phase 1 P0 Hardening | 2026-01-24 | Done |
+| Phase 2 Complete | 2026-01-31 | Done |
+| Phase 2.5 JIT Complete | 2026-02-03 | Done |
+| Phase 6a/6b Complete | 2026-02-15 | Done (6b), 93% (6a) |
+| Phase 3 Complete | TBD | 87% |
+| Phase 6c Server | TBD | Planned |
+| Phase 4 Security | TBD | Planned |
+| Phase 5 Admin | TBD | Planned |
+| First public release | TBD | Planned |

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -1,21 +1,25 @@
 # Feature Index
 
+> Last updated: 2026-02-22
+
 ## Overview
 
 | Phase | Total | Draft | In Progress | Hardening | Done | Superseded |
 |-------|-------|-------|-------------|-----------|------|------------|
-| Phase 1 | 12 | 0 | 0 | 0 | 12 | 0 |
-| Phase 1.5 | 1 | 0 | 0 | 0 | 1 | 0 |
-| Phase 2 | 38 | 0 | 0 | 0 | 38 | 0 |
-| Phase 2.5 | 12 | 0 | 0 | 0 | 12 | 0 |
-| Phase 3 | 93 | 12 | 0 | 0 | 81 | 0 |
-| Phase 4 | 11 | 11 | 0 | 0 | 0 | 0 |
-| Phase 5 | 10 | 10 | 0 | 0 | 0 | 0 |
-| Phase 6a | 29 | 0 | 0 | 0 | 27 | 2 |
-| Phase 6b | 14 | 0 | 0 | 0 | 14 | 0 |
-| Phase 6c | 10 | 9 | 0 | 0 | 0 | 1 |
+| Phase 1: Core Engine | 12 | 0 | 0 | 0 | 12 | 0 |
+| Phase 1.5: SQL Parser | 1 | 0 | 0 | 0 | 1 | 0 |
+| Phase 2: Production Hardening | 38 | 0 | 0 | 0 | 38 | 0 |
+| Phase 2.5: JIT Compiler | 12 | 0 | 0 | 0 | 12 | 0 |
+| Phase 3: Connectors | 93 | 12 | 0 | 0 | 81 | 0 |
+| Phase 4: Enterprise Security | 11 | 11 | 0 | 0 | 0 | 0 |
+| Phase 5: Admin & Observability | 10 | 10 | 0 | 0 | 0 | 0 |
+| Phase 6a: Partition-Parallel | 29 | 0 | 0 | 0 | 27 | 2 |
+| Phase 6b: Delta Foundation | 14 | 0 | 0 | 0 | 14 | 0 |
+| Phase 6c: Delta Hardening | 10 | 9 | 0 | 0 | 0 | 1 |
 | Perf Optimization | 12 | 12 | 0 | 0 | 0 | 0 |
 | **Total** | **242** | **54** | **0** | **0** | **185** | **3** |
+
+**Completion: 185/242 features (76%).** Phases 1, 1.5, 2, 2.5, and 6b are fully complete. Phases 3 and 6a are nearly complete. Phases 4, 5, 6c, and Perf Optimization are planned with specifications written but no implementation started.
 
 ## Status Legend
 


### PR DESCRIPTION
Update all project documentation to match actual codebase state:
- Rewrite README with developer-friendly getting started guide, all connectors, window types, join types, and SQL examples
- Update ARCHITECTURE.md with current design (AHashMap state store, directory-based snapshots, Delta architecture, WebSocket connectors)
- Rewrite ROADMAP.md with accurate phase progress (185/242 features)
- Update STEERING.md to February 2026 priorities
- Update all 9 crate READMEs with accurate module lists and examples
- Fix stale references: remove RocksDB (removed in F-LOOKUP-010), correct DataFusion version (52.x not 57.x), mark stub crates honestly
- Update CONTRIBUTING.md feature flags table
- Update SQL_REFERENCE.md version references

## What

<!-- Brief description of changes -->

## Why

<!-- Link to issue or explain motivation -->

## How

<!-- Technical approach taken -->

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests pass (`cargo test --all`)
- [ ] No clippy warnings (`cargo clippy --all -- -D warnings`)
- [ ] Code is formatted (`cargo fmt`)

## Ring 0 (if applicable)

- [ ] No heap allocations on hot path
- [ ] No locks on hot path
- [ ] Benchmarks run before and after

## Checklist

- [ ] Public APIs are documented
- [ ] Breaking changes documented (if any)
- [ ] Feature spec updated in `docs/features/` (if applicable)
