### PR TITLE
fix(site): mobile responsiveness for data flow playground

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -2007,6 +2007,18 @@ code {
 }
 
 /* ================================================
+   TOUCH / HOVER HINT VARIANTS
+   ================================================ */
+.hint-touch { display: none; }
+.hint-desktop { display: inline; }
+
+@media (hover: none), (pointer: coarse) {
+  .hint-touch { display: inline; }
+  .hint-desktop { display: none; }
+  .hint-hover { display: none !important; }
+}
+
+/* ================================================
    RESPONSIVE
    ================================================ */
 @media (max-width: 1024px) {
@@ -2080,6 +2092,15 @@ code {
 
   .sticky-bar-inner { gap: 0.75rem; font-size: 0.82rem; }
   .sticky-bar-install { display: none; }
+
+  /* Playground mobile adjustments at 768px */
+  .playground-controls { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .playground-controls-left,
+  .playground-controls-right { justify-content: center; }
+  .playground-presets { gap: 0.35rem; padding: 0.6rem 0.75rem; }
+  .preset-btn { padding: 0.35rem 0.7rem; font-size: 0.72rem; }
+  .playground-hint { gap: 1rem; }
+  .hint-hover { display: none; }
 }
 
 @media (max-width: 480px) {
@@ -2101,11 +2122,13 @@ code {
   .connector-card { padding: 1rem 0.75rem; }
   .dx-cta { flex-direction: column; align-items: stretch; }
   .dx-cta .btn { justify-content: center; }
-  .playground-controls { flex-direction: column; align-items: stretch; gap: 0.5rem; }
-  .playground-controls-left,
-  .playground-controls-right { justify-content: center; }
-  .playground-hint { gap: 0.75rem; }
-  .playground-presets { gap: 0.35rem; padding: 0.6rem 0.75rem; }
-  .preset-btn { padding: 0.35rem 0.7rem; font-size: 0.72rem; }
+  .playground-hint { gap: 0.5rem; padding: 0.5rem 0.75rem; }
+  .playground-hint span { font-size: 0.65rem; }
+  .playground-presets { gap: 0.25rem; padding: 0.5rem 0.5rem; }
+  .preset-btn { padding: 0.3rem 0.55rem; font-size: 0.68rem; gap: 0.25rem; }
+  .preset-icon { font-size: 0.75rem; }
+  .playground-speed-control label { font-size: 0.7rem; }
+  .playground-eps { font-size: 0.7rem; }
+  #playground-speed { width: 60px; }
   .comparison-highlights { grid-template-columns: 1fr; }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -246,9 +246,9 @@
               </div>
             </div>
             <div class="playground-hint">
-              <span><span class="playground-hint-dot"></span> Click operators to toggle on/off</span>
+              <span><span class="playground-hint-dot"></span> <span class="hint-desktop">Click</span><span class="hint-touch">Tap</span> operators to toggle on/off</span>
               <span><span class="playground-hint-dot"></span> Drag operators to rearrange</span>
-              <span><span class="playground-hint-dot"></span> Hover for details</span>
+              <span class="hint-hover"><span class="playground-hint-dot"></span> Hover for details</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Scales node dimensions, padding, fonts, and icons based on canvas width breakpoints so operators don't overlap on small screens
- Increases canvas height on mobile for more vertical breathing room
- Zigzags nodes into two staggered rows on narrow screens (<600px) to prevent horizontal crowding across all three presets
- Adds collision resolution as a safety net for any remaining edge cases
- Shows touch-appropriate hint text ("Tap" instead of "Click", hides "Hover for details") on touch devices
- Stacks and tightens playground controls at 768px and 480px breakpoints

## Test plan
- [ ] Open `site/index.html` in Chrome DevTools responsive mode
- [ ] Verify nodes do not overlap at iPhone SE (375px), iPhone 14 (390px), iPad Mini (768px)
- [ ] Verify zigzag layout appears on all three presets at mobile widths
- [ ] Verify presets, speed controls, and hints render cleanly
- [ ] Test touch interactions (tap to toggle, drag to move) on real device or DevTools touch simulation
- [ ] Verify desktop layout is unchanged above 768px