### PR TITLE
docs: sync all documentation with v0.16 codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-02-28
+
+### Added
+- **Stateful Streaming SQL (F-SSQL-000 through F-SSQL-006)**:
+  - Streaming aggregation hardening with incremental per-window accumulators
+  - StreamExecutor state checkpoint integration
+  - Ring 0 SQL operator routing for tumbling, hopping, and session windows
+  - Streaming physical optimizer rule (`StreamingPhysicalValidator`)
+  - DataFusion cooperative scheduling integration
+  - Dynamic watermark filter pushdown (`WatermarkDynamicFilter`)
+- **SQL audit P2 fixes**:
+  - SHOW SOURCES/SINKS/STREAMS with metadata columns
+  - SHOW CREATE SOURCE/SINK for DDL reconstruction
+  - Window offset support for timezone-aligned tumble/hop
+  - EXPLAIN ANALYZE with execution metrics
+  - ASOF NEAREST join direction
+- **Unified error handling** with structured `LDB-NNNN` error codes across 8 code ranges
+- Zero-alloc `HotPathError` enum for Ring 0 (2 bytes, `Copy`)
+- `DbError::code()` and `DbError::is_transient()` for programmatic error handling
+- Binance WebSocket streaming SQL demo (`examples/binance-ws/`)
+- Event-driven fan-out/fan-in pipeline architecture
+- End-to-end barrier wiring and checkpoint operational maturity
+- Benchmark baselines document (`docs/BENCHMARKS.md`)
+
+### Fixed
+- QueueFull panic in throughput benchmark
+- WAL guard against OOM on corrupted entry length (MAX_WAL_ENTRY_SIZE validation)
+- Sink integration audit fixes
+- Identifier normalization disabled for mixed-case column support
+
+### Changed
+- Replaced std HashMap with FxHashMap/AHashMap on hot paths in laminar-db
+
 ## [0.15.0] - 2026-02-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,13 @@ cargo +nightly fmt --all -- --check
 |-------|------|---------|
 | `laminar-core` | 0 | Reactor, operators, state stores, streaming channels, JIT compiler |
 | `laminar-sql` | -- | SQL parser (streaming extensions), query planner, DataFusion integration |
-| `laminar-storage` | 1 | WAL, incremental checkpointing, RocksDB backend |
-| `laminar-connectors` | 1 | Kafka, PostgreSQL CDC, MySQL CDC, Delta Lake, connector SDK |
+| `laminar-storage` | 1 | WAL, incremental checkpointing, checkpoint manifest |
+| `laminar-connectors` | 1 | Kafka, PostgreSQL CDC, MySQL CDC, WebSocket, Delta Lake, Iceberg, connector SDK |
 | `laminar-db` | -- | Unified database facade, checkpoint coordination, FFI API |
-| `laminar-auth` | 2 | JWT authentication, RBAC, ABAC |
-| `laminar-admin` | 2 | REST API (Axum), Swagger UI |
-| `laminar-observe` | 2 | Prometheus metrics, OpenTelemetry tracing |
-| `laminar-derive` | -- | Proc macros for `Record` and `FromRecordBatch` traits |
+| `laminar-auth` | 2 | JWT authentication, RBAC, ABAC (stubs -- Phase 4) |
+| `laminar-admin` | 2 | REST API (Axum), Swagger UI (stubs -- Phase 5) |
+| `laminar-observe` | 2 | Prometheus metrics, OpenTelemetry tracing (stubs -- Phase 5) |
+| `laminar-derive` | -- | Proc macros: `Record`, `FromRecordBatch`, `FromRow`, `ConnectorConfig` |
 | `laminar-server` | -- | Standalone server binary |
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
@@ -99,7 +99,7 @@ cargo test --all
 cargo test -p laminar-core
 
 # With feature flags
-cargo test --all --features kafka,postgres-cdc,mysql-cdc,delta-lake
+cargo test --all --features kafka,postgres-cdc,mysql-cdc,delta-lake,websocket
 
 # Run benchmarks
 cargo bench
@@ -118,10 +118,10 @@ Many features are optional to keep compile times manageable:
 | `kafka` | laminar-connectors, laminar-db | Kafka source/sink, Avro serde |
 | `postgres-cdc` | laminar-connectors, laminar-db | PostgreSQL CDC source |
 | `postgres-sink` | laminar-connectors, laminar-db | PostgreSQL sink |
