### PR TITLE
feat(connectors): json.path, json.column, json.explode for JSON decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/laminar-db",
     "examples/demo",
     "examples/binance-ws",
+    "examples/microstructure",
 ]
 resolver = "2"
 

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -5,6 +5,7 @@
 //! the decoder is stateless after construction so the Ring 1 hot path
 //! has zero schema lookups.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -57,6 +58,15 @@ impl TypeMismatchStrategy {
     }
 }
 
+/// Per-column extraction strategy, pre-computed at Ring 2.
+#[derive(Debug, Clone)]
+enum ColumnExtraction {
+    /// Extract field from the default path target (json.path or root).
+    DefaultPath,
+    /// Extract field from a custom absolute path from root.
+    CustomPath { segments: Vec<String> },
+}
+
 /// JSON decoder configuration.
 #[derive(Debug, Clone)]
 pub struct JsonDecoderConfig {
@@ -75,6 +85,21 @@ pub struct JsonDecoderConfig {
     /// instead of JSON-serialized Utf8. When true, nested objects
     /// become `LargeBinary` columns with JSONB encoding.
     pub nested_as_jsonb: bool,
+
+    /// Dot-separated path to navigate before field extraction.
+    /// e.g. `"data"` → navigate into `{"data": {...}}` before extraction.
+    /// e.g. `"data.trade"` → navigate into `{"data":{"trade":{...}}}`.
+    pub json_path: Option<Vec<String>>,
+
+    /// Per-column absolute path overrides: `column_name` → path segments.
+    /// Parsed from `json.column.<name> = 'path.to.field'` options.
+    /// These paths are absolute from the root, ignoring `json_path`.
+    pub json_column_paths: HashMap<String, Vec<String>>,
+
+    /// Column names for array-to-rows expansion.
+    /// When set, the target (after `json_path`) must be an array.
+    /// Each element becomes a row; positional names map array elements to columns.
+    pub json_explode: Option<Vec<String>>,
 }
 
 impl Default for JsonDecoderConfig {
@@ -90,7 +115,48 @@ impl Default for JsonDecoderConfig {
                 "%Y-%m-%d %H:%M:%S".into(),
             ],
             nested_as_jsonb: false,
+            json_path: None,
+            json_column_paths: HashMap::new(),
+            json_explode: None,
         }
+    }
+}
+
+impl JsonDecoderConfig {
+    /// Build config from a [`ConnectorConfig`](crate::config::ConnectorConfig).
+    ///
+    /// Parses `json.path`, `json.column.*`, `json.explode`,
+    /// `schema.enforcement`, and `nested.as.jsonb` properties.
+    /// Called once at Ring 2 (`CREATE SOURCE` time).
+    #[must_use]
+    pub fn from_connector_config(config: &crate::config::ConnectorConfig) -> Self {
+        let mut cfg = Self::default();
+
+        if let Some(path) = config.get("json.path") {
+            cfg.json_path = Some(path.split('.').map(ToString::to_string).collect());
+        }
+
+        let col_props = config.properties_with_prefix("json.column.");
+        for (col_name, path_str) in col_props {
+            cfg.json_column_paths.insert(
+                col_name,
+                path_str.split('.').map(ToString::to_string).collect(),
+            );
+        }
+
+        if let Some(explode) = config.get("json.explode") {
+            cfg.json_explode = Some(explode.split(',').map(|s| s.trim().to_string()).collect());
+        }
+
+        if let Some(enforcement) = config.get("schema.enforcement") {
+            if let Some(strategy) = TypeMismatchStrategy::from_enforcement_str(enforcement) {
+                cfg.type_mismatch = strategy;
+            }
+        }
+        if let Some(v) = config.get("nested.as.jsonb") {
+            cfg.nested_as_jsonb = v.eq_ignore_ascii_case("true");
+        }
+        cfg
     }
 }
 
@@ -109,6 +175,13 @@ pub struct JsonDecoder {
     field_indices: Vec<(String, usize)>,
     /// Cumulative type mismatch count (diagnostics).
     mismatch_count: AtomicU64,
+    /// Ring 2 pre-computed: extraction strategy per schema column.
+    column_extractions: Vec<ColumnExtraction>,
+    /// Ring 2 pre-computed: explode position → schema column index.
+    /// `Some` when `json.explode` is configured; each entry maps an
+    /// explode position to the schema column index (or `None` if
+    /// the explode name doesn't match any schema column).
+    explode_col_indices: Option<Vec<Option<usize>>>,
 }
 
 #[allow(clippy::missing_fields_in_debug)]
@@ -142,11 +215,40 @@ impl JsonDecoder {
             .map(|(i, f)| (f.name().clone(), i))
             .collect();
 
+        let column_extractions: Vec<ColumnExtraction> = schema
+            .fields()
+            .iter()
+            .map(|f| {
+                let col_name = f.name();
+                if let Some(path_segments) = config.json_column_paths.get(col_name.as_str()) {
+                    ColumnExtraction::CustomPath {
+                        segments: path_segments.clone(),
+                    }
+                } else {
+                    ColumnExtraction::DefaultPath
+                }
+            })
+            .collect();
+
+        let explode_col_indices = config.json_explode.as_ref().map(|names| {
+            names
+                .iter()
+                .map(|name| {
+                    field_indices
+                        .iter()
+                        .find(|(n, _)| n == name)
+                        .map(|(_, idx)| *idx)
+                })
+                .collect()
+        });
+
         Self {
             schema,
             config,
             field_indices,
             mismatch_count: AtomicU64::new(0),
+            column_extractions,
+            explode_col_indices,
         }
     }
 
@@ -161,6 +263,7 @@ impl FormatDecoder for JsonDecoder {
         self.schema.clone()
     }
 
