### PR TITLE
fix(ci): replace flaky choco protoc with arduino/setup-protoc on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
-        run: choco install protoc -y
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Tests include compilation - no separate build step needed
       - name: Run tests (Linux)


### PR DESCRIPTION
## Summary
- Replaces `choco install protoc` with `arduino/setup-protoc@v3` in the Windows CI job
- Fixes intermittent build failures where protoc was not found when compiling delta proto files
- `arduino/setup-protoc` downloads protoc directly from official GitHub releases and reliably adds it to PATH

## Test plan
- [ ] Verify Windows CI job passes with the `delta` feature enabled