-| `mysql-cdc` | laminar-connectors | MySQL CDC source |
+| `mysql-cdc` | laminar-connectors, laminar-db | MySQL CDC source |
+| `websocket` | laminar-connectors, laminar-db | WebSocket source and sink |
 | `delta-lake` | laminar-connectors, laminar-db | Delta Lake sink and source |
 | `delta-lake-s3` | laminar-connectors | S3 storage backend for Delta Lake |
-| `websocket` | laminar-connectors | WebSocket source and sink |
 | `ffi` | laminar-db | C FFI layer |
 | `api` | laminar-db | FFI-friendly API module |
 | `delta` | laminar-core, laminar-db | Distributed delta mode |

--- a/crates/laminar-core/README.md
+++ b/crates/laminar-core/README.md
@@ -29,6 +29,7 @@ This is the Ring 0 crate containing all latency-critical components. Everything 
 | `lookup` | Lookup table trait, predicate types, foyer caches (memory + hybrid), CDC-to-cache adapter |
 | `index` | redb secondary indexes for non-primary-key lookups |
 | `aggregation` | Cross-partition lock-free HashMap (papaya) |
+| `error_codes` | Structured `LDB-NNNN` error code registry and zero-alloc `HotPathError` |
 | `detect` | Platform detection utilities |
 | `xdp` | Linux eBPF/XDP network optimization |
 | `delta` | Distributed mode: discovery (gossip, Kafka), Raft consensus, partition ownership, gRPC RPC |

--- a/docs/COMPETITIVE.md
+++ b/docs/COMPETITIVE.md
@@ -1,6 +1,6 @@
 # Competitive Landscape Analysis
 
-> Last Updated: January 2026
+> Last Updated: February 2026
 
 ## Executive Summary
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ LaminarDB development is organized into phases, each building on the previous. D
 |  | Core |----->| SQL  |--->|Harden|--->  | JIT  |--->|Connect|  |
 |  |Engine|      |Parser|    | ing  |      |Compil|    | ors  |  |
 |  +------+      +------+    +------+      +------+    +------+  |
-|  DONE          DONE        DONE          DONE        87%       |
+|  DONE          DONE        DONE          DONE        85%       |
 |                                                                  |
 |  Phase 4       Phase 5     Phase 6a      Phase 6b    Phase 6c  |
 |  +------+      +------+    +------+      +------+    +------+  |
@@ -96,7 +96,7 @@ LaminarDB development is organized into phases, each building on the previous. D
 
 ---
 
-## Phase 3: Connectors & Integration -- 87% COMPLETE (81/93)
+## Phase 3: Connectors & Integration -- 85% COMPLETE (85/100)
 
 **Goal**: Connect to external systems for real-world data pipelines.
 
@@ -107,6 +107,7 @@ LaminarDB development is organized into phases, each building on the previous. D
 - Cloud storage infrastructure (credentials, validation, secret masking) -- 3/3
 - External connectors: Kafka source/sink, PostgreSQL CDC/sink, MySQL CDC, Delta Lake sink/source, Iceberg sink, Connector SDK -- 14/19
 - SQL extensions: ASOF JOIN, LAG/LEAD, ROW_NUMBER/RANK/DENSE_RANK, HAVING, multi-way JOINs, window frames, multi-partition scans -- 7/7
+- Stateful streaming SQL: aggregation hardening, EOWC incremental accumulators, checkpoint integration, Ring 0 SQL operator routing (tumbling/hopping/session), streaming physical optimizer, cooperative scheduling, dynamic watermark filter pushdown -- 7/7
 - Connector infrastructure: checkpoint recovery, reference tables, partial cache, RocksDB table store, Avro hardening -- 6/6
 - Pipeline observability -- 1/1
 - Demo application (market data pipeline, Ratatui TUI, Kafka mode, DAG visualization) -- 6/6
@@ -114,7 +115,7 @@ LaminarDB development is organized into phases, each building on the previous. D
 - FFI & language bindings (API module, C headers, Arrow C Data Interface, async callbacks) -- 4/4
 - Schema framework (trait architecture, resolver, inference registry, JSON/CSV/Avro/Parquet decoders, evolution, DLQ, JSON functions, array/struct/map functions, format bridges, schema hints) -- 15/16
 
