### PR TITLE
feat(server): hot-reload with config diffing and file watcher (F-SERVER-004)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4200,6 +4209,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,6 +4403,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -4608,10 +4657,12 @@ dependencies = [
  "laminar-observe",
  "laminar-sql",
  "laminar-storage",
+ "notify",
  "openssl",
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
@@ -5043,6 +5094,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "microstructure"
+version = "0.17.0"
+dependencies = [
+ "arrow",
+ "crossterm",
+ "laminar-db",
+ "laminar-derive",
+ "ratatui",
+ "tokio",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,6 +5317,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ sha2 = "0.10"  # SHA-256 for checkpoint integrity
 backoff = { version = "0.4", features = ["tokio"] }  # Exponential backoff retry
 regex = "1.10"
 humantime-serde = "1.1"
+notify = "8"
 
 # DataFusion and Arrow - using latest versions
 arrow = { version = "57.2", default-features = true }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -56,6 +56,9 @@ regex = { workspace = true }
 humantime-serde = { workspace = true }
 chrono = { workspace = true }
 
+# File watching for hot reload
+notify = { workspace = true }
+
 # Vendored OpenSSL for musl cross-compilation (behind vendored-openssl feature)
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
@@ -63,6 +66,9 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 # tikv-jemallocator does not support Windows MSVC.
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [features]
 default = ["jemalloc", "kafka", "websocket", "delta-lake"]

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -157,7 +157,7 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
 ///
 /// Deserialized from `laminardb.toml`. All sections except `[server]`
 /// are optional (an empty config starts a server with no pipelines).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct ServerConfig {
     /// Server-level settings.
     #[serde(default)]
@@ -198,7 +198,7 @@ pub struct ServerConfig {
 }
 
 /// `[server]` section: server-level settings.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct ServerSection {
     /// Operating mode: "embedded" (single-node) or "delta" (multi-node).
@@ -235,7 +235,7 @@ impl Default for ServerSection {
 }
 
 /// `[state]` section: state store backend configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct StateSection {
     /// Backend type: "memory" or "mmap".
@@ -262,7 +262,7 @@ impl Default for StateSection {
 }
 
 /// `[checkpoint]` section: checkpointing configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct CheckpointSection {
     /// Storage URL for checkpoint data.
@@ -295,7 +295,7 @@ impl Default for CheckpointSection {
 }
 
 /// `[[source]]` section: streaming source definition.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct SourceConfig {
     /// Unique name for this source (referenced by SQL and sinks).
@@ -321,7 +321,7 @@ pub struct SourceConfig {
 }
 
 /// Column definition within a source or lookup schema.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct ColumnDef {
     /// Column name.
@@ -337,7 +337,7 @@ pub struct ColumnDef {
 }
 
 /// Watermark configuration for a source.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct WatermarkConfig {
     /// Column containing event timestamps.
@@ -349,7 +349,7 @@ pub struct WatermarkConfig {
 }
 
 /// `[[lookup]]` section: lookup table for enrichment joins.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct LookupConfig {
     /// Unique name for this lookup table.
@@ -380,7 +380,7 @@ pub struct LookupConfig {
 }
 
 /// Cache configuration for lookup tables.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct LookupCacheConfig {
     /// Cache size in bytes.
@@ -407,7 +407,7 @@ impl Default for LookupCacheConfig {
 }
 
 /// `[[pipeline]]` section: SQL pipeline definition.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct PipelineConfig {
     /// Unique name for this pipeline.
@@ -421,7 +421,7 @@ pub struct PipelineConfig {
 }
 
 /// `[[sink]]` section: output sink definition.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct SinkConfig {
     /// Unique name for this sink.
@@ -443,7 +443,7 @@ pub struct SinkConfig {
 }
 
 /// `[discovery]` section: delta node discovery.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct DiscoverySection {
     /// Discovery strategy: "static", "dns", "gossip".
@@ -459,7 +459,7 @@ pub struct DiscoverySection {
 }
 
 /// `[coordination]` section: delta coordination.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 #[allow(dead_code)]
 pub struct CoordinationSection {
     /// Coordination strategy: "raft".

--- a/crates/laminar-server/src/http.rs
+++ b/crates/laminar-server/src/http.rs
@@ -18,6 +18,7 @@
 //! | `POST` | `/api/v1/sql` | Execute ad-hoc SQL |
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -28,10 +29,12 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
-use tracing::info;
+use tracing::{info, warn};
 
 use laminar_db::LaminarDB;
 
+use crate::config::ServerConfig;
+use crate::reload::{self, ReloadGuard};
 use crate::server::ServerError;
 
 /// Shared application state for all HTTP handlers.
@@ -43,6 +46,14 @@ pub struct AppState {
     pub config_path: PathBuf,
     /// Server start time (UTC).
     pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Current active configuration (updated on reload).
+    pub current_config: tokio::sync::RwLock<ServerConfig>,
+    /// Guard preventing concurrent reloads.
+    pub reload_guard: ReloadGuard,
+    /// Total number of successful + failed reloads.
+    pub reload_total: AtomicU64,
+    /// Unix timestamp (seconds) of last reload attempt.
+    pub reload_last_ts: AtomicU64,
 }
 
 /// Build the axum router with all endpoints.
@@ -60,10 +71,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Actions
         .route("/api/v1/checkpoint", post(trigger_checkpoint))
         .route("/api/v1/sql", post(execute_sql))
+        .route("/api/v1/reload", post(handle_reload))
         // Stubs (501 Not Implemented)
         .route("/api/v1/pause", post(not_implemented))
         .route("/api/v1/resume", post(not_implemented))
-        .route("/api/v1/reload", post(not_implemented))
         .layer(CorsLayer::permissive())
         .layer(axum::middleware::from_fn(request_logging))
         .with_state(state)
@@ -266,6 +277,13 @@ async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl IntoResp
     lines.push(format!("laminardb_stream_count {}", metrics.stream_count));
     lines.push(format!("laminardb_sink_count {}", metrics.sink_count));
 
+    let reload_total = state.reload_total.load(Ordering::Relaxed);
+    let reload_last_ts = state.reload_last_ts.load(Ordering::Relaxed);
+    lines.push(format!("laminardb_reload_total {reload_total}"));
+    if reload_last_ts > 0 {
+        lines.push(format!("laminardb_reload_last_timestamp {reload_last_ts}"));
+    }
+
     (
         StatusCode::OK,
         [("content-type", "text/plain; charset=utf-8")],
@@ -392,6 +410,75 @@ async fn execute_sql(
     }
 }
 
+/// `POST /api/v1/reload` — trigger a configuration reload.
+async fn handle_reload(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    // Acquire concurrency guard
+    let _guard = match state.reload_guard.try_acquire() {
+        Some(g) => g,
+        None => {
+            return error_response(StatusCode::CONFLICT, "a reload is already in progress")
+                .into_response();
+        }
+    };
+
+    // Load and validate the new config
+    let new_config = match crate::config::load_config(&state.config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Reload failed: config error: {e}");
+            return error_response(StatusCode::BAD_REQUEST, e.to_string()).into_response();
+        }
+    };
+
+    // Diff against current config
+    let current = state.current_config.read().await;
+    let diff = reload::diff_configs(&current, &new_config);
+    drop(current);
+
+    if diff.is_empty() && diff.warnings.is_empty() {
+        return Json(reload::ReloadResult {
+            success: true,
+            applied: vec![],
+            failed: vec![],
+            warnings: vec!["no changes detected".to_string()],
+        })
+        .into_response();
+    }
+
+    // Apply the diff
+    let result = reload::apply_reload(&state.db, &diff).await;
+
+    // Update metrics
+    state.reload_total.fetch_add(1, Ordering::Relaxed);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let now = chrono::Utc::now().timestamp() as u64;
+    state.reload_last_ts.store(now, Ordering::Relaxed);
+
+    // Update current config on success
+    if result.success {
+        let mut current = state.current_config.write().await;
+        *current = new_config;
+        info!(
+            "Configuration reloaded successfully ({} ops)",
+            result.applied.len()
+        );
+    } else {
+        warn!(
+            "Configuration reload partially failed: {} applied, {} failed",
+            result.applied.len(),
+            result.failed.len()
+        );
+    }
+
+    let status = if result.success {
+        StatusCode::OK
+    } else {
+        StatusCode::MULTI_STATUS
+    };
+
+    (status, Json(result)).into_response()
+}
+
 /// Stub handler for unimplemented endpoints.
 async fn not_implemented() -> impl IntoResponse {
     error_response(
@@ -416,6 +503,21 @@ mod tests {
             db: Arc::new(LaminarDB::open().unwrap()),
             config_path: PathBuf::from("test.toml"),
             started_at: chrono::Utc::now(),
+            current_config: tokio::sync::RwLock::new(crate::config::ServerConfig {
+                server: crate::config::ServerSection::default(),
+                state: crate::config::StateSection::default(),
+                checkpoint: crate::config::CheckpointSection::default(),
+                sources: vec![],
+                lookups: vec![],
+                pipelines: vec![],
+                sinks: vec![],
+                discovery: None,
+                coordination: None,
+                node_id: None,
+            }),
+            reload_guard: ReloadGuard::new(),
+            reload_total: AtomicU64::new(0),
+            reload_last_ts: AtomicU64::new(0),
         })
     }
 
@@ -590,5 +692,102 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_reload_invalid_config_path() {
+        // test_state has config_path = "test.toml" which doesn't exist → 400
+        let state = test_state();
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/reload")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_reload_concurrent_returns_conflict() {
+        let state = test_state();
+        // Hold the guard before making the request
+        let _guard = state.reload_guard.try_acquire().unwrap();
+
+        let app = build_router(state);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/reload")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_reload_with_valid_config() {
+        use std::io::Write;
+
+        // Create a real temp config file
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmpfile, "[server]").unwrap();
+        let path = tmpfile.path().to_path_buf();
+
+        let state = Arc::new(AppState {
+            db: Arc::new(LaminarDB::open().unwrap()),
+            config_path: path,
+            started_at: chrono::Utc::now(),
+            current_config: tokio::sync::RwLock::new(crate::config::ServerConfig {
+                server: crate::config::ServerSection::default(),
+                state: crate::config::StateSection::default(),
+                checkpoint: crate::config::CheckpointSection::default(),
+                sources: vec![],
+                lookups: vec![],
+                pipelines: vec![],
+                sinks: vec![],
+                discovery: None,
+                coordination: None,
+                node_id: None,
+            }),
+            reload_guard: ReloadGuard::new(),
+            reload_total: AtomicU64::new(0),
+            reload_last_ts: AtomicU64::new(0),
+        });
+
+        let app = build_router(state.clone());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/reload")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["success"], true);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_includes_reload() {
+        let state = test_state();
+        state.reload_total.store(5, Ordering::Relaxed);
+        state.reload_last_ts.store(1_700_000_000, Ordering::Relaxed);
+        let app = build_router(state);
+
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("laminardb_reload_total 5"));
+        assert!(text.contains("laminardb_reload_last_timestamp 1700000000"));
     }
 }

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -10,7 +10,9 @@
 
 mod config;
 mod http;
