### PR TITLE
fix(db): return error from cancel_query() for nonexistent query IDs

### DIFF
--- a/crates/laminar-db/src/api/connection.rs
+++ b/crates/laminar-db/src/api/connection.rs
@@ -620,9 +620,8 @@ mod tests {
     #[test]
     fn test_cancel_query_invalid() {
         let conn = Connection::open().unwrap();
-        // Cancelling a non-existent query should succeed (no-op in current impl)
         let result = conn.cancel_query(999);
-        assert!(result.is_ok());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/laminar-db/src/catalog.rs
+++ b/crates/laminar-db/src/catalog.rs
@@ -329,11 +329,13 @@ impl SourceCatalog {
         id
     }
 
-    /// Mark a query as inactive.
-    #[allow(dead_code)]
-    pub(crate) fn deactivate_query(&self, id: u64) {
+    /// Mark a query as inactive. Returns `true` if the query existed.
+    pub(crate) fn deactivate_query(&self, id: u64) -> bool {
         if let Some(entry) = self.queries.write().get_mut(&id) {
             entry.active = false;
+            true
+        } else {
+            false
         }
     }
 

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -3237,8 +3237,11 @@ impl LaminarDB {
     ///
     /// Returns `DbError` if the query is not found.
     pub fn cancel_query(&self, query_id: u64) -> Result<(), DbError> {
-        self.catalog.deactivate_query(query_id);
-        Ok(())
+        if self.catalog.deactivate_query(query_id) {
+            Ok(())
+        } else {
+            Err(DbError::QueryNotFound(query_id.to_string()))
+        }
     }
 
     /// Get the number of registered sources.


### PR DESCRIPTION
## Summary

- `cancel_query()` always returned `Ok(())` even for unknown query IDs, contradicting its doc comment and breaking tooling that relies on the error signal
- `deactivate_query()` now returns `bool` to indicate whether the query existed
- `cancel_query()` checks this and returns `DbError::QueryNotFound` when the ID doesn't exist
- Updated `test_cancel_query_invalid` to assert the error

Closes #89

## Test plan

- [x] `cargo test -p laminar-db test_cancel_query` passes
- [x] `cargo clippy -p laminar-db -- -D warnings` clean
- [x] `cargo fmt -p laminar-db -- --check` clean