+    #[allow(clippy::too_many_lines)]
     fn decode_batch(&self, records: &[RawRecord]) -> SchemaResult<RecordBatch> {
         if records.is_empty() {
             return Ok(RecordBatch::new_empty(self.schema.clone()));
@@ -189,76 +292,187 @@ impl FormatDecoder for JsonDecoder {
             None
         };
 
+        // Reusable populated-tracking buffer — avoids heap alloc per record.
+        let mut populated = vec![false; num_fields];
+
         for record in records {
             let value: serde_json::Value = serde_json::from_slice(&record.value)
                 .map_err(|e| SchemaError::DecodeError(format!("JSON parse error: {e}")))?;
 
-            let obj = value.as_object().ok_or_else(|| {
-                SchemaError::DecodeError("top-level JSON value must be an object".into())
-            })?;
+            // Navigate json.path → default target (borrowed, ZERO alloc).
+            let default_target: &serde_json::Value = if let Some(ref path) = self.config.json_path {
+                let mut current = &value;
+                for segment in path {
+                    current = current.get(segment.as_str()).ok_or_else(|| {
+                        SchemaError::DecodeError(format!("json.path segment '{segment}' not found"))
+                    })?;
+                }
+                current
+            } else {
+                &value
+            };
 
-            // Track which schema fields were populated for this record.
-            let mut populated = vec![false; num_fields];
-
-            // Collect unknown fields for CollectExtra.
-            let mut extra_fields: Option<serde_json::Map<String, serde_json::Value>> =
-                if collect_extra {
-                    Some(serde_json::Map::new())
-                } else {
-                    None
-                };
-
-            for (key, val) in obj {
-                if let Some(col_idx) = self.field_index(key) {
-                    populated[col_idx] = true;
-                    let field = &self.schema.fields()[col_idx];
-                    append_value(
-                        &mut builders[col_idx],
-                        field.data_type(),
-                        val,
-                        &self.config,
-                        &self.mismatch_count,
-                        jsonb_encoder.as_mut(),
-                    )?;
-                } else {
-                    match self.config.unknown_fields {
-                        UnknownFieldStrategy::Ignore => {}
-                        UnknownFieldStrategy::CollectExtra => {
-                            if let Some(ref mut extra) = extra_fields {
-                                extra.insert(key.clone(), val.clone());
+            if let Some(ref col_indices) = self.explode_col_indices {
+                // === EXPLODE MODE ===
+                let arr = default_target.as_array().ok_or_else(|| {
+                    SchemaError::DecodeError("json.explode target must be an array".into())
+                })?;
+                for element in arr {
+                    populated.fill(false);
+                    match element {
+                        serde_json::Value::Array(items) => {
+                            for (pos, col_idx_opt) in col_indices.iter().enumerate() {
+                                if let Some(col_idx) = col_idx_opt {
+                                    let val = items.get(pos).unwrap_or(&serde_json::Value::Null);
+                                    let field = &self.schema.fields()[*col_idx];
+                                    append_value(
+                                        &mut builders[*col_idx],
+                                        field.data_type(),
+                                        val,
+                                        &self.config,
+                                        &self.mismatch_count,
+                                        jsonb_encoder.as_mut(),
+                                    )?;
+                                    populated[*col_idx] = true;
+                                }
                             }
                         }
-                        UnknownFieldStrategy::Reject => {
+                        serde_json::Value::Object(obj) => {
+                            for (col_idx, (col_name, _)) in self.field_indices.iter().enumerate() {
+                                if let Some(val) = obj.get(col_name.as_str()) {
+                                    let field = &self.schema.fields()[col_idx];
+                                    append_value(
+                                        &mut builders[col_idx],
+                                        field.data_type(),
+                                        val,
+                                        &self.config,
+                                        &self.mismatch_count,
+                                        jsonb_encoder.as_mut(),
+                                    )?;
+                                    populated[col_idx] = true;
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(SchemaError::DecodeError(
+                                "json.explode array elements must be arrays or objects".into(),
+                            ));
+                        }
+                    }
+                    // Append nulls for missing fields.
+                    for (col_idx, was_populated) in populated.iter().enumerate() {
+                        if !was_populated {
+                            append_null(&mut builders[col_idx]);
+                        }
+                    }
+                    // _extra column: append null for each exploded row.
+                    if let Some(ref mut eb) = extra_builder {
+                        eb.append_null();
+                    }
+                }
+            } else {
+                // === NORMAL OBJECT MODE (with per-column path support) ===
+                let default_obj = default_target.as_object().ok_or_else(|| {
+                    SchemaError::DecodeError("JSON value must be an object".into())
+                })?;
+
+                populated.fill(false);
+
+                // Collect unknown fields for CollectExtra.
+                let mut extra_fields: Option<serde_json::Map<String, serde_json::Value>> =
+                    if collect_extra {
+                        Some(serde_json::Map::new())
+                    } else {
+                        None
+                    };
+
+                // Per-column extraction using pre-computed ColumnExtraction.
+                for (col_idx, (col_name, _)) in self.field_indices.iter().enumerate() {
+                    match &self.column_extractions[col_idx] {
+                        ColumnExtraction::DefaultPath => {
+                            if let Some(val) = default_obj.get(col_name.as_str()) {
+                                populated[col_idx] = true;
+                                let field = &self.schema.fields()[col_idx];
+                                append_value(
+                                    &mut builders[col_idx],
+                                    field.data_type(),
+                                    val,
+                                    &self.config,
+                                    &self.mismatch_count,
+                                    jsonb_encoder.as_mut(),
+                                )?;
+                            }
+                        }
+                        ColumnExtraction::CustomPath { segments } => {
+                            // Navigate custom path from root (ZERO alloc).
+                            let extracted = navigate_path(&value, segments);
+                            if let Some(val) = extracted {
+                                populated[col_idx] = true;
+                                let field = &self.schema.fields()[col_idx];
+                                append_value(
+                                    &mut builders[col_idx],
+                                    field.data_type(),
+                                    val,
+                                    &self.config,
+                                    &self.mismatch_count,
+                                    jsonb_encoder.as_mut(),
+                                )?;
+                            }
+                        }
+                    }
+                }
+
+                // Collect unknown fields (fields in default_obj not in schema).
+                if collect_extra {
+                    for (key, val) in default_obj {
+                        if self.field_index(key).is_none() {
+                            match self.config.unknown_fields {
+                                UnknownFieldStrategy::CollectExtra => {
+                                    if let Some(ref mut extra) = extra_fields {
+                                        extra.insert(key.clone(), val.clone());
+                                    }
+                                }
+                                UnknownFieldStrategy::Reject => {
+                                    return Err(SchemaError::DecodeError(format!(
+                                        "unknown field '{key}' not in schema"
+                                    )));
+                                }
+                                UnknownFieldStrategy::Ignore => {}
+                            }
+                        }
+                    }
+                } else if matches!(self.config.unknown_fields, UnknownFieldStrategy::Reject) {
+                    for key in default_obj.keys() {
+                        if self.field_index(key).is_none() {
                             return Err(SchemaError::DecodeError(format!(
                                 "unknown field '{key}' not in schema"
                             )));
                         }
                     }
                 }
-            }
 
-            // Append nulls for missing fields.
-            for (col_idx, was_populated) in populated.iter().enumerate() {
-                if !was_populated {
-                    append_null(&mut builders[col_idx]);
-                }
-            }
-
-            // Append _extra column.
-            if let Some(ref mut eb) = extra_builder {
-                if let Some(ref extra) = extra_fields {
-                    if extra.is_empty() {
-                        eb.append_null();
-                    } else {
-                        let mut enc = jsonb_encoder.as_mut().map_or_else(JsonbEncoder::new, |_| {
-                            // Borrow-safe: take a fresh encoder for extra.
-                            JsonbEncoder::new()
-                        });
-                        let bytes = enc.encode(&serde_json::Value::Object(extra.clone()));
-                        eb.append_value(&bytes);
+                // Append nulls for missing fields.
+                for (col_idx, was_populated) in populated.iter().enumerate() {
+                    if !was_populated {
+                        append_null(&mut builders[col_idx]);
                     }
-                } else {
-                    eb.append_null();
+                }
+
+                // Append _extra column.
+                if let Some(ref mut eb) = extra_builder {
+                    if let Some(ref extra) = extra_fields {
+                        if extra.is_empty() {
+                            eb.append_null();
+                        } else {
+                            let mut enc = jsonb_encoder
+                                .as_mut()
+                                .map_or_else(JsonbEncoder::new, |_| JsonbEncoder::new());
+                            let bytes = enc.encode(&serde_json::Value::Object(extra.clone()));
+                            eb.append_value(&bytes);
+                        }
+                    } else {
+                        eb.append_null();
+                    }
                 }
             }
         }
@@ -299,6 +513,19 @@ impl JsonDecoder {
             .find(|(n, _)| n == name)
             .map(|(_, idx)| *idx)
     }
+}
+
+/// Navigate a dot-path through a JSON value tree. Returns `None` if any
+/// segment is missing. Zero allocations — pure pointer-chasing.
+fn navigate_path<'a>(
+    root: &'a serde_json::Value,
+    segments: &[String],
+) -> Option<&'a serde_json::Value> {
+    let mut current = root;
+    for segment in segments {
+        current = current.get(segment.as_str())?;
+    }
+    Some(current)
 }
 
 // ── Builder helpers ────────────────────────────────────────────────
@@ -1433,5 +1660,277 @@ mod tests {
                 .value(0),
             200
         );
+    }
+
+    // ── json.path tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_json_path_single() {
+        let schema = make_schema(vec![("id", DataType::Int64, false)]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["data".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"data":{"id":1}}"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            1
+        );
+    }
+
+    #[test]
+    fn test_json_path_multi() {
+        let schema = make_schema(vec![("id", DataType::Int64, false)]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["a".into(), "b".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"a":{"b":{"id":1}}}"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            1
+        );
+    }
+
+    #[test]
+    fn test_json_path_missing_errors() {
+        let schema = make_schema(vec![("id", DataType::Int64, false)]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["nonexistent".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"data":{"id":1}}"#)];
+        let result = decoder.decode_batch(&records);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    // ── json.column.* tests ─────────────────────────────────────
+
+    #[test]
+    fn test_json_column_custom_path() {
+        let schema = make_schema(vec![
+            ("p", DataType::Float64, false),
+            ("stream_name", DataType::Utf8, true),
+        ]);
+        let mut col_paths = HashMap::new();
+        col_paths.insert("stream_name".into(), vec!["stream".into()]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["data".into()]),
+            json_column_paths: col_paths,
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(
+            r#"{"stream":"btcusdt@trade","data":{"p":67523.0}}"#,
+        )];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let price = batch
+            .column(0)
+            .as_primitive::<arrow_array::types::Float64Type>()
+            .value(0);
+        assert!((price - 67523.0).abs() < f64::EPSILON);
+        assert_eq!(batch.column(1).as_string::<i32>().value(0), "btcusdt@trade");
+    }
+
+    #[test]
+    fn test_json_column_deep_path() {
+        let schema = make_schema(vec![
+            ("p", DataType::Float64, false),
+            ("ts", DataType::Int64, true),
+        ]);
+        let mut col_paths = HashMap::new();
+        col_paths.insert("ts".into(), vec!["meta".into(), "timestamp".into()]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["data".into()]),
+            json_column_paths: col_paths,
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(
+            r#"{"meta":{"timestamp":123456},"data":{"p":99.5}}"#,
+        )];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(
+            batch
+                .column(1)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            123456
+        );
+    }
+
+    #[test]
+    fn test_json_column_missing_returns_null() {
+        let schema = make_schema(vec![
+            ("id", DataType::Int64, false),
+            ("missing_col", DataType::Utf8, true),
+        ]);
+        let mut col_paths = HashMap::new();
+        col_paths.insert("missing_col".into(), vec!["nowhere".into(), "gone".into()]);
+        let config = JsonDecoderConfig {
+            json_column_paths: col_paths,
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"id":42}"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            42
+        );
+        assert!(batch.column(1).is_null(0));
+    }
+
+    // ── json.explode tests ──────────────────────────────────────
+
+    #[test]
+    fn test_json_explode_arrays() {
+        let schema = make_schema(vec![
+            ("price", DataType::Utf8, true),
+            ("qty", DataType::Utf8, true),
+        ]);
+        let config = JsonDecoderConfig {
+            json_explode: Some(vec!["price".into(), "qty".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"[["67523","1.5"],["67522","0.8"]]"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.column(0).as_string::<i32>().value(0), "67523");
+        assert_eq!(batch.column(0).as_string::<i32>().value(1), "67522");
+        assert_eq!(batch.column(1).as_string::<i32>().value(0), "1.5");
+        assert_eq!(batch.column(1).as_string::<i32>().value(1), "0.8");
+    }
+
+    #[test]
+    fn test_json_explode_objects() {
+        let schema = make_schema(vec![
+            ("id", DataType::Int64, true),
+            ("name", DataType::Utf8, true),
+        ]);
+        let config = JsonDecoderConfig {
+            json_explode: Some(vec!["id".into(), "name".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(
+            r#"[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]"#,
+        )];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            1
+        );
+        assert_eq!(batch.column(1).as_string::<i32>().value(1), "Bob");
+    }
+
+    // ── Combined json.path + json.explode ───────────────────────
+
+    #[test]
+    fn test_json_path_plus_explode() {
+        let schema = make_schema(vec![
+            ("price", DataType::Utf8, true),
+            ("qty", DataType::Utf8, true),
+        ]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["bids".into()]),
+            json_explode: Some(vec!["price".into(), "qty".into()]),
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"bids":[["67523","1.5"],["67522","0.8"]]}"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.column(0).as_string::<i32>().value(0), "67523");
+        assert_eq!(batch.column(1).as_string::<i32>().value(1), "0.8");
+    }
+
+    // ── from_connector_config tests ─────────────────────────────
+
+    #[test]
+    fn test_from_connector_config() {
+        let mut config = crate::config::ConnectorConfig::new("websocket");
+        config.set("json.path", "data.trade");
+        config.set("json.column.stream_name", "stream");
+        config.set("json.column.ts", "meta.timestamp");
+        config.set("json.explode", "price, qty");
+        config.set("schema.enforcement", "strict");
+        config.set("nested.as.jsonb", "true");
+
+        let cfg = JsonDecoderConfig::from_connector_config(&config);
+        assert_eq!(cfg.json_path, Some(vec!["data".into(), "trade".into()]));
+        assert_eq!(
+            cfg.json_column_paths.get("stream_name"),
+            Some(&vec!["stream".into()])
+        );
+        assert_eq!(
+            cfg.json_column_paths.get("ts"),
+            Some(&vec!["meta".into(), "timestamp".into()])
+        );
+        assert_eq!(cfg.json_explode, Some(vec!["price".into(), "qty".into()]));
+        assert_eq!(cfg.type_mismatch, TypeMismatchStrategy::Reject);
+        assert!(cfg.nested_as_jsonb);
+    }
+
+    #[test]
+    fn test_default_config_unchanged() {
+        let schema = make_schema(vec![
+            ("a", DataType::Int64, false),
+            ("b", DataType::Utf8, true),
+        ]);
+        let decoder = JsonDecoder::new(schema);
+        let records = vec![
+            json_record(r#"{"a": 1, "b": "hello"}"#),
+            json_record(r#"{"a": 2, "b": "world"}"#),
+        ];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            1
+        );
+        assert_eq!(batch.column(1).as_string::<i32>().value(1), "world");
+    }
+
+    #[test]
+    fn test_unknown_fields_with_path() {
+        let schema = make_schema(vec![("a", DataType::Int64, false)]);
+        let config = JsonDecoderConfig {
+            json_path: Some(vec!["data".into()]),
+            unknown_fields: UnknownFieldStrategy::CollectExtra,
+            ..Default::default()
+        };
+        let decoder = JsonDecoder::with_config(schema, config);
+        let records = vec![json_record(r#"{"data":{"a":1,"extra":"value"}}"#)];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_columns(), 2); // a + _extra
+        assert_eq!(batch.schema().field(1).name(), "_extra");
+        assert!(!batch.column(1).is_null(0));
     }
 }

--- a/crates/laminar-connectors/src/websocket/parser.rs
+++ b/crates/laminar-connectors/src/websocket/parser.rs
@@ -10,7 +10,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 
 use crate::error::ConnectorError;
-use crate::schema::json::decoder::JsonDecoder;
+use crate::schema::json::decoder::{JsonDecoder, JsonDecoderConfig};
 use crate::schema::traits::FormatDecoder;
 use crate::schema::types::RawRecord;
 
@@ -27,12 +27,16 @@ pub struct MessageParser {
 }
 
 impl MessageParser {
-    /// Creates a new parser for the given schema and format.
+    /// Creates a new parser for the given schema, format, and JSON decoder config.
     #[must_use]
-    pub fn new(schema: SchemaRef, format: MessageFormat) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        format: MessageFormat,
+        decoder_config: JsonDecoderConfig,
+    ) -> Self {
         let json_decoder = match &format {
             MessageFormat::Json | MessageFormat::JsonLines => {
-                Some(JsonDecoder::new(schema.clone()))
+                Some(JsonDecoder::with_config(schema.clone(), decoder_config))
             }
             _ => None,
         };
@@ -161,13 +165,27 @@ impl MessageParser {
 
 /// Creates a default schema for JSON messages when no explicit schema is provided.
 ///
-/// Uses schema inference from the first message.
+/// Uses schema inference from the first message. If `json_path` is provided,
+/// navigates into the object before inferring fields.
 ///
 /// # Errors
 ///
 /// Returns `ConnectorError::Serde` if the sample is not valid UTF-8 or valid JSON,
 /// or if the top-level value is not a JSON object.
 pub fn infer_schema_from_json(sample: &[u8]) -> Result<SchemaRef, ConnectorError> {
+    infer_schema_from_json_with_path(sample, None)
+}
+
+/// Like [`infer_schema_from_json`] but navigates a `json.path` first.
+///
+/// # Errors
+///
+/// Returns `ConnectorError::Serde` if the sample is not valid UTF-8 or valid JSON,
+/// if a path segment is not found, or if the target is not a JSON object.
+pub fn infer_schema_from_json_with_path(
+    sample: &[u8],
+    json_path: Option<&[String]>,
+) -> Result<SchemaRef, ConnectorError> {
     let text = std::str::from_utf8(sample).map_err(|e| {
         ConnectorError::Serde(crate::error::SerdeError::MalformedInput(format!(
             "invalid UTF-8: {e}"
@@ -177,7 +195,21 @@ pub fn infer_schema_from_json(sample: &[u8]) -> Result<SchemaRef, ConnectorError
     let value: serde_json::Value = serde_json::from_str(text)
         .map_err(|e| ConnectorError::Serde(crate::error::SerdeError::Json(e.to_string())))?;
 
-    let obj = value.as_object().ok_or_else(|| {
+    let target = if let Some(path) = json_path {
+        let mut current = &value;
+        for segment in path {
+            current = current.get(segment.as_str()).ok_or_else(|| {
+                ConnectorError::Serde(crate::error::SerdeError::MalformedInput(format!(
+                    "json.path segment '{segment}' not found during inference"
+                )))
+            })?;
+        }
+        current
+    } else {
+        &value
+    };
+
+    let obj = target.as_object().ok_or_else(|| {
         ConnectorError::Serde(crate::error::SerdeError::MalformedInput(
             "schema inference requires a JSON object".into(),
         ))
@@ -217,7 +249,11 @@ mod tests {
 
     #[test]
     fn test_parse_json_batch() {
-        let parser = MessageParser::new(json_schema(), MessageFormat::Json);
+        let parser = MessageParser::new(
+            json_schema(),
+            MessageFormat::Json,
+            JsonDecoderConfig::default(),
+        );
         let messages: Vec<&[u8]> = vec![
             br#"{"id": "1", "value": "hello"}"#,
             br#"{"id": "2", "value": "world"}"#,
@@ -230,7 +266,11 @@ mod tests {
 
     #[test]
     fn test_parse_json_missing_field() {
-        let parser = MessageParser::new(json_schema(), MessageFormat::Json);
+        let parser = MessageParser::new(
+            json_schema(),
+            MessageFormat::Json,
+            JsonDecoderConfig::default(),
+        );
         let messages: Vec<&[u8]> = vec![br#"{"id": "1"}"#];
 
         let batch = parser.parse_batch(&messages).unwrap();
@@ -240,7 +280,11 @@ mod tests {
 
     #[test]
     fn test_parse_json_numeric_values() {
-        let parser = MessageParser::new(json_schema(), MessageFormat::Json);
+        let parser = MessageParser::new(
+            json_schema(),
+            MessageFormat::Json,
+            JsonDecoderConfig::default(),
+        );
         let messages: Vec<&[u8]> = vec![br#"{"id": "1", "value": 42}"#];
 
         let batch = parser.parse_batch(&messages).unwrap();
@@ -254,7 +298,8 @@ mod tests {
             DataType::Binary,
             false,
         )]));
-        let parser = MessageParser::new(schema, MessageFormat::Binary);
+        let parser =
+            MessageParser::new(schema, MessageFormat::Binary, JsonDecoderConfig::default());
         let messages: Vec<&[u8]> = vec![b"hello", b"world"];
 
         let batch = parser.parse_batch(&messages).unwrap();
@@ -269,6 +314,7 @@ mod tests {
                 delimiter: ',',
                 has_header: false,
             },
+            JsonDecoderConfig::default(),
         );
         let messages: Vec<&[u8]> = vec![b"1,hello", b"2,world"];
 
@@ -278,7 +324,11 @@ mod tests {
 
     #[test]
     fn test_parse_empty() {
-        let parser = MessageParser::new(json_schema(), MessageFormat::Json);
+        let parser = MessageParser::new(
+            json_schema(),
+            MessageFormat::Json,
+            JsonDecoderConfig::default(),
+        );
         let messages: Vec<&[u8]> = vec![];
 
         let batch = parser.parse_batch(&messages).unwrap();
@@ -287,7 +337,11 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_json() {
-        let parser = MessageParser::new(json_schema(), MessageFormat::Json);
+        let parser = MessageParser::new(
+            json_schema(),
+            MessageFormat::Json,
+            JsonDecoderConfig::default(),
+        );
         let messages: Vec<&[u8]> = vec![b"not json"];
 
         assert!(parser.parse_batch(&messages).is_err());
@@ -300,7 +354,7 @@ mod tests {
             Field::new("price", DataType::Float64, false),
             Field::new("name", DataType::Utf8, true),
         ]));
-        let parser = MessageParser::new(schema, MessageFormat::Json);
+        let parser = MessageParser::new(schema, MessageFormat::Json, JsonDecoderConfig::default());
         let messages: Vec<&[u8]> = vec![
             br#"{"id": 1, "price": 99.5, "name": "Widget"}"#,
             br#"{"id": 2, "price": 10.0, "name": "Gadget"}"#,
@@ -330,7 +384,7 @@ mod tests {
             DataType::Float64,
             false,
         )]));
-        let parser = MessageParser::new(schema, MessageFormat::Json);
+        let parser = MessageParser::new(schema, MessageFormat::Json, JsonDecoderConfig::default());
         let messages: Vec<&[u8]> = vec![br#"{"price": "187.52"}"#];
 
         let batch = parser.parse_batch(&messages).unwrap();

--- a/crates/laminar-connectors/src/websocket/source.rs
+++ b/crates/laminar-connectors/src/websocket/source.rs
@@ -24,6 +24,8 @@ use crate::error::ConnectorError;
 use crate::health::HealthStatus;
 use crate::metrics::ConnectorMetrics;
 
+use crate::schema::json::decoder::JsonDecoderConfig;
+
 use super::backpressure::BackpressureStrategy;
 use super::checkpoint::WebSocketSourceCheckpoint;
 use super::connection::ConnectionManager;
@@ -84,7 +86,11 @@ impl WebSocketSource {
     /// * `config` - WebSocket source configuration.
     #[must_use]
     pub fn new(schema: SchemaRef, config: WebSocketSourceConfig) -> Self {
-        let parser = MessageParser::new(schema.clone(), config.format.clone());
+        let parser = MessageParser::new(
+            schema.clone(),
+            config.format.clone(),
+            JsonDecoderConfig::default(),
+        );
 
         Self {
             config,
@@ -303,7 +309,12 @@ impl SourceConnector for WebSocketSource {
                 "using SQL-defined schema for deserialization"
             );
             self.schema = schema;
-            self.parser = MessageParser::new(self.schema.clone(), self.config.format.clone());
+            let decoder_config = JsonDecoderConfig::from_connector_config(config);
+            self.parser = MessageParser::new(
+                self.schema.clone(),
+                self.config.format.clone(),
+                decoder_config,
+            );
         }
 
         let mode = &self.config.mode;

--- a/crates/laminar-connectors/src/websocket/source_server.rs
+++ b/crates/laminar-connectors/src/websocket/source_server.rs
@@ -21,6 +21,8 @@ use crate::error::ConnectorError;
 use crate::health::HealthStatus;
 use crate::metrics::ConnectorMetrics;
 
+use crate::schema::json::decoder::JsonDecoderConfig;
+
 use super::checkpoint::WebSocketSourceCheckpoint;
 use super::metrics::WebSocketSourceMetrics;
 use super::parser::MessageParser;
@@ -64,7 +66,11 @@ impl WebSocketSourceServer {
     /// Creates a new WebSocket source connector in server mode.
     #[must_use]
     pub fn new(schema: SchemaRef, config: WebSocketSourceConfig) -> Self {
-        let parser = MessageParser::new(schema.clone(), config.format.clone());
+        let parser = MessageParser::new(
+            schema.clone(),
+            config.format.clone(),
+            JsonDecoderConfig::default(),
+        );
 
         Self {
             config,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -2677,12 +2677,17 @@ impl LaminarDB {
         laminar_sql::register_streaming_functions(&ctx);
         let mut executor = StreamExecutor::new(ctx);
 
-        // Register source schemas so the executor can create empty placeholder
-        // tables for sources that have no data in a given cycle (prevents
-        // DataFusion "table not found" errors when only some sources have data).
-        for name in self.catalog.list_sources() {
-            if let Some(entry) = self.catalog.get_source(&name) {
-                executor.register_source_schema(name, entry.schema.clone());
+        // Register source schemas for sources that have connectors so the
+        // executor can create empty placeholder tables when no data arrives in
+        // a given cycle.  Connector-less sources (created without a FROM clause)
+        // are intentionally skipped — they receive data via push_arrow() and
+        // registering them would create broken zero-row MemTables every cycle.
+        for (name, reg) in &source_regs {
+            if reg.connector_type.is_none() {
+                continue;
+            }
+            if let Some(entry) = self.catalog.get_source(name) {
+                executor.register_source_schema(name.clone(), entry.schema.clone());
             }
         }
 
@@ -7611,5 +7616,74 @@ mod tests {
             }
             _ => panic!("Expected Metadata result"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_connectorless_source_does_not_break_pipeline() {
+        let db = LaminarDB::open().unwrap();
+
+        // Connector-less source (no FROM clause) — formerly caused
+        // LDB-1002 "No partitions provided" on every pipeline cycle.
+        db.execute("CREATE SOURCE metadata (symbol VARCHAR, category VARCHAR)")
+            .await
+            .unwrap();
+
+        // A real source with a watermark that the pipeline will process.
+        db.execute(
+            "CREATE SOURCE trades (id BIGINT, price DOUBLE, ts BIGINT, \
+             WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+        )
+        .await
+        .unwrap();
+
+        db.execute("CREATE STREAM out AS SELECT id, price FROM trades")
+            .await
+            .unwrap();
+
+        db.start().await.unwrap();
+
+        // Push data into the real source.
+        let handle = db.source_untyped("trades").unwrap();
+        let schema = handle.schema().clone();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![1, 2])),
+                Arc::new(arrow::array::Float64Array::from(vec![100.0, 200.0])),
+                Arc::new(arrow::array::Int64Array::from(vec![1000, 2000])),
+            ],
+        )
+        .unwrap();
+        handle.push_arrow(batch).unwrap();
+
+        // Let the pipeline run a few cycles.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // Verify the pipeline processed data without errors.
+        let m = db.metrics();
+        assert!(m.total_events_ingested > 0, "pipeline should ingest events");
+
+        // Push data into the connector-less source via push_arrow — should
+        // work without causing pipeline errors.
+        let meta_handle = db.source_untyped("metadata").unwrap();
+        let meta_schema = meta_handle.schema().clone();
+        let meta_batch = RecordBatch::try_new(
+            meta_schema,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["BTC", "ETH"])),
+                Arc::new(arrow::array::StringArray::from(vec!["L1", "L1"])),
+            ],
+        )
+        .unwrap();
+        meta_handle.push_arrow(meta_batch).unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // Pipeline should still be healthy.
+        let m2 = db.metrics();
+        assert!(
+            m2.total_events_ingested >= m.total_events_ingested,
+            "pipeline should continue after connector-less source push"
+        );
     }
 }

--- a/crates/laminar-db/src/stream_executor.rs
+++ b/crates/laminar-db/src/stream_executor.rs
@@ -539,7 +539,7 @@ impl StreamExecutor {
             if source_batches.contains_key(name) {
                 continue;
             }
-            let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![])
+            let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]])
                 .map_err(|e| DbError::query_pipeline(name, &e))?;
             let _ = self.ctx.deregister_table(name);
             self.ctx

--- a/crates/laminar-sql/src/parser/source_parser.rs
+++ b/crates/laminar-sql/src/parser/source_parser.rs
@@ -264,7 +264,7 @@ fn parse_from_connector(
             if parser.consume_token(&Token::RParen) {
                 break;
             }
-            let key = parse_connector_option_string(parser)?;
+            let key = parse_connector_option_key(parser)?;
             parser
                 .expect_token(&Token::Eq)
                 .map_err(ParseError::SqlParseError)?;
@@ -309,6 +309,19 @@ fn parse_format_clause(parser: &mut Parser) -> Result<Option<FormatSpec>, ParseE
         format_type,
         options,
     }))
+}
+
+/// Parse a connector option key, which may be a dotted identifier
+/// (e.g., `json.path`, `json.column.stream_name`, `auth.type`).
+fn parse_connector_option_key(parser: &mut Parser) -> Result<String, ParseError> {
+    let first = parse_connector_option_string(parser)?;
+    let mut key = first;
+    while parser.consume_token(&Token::Period) {
+        let next = parse_connector_option_string(parser)?;
+        key.push('.');
+        key.push_str(&next);
+    }
+    Ok(key)
 }
 
 /// Parse a single option key or value string in connector options.
@@ -756,5 +769,52 @@ mod tests {
         let source = parse("CREATE SOURCE events (id BIGINT, name VARCHAR)");
         assert!(!source.has_wildcard);
         assert!(source.wildcard_prefix.is_none());
+    }
+
+    // ── Dotted option key tests ────────────────────────────
+
+    #[test]
+    fn test_dotted_option_keys_unquoted() {
+        let source = parse(
+            "CREATE SOURCE trades (
+                s VARCHAR, p DOUBLE
+            ) FROM WEBSOCKET (
+                url = 'wss://example.com/ws',
+                format = 'json',
+                json.path = 'data',
+                json.explode = 'price,qty'
+            )",
+        );
+        assert_eq!(source.connector_type, Some("WEBSOCKET".to_string()));
+        assert_eq!(
+            source.connector_options.get("json.path"),
+            Some(&"data".to_string())
+        );
+        assert_eq!(
+            source.connector_options.get("json.explode"),
+            Some(&"price,qty".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deep_dotted_option_keys() {
+        let source = parse(
+            "CREATE SOURCE events FROM WEBSOCKET (
+                url = 'wss://example.com',
+                json.column.stream_name = 'stream',
+                json.column.ts = 'meta.timestamp'
+            ) SCHEMA (
+                stream_name VARCHAR,
+                ts BIGINT
+            )",
+        );
+        assert_eq!(
+            source.connector_options.get("json.column.stream_name"),
+            Some(&"stream".to_string())
+        );
+        assert_eq!(
+            source.connector_options.get("json.column.ts"),
+            Some(&"meta.timestamp".to_string())
+        );
     }
 }

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "microstructure"
+version = "0.16.0"
+edition = "2021"
+publish = false
+description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
+
+[[bin]]
+name = "microstructure"
+path = "src/main.rs"
+
+[dependencies]
+laminar-db = { path = "../../crates/laminar-db", version = "0.16.0", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.16.0" }
+arrow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+crossterm = "0.29"
+ratatui = "0.30"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"

--- a/examples/microstructure/pipeline.sql
+++ b/examples/microstructure/pipeline.sql
@@ -1,0 +1,128 @@
+-- LaminarDB Market Microstructure Intelligence
+-- 4 sources, 8 SQL stages, 3 window types, sub-us latency.
+--
+-- Demonstrates:
+--   json.path    = envelope unwrapping (combined WebSocket streams)
+--   json.explode = array-to-rows (orderbook depth levels)
+--
+-- Combined streams reduce 12 WebSocket connections to 2.
+-- Depth adds 2 more for BTC orderbook = 4 total connections.
+--
+-- Cross-path selection example (not used here but supported):
+--   json.column.stream_name = 'stream'
+-- would extract the envelope's "stream" field into a column while
+-- json.path navigates into "data" for the remaining columns.
+
+-- ── Layer 0: Combined Trade Source ───────────────────────────────
+-- One WebSocket carries all 6 symbols via Binance combined stream.
+-- json.path = 'data' unwraps {"stream":"...","data":{trade fields}}.
+
+CREATE SOURCE all_trades (
+    s VARCHAR, p DOUBLE, q DOUBLE, "T" BIGINT, m BOOLEAN,
+    WATERMARK FOR "T" AS "T" - INTERVAL '0' SECOND
+) FROM WEBSOCKET (
+    url = 'wss://stream.binance.com:9443/stream?streams=btcusdt@trade/ethusdt@trade/solusdt@trade/dogeusdt@trade/xrpusdt@trade/bnbusdt@trade',
+    format = 'json',
+    json.path = 'data'
+);
+
+-- ── Layer 0: Combined Book Ticker Source ─────────────────────────
+
+CREATE SOURCE all_books (
+    s VARCHAR, b DOUBLE, "B" DOUBLE, a DOUBLE, "A" DOUBLE, u BIGINT
+) FROM WEBSOCKET (
+    url = 'wss://stream.binance.com:9443/stream?streams=btcusdt@bookTicker/ethusdt@bookTicker/solusdt@bookTicker/dogeusdt@bookTicker/xrpusdt@bookTicker/bnbusdt@bookTicker',
+    format = 'json',
+    json.path = 'data'
+);
+
+-- ── Layer 0: BTC Depth (orderbook) ──────────────────────────────
+-- json.path navigates to the "bids"/"asks" array.
+-- json.explode maps positional elements: [[price, qty], ...] → rows.
+-- String values are coerced to DOUBLE by the default Coerce strategy.
+
+CREATE SOURCE btc_depth_bids (
+    price DOUBLE, qty DOUBLE
+) FROM WEBSOCKET (
+    url = 'wss://stream.binance.com:9443/ws/btcusdt@depth20',
+    format = 'json',
+    json.path = 'bids',
+    json.explode = 'price,qty'
+);
+
+CREATE SOURCE btc_depth_asks (
+    price DOUBLE, qty DOUBLE
+) FROM WEBSOCKET (
+    url = 'wss://stream.binance.com:9443/ws/btcusdt@depth20',
+    format = 'json',
+    json.path = 'asks',
+    json.explode = 'price,qty'
+);
+
+-- ── Layer 0b: Depth Passthrough ───────────────────────────────
+-- Passthrough streams so the TUI can subscribe to depth data.
+
+CREATE STREAM depth_bids AS SELECT price, qty FROM btc_depth_bids;
+CREATE STREAM depth_asks AS SELECT price, qty FROM btc_depth_asks;
+
+-- ── Layer 1: Spread Monitor (unified) ───────────────────────────
+
+CREATE STREAM spreads AS
+SELECT s AS symbol,
+       a - b AS spread,
+       (a - b) / ((a + b) / 2.0) * 10000.0 AS spread_bps,
+       b AS bid_price, a AS ask_price,
+       "B" AS bid_qty, "A" AS ask_qty,
+       "B" / ("B" + "A") AS bid_pressure
+FROM all_books;
+
+-- ── Layer 2: VWAP + OHLC (unified, tumbling 10s) ───────────────
+-- GROUP BY s naturally partitions windows per symbol.
+
+CREATE STREAM vwap AS
+SELECT s AS symbol, SUM(p * q) / SUM(q) AS vwap, AVG(p) AS avg_price,
+       MIN(p) AS low, MAX(p) AS high, SUM(q) AS volume, COUNT(*) AS trades,
+       (MAX(p) - MIN(p)) / AVG(p) * 10000.0 AS volatility_bps,
+       SUM(CASE WHEN m THEN q ELSE 0.0 END) / SUM(q) AS maker_ratio
+FROM all_trades GROUP BY s, TUMBLE("T", INTERVAL '10' SECOND) EMIT ON WINDOW CLOSE;
+
+-- ── Layer 2b: Micro-OHLC (unified, tumbling 5s) ────────────────
+
+CREATE STREAM micro AS
+SELECT s AS symbol,
+       COUNT(*) AS ticks,
+       SUM(p * q) / SUM(q) AS vwap,
+       MIN(p) AS low, MAX(p) AS high,
+       SUM(q) AS volume,
+       SUM(CASE WHEN NOT m THEN q ELSE 0.0 END) AS buy_vol,
+       SUM(CASE WHEN m THEN q ELSE 0.0 END) AS sell_vol
+FROM all_trades GROUP BY s, TUMBLE("T", INTERVAL '5' SECOND) EMIT ON WINDOW CLOSE;
+
+-- ── Layer 3: Rolling Momentum (unified, hopping 5s/30s) ────────
+
+CREATE STREAM momentum AS
+SELECT s AS symbol,
+       AVG(p) AS avg_30s,
+       MIN(p) AS low_30s, MAX(p) AS high_30s,
+       SUM(q) AS vol_30s, COUNT(*) AS trades_30s,
+       (MAX(p) - MIN(p)) / AVG(p) * 10000.0 AS range_bps_30s
+FROM all_trades GROUP BY s, HOP("T", INTERVAL '5' SECOND, INTERVAL '30' SECOND) EMIT ON WINDOW CLOSE;
+
+-- ── Layer 4: Activity Bursts (unified, session 2s gap) ─────────
+
+CREATE STREAM bursts AS
+SELECT s AS symbol,
+       COUNT(*) AS burst_trades,
+       SUM(q) AS burst_volume,
+       (MAX(p) - MIN(p)) / AVG(p) * 10000.0 AS burst_range_bps,
+       SUM(CASE WHEN m THEN q ELSE 0.0 END) / SUM(q) AS maker_ratio
+FROM all_trades GROUP BY s, SESSION("T", INTERVAL '2' SECOND) EMIT ON WINDOW CLOSE;
+
+-- ── Layer 5: Trade Signals (unified, derived from VWAP) ────────
+
+CREATE STREAM signals AS
+SELECT symbol, vwap, avg_price, volume, trades, volatility_bps, maker_ratio,
+       CASE WHEN avg_price > vwap * 1.001 THEN 'SELL'
+            WHEN avg_price < vwap * 0.999 THEN 'BUY'
+            ELSE 'HOLD' END AS signal
+FROM vwap;

--- a/examples/microstructure/src/history.rs
+++ b/examples/microstructure/src/history.rs
@@ -1,0 +1,30 @@
+use std::collections::VecDeque;
+
+pub struct RingBuf<T> {
+    data: VecDeque<T>,
+    capacity: usize,
+}
+
+impl<T> RingBuf<T> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            data: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        if self.data.len() >= self.capacity {
+            self.data.pop_front();
+        }
+        self.data.push_back(value);
+    }
+
+    pub fn as_slice(&self) -> &VecDeque<T> {
+        &self.data
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+}

--- a/examples/microstructure/src/latency.rs
+++ b/examples/microstructure/src/latency.rs
@@ -1,0 +1,52 @@
+use std::collections::VecDeque;
+
+pub struct LatencyTracker {
+    samples: VecDeque<u64>,
+    capacity: usize,
+    max: u64,
+}
+
+impl LatencyTracker {
+    pub fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(1000),
+            capacity: 1000,
+            max: 0,
+        }
+    }
+
+    pub fn record(&mut self, ns: u64) {
+        if ns == 0 {
+            return;
+        }
+        if self.samples.len() >= self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(ns);
+        if ns > self.max {
+            self.max = ns;
+        }
+    }
+
+    pub fn p50(&self) -> u64 {
+        self.percentile(50)
+    }
+
+    pub fn p99(&self) -> u64 {
+        self.percentile(99)
+    }
+
+    pub fn max(&self) -> u64 {
+        self.max
+    }
+
+    fn percentile(&self, pct: usize) -> u64 {
+        if self.samples.is_empty() {
+            return 0;
+        }
+        let mut sorted: Vec<u64> = self.samples.iter().copied().collect();
+        sorted.sort_unstable();
+        let idx = (pct * sorted.len() / 100).min(sorted.len() - 1);
+        sorted[idx]
+    }
+}

--- a/examples/microstructure/src/main.rs
+++ b/examples/microstructure/src/main.rs
@@ -1,0 +1,161 @@
+#![allow(clippy::disallowed_types)]
+
+mod history;
+mod latency;
+mod tui;
+mod types;
+
+use std::collections::HashMap;
+use std::io;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use laminar_db::{FromBatch, LaminarDB, TypedSubscription};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+use crate::tui::DashState;
+use crate::types::{Burst, DepthLevel, MicroCandle, Momentum, Signal, Spread, Vwap};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_appender = tracing_appender::rolling::never(".", "microstructure.log");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    tracing_subscriber::fmt()
+        .with_writer(non_blocking)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let db = LaminarDB::open()?;
+    db.execute(include_str!("../pipeline.sql")).await?;
+    db.start().await?;
+    std::thread::sleep(Duration::from_secs(2));
+
+    // ── Subscribe to 8 unified streams + 2 depth streams ─────
+    let spread_sub = db.subscribe::<Spread>("spreads")?;
+    let vwap_sub = db.subscribe::<Vwap>("vwap")?;
+    let micro_sub = db.subscribe::<MicroCandle>("micro")?;
+    let momentum_sub = db.subscribe::<Momentum>("momentum")?;
+    let burst_sub = db.subscribe::<Burst>("bursts")?;
+    let signal_sub = db.subscribe::<Signal>("signals")?;
+    let depth_bids_sub = db.subscribe::<DepthLevel>("depth_bids")?;
+    let depth_asks_sub = db.subscribe::<DepthLevel>("depth_asks")?;
+
+    let mut state = DashState::new();
+    let mut last_events = 0u64;
+    let mut last_tp_time = Instant::now();
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(info);
+    }));
+
+    loop {
+        if event::poll(Duration::from_millis(200))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press
+                    && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+                {
+                    break;
+                }
+            }
+        }
+
+        drain_sub(&spread_sub, &mut state.spreads, |r| r.symbol.clone());
+        drain_sub(&vwap_sub, &mut state.vwap, |r| r.symbol.clone());
+        drain_sub(&momentum_sub, &mut state.momentum, |r| r.symbol.clone());
+        drain_sub(&burst_sub, &mut state.bursts, |r| r.symbol.clone());
+        drain_sub(&signal_sub, &mut state.signals, |r| r.symbol.clone());
+        drain_micro(&micro_sub, &mut state);
+        drain_depth(&depth_bids_sub, &mut state.depth_bids);
+        drain_depth(&depth_asks_sub, &mut state.depth_asks);
+
+        let m = db.metrics();
+        state.total_events = m.total_events_ingested;
+        state.total_emitted = m.total_events_emitted;
+        state.total_dropped = m.total_events_dropped;
+        state.source_count = m.source_count;
+        state.stream_count = m.stream_count;
+        state.pipeline_watermark = m.pipeline_watermark;
+        state.latency.record(m.last_cycle_duration_ns);
+        state.latency_history.push(m.last_cycle_duration_ns);
+
+        let elapsed = last_tp_time.elapsed().as_secs_f64();
+        if elapsed >= 1.0 {
+            state.throughput = state.total_events.saturating_sub(last_events) as f64 / elapsed;
+            last_events = state.total_events;
+            last_tp_time = Instant::now();
+        }
+
+        terminal.draw(|f| tui::render(f, &state))?;
+    }
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    db.shutdown().await?;
+    Ok(())
+}
+
+fn drain_sub<T: Clone + FromBatch>(
+    sub: &TypedSubscription<T>,
+    map: &mut HashMap<String, T>,
+    key_fn: fn(&T) -> String,
+) {
+    for _ in 0..64 {
+        match sub.poll() {
+            Some(rows) => {
+                for r in rows {
+                    map.insert(key_fn(&r), r);
+                }
+            }
+            None => break,
+        }
+    }
+}
+
+fn drain_micro(sub: &TypedSubscription<MicroCandle>, state: &mut DashState) {
+    for _ in 0..64 {
+        match sub.poll() {
+            Some(rows) => {
+                for r in rows {
+                    let key = r.symbol.clone();
+                    state
+                        .price_history
+                        .entry(key.clone())
+                        .or_insert_with(|| crate::history::RingBuf::new(60))
+                        .push(r.vwap);
+                    state.micro_candles.insert(key, r);
+                }
+            }
+            None => break,
+        }
+    }
+}
+
+fn drain_depth(sub: &TypedSubscription<DepthLevel>, buf: &mut Vec<DepthLevel>) {
+    for _ in 0..64 {
+        match sub.poll() {
+            Some(rows) => {
+                buf.clear();
+                buf.extend(rows);
+            }
+            None => break,
+        }
+    }
+}

--- a/examples/microstructure/src/tui.rs
+++ b/examples/microstructure/src/tui.rs
@@ -1,0 +1,731 @@
+#![allow(clippy::disallowed_types)]
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::Marker;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, Padding, Paragraph, Sparkline};
+
+use crate::history::RingBuf;
+use crate::latency::LatencyTracker;
+use crate::types::{
+    Burst, DepthLevel, MicroCandle, Momentum, Signal, Spread, Vwap, LABELS, SYMBOLS,
+};
+
+// ── LaminarDB brand palette ──────────────────────────────────
+const CYAN: Color = Color::Rgb(6, 182, 212);
+const VIOLET: Color = Color::Rgb(139, 92, 246);
+const AMBER: Color = Color::Rgb(251, 191, 36);
+const GREEN: Color = Color::Rgb(74, 222, 128);
+const ROSE: Color = Color::Rgb(251, 113, 133);
+const TEXT_PRI: Color = Color::Rgb(241, 245, 249);
+const TEXT_SEC: Color = Color::Rgb(148, 163, 184);
+const TEXT_MUT: Color = Color::Rgb(100, 116, 139);
+const BORDER: Color = Color::Rgb(51, 65, 85);
+
+const SYMBOL_COLORS: &[Color] = &[
+    AMBER,                     // BTC
+    CYAN,                      // ETH
+    VIOLET,                    // SOL
+    GREEN,                     // DOGE
+    Color::Rgb(103, 232, 249), // XRP — cyan-300
+    ROSE,                      // BNB
+];
+
+pub struct DashState {
+    pub spreads: HashMap<String, Spread>,
+    pub vwap: HashMap<String, Vwap>,
+    pub momentum: HashMap<String, Momentum>,
+    pub bursts: HashMap<String, Burst>,
+    pub signals: HashMap<String, Signal>,
+    pub micro_candles: HashMap<String, MicroCandle>,
+    pub price_history: HashMap<String, RingBuf<f64>>,
+    pub depth_bids: Vec<DepthLevel>,
+    pub depth_asks: Vec<DepthLevel>,
+    pub latency_history: RingBuf<u64>,
+    pub start: Instant,
+    pub total_events: u64,
+    pub total_emitted: u64,
+    pub total_dropped: u64,
+    pub throughput: f64,
+    pub source_count: usize,
+    pub stream_count: usize,
+    pub pipeline_watermark: i64,
+    pub latency: LatencyTracker,
+}
+
+impl DashState {
+    pub fn new() -> Self {
+        Self {
+            spreads: HashMap::new(),
+            vwap: HashMap::new(),
+            momentum: HashMap::new(),
+            bursts: HashMap::new(),
+            signals: HashMap::new(),
+            micro_candles: HashMap::new(),
+            price_history: HashMap::new(),
+            depth_bids: Vec::new(),
+            depth_asks: Vec::new(),
+            latency_history: RingBuf::new(120),
+            start: Instant::now(),
+            total_events: 0,
+            total_emitted: 0,
+            total_dropped: 0,
+            throughput: 0.0,
+            source_count: 0,
+            stream_count: 0,
+            pipeline_watermark: 0,
+            latency: LatencyTracker::new(),
+        }
+    }
+}
+
+// ── Main render ────────────────────────────────────────────────
+
+pub fn render(frame: &mut ratatui::Frame, s: &DashState) {
+    let outer = Layout::vertical([
+        Constraint::Length(2), // banner
+        Constraint::Min(10),   // main area
+        Constraint::Length(2), // footer
+    ])
+    .split(frame.area());
+
+    draw_banner(frame, outer[0], s);
+
+    let rows =
+        Layout::vertical([Constraint::Percentage(55), Constraint::Percentage(45)]).split(outer[1]);
+
+    let top = Layout::horizontal([
+        Constraint::Length(24), // tickers
+        Constraint::Min(20),    // price chart
+        Constraint::Length(30), // depth orderbook
+    ])
+    .split(rows[0]);
+
+    let bottom = Layout::horizontal([
+        Constraint::Length(24), // latency
+        Constraint::Min(16),    // momentum
+        Constraint::Length(18), // signals
+        Constraint::Length(20), // bursts
+    ])
+    .split(rows[1]);
+
+    draw_tickers(frame, top[0], s);
+    draw_price_chart(frame, top[1], s);
+    draw_depth(frame, top[2], s);
+
+    draw_latency(frame, bottom[0], s);
+    draw_momentum(frame, bottom[1], s);
+    draw_signals(frame, bottom[2], s);
+    draw_bursts(frame, bottom[3], s);
+
+    draw_footer(frame, outer[2], s);
+}
+
+// ── Banner ─────────────────────────────────────────────────────
+
+fn draw_banner(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let uptime = fmt_duration(s.start.elapsed());
+    let banner = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " LaminarDB",
+            Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " Microstructure ",
+            Style::default().fg(VIOLET).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("| ", Style::default().fg(TEXT_MUT)),
+        Span::styled(format!("{} src", s.source_count), Style::default().fg(CYAN)),
+        Span::styled("  ", Style::default()),
+        Span::styled(
+            format!("{} streams", s.stream_count),
+            Style::default().fg(CYAN),
+        ),
+        Span::styled("  ", Style::default()),
+        Span::styled(
+            format!("{}/s", fmt_int(s.throughput as u64)),
+            Style::default().fg(GREEN),
+        ),
+        Span::styled("  ", Style::default()),
+        Span::styled(
+            format!("p50 {}", fmt_latency(s.latency.p50())),
+            Style::default().fg(CYAN),
+        ),
+        Span::styled("  ", Style::default()),
+        Span::styled(uptime, Style::default().fg(TEXT_MUT)),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .border_style(Style::default().fg(BORDER)),
+    );
+    frame.render_widget(banner, area);
+}
+
+// ── Tickers (left column, top) ─────────────────────────────────
+
+fn draw_tickers(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let mut lines = Vec::new();
+    for (i, sym) in SYMBOLS.iter().enumerate() {
+        let key = sym.to_uppercase();
+
+        let (price_str, arrow, arrow_color) = if let Some(v) = s.vwap.get(&key) {
+            let (a, c) = if v.avg_price > v.vwap * 1.0001 {
+                (" \u{25b2}", GREEN) // ▲
+            } else if v.avg_price < v.vwap * 0.9999 {
+                (" \u{25bc}", ROSE) // ▼
+            } else {
+                (" \u{2500}", TEXT_MUT) // ─
+            };
+            (fmt_price_compact(v.avg_price), a, c)
+        } else {
+            ("-".to_string(), " \u{2500}", TEXT_MUT)
+        };
+
+        let spread = s
+            .spreads
+            .get(&key)
+            .map(|sp| format!("{:>4.1}", sp.spread_bps))
+            .unwrap_or_else(|| "   -".to_string());
+
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:>4}", LABELS[i]),
+                Style::default()
+                    .fg(SYMBOL_COLORS[i])
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(arrow, Style::default().fg(arrow_color)),
+            Span::styled(format!(" {:>9}", price_str), Style::default().fg(TEXT_PRI)),
+            Span::styled(spread, Style::default().fg(AMBER)),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(Line::from(Span::styled(
+                " TICKERS ",
+                Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+// ── Price chart (center, top) ──────────────────────────────────
+
+fn draw_price_chart(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let mut all_data: Vec<(usize, Vec<(f64, f64)>)> = Vec::new();
+    let mut y_min = f64::MAX;
+    let mut y_max = f64::MIN;
+    let mut max_len: usize = 0;
+
+    for (i, sym) in SYMBOLS.iter().enumerate() {
+        let key = sym.to_uppercase();
+        if let Some(hist) = s.price_history.get(&key) {
+            if hist.len() >= 2 {
+                let slice: Vec<f64> = hist.as_slice().iter().copied().collect();
+                let base = slice[0];
+                if base == 0.0 {
+                    continue;
+                }
+                let points: Vec<(f64, f64)> = slice
+                    .iter()
+                    .enumerate()
+                    .map(|(j, &v)| (j as f64, (v - base) / base * 100.0))
+                    .collect();
+                for &(_, v) in &points {
+                    if v < y_min {
+                        y_min = v;
+                    }
+                    if v > y_max {
+                        y_max = v;
+                    }
+                }
+                if points.len() > max_len {
+                    max_len = points.len();
+                }
+                all_data.push((i, points));
+            }
+        }
+    }
+
+    if all_data.is_empty() || y_min >= y_max {
+        y_min = -0.5;
+        y_max = 0.5;
+    }
+
+    let range = y_max - y_min;
+    let pad = (range * 0.1).max(0.01);
+    y_min -= pad;
+    y_max += pad;
+
+    let x_max = if max_len > 1 {
+        (max_len - 1) as f64
+    } else {
+        1.0
+    };
+
+    let mut title_parts = vec![Span::styled(
+        " PRICE ",
+        Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+    )];
+    for (i, _) in &all_data {
+        title_parts.push(Span::styled(
+            format!(" {} ", LABELS[*i]),
+            Style::default().fg(SYMBOL_COLORS[*i]),
+        ));
+    }
+    if all_data.is_empty() {
+        title_parts.push(Span::styled(
+            " waiting for data... ",
+            Style::default().fg(TEXT_MUT),
+        ));
+    }
+
+    let datasets: Vec<Dataset> = all_data
+        .iter()
+        .map(|(i, points)| {
+            Dataset::default()
+                .name(LABELS[*i])
+                .marker(Marker::Braille)
+                .style(Style::default().fg(SYMBOL_COLORS[*i]))
+                .data(points)
+        })
+        .collect();
+
+    let chart = Chart::new(datasets)
+        .block(
+            Block::default()
+                .title(Line::from(title_parts))
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(BORDER)),
+        )
+        .x_axis(
+            Axis::default()
+                .style(Style::default().fg(TEXT_MUT))
+                .bounds([0.0, x_max])
+                .labels(vec![
+                    Span::styled("-5m", Style::default().fg(TEXT_MUT)),
+                    Span::styled("now", Style::default().fg(TEXT_MUT)),
+                ]),
+        )
+        .y_axis(
+            Axis::default()
+                .style(Style::default().fg(TEXT_MUT))
+                .bounds([y_min, y_max])
+                .labels(vec![
+                    Span::styled(format!("{:+.2}%", y_min), Style::default().fg(TEXT_MUT)),
+                    Span::styled("  0%", Style::default().fg(TEXT_MUT)),
+                    Span::styled(format!("{:+.2}%", y_max), Style::default().fg(TEXT_MUT)),
+                ]),
+        );
+    frame.render_widget(chart, area);
+}
+
+// ── BTC Depth Orderbook (right column, top) ─────────────────────
+
+fn draw_depth(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let max_levels = 5;
+    let mut lines = Vec::new();
+
+    if s.depth_asks.is_empty() && s.depth_bids.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " waiting for depth...",
+            Style::default().fg(TEXT_MUT),
+        )));
+    } else {
+        // Asks: show lowest N asks, displayed top-to-bottom (highest first)
+        let ask_count = s.depth_asks.len().min(max_levels);
+        for i in (0..ask_count).rev() {
+            let lvl = &s.depth_asks[i];
+            let bar_len = (lvl.qty * 4.0).min(10.0) as usize;
+            let bar: String = "\u{2591}".repeat(bar_len);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{:>12}", fmt_price_compact(lvl.price)),
+                    Style::default().fg(ROSE),
+                ),
+                Span::styled(format!(" {:>6.3}", lvl.qty), Style::default().fg(TEXT_SEC)),
+                Span::styled(format!(" {bar}"), Style::default().fg(ROSE)),
+            ]));
+        }
+
+        // Spread line
+        let spread = if !s.depth_asks.is_empty() && !s.depth_bids.is_empty() {
+            let best_ask = s.depth_asks[0].price;
+            let best_bid = s.depth_bids[0].price;
+            let mid = (best_ask + best_bid) / 2.0;
+            let sp_bps = if mid > 0.0 {
+                (best_ask - best_bid) / mid * 10000.0
+            } else {
+                0.0
+            };
+            format!("{:.1}bp", sp_bps)
+        } else {
+            "-".to_string()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  \u{2500}\u{2500} spread {spread} "),
+                Style::default().fg(TEXT_MUT),
+            ),
+            Span::styled(
+                "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}",
+                Style::default().fg(TEXT_MUT),
+            ),
+        ]));
+
+        // Bids: show top N bids, highest first
+        let bid_count = s.depth_bids.len().min(max_levels);
+        for lvl in s.depth_bids.iter().take(bid_count) {
+            let bar_len = (lvl.qty * 4.0).min(10.0) as usize;
+            let bar: String = "\u{2588}".repeat(bar_len);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{:>12}", fmt_price_compact(lvl.price)),
+                    Style::default().fg(GREEN),
+                ),
+                Span::styled(format!(" {:>6.3}", lvl.qty), Style::default().fg(TEXT_SEC)),
+                Span::styled(format!(" {bar}"), Style::default().fg(GREEN)),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(Line::from(vec![
+                Span::styled(
+                    " BTC DEPTH ",
+                    Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("\u{2588}", Style::default().fg(GREEN)),
+                Span::styled("bid ", Style::default().fg(TEXT_MUT)),
+                Span::styled("\u{2591}", Style::default().fg(ROSE)),
+                Span::styled("ask ", Style::default().fg(TEXT_MUT)),
+            ]))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+// ── Latency (left column, bottom) ──────────────────────────────
+
+fn draw_latency(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let chunks = Layout::vertical([
+        Constraint::Length(3), // sparkline
+        Constraint::Min(3),    // stats
+    ])
+    .split(area);
+
+    let lat_data: Vec<u64> = s.latency_history.as_slice().iter().copied().collect();
+    let sparkline = Sparkline::default()
+        .data(&lat_data)
+        .style(Style::default().fg(CYAN))
+        .block(
+            Block::default()
+                .title(Line::from(Span::styled(
+                    " LATENCY ",
+                    Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+                )))
+                .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+                .border_style(Style::default().fg(BORDER))
+                .padding(Padding::horizontal(1)),
+        );
+    frame.render_widget(sparkline, chunks[0]);
+
+    let lat = &s.latency;
+    let wm_lag = if s.pipeline_watermark > 0 {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        format!(
+            "{}ms",
+            fmt_int(now_ms.saturating_sub(s.pipeline_watermark) as u64)
+        )
+    } else {
+        "-".to_string()
+    };
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("p50 ", Style::default().fg(TEXT_MUT)),
+            Span::styled(fmt_latency(lat.p50()), Style::default().fg(CYAN)),
+        ]),
+        Line::from(vec![
+            Span::styled("p99 ", Style::default().fg(TEXT_MUT)),
+            Span::styled(fmt_latency(lat.p99()), Style::default().fg(AMBER)),
+        ]),
+        Line::from(vec![
+            Span::styled("max ", Style::default().fg(TEXT_MUT)),
+            Span::styled(fmt_latency(lat.max()), Style::default().fg(ROSE)),
+        ]),
+        Line::from(vec![
+            Span::styled("tpt ", Style::default().fg(TEXT_MUT)),
+            Span::styled(
+                format!("{}/s", fmt_int(s.throughput as u64)),
+                Style::default().fg(GREEN),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("evt ", Style::default().fg(TEXT_MUT)),
+            Span::styled(fmt_int(s.total_events), Style::default().fg(TEXT_PRI)),
+        ]),
+        Line::from(vec![
+            Span::styled("wml ", Style::default().fg(TEXT_MUT)),
+            Span::styled(wm_lag, Style::default().fg(AMBER)),
+        ]),
+    ];
+
+    let stats = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(stats, chunks[1]);
+}
+
+// ── Momentum heatmap (center, bottom) ──────────────────────────
+
+fn draw_momentum(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let mut lines = Vec::new();
+
+    for (i, sym) in SYMBOLS.iter().enumerate() {
+        let key = sym.to_uppercase();
+
+        if let Some(m) = s.momentum.get(&key) {
+            let blocks = ((m.range_bps_30s / 5.0).min(7.0)) as usize;
+            let filled: String = "\u{25a0}".repeat(blocks);
+            let empty: String = "\u{25a1}".repeat(7 - blocks);
+
+            let (sign, color) = if let Some(sig) = s.signals.get(&key) {
+                match sig.signal.as_str() {
+                    "BUY" => ("+", GREEN),
+                    "SELL" => ("-", ROSE),
+                    _ => (" ", TEXT_MUT),
+                }
+            } else {
+                (" ", TEXT_MUT)
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{:>4} ", LABELS[i]),
+                    Style::default()
+                        .fg(SYMBOL_COLORS[i])
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(filled, Style::default().fg(color)),
+                Span::styled(empty, Style::default().fg(TEXT_MUT)),
+                Span::styled(
+                    format!(" {}{:.1}bp", sign, m.range_bps_30s),
+                    Style::default().fg(color),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled(
+                format!("{:>4}  waiting...", LABELS[i]),
+                Style::default().fg(TEXT_MUT),
+            )));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(Line::from(Span::styled(
+                " MOMENTUM ",
+                Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+// ── Signals (center-right, bottom) ─────────────────────────────
+
+fn draw_signals(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let mut lines = Vec::new();
+
+    for (i, sym) in SYMBOLS.iter().enumerate() {
+        let key = sym.to_uppercase();
+
+        if let Some(sig) = s.signals.get(&key) {
+            let (text, color) = match sig.signal.as_str() {
+                "BUY" => ("BUY  \u{25cf}", GREEN),
+                "SELL" => ("SELL \u{25cf}", ROSE),
+                _ => ("HOLD  ", TEXT_MUT),
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{:>4} ", LABELS[i]),
+                    Style::default()
+                        .fg(SYMBOL_COLORS[i])
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    text,
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled(
+                format!("{:>4}  -", LABELS[i]),
+                Style::default().fg(TEXT_MUT),
+            )));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(Line::from(Span::styled(
+                " SIGNALS ",
+                Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+// ── Bursts (right, bottom) ─────────────────────────────────────
+
+fn draw_bursts(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let mut lines = Vec::new();
+
+    for (i, sym) in SYMBOLS.iter().enumerate() {
+        let key = sym.to_uppercase();
+
+        if let Some(b) = s.bursts.get(&key) {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{:>4} ", LABELS[i]),
+                    Style::default()
+                        .fg(SYMBOL_COLORS[i])
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{:>4}t", b.burst_trades), Style::default().fg(CYAN)),
+                Span::styled(
+                    format!(" {:>5.1}bp", b.burst_range_bps),
+                    Style::default().fg(AMBER),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled(
+                format!("{:>4}  -", LABELS[i]),
+                Style::default().fg(TEXT_MUT),
+            )));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .title(Line::from(Span::styled(
+                " BURSTS ",
+                Style::default().fg(AMBER).add_modifier(Modifier::BOLD),
+            )))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(BORDER))
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(paragraph, area);
+}
+
+// ── Footer ─────────────────────────────────────────────────────
+
+fn draw_footer(frame: &mut ratatui::Frame, area: Rect, s: &DashState) {
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled(" events: ", Style::default().fg(TEXT_MUT)),
+        Span::styled(fmt_int(s.total_events), Style::default().fg(TEXT_PRI)),
+        Span::styled("  emitted: ", Style::default().fg(TEXT_MUT)),
+        Span::styled(fmt_int(s.total_emitted), Style::default().fg(GREEN)),
+        Span::styled("  dropped: ", Style::default().fg(TEXT_MUT)),
+        Span::styled(
+            fmt_int(s.total_dropped),
+            Style::default().fg(if s.total_dropped > 0 { ROSE } else { GREEN }),
+        ),
+        Span::styled(
+            "                                         q: quit",
+            Style::default().fg(TEXT_MUT),
+        ),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::TOP)
+            .border_style(Style::default().fg(BORDER)),
+    );
+    frame.render_widget(footer, area);
+}
+
+// ── Formatting helpers ─────────────────────────────────────────
+
+fn fmt_price_compact(v: f64) -> String {
+    if v < 1.0 {
+        return format!("${v:.4}");
+    }
+    if v < 10.0 {
+        return format!("${v:.3}");
+    }
+    let s = format!("{:.2}", v.abs());
+    let mut parts = s.splitn(2, '.');
+    let whole = parts.next().unwrap_or("0");
+    let frac = parts.next().unwrap_or("00");
+    let with_commas: String = whole
+        .as_bytes()
+        .rchunks(3)
+        .rev()
+        .map(|c| std::str::from_utf8(c).unwrap())
+        .collect::<Vec<_>>()
+        .join(",");
+    if v < 0.0 {
+        format!("-${with_commas}.{frac}")
+    } else {
+        format!("${with_commas}.{frac}")
+    }
+}
+
+fn fmt_int(v: u64) -> String {
+    let s = v.to_string();
+    s.as_bytes()
+        .rchunks(3)
+        .rev()
+        .map(|c| std::str::from_utf8(c).unwrap())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn fmt_latency(ns: u64) -> String {
+    if ns < 1_000 {
+        format!("{ns}ns")
+    } else if ns < 1_000_000 {
+        format!("{:.1}us", ns as f64 / 1_000.0)
+    } else if ns < 1_000_000_000 {
+        format!("{:.1}ms", ns as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2}s", ns as f64 / 1_000_000_000.0)
+    }
+}
+
+fn fmt_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    }
+}

--- a/examples/microstructure/src/types.rs
+++ b/examples/microstructure/src/types.rs
@@ -1,0 +1,88 @@
+use laminar_derive::FromRow;
+
+pub const SYMBOLS: &[&str] = &[
+    "btcusdt", "ethusdt", "solusdt", "dogeusdt", "xrpusdt", "bnbusdt",
+];
+pub const LABELS: &[&str] = &["BTC", "ETH", "SOL", "DOGE", "XRP", "BNB"];
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct Spread {
+    pub symbol: String,
+    pub spread: f64,
+    pub spread_bps: f64,
+    pub bid_price: f64,
+    pub ask_price: f64,
+    pub bid_qty: f64,
+    pub ask_qty: f64,
+    pub bid_pressure: f64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct Vwap {
+    pub symbol: String,
+    pub vwap: f64,
+    pub avg_price: f64,
+    pub low: f64,
+    pub high: f64,
+    pub volume: f64,
+    pub trades: i64,
+    pub volatility_bps: f64,
+    pub maker_ratio: f64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct Momentum {
+    pub symbol: String,
+    pub avg_30s: f64,
+    pub low_30s: f64,
+    pub high_30s: f64,
+    pub vol_30s: f64,
+    pub trades_30s: i64,
+    pub range_bps_30s: f64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct Burst {
+    pub symbol: String,
+    pub burst_trades: i64,
+    pub burst_volume: f64,
+    pub burst_range_bps: f64,
+    pub maker_ratio: f64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct Signal {
+    pub symbol: String,
+    pub vwap: f64,
+    pub avg_price: f64,
+    pub volume: f64,
+    pub trades: i64,
+    pub volatility_bps: f64,
+    pub maker_ratio: f64,
+    pub signal: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct MicroCandle {
+    pub symbol: String,
+    pub ticks: i64,
+    pub vwap: f64,
+    pub low: f64,
+    pub high: f64,
+    pub volume: f64,
+    pub buy_vol: f64,
+    pub sell_vol: f64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+#[allow(dead_code)]
+pub struct DepthLevel {
+    pub price: f64,
+    pub qty: f64,
+}


### PR DESCRIPTION
## Summary

- **`json.path`** — navigate into nested JSON before field extraction (envelope unwrapping for combined WebSocket streams)
- **`json.column.<name>`** — per-column absolute path overrides for cross-path selection (fields from different nesting levels)
- **`json.explode`** — expand arrays into multiple rows with positional or field-name mapping (orderbook depth `[[price,qty],...]` → rows)
- **SQL parser** — support unquoted dotted option keys (`json.path`, `auth.type`) in `FROM CONNECTOR (...)` clauses
- **Bug fix** — connector-less sources no longer cause LDB-1002 on every pipeline cycle; MemTable empty partition fix
- **Microstructure example** — 4 sources, 10 streams, 3 window types, BTC depth orderbook, LaminarDB brand color TUI

All three JSON features are generic in `JsonDecoderConfig`/`JsonDecoder` — any connector using JSON format benefits. Pre-computed at Ring 2 (CREATE SOURCE) with zero additional allocations on the Ring 1 hot path.

## SQL Syntax

```sql
-- Envelope unwrapping (combined stream)
CREATE SOURCE trades (s VARCHAR, p DOUBLE) FROM WEBSOCKET (
    url = 'wss://stream.binance.com:9443/stream?streams=btcusdt@trade',
    format = 'json',
    json.path = 'data'
);

-- Cross-path selection
CREATE SOURCE trades (s VARCHAR, p DOUBLE, stream_name VARCHAR) FROM WEBSOCKET (
    url = '...', format = 'json',
    json.path = 'data',
    json.column.stream_name = 'stream'
);

-- Array-to-rows (orderbook depth)
CREATE SOURCE depth (price DOUBLE, qty DOUBLE) FROM WEBSOCKET (
    url = 'wss://stream.binance.com:9443/ws/btcusdt@depth20',
    format = 'json',
    json.path = 'bids',
    json.explode = 'price,qty'
);
```

## Files Changed

| File | Change |
|------|--------|
| `connectors/schema/json/decoder.rs` | `ColumnExtraction` enum, 3 new config fields, `from_connector_config()`, rewritten `decode_batch()` with path/explode/per-column support, 12 new tests |
| `connectors/websocket/parser.rs` | `MessageParser::new()` accepts `JsonDecoderConfig`, `infer_schema_from_json_with_path()` |
| `connectors/websocket/source.rs` | Builds `JsonDecoderConfig` from connector config |
| `connectors/websocket/source_server.rs` | Same |
| `sql/parser/source_parser.rs` | `parse_connector_option_key()` for dotted identifiers, 2 new tests |
| `db/src/db.rs` | Skip connector-less sources in schema registration, 1 new test |
| `db/src/stream_executor.rs` | MemTable fix (`vec![]` → `vec![vec![]]`) |
| `examples/microstructure/` | Full TUI demo: 4 combined/depth sources, unified streams, brand colors |

## Test plan

- [x] `cargo test -p laminar-connectors` — 730 tests pass (12 new decoder tests)
- [x] `cargo test -p laminar-sql -- source_parser` — 29 tests pass (2 new dotted-key tests)
- [x] `cargo clippy -p laminar-connectors -p laminar-sql -p microstructure -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc --no-deps` — no warnings
- [x] Microstructure example compiles and runs against live Binance WebSocket