+mod reload;
 mod server;
+mod watcher;
 
 #[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]

--- a/crates/laminar-server/src/reload.rs
+++ b/crates/laminar-server/src/reload.rs
@@ -1,0 +1,819 @@
+//! Hot-reload config diff engine and incremental DDL application.
+//!
+//! Compares two `ServerConfig` snapshots, computes the diff, and applies
+//! incremental DDL (DROP + CREATE) against a live `LaminarDB` instance.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde::Serialize;
+use tracing::{info, warn};
+
+use laminar_db::LaminarDB;
+
+use crate::config::{LookupConfig, PipelineConfig, ServerConfig, SinkConfig, SourceConfig};
+use crate::server;
+
+/// Diff between two configuration snapshots.
+#[derive(Debug, Default)]
+pub struct ConfigDiff {
+    pub sources_added: Vec<SourceConfig>,
+    pub sources_removed: Vec<SourceConfig>,
+    pub sources_changed: Vec<SourceConfig>,
+
+    pub lookups_added: Vec<LookupConfig>,
+    pub lookups_removed: Vec<LookupConfig>,
+    pub lookups_changed: Vec<LookupConfig>,
+
+    pub pipelines_added: Vec<PipelineConfig>,
+    pub pipelines_removed: Vec<PipelineConfig>,
+    pub pipelines_changed: Vec<PipelineConfig>,
+
+    pub sinks_added: Vec<SinkConfig>,
+    pub sinks_removed: Vec<SinkConfig>,
+    pub sinks_changed: Vec<SinkConfig>,
+
+    pub warnings: Vec<String>,
+}
+
+impl ConfigDiff {
+    /// Returns `true` when no reloadable changes were detected.
+    pub fn is_empty(&self) -> bool {
+        self.sources_added.is_empty()
+            && self.sources_removed.is_empty()
+            && self.sources_changed.is_empty()
+            && self.lookups_added.is_empty()
+            && self.lookups_removed.is_empty()
+            && self.lookups_changed.is_empty()
+            && self.pipelines_added.is_empty()
+            && self.pipelines_removed.is_empty()
+            && self.pipelines_changed.is_empty()
+            && self.sinks_added.is_empty()
+            && self.sinks_removed.is_empty()
+            && self.sinks_changed.is_empty()
+    }
+}
+
+/// Result of applying a reload diff.
+#[derive(Debug, Serialize)]
+pub struct ReloadResult {
+    pub success: bool,
+    pub applied: Vec<ReloadOp>,
+    pub failed: Vec<ReloadFailure>,
+    pub warnings: Vec<String>,
+}
+
+/// A successfully applied reload operation.
+#[derive(Debug, Serialize)]
+pub struct ReloadOp {
+    pub action: String,
+    pub object_type: String,
+    pub name: String,
+}
+
+/// A failed reload operation.
+#[derive(Debug, Serialize)]
+pub struct ReloadFailure {
+    pub action: String,
+    pub object_type: String,
+    pub name: String,
+    pub error: String,
+}
+
+// ---------------------------------------------------------------------------
+// Config diffing
+// ---------------------------------------------------------------------------
+
+/// Compute the diff between an old and new configuration.
+pub fn diff_configs(old: &ServerConfig, new: &ServerConfig) -> ConfigDiff {
+    let mut diff = ConfigDiff::default();
+
+    // Diff named sections
+    diff_named_section(
+        &old.sources,
+        &new.sources,
+        |s| &s.name,
+        &mut diff.sources_added,
+        &mut diff.sources_removed,
+        &mut diff.sources_changed,
+    );
+
+    diff_named_section(
+        &old.lookups,
+        &new.lookups,
+        |l| &l.name,
+        &mut diff.lookups_added,
+        &mut diff.lookups_removed,
+        &mut diff.lookups_changed,
+    );
+
+    diff_named_section(
+        &old.pipelines,
+        &new.pipelines,
+        |p| &p.name,
+        &mut diff.pipelines_added,
+        &mut diff.pipelines_removed,
+        &mut diff.pipelines_changed,
+    );
+
+    diff_named_section(
+        &old.sinks,
+        &new.sinks,
+        |s| &s.name,
+        &mut diff.sinks_added,
+        &mut diff.sinks_removed,
+        &mut diff.sinks_changed,
+    );
+
+    // Non-reloadable section warnings
+    if old.server != new.server {
+        diff.warnings
+            .push("[server] section changed — requires restart".to_string());
+    }
+    if old.state != new.state {
+        diff.warnings
+            .push("[state] section changed — requires restart".to_string());
+    }
+    if old.checkpoint != new.checkpoint {
+        diff.warnings
+            .push("[checkpoint] section changed — requires restart".to_string());
+    }
+    if old.discovery != new.discovery {
+        diff.warnings
+            .push("[discovery] section changed — requires restart".to_string());
+    }
+    if old.coordination != new.coordination {
+        diff.warnings
+            .push("[coordination] section changed — requires restart".to_string());
+    }
+    if old.node_id != new.node_id {
+        diff.warnings
+            .push("node_id changed — requires restart".to_string());
+    }
+
+    diff
+}
+
+/// Generic helper: diff two name-keyed Vec slices using `PartialEq`.
+fn diff_named_section<T: Clone + PartialEq>(
+    old: &[T],
+    new: &[T],
+    name_fn: fn(&T) -> &str,
+    added: &mut Vec<T>,
+    removed: &mut Vec<T>,
+    changed: &mut Vec<T>,
+) {
+    // Build name → item maps
+    let old_map: std::collections::HashMap<&str, &T> =
+        old.iter().map(|item| (name_fn(item), item)).collect();
+    let new_map: std::collections::HashMap<&str, &T> =
+        new.iter().map(|item| (name_fn(item), item)).collect();
+
+    // Removed: in old but not in new
+    for (name, item) in &old_map {
+        if !new_map.contains_key(name) {
+            removed.push((*item).clone());
+        }
+    }
+
+    // Added or changed: in new
+    for (name, new_item) in &new_map {
+        match old_map.get(name) {
+            None => added.push((*new_item).clone()),
+            Some(old_item) => {
+                if *old_item != *new_item {
+                    changed.push((*new_item).clone());
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Apply reload
+// ---------------------------------------------------------------------------
+
+/// Apply a config diff to a live `LaminarDB` instance via incremental DDL.
+///
+/// **Remove phase** (reverse dependency order): sinks → streams → lookups → sources
+/// **Create phase** (dependency order): sources → lookups → pipelines → sinks
+///
+/// Each operation is independent — failures are recorded but do not stop
+/// remaining operations.
+pub async fn apply_reload(db: &LaminarDB, diff: &ConfigDiff) -> ReloadResult {
+    let mut applied = Vec::new();
+    let mut failed = Vec::new();
+
+    // --- Remove phase (reverse dependency order) ---
+
+    // Remove sinks (removed + changed)
+    for sink in diff.sinks_removed.iter().chain(diff.sinks_changed.iter()) {
+        let ddl = format!("DROP SINK IF EXISTS {} CASCADE", sink.name);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Dropped sink: {}", sink.name);
+                applied.push(ReloadOp {
+                    action: "drop".to_string(),
+                    object_type: "sink".to_string(),
+                    name: sink.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to drop sink '{}': {}", sink.name, e);
+                failed.push(ReloadFailure {
+                    action: "drop".to_string(),
+                    object_type: "sink".to_string(),
+                    name: sink.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Remove pipelines/streams (removed + changed)
+    for pipeline in diff
+        .pipelines_removed
+        .iter()
+        .chain(diff.pipelines_changed.iter())
+    {
+        let ddl = format!("DROP STREAM IF EXISTS {} CASCADE", pipeline.name);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Dropped stream: {}", pipeline.name);
+                applied.push(ReloadOp {
+                    action: "drop".to_string(),
+                    object_type: "stream".to_string(),
+                    name: pipeline.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to drop stream '{}': {}", pipeline.name, e);
+                failed.push(ReloadFailure {
+                    action: "drop".to_string(),
+                    object_type: "stream".to_string(),
+                    name: pipeline.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Remove lookups (removed + changed)
+    for lookup in diff
+        .lookups_removed
+        .iter()
+        .chain(diff.lookups_changed.iter())
+    {
+        let ddl = format!("DROP LOOKUP TABLE IF EXISTS {} CASCADE", lookup.name);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Dropped lookup table: {}", lookup.name);
+                applied.push(ReloadOp {
+                    action: "drop".to_string(),
+                    object_type: "lookup".to_string(),
+                    name: lookup.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to drop lookup table '{}': {}", lookup.name, e);
+                failed.push(ReloadFailure {
+                    action: "drop".to_string(),
+                    object_type: "lookup".to_string(),
+                    name: lookup.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Remove sources (removed + changed)
+    for source in diff
+        .sources_removed
+        .iter()
+        .chain(diff.sources_changed.iter())
+    {
+        let ddl = format!("DROP SOURCE IF EXISTS {} CASCADE", source.name);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Dropped source: {}", source.name);
+                applied.push(ReloadOp {
+                    action: "drop".to_string(),
+                    object_type: "source".to_string(),
+                    name: source.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to drop source '{}': {}", source.name, e);
+                failed.push(ReloadFailure {
+                    action: "drop".to_string(),
+                    object_type: "source".to_string(),
+                    name: source.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // --- Create phase (dependency order) ---
+
+    // Create sources (added + changed)
+    for source in diff.sources_added.iter().chain(diff.sources_changed.iter()) {
+        let ddl = server::source_to_ddl(source);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Created source: {}", source.name);
+                applied.push(ReloadOp {
+                    action: "create".to_string(),
+                    object_type: "source".to_string(),
+                    name: source.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to create source '{}': {}", source.name, e);
+                failed.push(ReloadFailure {
+                    action: "create".to_string(),
+                    object_type: "source".to_string(),
+                    name: source.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Create lookups (added + changed)
+    for lookup in diff.lookups_added.iter().chain(diff.lookups_changed.iter()) {
+        let ddl = server::lookup_to_ddl(lookup);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Created lookup table: {}", lookup.name);
+                applied.push(ReloadOp {
+                    action: "create".to_string(),
+                    object_type: "lookup".to_string(),
+                    name: lookup.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to create lookup table '{}': {}", lookup.name, e);
+                failed.push(ReloadFailure {
+                    action: "create".to_string(),
+                    object_type: "lookup".to_string(),
+                    name: lookup.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Create pipelines (added + changed)
+    for pipeline in diff
+        .pipelines_added
+        .iter()
+        .chain(diff.pipelines_changed.iter())
+    {
+        let ddl = server::pipeline_to_ddl(pipeline);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Created pipeline: {}", pipeline.name);
+                applied.push(ReloadOp {
+                    action: "create".to_string(),
+                    object_type: "stream".to_string(),
+                    name: pipeline.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to create pipeline '{}': {}", pipeline.name, e);
+                failed.push(ReloadFailure {
+                    action: "create".to_string(),
+                    object_type: "stream".to_string(),
+                    name: pipeline.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Create sinks (added + changed)
+    for sink in diff.sinks_added.iter().chain(diff.sinks_changed.iter()) {
+        let ddl = server::sink_to_ddl(sink);
+        match db.execute(&ddl).await {
+            Ok(_) => {
+                info!("Created sink: {}", sink.name);
+                applied.push(ReloadOp {
+                    action: "create".to_string(),
+                    object_type: "sink".to_string(),
+                    name: sink.name.clone(),
+                });
+            }
+            Err(e) => {
+                warn!("Failed to create sink '{}': {}", sink.name, e);
+                failed.push(ReloadFailure {
+                    action: "create".to_string(),
+                    object_type: "sink".to_string(),
+                    name: sink.name.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    let success = failed.is_empty();
+    let warnings = diff.warnings.clone();
+    ReloadResult {
+        success,
+        applied,
+        failed,
+        warnings,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency guard
+// ---------------------------------------------------------------------------
+
+/// Prevents concurrent reloads.
+///
+/// Acquire via [`try_acquire`](ReloadGuard::try_acquire). The returned
+/// [`ReloadGuardHandle`] releases the guard on drop.
+#[derive(Clone)]
+pub struct ReloadGuard {
+    in_progress: Arc<AtomicBool>,
+}
+
+impl ReloadGuard {
+    pub fn new() -> Self {
+        Self {
+            in_progress: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Try to acquire the reload guard. Returns `None` if another reload
+    /// is already in progress.
+    pub fn try_acquire(&self) -> Option<ReloadGuardHandle> {
+        let was_free =
+            self.in_progress
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire);
+        if was_free.is_ok() {
+            Some(ReloadGuardHandle {
+                flag: Arc::clone(&self.in_progress),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// RAII handle that releases the [`ReloadGuard`] on drop.
+pub struct ReloadGuardHandle {
+    flag: Arc<AtomicBool>,
+}
+
+impl Drop for ReloadGuardHandle {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::*;
+
+    fn empty_config() -> ServerConfig {
+        ServerConfig {
+            server: ServerSection::default(),
+            state: StateSection::default(),
+            checkpoint: CheckpointSection::default(),
+            sources: vec![],
+            lookups: vec![],
+            pipelines: vec![],
+            sinks: vec![],
+            discovery: None,
+            coordination: None,
+            node_id: None,
+        }
+    }
+
+    fn make_source(name: &str) -> SourceConfig {
+        SourceConfig {
+            name: name.to_string(),
+            connector: "kafka".to_string(),
+            format: "json".to_string(),
+            properties: toml::Table::new(),
+            schema: vec![],
+            watermark: None,
+        }
+    }
+
+    fn make_pipeline(name: &str, sql: &str) -> PipelineConfig {
+        PipelineConfig {
+            name: name.to_string(),
+            sql: sql.to_string(),
+            parallelism: None,
+        }
+    }
+
+    fn make_sink(name: &str, pipeline: &str) -> SinkConfig {
+        SinkConfig {
+            name: name.to_string(),
+            pipeline: pipeline.to_string(),
+            connector: "kafka".to_string(),
+            delivery: "at_least_once".to_string(),
+            properties: toml::Table::new(),
+        }
+    }
+
+    fn make_lookup(name: &str) -> LookupConfig {
+        LookupConfig {
+            name: name.to_string(),
+            connector: "postgres".to_string(),
+            strategy: "poll".to_string(),
+            pushdown: true,
+            cache: LookupCacheConfig::default(),
+            properties: toml::Table::new(),
+            schema: vec![],
+        }
+    }
+
+    // -- diff_configs tests --
+
+    #[test]
+    fn test_diff_empty_configs() {
+        let old = empty_config();
+        let new = empty_config();
+        let diff = diff_configs(&old, &new);
+        assert!(diff.is_empty());
+        assert!(diff.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_diff_identical_configs() {
+        let mut old = empty_config();
+        old.sources.push(make_source("s1"));
+        old.pipelines.push(make_pipeline("p1", "SELECT 1"));
+        let new = old.clone();
+        let diff = diff_configs(&old, &new);
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn test_diff_source_added() {
+        let old = empty_config();
+        let mut new = empty_config();
+        new.sources.push(make_source("new_src"));
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.sources_added.len(), 1);
+        assert_eq!(diff.sources_added[0].name, "new_src");
+        assert!(diff.sources_removed.is_empty());
+        assert!(diff.sources_changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_source_removed() {
+        let mut old = empty_config();
+        old.sources.push(make_source("old_src"));
+        let new = empty_config();
+        let diff = diff_configs(&old, &new);
+        assert!(diff.sources_added.is_empty());
+        assert_eq!(diff.sources_removed.len(), 1);
+        assert_eq!(diff.sources_removed[0].name, "old_src");
+    }
+
+    #[test]
+    fn test_diff_source_changed() {
+        let mut old = empty_config();
+        old.sources.push(make_source("s1"));
+        let mut new = empty_config();
+        let mut changed = make_source("s1");
+        changed.format = "avro".to_string();
+        new.sources.push(changed);
+        let diff = diff_configs(&old, &new);
+        assert!(diff.sources_added.is_empty());
+        assert!(diff.sources_removed.is_empty());
+        assert_eq!(diff.sources_changed.len(), 1);
+        assert_eq!(diff.sources_changed[0].format, "avro");
+    }
+
+    #[test]
+    fn test_diff_pipeline_sql_changed() {
+        let mut old = empty_config();
+        old.pipelines.push(make_pipeline("p1", "SELECT 1"));
+        let mut new = empty_config();
+        new.pipelines.push(make_pipeline("p1", "SELECT 2"));
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.pipelines_changed.len(), 1);
+        assert_eq!(diff.pipelines_changed[0].sql, "SELECT 2");
+    }
+
+    #[test]
+    fn test_diff_sink_changed() {
+        let mut old = empty_config();
+        old.sinks.push(make_sink("out", "p1"));
+        let mut new = empty_config();
+        let mut changed = make_sink("out", "p1");
+        changed.delivery = "exactly_once".to_string();
+        new.sinks.push(changed);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.sinks_changed.len(), 1);
+    }
+
+    #[test]
+    fn test_diff_lookup_changed() {
+        let mut old = empty_config();
+        old.lookups.push(make_lookup("lk1"));
+        let mut new = empty_config();
+        let mut changed = make_lookup("lk1");
+        changed.strategy = "cdc".to_string();
+        new.lookups.push(changed);
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.lookups_changed.len(), 1);
+    }
+
+    #[test]
+    fn test_diff_non_reloadable_warnings() {
+        let old = empty_config();
+        let mut new = empty_config();
+        new.server.bind = "0.0.0.0:9999".to_string();
+        new.state.backend = "mmap".to_string();
+        let diff = diff_configs(&old, &new);
+        assert!(diff.is_empty()); // no reloadable changes
+        assert!(diff.warnings.iter().any(|w| w.contains("[server]")));
+        assert!(diff.warnings.iter().any(|w| w.contains("[state]")));
+    }
+
+    #[test]
+    fn test_diff_multiple_sections_changed() {
+        let old = empty_config();
+        let mut new = empty_config();
+        new.sources.push(make_source("s1"));
+        new.pipelines.push(make_pipeline("p1", "SELECT 1"));
+        new.sinks.push(make_sink("out", "p1"));
+        let diff = diff_configs(&old, &new);
+        assert_eq!(diff.sources_added.len(), 1);
+        assert_eq!(diff.pipelines_added.len(), 1);
+        assert_eq!(diff.sinks_added.len(), 1);
+        assert!(!diff.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_on_default() {
+        let diff = ConfigDiff::default();
+        assert!(diff.is_empty());
+    }
+
+    // -- ReloadGuard tests --
+
+    #[test]
+    fn test_guard_acquire_release() {
+        let guard = ReloadGuard::new();
+        {
+            let handle = guard.try_acquire();
+            assert!(handle.is_some());
+            // While held, second acquire fails
+            assert!(guard.try_acquire().is_none());
+        }
+        // After drop, can acquire again
+        assert!(guard.try_acquire().is_some());
+    }
+
+    #[test]
+    fn test_guard_concurrent_reject() {
+        let guard = ReloadGuard::new();
+        let _handle = guard.try_acquire().unwrap();
+        assert!(guard.try_acquire().is_none());
+        assert!(guard.try_acquire().is_none());
+    }
+
+    #[test]
+    fn test_guard_raii_drop() {
+        let guard = ReloadGuard::new();
+        let handle = guard.try_acquire().unwrap();
+        drop(handle);
+        let handle2 = guard.try_acquire();
+        assert!(handle2.is_some());
+    }
+
+    // -- apply_reload tests (using real LaminarDB) --
+
+    #[tokio::test]
+    async fn test_apply_add_source() {
+        let db = LaminarDB::open().unwrap();
+        let mut diff = ConfigDiff::default();
+        diff.sources_added.push(SourceConfig {
+            name: "test_src".to_string(),
+            connector: "kafka".to_string(),
+            format: "json".to_string(),
+            properties: toml::Table::new(),
+            schema: vec![ColumnDef {
+                name: "id".to_string(),
+                data_type: "BIGINT".to_string(),
+                nullable: false,
+            }],
+            watermark: None,
+        });
+        let result = apply_reload(&db, &diff).await;
+        // Connector may not be available in test builds; verify the op was attempted
+        let total = result.applied.len() + result.failed.len();
+        assert_eq!(total, 1, "expected exactly one create operation");
+        if result.success {
+            assert_eq!(result.applied[0].action, "create");
+            assert_eq!(result.applied[0].name, "test_src");
+        } else {
+            assert_eq!(result.failed[0].action, "create");
+            assert_eq!(result.failed[0].name, "test_src");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_apply_remove_source() {
+        let db = LaminarDB::open().unwrap();
+        // First create the source
+        db.execute("CREATE SOURCE rm_src (id BIGINT)")
+            .await
+            .unwrap();
+
+        let mut diff = ConfigDiff::default();
+        diff.sources_removed.push(make_source("rm_src"));
+        let result = apply_reload(&db, &diff).await;
+        assert!(result.success);
+        assert_eq!(result.applied.len(), 1);
+        assert_eq!(result.applied[0].action, "drop");
+    }
+
+    #[tokio::test]
+    async fn test_apply_change_pipeline() {
+        let db = LaminarDB::open().unwrap();
+        // Create source and initial pipeline
+        db.execute("CREATE SOURCE cp_src (id BIGINT, val DOUBLE)")
+            .await
+            .unwrap();
+        db.execute("CREATE STREAM cp_pipe AS SELECT id, val FROM cp_src")
+            .await
+            .unwrap();
+
+        // Change pipeline SQL
+        let mut diff = ConfigDiff::default();
+        diff.pipelines_changed
+            .push(make_pipeline("cp_pipe", "SELECT id FROM cp_src"));
+        let result = apply_reload(&db, &diff).await;
+        assert!(result.success);
+        // Should have 2 ops: drop + create
+        assert_eq!(result.applied.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_apply_ordered_removal() {
+        let db = LaminarDB::open().unwrap();
+        // Create a full pipeline chain: source → pipeline → sink
+        db.execute("CREATE SOURCE ord_src (id BIGINT)")
+            .await
+            .unwrap();
+        db.execute("CREATE STREAM ord_pipe AS SELECT id FROM ord_src")
+            .await
+            .unwrap();
+
+        // Remove all in one diff — should respect dependency order
+        let mut diff = ConfigDiff::default();
+        diff.sources_removed.push(make_source("ord_src"));
+        diff.pipelines_removed
+            .push(make_pipeline("ord_pipe", "SELECT id FROM ord_src"));
+
+        let result = apply_reload(&db, &diff).await;
+        assert!(result.success);
+        // Pipeline should be dropped before source
+        let drop_names: Vec<&str> = result
+            .applied
+            .iter()
+            .filter(|op| op.action == "drop")
+            .map(|op| op.name.as_str())
+            .collect();
+        let pipe_idx = drop_names.iter().position(|n| *n == "ord_pipe");
+        let src_idx = drop_names.iter().position(|n| *n == "ord_src");
+        assert!(pipe_idx < src_idx, "pipeline must be dropped before source");
+    }
+
+    #[tokio::test]
+    async fn test_apply_empty_diff() {
+        let db = LaminarDB::open().unwrap();
+        let diff = ConfigDiff::default();
+        let result = apply_reload(&db, &diff).await;
+        assert!(result.success);
+        assert!(result.applied.is_empty());
+        assert!(result.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_apply_warnings_passed_through() {
+        let db = LaminarDB::open().unwrap();
+        let mut diff = ConfigDiff::default();
+        diff.warnings
+            .push("[server] section changed — requires restart".to_string());
+        let result = apply_reload(&db, &diff).await;
+        assert!(result.success);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("[server]"));
+    }
+}

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -5,6 +5,7 @@
 //! shutdown).
 
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use tokio::signal;
@@ -17,6 +18,7 @@ use crate::config::{
     ConfigError, LookupConfig, PipelineConfig, ServerConfig, SinkConfig, SourceConfig,
 };
 use crate::http;
+use crate::reload::ReloadGuard;
 
 /// Handle to a running LaminarDB server.
 ///
@@ -25,6 +27,7 @@ use crate::http;
 pub struct ServerHandle {
     db: Arc<LaminarDB>,
     api_handle: tokio::task::JoinHandle<()>,
+    watcher_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl ServerHandle {
@@ -36,6 +39,9 @@ impl ServerHandle {
 
         info!("Received shutdown signal, shutting down...");
 
+        if let Some(wh) = &self.watcher_handle {
+            wh.abort();
+        }
         self.db
             .shutdown()
             .await
@@ -156,16 +162,40 @@ pub async fn run_server(
     info!("Pipeline started");
 
     // 4. Start HTTP API
+    let bind = config.server.bind.clone();
     let app_state = Arc::new(http::AppState {
         db: Arc::clone(&db),
-        config_path,
+        config_path: config_path.clone(),
         started_at: chrono::Utc::now(),
+        current_config: tokio::sync::RwLock::new(config),
+        reload_guard: ReloadGuard::new(),
+        reload_total: AtomicU64::new(0),
+        reload_last_ts: AtomicU64::new(0),
     });
-    let router = http::build_router(app_state);
-    let api_handle = http::serve(router, &config.server.bind).await?;
-    info!("HTTP API listening on {}", config.server.bind);
+    let router = http::build_router(Arc::clone(&app_state));
+    let api_handle = http::serve(router, &bind).await?;
+    info!("HTTP API listening on {bind}");
 
-    Ok(ServerHandle { db, api_handle })
+    // 5. Spawn config file watcher
+    let watcher_handle = {
+        let watcher_state = Arc::clone(&app_state);
+        let watcher_path = config_path;
+        Some(tokio::spawn(async move {
+            crate::watcher::watch_config(
+                watcher_path,
+                watcher_state,
+                std::time::Duration::from_millis(500),
+            )
+            .await;
+        }))
+    };
+    info!("Config file watcher started");
+
+    Ok(ServerHandle {
+        db,
+        api_handle,
+        watcher_handle,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/laminar-server/src/watcher.rs
+++ b/crates/laminar-server/src/watcher.rs
@@ -1,0 +1,158 @@
+//! File system watcher for automatic config hot-reload.
+//!
+//! Watches the config file's parent directory using the `notify` crate and
+//! triggers a reload when the target file is modified. Handles atomic editor
+//! saves (write-temp + rename) by watching the directory rather than the file.
+
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+use crate::config;
+use crate::http::AppState;
+use crate::reload;
+
+/// Watch the config file and trigger reload on changes.
+///
+/// Runs forever until the task is aborted. Errors are logged but never
+/// cause the watcher to exit (resilience against transient failures).
+pub async fn watch_config(config_path: PathBuf, state: Arc<AppState>, debounce: Duration) {
+    let (tx, mut rx) = mpsc::channel::<()>(16);
+
+    // Canonicalize the config path for reliable comparison
+    let canonical = match config_path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "Could not canonicalize config path '{}': {e} — watcher disabled",
+                config_path.display()
+            );
+            return;
+        }
+    };
+
+    // Watch the parent directory (handles atomic saves: write-tmp + rename)
+    let watch_dir = match canonical.parent() {
+        Some(p) => p.to_path_buf(),
+        None => {
+            warn!("Config file has no parent directory — watcher disabled");
+            return;
+        }
+    };
+
+    let target = canonical.clone();
+    let mut watcher: RecommendedWatcher =
+        match notify::recommended_watcher(move |result: Result<Event, notify::Error>| {
+            match result {
+                Ok(event) => {
+                    let dominated = event.paths.iter().any(|p| {
+                        // Compare canonical paths to handle symlinks/relative paths
+                        p.canonicalize().ok().as_ref() == Some(&target)
+                    });
+                    if dominated {
+                        let _ = tx.blocking_send(());
+                    }
+                }
+                Err(e) => {
+                    warn!("File watcher error: {e}");
+                }
+            }
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                error!("Failed to create file watcher: {e} — hot reload disabled");
+                return;
+            }
+        };
+
+    if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        error!(
+            "Failed to watch directory '{}': {e} — hot reload disabled",
+            watch_dir.display()
+        );
+        return;
+    }
+
+    info!("Watching config file '{}' for changes", canonical.display());
+
+    // Keep the watcher alive and process debounced events
+    loop {
+        // Wait for first notification
+        if rx.recv().await.is_none() {
+            debug!("Watcher channel closed, exiting");
+            return;
+        }
+
+        // Debounce: sleep then drain any queued notifications
+        tokio::time::sleep(debounce).await;
+        while rx.try_recv().is_ok() {}
+
+        info!("Config file change detected, reloading...");
+
+        // Load new config
+        let new_config = match config::load_config(&canonical) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Failed to load config on file change: {e}");
+                continue;
+            }
+        };
+
+        // Acquire reload guard
+        let _guard = match state.reload_guard.try_acquire() {
+            Some(g) => g,
+            None => {
+                debug!("Another reload in progress, skipping file-triggered reload");
+                continue;
+            }
+        };
+
+        // Diff against current config
+        let current = state.current_config.read().await;
+        let diff = reload::diff_configs(&current, &new_config);
+        drop(current);
+
+        if diff.is_empty() {
+            for w in &diff.warnings {
+                warn!("Config reload warning: {w}");
+            }
+            if diff.warnings.is_empty() {
+                debug!("No reloadable changes detected");
+            }
+            continue;
+        }
+
+        // Apply the diff
+        let result = reload::apply_reload(&state.db, &diff).await;
+
+        // Update metrics
+        state.reload_total.fetch_add(1, Ordering::Relaxed);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let now = chrono::Utc::now().timestamp() as u64;
+        state.reload_last_ts.store(now, Ordering::Relaxed);
+
+        if result.success {
+            let mut current = state.current_config.write().await;
+            *current = new_config;
+            info!(
+                "File-triggered reload complete: {} ops applied",
+                result.applied.len()
+            );
+        } else {
+            warn!(
+                "File-triggered reload partial failure: {} applied, {} failed",
+                result.applied.len(),
+                result.failed.len()
+            );
+        }
+
+        for w in &result.warnings {
+            warn!("Reload warning: {w}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add config diff engine (`reload.rs`) that compares two `ServerConfig` snapshots by name-keyed sections, detecting added/removed/changed sources, lookups, pipelines, and sinks
- Implement incremental DDL application via `apply_reload()` — drops in reverse dependency order (sinks → streams → lookups → sources), then creates in dependency order
- Wire `/api/v1/reload` endpoint with concurrency guard (409 Conflict), config validation (400), and partial-failure reporting (207 Multi-Status)
- Add debounced file watcher (`watcher.rs`) using `notify` crate that watches the config file's parent directory for atomic editor saves
- Add `PartialEq` derives to all 13 config structs to enable diffing
- Add reload metrics (`laminardb_reload_total`, `laminardb_reload_last_timestamp`) to `/metrics` endpoint
- Non-reloadable section changes (`[server]`, `[state]`, `[checkpoint]`, `[discovery]`, `[coordination]`, `node_id`) produce warnings instead of errors

## Test plan

- [x] 59 tests pass (`cargo test -p laminar-server --no-default-features`)
- [x] 0 clippy warnings (`cargo clippy -p laminar-server -- -D warnings`)
- [x] Docs build (`cargo doc -p laminar-server --no-deps`)
- [ ] Manual: start server with TOML config, modify file, verify reload logs and `/api/v1/reload` response