-**Remaining (12 features, all Draft status):**
+**Remaining (15 features, all Draft status):**
 - MongoDB CDC Source (F029)
 - Redis Lookup Table (F030)
 - Delta Lake Recovery, Compaction, Schema Evolution (F031B-D)
@@ -246,13 +247,13 @@ Architectural performance improvements identified by audit. All actionable local
 | Phase 1.5: SQL Parser | 1 | 1 | COMPLETE |
 | Phase 2: Hardening | 38 | 38 | COMPLETE |
 | Phase 2.5: JIT Compiler | 12 | 12 | COMPLETE |
-| Phase 3: Connectors | 93 | 81 | 87% |
+| Phase 3: Connectors | 100 | 85 | 85% |
 | Phase 4: Security | 11 | 0 | Planned |
 | Phase 5: Admin | 10 | 0 | Planned |
 | Phase 6a: Partition-Parallel | 29 | 27 | 93% |
 | Phase 6b: Delta Foundation | 14 | 14 | COMPLETE |
 | Phase 6c: Delta Hardening | 10 | 0 | Planned |
 | Perf Optimization | 12 | 0 | Planned |
-| **Total** | **242** | **185** | **76%** |
+| **Total** | **249** | **189** | **76%** |
 
 Note: Phases 4 and 5 can be developed in parallel with Phase 3 completion and Phase 6c since they build on Phase 1 independently.

--- a/docs/STEERING.md
+++ b/docs/STEERING.md
@@ -1,14 +1,14 @@
 # Steering Document
 
-> Last Updated: February 2026
+> Last Updated: February 28, 2026
 
 ## Current Focus
 
-**Phase 3 Connectors & Integration** -- 87% complete (81/93 features)
+**Phase 3 Connectors & Integration** -- 85% complete (85/100 features)
 
 ### Active Work
 
-Phase 3 is nearly complete. The remaining 12 features are all in Draft status:
+Phase 3 is nearly complete. The remaining 15 features are all in Draft status:
 
 | Feature | Priority | Notes |
 |---------|----------|-------|
@@ -22,8 +22,9 @@ Phase 3 is nearly complete. The remaining 12 features are all in Draft status:
 | Async State Access (F058) | P2 | Not started |
 | Historical Backfill (F061) | P2 | Not started |
 | Protobuf Format Decoder (F-SCHEMA-008) | P2 | Spec written |
-| WebSocket connector improvements | -- | Recently merged (PR #103) |
-| Schema inference framework | -- | Recently merged (PR #104) |
+| Stateful Streaming SQL (F-SSQL-000 through F-SSQL-006) | -- | Complete (merged PR #128) |
+| SQL audit P2 (SHOW, EXPLAIN ANALYZE, ASOF NEAREST) | -- | Complete (merged PR #136) |
+| Unified error handling with LDB-NNNN codes | -- | Complete (merged PR #134) |
 
 ### Phase 6 Status
 
@@ -146,7 +147,7 @@ All Phase 1 P0 issues resolved:
 | Phase 2 Complete | 2026-01-31 | Done |
 | Phase 2.5 JIT Complete | 2026-02-03 | Done |
 | Phase 6a/6b Complete | 2026-02-15 | Done (6b), 93% (6a) |
-| Phase 3 Complete | TBD | 87% |
+| Phase 3 Complete | TBD | 85% |
 | Phase 6c Server | TBD | Planned |
 | Phase 4 Security | TBD | Planned |
 | Phase 5 Admin | TBD | Planned |

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -1,6 +1,6 @@
 # Feature Index
 
-> Last updated: 2026-02-26
+> Last updated: 2026-02-28
 
 ## Overview
 
@@ -10,16 +10,16 @@
 | Phase 1.5: SQL Parser | 1 | 0 | 0 | 0 | 1 | 0 |
 | Phase 2: Production Hardening | 38 | 0 | 0 | 0 | 38 | 0 |
 | Phase 2.5: JIT Compiler | 12 | 0 | 0 | 0 | 12 | 0 |
-| Phase 3: Connectors | 100 | 16 | 0 | 0 | 84 | 0 |
+| Phase 3: Connectors | 100 | 15 | 0 | 0 | 85 | 0 |
 | Phase 4: Enterprise Security | 11 | 11 | 0 | 0 | 0 | 0 |
 | Phase 5: Admin & Observability | 10 | 10 | 0 | 0 | 0 | 0 |
 | Phase 6a: Partition-Parallel | 29 | 0 | 0 | 0 | 27 | 2 |
 | Phase 6b: Delta Foundation | 14 | 0 | 0 | 0 | 14 | 0 |
 | Phase 6c: Delta Hardening | 10 | 9 | 0 | 0 | 0 | 1 |
 | Perf Optimization | 12 | 12 | 0 | 0 | 0 | 0 |
-| **Total** | **249** | **58** | **0** | **0** | **188** | **3** |
+| **Total** | **249** | **57** | **0** | **0** | **189** | **3** |
 
-**Completion: 188/249 features (75%).** Phases 1, 1.5, 2, 2.5, and 6b are fully complete. Phases 3 and 6a are nearly complete. Phases 4, 5, 6c, and Perf Optimization are planned with specifications written but no implementation started.
+**Completion: 189/249 features (76%).** Phases 1, 1.5, 2, 2.5, and 6b are fully complete. Phases 3 and 6a are nearly complete. Phases 4, 5, 6c, and Perf Optimization are planned with specifications written but no implementation started.
 
 ## Status Legend
 
@@ -144,7 +144,7 @@ See [Plan Compiler Index](plan-compiler/INDEX.md) for architecture details and [
 
 ## Phase 3: Connectors & Integration
 
-> **Status**: 84/100 features complete (84%)
+> **Status**: 85/100 features complete (85%)
 
 ### Streaming API ✅
 
@@ -249,7 +249,7 @@ See [Stateful Streaming SQL Index](phase-3/stateful-sql/INDEX.md).
 | F-SSQL-003 | Ring 0 SQL Operator Routing | ✅ | [Link](phase-3/stateful-sql/F-SSQL-003-ring0-sql-routing.md) |
 | F-SSQL-004 | Streaming Physical Optimizer Rule | ✅ | [Link](phase-3/stateful-sql/F-SSQL-004-streaming-physical-optimizer.md) |
 | F-SSQL-005 | DataFusion Cooperative Scheduling | ✅ | [Link](phase-3/stateful-sql/F-SSQL-005-cooperative-scheduling.md) |
-| F-SSQL-006 | Dynamic Watermark Filter Pushdown | 📝 | [Link](phase-3/stateful-sql/F-SSQL-006-dynamic-watermark-pushdown.md) |
+| F-SSQL-006 | Dynamic Watermark Filter Pushdown | ✅ | [Link](phase-3/stateful-sql/F-SSQL-006-dynamic-watermark-pushdown.md) |
 
 ### Connector Infrastructure
 
@@ -634,13 +634,17 @@ See [Delta Index](delta/INDEX.md) for full details, dependency graph, performanc
 
 ## Active Gaps
 
-Remaining work for Phase 3:
+Remaining work for Phase 3 (15 features in Draft):
 
 | Gap | Feature | Priority | Notes |
 |-----|---------|----------|-------|
-| Delta Lake I/O | F031A | P0 | ✅ **COMPLETE** (2026-02-05) - 13 integration tests |
 | Delta Lake Advanced | F031B-D | P1 | Recovery, Compaction, Schema Evolution |
-| MySQL CDC I/O | F028A | P1 | ✅ **COMPLETE** (2026-02-06) - 21 new tests, mysql_async binlog I/O |
 | Iceberg I/O | F032A | P1 | Blocked by iceberg-datafusion 0.9.0 (needs DF 52.0 compat) |
+| Redis Lookup | F030 | P1 | Not started |
+| MongoDB CDC | F029 | P2 | Not started |
+| Parquet File Source | F033 | P2 | Not started |
+| Protobuf Decoder | F-SCHEMA-008 | P2 | Spec written |
+| Async State Access | F058 | P2 | Not started |
+| Historical Backfill | F061 | P2 | Not started |
 
 For historical gap analysis, see the [research documents](../research/).

--- a/docs/features/phase-3/stateful-sql/F-SSQL-006-dynamic-watermark-pushdown.md
+++ b/docs/features/phase-3/stateful-sql/F-SSQL-006-dynamic-watermark-pushdown.md
@@ -5,14 +5,14 @@
 | Field | Value |
 |-------|-------|
 | **ID** | F-SSQL-006 |
-| **Status** | 📝 Draft |
+| **Status** | Done |
 | **Priority** | P3 |
 | **Phase** | 3 |
 | **Effort** | M |
 | **Dependencies** | F-SSQL-005 |
-| **Owner** | TBD |
+| **Owner** | -- |
 | **Created** | 2026-02-25 |
-| **Updated** | 2026-02-25 |
+| **Updated** | 2026-02-28 |
 
 ## Summary
 

--- a/docs/features/phase-3/stateful-sql/INDEX.md
+++ b/docs/features/phase-3/stateful-sql/INDEX.md
@@ -1,7 +1,7 @@
 # Stateful Streaming SQL Feature Index
 
 > **Phase**: 3 - Connectors & Integration
-> **Status**: 📝 Draft (all specs written)
+> **Status**: Complete (all 7 features implemented)
 > **Reference**: [Gap Analysis](../../../GAP-ANALYSIS-STATEFUL-STREAMING.md)
 
 ## Overview
@@ -22,7 +22,7 @@ Gap 1 (non-EOWC aggregation state loss) has been fixed via `IncrementalAggState`
 | F-SSQL-003 | Ring 0 SQL Operator Routing | P2 | M-XL | ✅ | [Link](F-SSQL-003-ring0-sql-routing.md) |
 | F-SSQL-004 | Streaming Physical Optimizer Rule | P2 | M | ✅ | [Link](F-SSQL-004-streaming-physical-optimizer.md) |
 | F-SSQL-005 | DataFusion Cooperative Scheduling | P3 | S | ✅ | [Link](F-SSQL-005-cooperative-scheduling.md) |
-| F-SSQL-006 | Dynamic Watermark Filter Pushdown | P3 | M | 📝 | [Link](F-SSQL-006-dynamic-watermark-pushdown.md) |
+| F-SSQL-006 | Dynamic Watermark Filter Pushdown | P3 | M | ✅ | [Link](F-SSQL-006-dynamic-watermark-pushdown.md) |
 
 ---
 
@@ -93,8 +93,12 @@ Gap 1 fix (done) ──► F-SSQL-000 (Aggregation Hardening)
 |------|------|
 | `crates/laminar-db/src/stream_executor.rs` | SQL execution loop, EOWC state |
 | `crates/laminar-db/src/aggregate_state.rs` | `IncrementalAggState` (Gap 1 fix) |
+| `crates/laminar-db/src/eowc_state.rs` | EOWC incremental window accumulators |
+| `crates/laminar-db/src/core_window_state.rs` | Ring 0 SQL operator routing (tumbling/hopping/session) |
 | `crates/laminar-sql/src/datafusion/aggregate_bridge.rs` | DataFusion ↔ Ring 0 accumulator bridge |
 | `crates/laminar-sql/src/datafusion/exec.rs` | `StreamingScanExec` execution plan |
+| `crates/laminar-sql/src/planner/streaming_optimizer.rs` | `StreamingPhysicalValidator` rule |
+| `crates/laminar-sql/src/datafusion/watermark_filter.rs` | `WatermarkDynamicFilter` pushdown |
 | `crates/laminar-db/src/checkpoint_coordinator.rs` | Checkpoint coordination |
 | `crates/laminar-core/src/operator/window.rs` | Ring 0 window operators |
 


### PR DESCRIPTION
## Summary
- Sync 14 documentation files to match the current v0.16 codebase state
- Fix inconsistencies: F-SSQL-006 incorrectly marked Draft (now Done), wrong feature flag re-export docs, stale Phase 3 totals (93→100)
- Add new content: v0.16 CHANGELOG, streaming optimizer/watermark pushdown/Ring 0 routing in ARCHITECTURE, window offsets/ASOF NEAREST/introspection in SQL_REFERENCE

## Test plan
- [ ] Verify all internal doc links resolve
- [ ] Confirm feature counts are consistent across INDEX.md, ROADMAP.md, README.md
- [ ] Spot-check crate READMEs against actual module structure