### PR TITLE
chore: bump to 0.18.0, humanize docs, SEO optimize site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.15.0] - 2026-02-22
 
 ### Added
-- Comprehensive project documentation (README, ARCHITECTURE, CONTRIBUTING, crate READMEs)
+- Project documentation (README, ARCHITECTURE, CONTRIBUTING, crate READMEs)
 - PR template and SECURITY.md
 - Interactive data flow playground on docs website
 - WebSocket source and sink connectors registered in connector registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to LaminarDB
 
-Thank you for your interest in contributing to LaminarDB! This guide covers everything you need to get started.
+This guide covers development setup, code style, and the pull request process.
 
 ## Prerequisites
 
@@ -189,4 +189,4 @@ Use the [GitHub issue templates](https://github.com/laminardb/laminardb/issues/n
 
 ## Questions?
 
-Feel free to open an issue for any questions!
+Open an issue on GitHub.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6772,6 +6772,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-laminar-db = "0.16"
+laminar-db = "0.18"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -80,7 +80,7 @@ cargo run
 
 ### Python Quick Start
 
-LaminarDB also has Python bindings via [laminardb-python](https://github.com/laminardb/laminardb-python):
+Python bindings via [laminardb-python](https://github.com/laminardb/laminardb-python):
 
 ```bash
 pip install laminardb
@@ -111,7 +111,7 @@ See the [Python README](https://github.com/laminardb/laminardb-python) for the f
 
 ### Streaming SQL
 
-LaminarDB extends standard SQL with streaming primitives. All window types, join types, and EMIT strategies listed below are implemented and tested.
+Standard SQL with streaming extensions. All window types, join types, and EMIT strategies below are implemented and tested.
 
 #### Window Types
 
@@ -239,7 +239,7 @@ See [docs/SQL_REFERENCE.md](docs/SQL_REFERENCE.md) for the complete SQL dialect 
 
 ### Watermarks and Event Time
 
-LaminarDB uses event-time processing with watermarks to handle out-of-order data.
+Event-time processing with watermarks handles out-of-order data.
 
 ```sql
 -- Bounded out-of-orderness: allow up to 5 seconds of late data
@@ -260,7 +260,7 @@ Late data can be dropped (default) or redirected to a side output.
 
 ## Connectors
 
-LaminarDB connects to external systems via feature-gated connectors. Each connector implements the `SourceConnector` or `SinkConnector` trait with exactly-once semantics via two-phase commit.
+Feature-gated connectors for external systems. Each implements the `SourceConnector` or `SinkConnector` trait with exactly-once semantics via two-phase commit.
 
 ### Source Connectors
 
@@ -345,20 +345,20 @@ Cloud storage backends: S3 (`delta-lake-s3`), Azure ADLS (`delta-lake-azure`), G
 
 ### Connector SDK
 
-Build custom connectors using the SDK with operational resilience built in:
+Build custom connectors with the SDK:
 
 ```rust
 use laminar_connectors::connector::{SourceConnector, SinkConnector};
 use laminar_connectors::sdk::{RetryPolicy, CircuitBreaker, RateLimiter};
 ```
 
-The SDK provides retry policies with exponential backoff, circuit breakers, rate limiters, and a test harness for connector development.
+Includes retry policies, circuit breakers, rate limiters, and a test harness.
 
 ---
 
 ## Schema Framework
 
-LaminarDB includes a pluggable schema framework for format decoding, schema inference, and schema evolution.
+Pluggable format decoding, schema inference, and schema evolution.
 
 ### Format Decoders
 
@@ -382,7 +382,7 @@ LaminarDB includes a pluggable schema framework for format decoding, schema infe
 
 ## Architecture
 
-LaminarDB uses a three-ring architecture to separate latency-critical event processing from background I/O and control plane operations:
+Three-ring architecture separating latency-critical event processing from background I/O and the control plane:
 
 ```
 +------------------------------------------------------------------+
@@ -427,7 +427,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
 
 ## Checkpointing and Recovery
 
-LaminarDB provides exactly-once semantics through a coordinated checkpointing system:
+Exactly-once semantics through coordinated checkpointing:
 
 1. **Ring 0 Changelog** -- Every state mutation is captured by `ChangelogAwareStore` (~2-5ns overhead per mutation)
 2. **Per-Core WAL** -- Each CPU core writes to its own WAL segment with CRC32C checksums and torn write detection
@@ -453,13 +453,13 @@ let db = LaminarDB::builder()
 
 ## JIT Compilation
 
-LaminarDB optionally compiles DataFusion logical plans into native machine code via Cranelift for Ring 0 execution. Enable with the `jit` feature flag.
+DataFusion logical plans can be compiled to native machine code via Cranelift for Ring 0 execution. Enable with the `jit` feature flag.
 
 The `AdaptiveQueryRunner` runs queries interpreted first, compiles in the background, and hot-swaps to compiled execution when ready -- zero downtime during compilation.
 
 ```toml
 [dependencies]
-laminar-db = { version = "0.16", features = ["jit"] }
+laminar-db = { version = "0.18", features = ["jit"] }
 ```
 
 ---
@@ -510,7 +510,7 @@ struct MySourceConfig {
 
 ## Distributed Mode (Delta Architecture)
 
-LaminarDB extends from single-process to multi-node via the Delta architecture. Enable with the `delta` feature flag.
+Single-process to multi-node via the Delta architecture. Enable with the `delta` feature flag.
 
 Implemented:
 - Gossip-based node discovery (chitchat)
@@ -522,7 +522,7 @@ Implemented:
 
 ```toml
 [dependencies]
-laminar-db = { version = "0.16", features = ["delta"] }
+laminar-db = { version = "0.18", features = ["delta"] }
 ```
 
 ---
@@ -621,7 +621,7 @@ laminar-server            (binary: laminar-db + laminar-admin + laminar-auth + l
 
 ## Project Status
 
-LaminarDB is in active development. Here is the current phase progress:
+Active development. Current phase progress:
 
 | Phase | Description | Features | Status |
 |-------|-------------|----------|--------|
@@ -726,7 +726,7 @@ cargo bench
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style guidelines, Ring 0 rules, and the pull request process.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, Ring 0 rules, and the PR process.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.12.x (latest) | Yes |
-| < 0.12 | No |
+| 0.18.x (latest) | Yes |
+| < 0.18 | No |
 
 ## Reporting a Vulnerability
 

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,8 +11,8 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.17.0" }
-laminar-storage = { path = "../laminar-storage", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.0" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }

--- a/crates/laminar-connectors/README.md
+++ b/crates/laminar-connectors/README.md
@@ -4,7 +4,7 @@ External system connectors for LaminarDB -- Kafka, CDC, WebSocket, lakehouse sin
 
 ## Overview
 
-Provides source and sink connectors for integrating LaminarDB with external systems. Each connector implements the `SourceConnector` or `SinkConnector` trait and supports exactly-once semantics via two-phase commit.
+Source and sink connectors for Kafka, CDC, WebSocket, lakehouse sinks, and custom connectors. Each connector implements the `SourceConnector` or `SinkConnector` trait and supports exactly-once semantics via two-phase commit.
 
 ## Connectors
 
@@ -52,8 +52,6 @@ Provides source and sink connectors for integrating LaminarDB with external syst
 | `error_handling` | Dead letter queue and error routing for malformed records |
 
 ## Schema Framework
-
-The schema module provides a pluggable framework for format decoding and schema management:
 
 | Sub-module | Description |
 |------------|-------------|

--- a/crates/laminar-core/README.md
+++ b/crates/laminar-core/README.md
@@ -4,7 +4,7 @@ Core streaming engine for LaminarDB -- reactor, operators, state stores, and str
 
 ## Overview
 
-This is the Ring 0 crate containing all latency-critical components. Everything here is designed for sub-microsecond execution with zero heap allocations on the hot path.
+Ring 0 crate. Everything here targets sub-microsecond execution with zero heap allocations on the hot path.
 
 ## Key Modules
 
@@ -48,7 +48,7 @@ This is the Ring 0 crate containing all latency-critical components. Everything 
 
 ## Ring Placement
 
-This crate operates in **Ring 0 (Hot Path)**. All code must:
+All code in this crate must:
 - Make zero heap allocations
 - Use no locks (SPSC queues for communication)
 - Avoid system calls on the fast path

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -33,10 +33,10 @@ gcs = ["laminar-storage/gcs"]
 azure = ["laminar-storage/azure"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.17.0" }
-laminar-sql = { path = "../laminar-sql", version = "0.17.0" }
-laminar-storage = { path = "../laminar-storage", version = "0.17.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0" }
+laminar-sql = { path = "../laminar-sql", version = "0.18.0" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.0" }
 
 # Arrow
 arrow = { workspace = true }
@@ -84,7 +84,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = { workspace = true }
-laminar-derive = { path = "../laminar-derive", version = "0.17.0" }
+laminar-derive = { path = "../laminar-derive", version = "0.18.0" }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/laminar-db/README.md
+++ b/crates/laminar-db/README.md
@@ -4,7 +4,7 @@ Unified database facade for LaminarDB.
 
 ## Overview
 
-This crate provides `LaminarDB`, the primary user-facing type that ties together the SQL parser, query planner, DataFusion context, streaming infrastructure, and connector registry into a single interface. It is the entry point for all LaminarDB applications.
+`LaminarDB` lives here -- the main entry point that wires together the SQL parser, query planner, DataFusion context, streaming infrastructure, and connector registry.
 
 ## Key Types
 

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -21,5 +21,5 @@ proc-macro2 = "1.0"
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.17.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.0" }

--- a/crates/laminar-derive/README.md
+++ b/crates/laminar-derive/README.md
@@ -4,7 +4,7 @@ Derive macros for LaminarDB -- `Record`, `FromRecordBatch`, `FromRow`, and `Conn
 
 ## Overview
 
-Provides procedural macros that automatically generate Arrow RecordBatch conversion code and connector configuration parsing, eliminating boilerplate in typed data ingestion, result consumption, and connector development.
+Procedural macros for Arrow RecordBatch conversion and connector config parsing. Eliminates the boilerplate of writing `to_record_batch()` / `from_batch()` by hand.
 
 ## Macros
 

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -16,14 +16,14 @@ path = "src/main.rs"
 
 [dependencies]
 # All LaminarDB crates
-laminar-core = { path = "../laminar-core", version = "0.17.0", features = ["delta"] }
-laminar-sql = { path = "../laminar-sql", version = "0.17.0" }
-laminar-storage = { path = "../laminar-storage", version = "0.17.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.17.0" }
-laminar-auth = { path = "../laminar-auth", version = "0.17.0" }
-laminar-admin = { path = "../laminar-admin", version = "0.17.0" }
-laminar-observe = { path = "../laminar-observe", version = "0.17.0" }
-laminar-db = { path = "../laminar-db", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0", features = ["delta"] }
+laminar-sql = { path = "../laminar-sql", version = "0.18.0" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.0" }
+laminar-auth = { path = "../laminar-auth", version = "0.18.0" }
+laminar-admin = { path = "../laminar-admin", version = "0.18.0" }
+laminar-observe = { path = "../laminar-observe", version = "0.18.0" }
+laminar-db = { path = "../laminar-db", version = "0.18.0" }
 
 # CLI and configuration
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -11,7 +11,7 @@ description = "SQL layer for LaminarDB with streaming extensions"
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0" }
 
 # DataFusion for SQL processing
 datafusion = { workspace = true }

--- a/crates/laminar-sql/README.md
+++ b/crates/laminar-sql/README.md
@@ -4,7 +4,7 @@ SQL layer for LaminarDB with streaming extensions.
 
 ## Overview
 
-Extends standard SQL (via sqlparser-rs) with streaming constructs like tumbling windows, session windows, watermarks, EMIT clauses, and ASOF joins. Integrates with Apache DataFusion for query planning and execution.
+Streaming SQL extensions on top of sqlparser-rs: tumbling windows, session windows, watermarks, EMIT clauses, ASOF joins. DataFusion handles query planning and execution.
 
 ## Key Modules
 

--- a/crates/laminar-storage/Cargo.toml
+++ b/crates/laminar-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage layer for LaminarDB - WAL, checkpointing, and lakehouse i
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.17.0" }
+laminar-core = { path = "../laminar-core", version = "0.18.0" }
 
 # Storage
 object_store = "0.13"  # For cloud storage

--- a/crates/laminar-storage/README.md
+++ b/crates/laminar-storage/README.md
@@ -4,7 +4,7 @@ Storage layer for LaminarDB -- WAL, checkpointing, and recovery.
 
 ## Overview
 
-Ring 1 crate handling all durability concerns. Provides write-ahead logging with per-core segments, incremental checkpointing with directory-based snapshots, and checkpoint manifests. Designed to never block Ring 0 operations.
+Ring 1 durability: write-ahead logging with per-core segments, incremental checkpointing with directory-based snapshots, and checkpoint manifests. Never blocks Ring 0.
 
 Note: Lakehouse sinks (Delta Lake, Iceberg) are in `laminar-connectors`, not here. This crate handles LaminarDB's internal durability.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-LaminarDB is an embedded streaming database designed for sub-microsecond latency. It combines the deployment simplicity of SQLite with the streaming capabilities of Apache Flink.
+LaminarDB is an embedded streaming database designed for sub-microsecond latency. You link it into your application like SQLite, but instead of querying stored data, you're querying data as it arrives.
 
 ## Design Principles
 
@@ -15,7 +15,7 @@ LaminarDB is an embedded streaming database designed for sub-microsecond latency
 
 ## Three-Ring Architecture
 
-LaminarDB separates concerns into three concentric rings, each with different latency budgets and constraints:
+Three concentric rings, each with different latency budgets:
 
 ```
 +------------------------------------------------------------------+
@@ -55,7 +55,7 @@ LaminarDB separates concerns into three concentric rings, each with different la
 
 ### Ring 0: Hot Path
 
-The event processing path where latency matters most. All code in Ring 0 runs on a CPU-pinned reactor thread.
+All code here runs on a CPU-pinned reactor thread.
 
 **Components:**
 - **Reactor Loop** -- Single-threaded event loop that pulls batches from sources, runs them through operators, and emits results. CPU-pinned via the thread-per-core runtime (`laminar-core/src/tpc/`).
@@ -82,7 +82,7 @@ The event processing path where latency matters most. All code in Ring 0 runs on
 
 ### Ring 1: Background
 
-Handles durability and I/O without blocking the hot path. Runs on Tokio async runtime.
+Durability and I/O, never blocking the hot path. Runs on Tokio.
 
 **Components:**
 - **Checkpoint Manager** -- Incremental checkpointing with directory-based snapshots. Unified `CheckpointCoordinator` orchestrates two-phase commit across all operators and sinks (`laminar-db/src/checkpoint_coordinator.rs`).
@@ -97,7 +97,7 @@ Handles durability and I/O without blocking the hot path. Runs on Tokio async ru
 
 ### Ring 2: Control Plane
 
-Administrative and observability functions with no latency requirements.
+Admin and observability. No latency requirements.
 
 **Components (planned -- crate stubs exist, no implementation yet):**
 - **Admin API** -- REST API via Axum with Swagger UI (`laminar-admin/`)
@@ -109,7 +109,7 @@ Note: While the Ring 2 crate stubs (`laminar-auth`, `laminar-admin`, `laminar-ob
 
 ## Data Flow
 
-An event's journey through LaminarDB:
+How an event moves through the system:
 
 ```
                          Ring 0 (< 1us)
@@ -180,7 +180,7 @@ laminar-server        Standalone binary: CLI args, logging init (skeleton with T
 
 ### LaminarDB (Database Facade)
 
-The primary user-facing type. Manages the lifecycle of sources, streams, sinks, and the streaming pipeline.
+The main entry point. Owns sources, streams, sinks, and the pipeline lifecycle.
 
 ```rust
 let db = LaminarDB::open()?;
@@ -233,7 +233,7 @@ let db = LaminarDB::builder()
 
 ### State Store
 
-All operator state goes through the `StateStore` trait, optionally wrapped in `ChangelogAwareStore` for zero-allocation changelog capture:
+All operator state goes through the `StateStore` trait. Wrapping it in `ChangelogAwareStore` captures every mutation for checkpointing:
 
 ```rust
 pub trait StateStore: Send {
@@ -251,7 +251,7 @@ Implementations:
 
 ### Streaming Channels
 
-Lock-free communication between components:
+Lock-free channels between components:
 
 - **RingBuffer** -- Fixed-capacity, cache-line-padded ring buffer
 - **SPSC Channel** -- Single-producer single-consumer, zero-allocation on hot path
@@ -260,7 +260,7 @@ Lock-free communication between components:
 
 ### DAG Pipeline
 
-The DAG executor connects operators into a directed acyclic graph:
+Operators wired into a DAG:
 
 - **Core DAG Topology** -- Nodes (operators) and edges (channels) with type-safe wiring
 - **Multicast & Routing** -- Fan-out and key-based routing between DAG nodes
@@ -270,7 +270,7 @@ The DAG executor connects operators into a directed acyclic graph:
 
 ### Connector SDK
 
-Custom connectors implement the `SourceConnector` and `SinkConnector` traits:
+Custom connectors implement `SourceConnector` and `SinkConnector`:
 
 ```rust
 #[async_trait]
@@ -296,11 +296,11 @@ pub trait SinkConnector: Send {
 }
 ```
 
-The SDK provides retry policies, rate limiting, circuit breakers, and a test harness.
+The SDK adds retry policies, rate limiting, circuit breakers, and a test harness.
 
 ### Lookup Tables
 
-Lookup tables provide enrichment join support with multiple caching strategies:
+Enrichment joins with multiple caching strategies:
 
 - **Full cache (Ring 0)** -- foyer in-memory cache with S3-FIFO eviction
 - **Hybrid cache (Ring 1)** -- foyer HybridCache with disk-backed overflow
@@ -321,7 +321,7 @@ Pre-configured deployment tiers:
 
 ## Streaming SQL
 
-LaminarDB extends standard SQL (via sqlparser-rs) with streaming constructs:
+SQL parsing goes through sqlparser-rs with these streaming extensions:
 
 | Extension | Syntax | Example |
 |-----------|--------|---------|
@@ -388,7 +388,7 @@ Key-based routing ensures all events for a given key are processed on the same c
 
 ## Exactly-Once Semantics
 
-LaminarDB provides exactly-once processing through:
+Exactly-once processing works through:
 
 1. **Source offsets** -- Tracked per-source, persisted in checkpoint manifests
 2. **Changelog capture** -- `ChangelogAwareStore` records every state mutation
@@ -399,7 +399,7 @@ LaminarDB provides exactly-once processing through:
 
 ## Delta Architecture (Distributed Mode)
 
-When enabled with the `delta` feature, LaminarDB extends to multi-node operation:
+With the `delta` feature enabled, multi-node operation:
 
 - **Discovery** -- Static configuration, gossip-based (chitchat), or Kafka group discovery
 - **Coordination** -- Raft-based metadata consensus via openraft
@@ -408,4 +408,4 @@ When enabled with the `delta` feature, LaminarDB extends to multi-node operation
 - **Cross-Node Aggregation** -- Gossip partial aggregates and gRPC fan-out
 - **Inter-Node RPC** -- gRPC service definitions for remote lookups, barrier forwarding, aggregate fan-out
 
-The Delta architecture maintains Ring 0's sub-500ns hot path guarantees while adding distributed coordination in Ring 1 and Ring 2.
+Distributed coordination runs in Ring 1 and Ring 2 — Ring 0's sub-500ns hot path is not affected.

--- a/docs/COMPETITIVE.md
+++ b/docs/COMPETITIVE.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-LaminarDB occupies a unique position: **no existing system offers all of embedded-first deployment, thread-per-core architecture, sub-microsecond latency, SQL-native streaming, and lakehouse integration**.
+The closest alternatives are either distributed-only (Flink, RisingWave, Materialize) or lack SQL (Kafka Streams). LaminarDB is embedded, thread-per-core, sub-microsecond, and SQL-native.
 
 ## Competitive Matrix
 
@@ -176,4 +176,4 @@ LaminarDB occupies a unique position: **no existing system offers all of embedde
 2. **Simplicity**: Single binary, no cluster, immediate productivity
 3. **Flexibility**: Embedded or standalone, multiple sources/sinks
 4. **Open Source**: Apache 2.0, no licensing concerns
-5. **Modern Stack**: Rust, Arrow, DataFusion - cutting-edge foundations
+5. **Modern Stack**: Rust, Arrow, DataFusion

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ LaminarDB development is organized into phases, each building on the previous. D
 
 ## Phase 2: Production Hardening -- COMPLETE
 
-**Goal**: Make the engine production-ready with advanced features.
+**Goal**: Harden the engine with advanced window types, joins, per-core WAL, exactly-once sinks, and performance infrastructure.
 
 **Completed Features (38/38):**
 - Thread-per-core architecture with CPU pinning (F013-F015)

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -422,4 +422,4 @@ The following patterns are confirmed working in LaminarDB embedded mode (tested 
 
 ---
 
-*This reference is based on LaminarDB v0.16.x with DataFusion 52.x and Arrow 57.x. Contributions and corrections welcome -- please open an issue or PR.*
+*This reference is based on LaminarDB v0.18.x with DataFusion 52.x and Arrow 57.x. Contributions and corrections welcome -- please open an issue or PR.*

--- a/docs/STEERING.md
+++ b/docs/STEERING.md
@@ -109,7 +109,7 @@ Gossip discovery, Raft consensus, partition ownership, distributed checkpoints, 
 All Phase 1 P0 issues resolved:
 - WAL durability fixes (fdatasync, CRC32C, torn write detection)
 - Watermark persistence in WAL commits and checkpoint metadata
-- Recovery integration tests (6 comprehensive tests)
+- Recovery integration tests (6 tests covering all recovery paths)
 
 ### Remaining
 

--- a/docs/adr/ADR-003-sql-parser-strategy.md
+++ b/docs/adr/ADR-003-sql-parser-strategy.md
@@ -20,7 +20,7 @@ LaminarDB promises "Full SQL Support" as a key differentiator from competitors l
 1. **Production Requirements**
    - Must parse complex streaming SQL queries correctly
    - Must provide clear error messages with line/column information
-   - Must integrate seamlessly with DataFusion
+   - Must integrate with DataFusion without hacks
    - Must support all promised SQL features
 
 2. **Performance Requirements**
@@ -87,7 +87,7 @@ LaminarDB promises "Full SQL Support" as a key differentiator from competitors l
 
 This approach:
 1. Maintains compatibility with DataFusion
-2. Leverages existing parsing infrastructure
+2. Reuses existing parsing infrastructure
 3. Benefits from sqlparser community improvements
 4. Allows incremental enhancement
 
@@ -95,7 +95,7 @@ Implementation strategy:
 1. Create a `StreamingSqlDialect` that adds keywords: TUMBLE, HOP, SESSION, WATERMARK, EMIT
 2. Extend the parser with streaming-specific statement types
 3. Create a translation layer to DataFusion's LogicalPlan
-4. Add comprehensive tests for streaming SQL
+4. Add tests for streaming SQL
 
 ## Consequences
 
@@ -130,7 +130,7 @@ Implementation strategy:
 - Integration with DataFusion logical plans
 
 ### Phase 3: Production Hardening (2 weeks)
-- Comprehensive error messages
+- Clear error messages
 - Performance optimization
 - SQL injection prevention
 - Prepared statement support

--- a/docs/adr/ADR-005-tiered-reference-tables.md
+++ b/docs/adr/ADR-005-tiered-reference-tables.md
@@ -71,7 +71,7 @@ during stream-table joins via DataFusion `TableProvider`.
 **Pros:**
 - Zero memory usage for reference data
 - Always-fresh data
-- Leverages existing DataFusion federation crate
+- Reuses existing DataFusion federation crate
 
 **Cons:**
 - Network round-trip per lookup (1-100ms) — **incompatible with Ring 0 latency**

--- a/docs/audits/phase-2-verification-20260128.md
+++ b/docs/audits/phase-2-verification-20260128.md
@@ -18,7 +18,7 @@
 
 **Overall Production Readiness Score: 96/100**
 
-The codebase is well-engineered with zero compiler warnings, zero clippy violations, and comprehensive test coverage. All P0 issues have been fixed. The remaining gap is the SQL parser panic-based error handling (P1), which affects configuration-time robustness but not runtime hot paths.
+Zero compiler warnings, zero clippy violations, thorough test coverage. All P0 issues have been fixed. The remaining gap is the SQL parser panic-based error handling (P1), which affects configuration-time robustness but not runtime hot paths.
 
 ---
 
@@ -534,10 +534,10 @@ NumaPlacement::for_checkpoint()            // Any node
 
 ## Conclusion
 
-LaminarDB's Phase 1 and Phase 2 implementation is **production-ready**. The codebase demonstrates:
+Phase 1 and Phase 2 are solid. The codebase demonstrates:
 
-- **Genuine implementations** (no AI slop) - zero dead code, zero placeholder implementations
-- **Comprehensive testing** - 1,382 tests across 47 features
+- **Genuine implementations** - zero dead code, zero placeholder implementations
+- **1,382 tests** across 47 features
 - **Clean code quality** - zero compiler/clippy warnings
 - **Research-backed architecture** - io_uring, NUMA, keyed watermarks all properly implemented
 - **Sound engineering** - proper error types, SAFETY comments on all unsafe blocks, feature-gated platform code

--- a/docs/error-audit-report.md
+++ b/docs/error-audit-report.md
@@ -451,7 +451,7 @@ No error counters exist. There is no Prometheus/metrics integration for error tr
 14. **Add Clippy lints** — `unwrap_used = "deny"` (after migration)
 15. **Ban `eprintln!`** — Replace with `tracing::warn!`
 
-### P3 — Polish (World-Class)
+### P3 — Polish
 
 16. **Ring 0 zero-alloc error type** — For hot path error reporting
 17. **Error snapshot debug mode** — Dump pipeline state on error

--- a/docs/features/delta/ARCHITECTURE-FIX-PLAN.md
+++ b/docs/features/delta/ARCHITECTURE-FIX-PLAN.md
@@ -719,7 +719,7 @@ Each fix must include:
 
 | Date | Decision | Rationale |
 |------|----------|-----------|
-| 2026-02-17 | Changelog-based incremental snapshots over `im::OrdMap` | Preserves FxHashMap O(1) get performance; leverages existing `ChangelogAwareStore` |
+| 2026-02-17 | Changelog-based incremental snapshots over `im::OrdMap` | Preserves FxHashMap O(1) get performance; reuses existing `ChangelogAwareStore` |
 | 2026-02-17 | Memcomparable key encoding over rkyv for index keys | rkyv doesn't preserve lexicographic order for numeric types |
 | 2026-02-17 | `WatermarkPassThrough` variant over silent discard | Type-safe, self-documenting, prevents future regressions |
 | 2026-02-17 | `AtomicU128` packed barrier over Mutex | Lock-free, single atomic operation, no contention |

--- a/docs/features/phase-1/F006-sql-parser-improvements.md
+++ b/docs/features/phase-1/F006-sql-parser-improvements.md
@@ -47,7 +47,7 @@ The current F006 implementation uses a simplified parser that has several critic
    - Transform GROUP BY TUMBLE(...) into appropriate operators
    - Add window_start/window_end column generation
 
-3. **Comprehensive Testing**
+3. **Testing**
    - Test all SQL edge cases
    - Validate error messages
    - Performance benchmarks for parsing
@@ -137,7 +137,7 @@ EMIT AFTER WATERMARK;
 - [ ] Create proper AST visitor for streaming keywords
 - [ ] Implement tokenizer extensions for streaming SQL
 - [ ] Add proper error handling with line/column info
-- [ ] Create comprehensive test suite
+- [ ] Create test suite
 
 ### Step 2: Integrate with DataFusion (2 weeks)
 - [ ] Create custom LogicalPlan nodes
@@ -148,7 +148,7 @@ EMIT AFTER WATERMARK;
 ### Step 3: Production Hardening (1 week)
 - [ ] Add SQL injection protection
 - [ ] Performance optimization
-- [ ] Comprehensive error messages
+- [ ] Clear error messages
 - [ ] Documentation and examples
 
 ## Alternative: Use Existing Streaming SQL Parser

--- a/docs/features/phase-2/F013-thread-per-core.md
+++ b/docs/features/phase-2/F013-thread-per-core.md
@@ -14,7 +14,7 @@
 
 ## Summary
 
-Implement thread-per-core architecture where each CPU core runs a dedicated reactor with its own state partition. This enables linear scaling and eliminates lock contention.
+Each CPU core runs a dedicated reactor with its own state partition. No shared state, no locks, linear scaling.
 
 ## Goals
 

--- a/docs/features/phase-3/F027-postgres-cdc.md
+++ b/docs/features/phase-3/F027-postgres-cdc.md
@@ -2536,7 +2536,7 @@ if let WalMessage::Keepalive(ka) = msg {
 ### Phase 4: Initial Snapshot (2-3 days)
 - [ ] `perform_snapshot()` with SERIALIZABLE transaction
 - [ ] Batched table reading with progress logging
-- [ ] Snapshot LSN recording for seamless transition to streaming
+- [ ] Snapshot LSN recording for transition to streaming
 - [ ] Snapshot mode configuration (initial, never, always)
 - [ ] Unit tests for snapshot logic
 - [ ] Integration test: snapshot + streaming transition

--- a/docs/features/phase-3/demo/SQL-PARSER-GAPS.md
+++ b/docs/features/phase-3/demo/SQL-PARSER-GAPS.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-The LaminarDB SQL parser is **very comprehensive** for streaming use cases, with 30+ aggregate functions, all window types (TUMBLE/HOP/SESSION), and full EMIT clause support. However, several SQL features commonly used in timeseries analytics are missing.
+The LaminarDB SQL parser covers most streaming SQL needs for streaming use cases, with 30+ aggregate functions, all window types (TUMBLE/HOP/SESSION), and full EMIT clause support. However, several SQL features commonly used in timeseries analytics are missing.
 
 ---
 

--- a/docs/features/phase-3/schema/F-SCHEMA-009-schema-evolution.md
+++ b/docs/features/phase-3/schema/F-SCHEMA-009-schema-evolution.md
@@ -32,7 +32,7 @@ Ring 0 hot path continues processing. Schema history is tracked in the
 - SQL DDL for schema mutations: `ALTER SOURCE ... ADD COLUMN`, `DROP COLUMN`, `ALTER COLUMN TYPE`, `REFRESH SCHEMA`
 - Schema version history tracking with queryable `laminar_catalog.schema_history`
 - Safe handling of all evolution cases: add nullable, add with default, drop, rename (field-ID sources only), widen, reject narrow
-- `ColumnProjection` mapping from old to new schema for seamless batch translation
+- `ColumnProjection` mapping from old to new schema for transparent batch translation
 
 ## Non-Goals
 

--- a/examples/binance-ws/Cargo.toml
+++ b/examples/binance-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-ws"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 publish = false
 description = "Binance VWAP signals: minimal LaminarDB streaming example"
@@ -10,8 +10,8 @@ name = "binance-ws"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.17.0", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.17.0" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.0", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.0" }
 arrow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 crossterm = "0.29"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb-demo"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 publish = false
 description = "Market Data Demo: Real-time analytics with Ratatui TUI for LaminarDB"
@@ -23,9 +23,9 @@ default = []
 kafka = ["laminar-db/kafka", "dep:rdkafka", "dep:serde", "dep:serde_json"]
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.17.0" }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.17.0" }
-laminar-core = { path = "../../crates/laminar-core", version = "0.17.0" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.0" }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.0" }
+laminar-core = { path = "../../crates/laminar-core", version = "0.18.0" }
 
 # Arrow
 arrow = { workspace = true }

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microstructure"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 publish = false
 description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
@@ -10,8 +10,8 @@ name = "microstructure"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.17.0", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.17.0" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.0", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.0" }
 arrow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 crossterm = "0.29"

--- a/site/index.html
+++ b/site/index.html
@@ -4,17 +4,23 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>LaminarDB — The Embedded Streaming Database | Real-Time SQL Processing</title>
-  <meta name="description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, powerful like Flink. Python and Rust APIs. Apache 2.0 open source.">
-  <meta name="keywords" content="streaming database, embedded database, real-time analytics, stream processing, Rust, Python, SQL, Apache Arrow, DataFusion, sub-microsecond latency, Kafka, CDC, Delta Lake, PyArrow">
+  <meta name="description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, streams like Flink. Python and Rust APIs. Apache 2.0 open source.">
+  <meta name="keywords" content="streaming database, embedded database, real-time analytics, stream processing, Rust database, Python streaming, SQL stream processing, Apache Arrow, DataFusion, sub-microsecond latency, Kafka connector, CDC, Delta Lake, PyArrow, tumbling window, session window, ASOF join, embedded analytics, event processing, streaming SQL engine">
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
+  <meta name="author" content="LaminarDB Contributors">
+  <meta name="theme-color" content="#0a0a1a">
   <link rel="canonical" href="https://laminardb.io">
 
   <!-- Open Graph -->
   <meta property="og:title" content="LaminarDB — The Embedded Streaming Database | Real-Time SQL Processing">
-  <meta property="og:description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, powerful like Flink. Python and Rust APIs.">
+  <meta property="og:description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, streams like Flink. Python and Rust APIs.">
   <meta property="og:image" content="https://laminardb.io/img/logo.jpg">
   <meta property="og:url" content="https://laminardb.io">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="LaminarDB">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -36,19 +42,44 @@
   <!-- Styles -->
   <link rel="stylesheet" href="css/style.css">
 
-  <!-- JSON-LD -->
+  <!-- JSON-LD: SoftwareApplication -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "LaminarDB",
-    "description": "High-performance embedded streaming SQL database with sub-microsecond latency. Python and Rust APIs.",
+    "description": "High-performance embedded streaming SQL database with sub-microsecond latency. Process streaming data with familiar SQL, zero infrastructure, and Python or Rust APIs.",
     "applicationCategory": "Database",
+    "applicationSubCategory": "Streaming Database",
     "operatingSystem": "Linux, macOS, Windows",
     "license": "https://opensource.org/licenses/Apache-2.0",
     "url": "https://laminardb.io",
     "codeRepository": "https://github.com/laminardb/laminardb",
-    "programmingLanguage": ["Rust", "Python", "SQL"]
+    "programmingLanguage": ["Rust", "Python", "SQL"],
+    "softwareVersion": "0.18.0",
+    "datePublished": "2026-01-01",
+    "dateModified": "2026-03-03",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Organization",
+      "name": "LaminarDB Contributors",
+      "url": "https://github.com/laminardb"
+    },
+    "keywords": "streaming database, embedded database, real-time SQL, stream processing, Apache Arrow, DataFusion"
+  }
+  </script>
+  <!-- JSON-LD: WebSite (enables sitelinks search box) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "LaminarDB",
+    "url": "https://laminardb.io",
+    "description": "The embedded streaming SQL database. Sub-microsecond latency, zero infrastructure, Python and Rust APIs."
   }
   </script>
 </head>
@@ -85,7 +116,7 @@
           <path d="M4 32 C12 32,14 30,22 30 C30 30,32 34,36 34" stroke="url(#nav-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".5"/>
         </svg>
         <span>LaminarDB</span>
-        <span class="version-badge">v0.15</span>
+        <span class="version-badge">v0.18</span>
       </a>
 
       <nav class="nav-links" aria-label="Main navigation">
@@ -138,14 +169,14 @@
 
       <div class="hero-content">
         <a href="https://github.com/laminardb/laminardb/releases" class="hero-eyebrow" target="_blank" rel="noopener">
-          <span class="eyebrow-badge">v0.15</span>
-          <span>WebSocket connectors, schema inference, and 185 features shipped</span>
+          <span class="eyebrow-badge">v0.18</span>
+          <span>Delta Lake, checkpoint barriers, and 189 features shipped</span>
           <span class="eyebrow-arrow">&rarr;</span>
         </a>
 
         <h1>
-          <span class="gradient-text">Stop stitching.</span><br>
-          Start streaming.
+          <span class="gradient-text">Embedded Streaming Database.</span><br>
+          Sub-Microsecond SQL.
         </h1>
 
         <p class="hero-subtitle">
@@ -190,7 +221,7 @@
             <div class="hero-metric-label">events/sec per core</div>
           </div>
           <div class="hero-metric">
-            <div class="hero-metric-value">185</div>
+            <div class="hero-metric-value">189</div>
             <div class="hero-metric-label">features shipped</div>
           </div>
           <div class="hero-metric">
@@ -348,7 +379,7 @@
       <div class="container">
         <div class="section-header text-center">
           <div class="section-label reveal">Use Cases</div>
-          <h2 class="section-title reveal">What will you <span class="gradient-text">build</span>?</h2>
+          <h2 class="section-title reveal">Real-time stream processing <span class="gradient-text">use cases</span></h2>
           <p class="section-desc centered reveal">
             From fraud detection to live dashboards, LaminarDB powers real-time workloads
             that used to require a distributed cluster.
@@ -400,7 +431,7 @@
       <div class="container">
         <div class="section-header text-center">
           <div class="section-label reveal">Performance</div>
-          <h2 class="section-title reveal">Engineered for <span class="gradient-text">every nanosecond</span></h2>
+          <h2 class="section-title reveal">Streaming database <span class="gradient-text">benchmarks</span></h2>
           <p class="section-desc centered reveal">
             Criterion benchmarks from <code>cargo bench</code>. Thread-per-core architecture
             with CPU pinning, lock-free SPSC queues, and arena allocators.
@@ -792,7 +823,7 @@ pipeline.run()</code></pre>
               </div>
               <div>
                 <h4>Native PyArrow Integration</h4>
-                <p>Query results arrive as PyArrow Tables. Seamless interop with pandas, Polars, DuckDB, and the entire PyData stack.</p>
+                <p>Query results arrive as PyArrow Tables. Works directly with pandas, Polars, DuckDB, and the rest of the PyData stack.</p>
               </div>
             </div>
             <div class="python-feature">
@@ -906,7 +937,7 @@ pipeline.run()</code></pre>
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
             </div>
             <h4>Adaptive JIT</h4>
-            <p>Cranelift compiles SQL plans to native code in the background. Seamless hot-swap from interpreted to compiled execution.</p>
+            <p>Cranelift compiles SQL plans to native code in the background. Hot-swaps from interpreted to compiled with zero downtime.</p>
           </div>
         </div>
       </div>
@@ -917,7 +948,7 @@ pipeline.run()</code></pre>
       <div class="container">
         <div class="section-header text-center">
           <div class="section-label reveal">Connectors</div>
-          <h2 class="section-title reveal">Connect to <span class="gradient-text">everything</span></h2>
+          <h2 class="section-title reveal">Data source and sink <span class="gradient-text">connectors</span></h2>
           <p class="section-desc centered reveal">
             Feature-gated connectors with exactly-once semantics via two-phase commit.
             Build custom connectors with the SDK.
@@ -981,7 +1012,7 @@ pipeline.run()</code></pre>
       <div class="container">
         <div class="section-header text-center">
           <div class="section-label reveal">Features</div>
-          <h2 class="section-title reveal">185 features. <span class="gradient-text">76% complete.</span></h2>
+          <h2 class="section-title reveal">189 features. <span class="gradient-text">76% complete.</span></h2>
           <p class="section-desc centered reveal">
             From core engine primitives to distributed delta mode. Every feature is specified,
             implemented, and tested.
@@ -1040,7 +1071,7 @@ pipeline.run()</code></pre>
       <div class="container">
         <div class="section-header text-center">
           <div class="section-label reveal">Comparison</div>
-          <h2 class="section-title reveal">Why developers <span class="gradient-text">switch</span></h2>
+          <h2 class="section-title reveal">LaminarDB vs Flink vs Kafka Streams <span class="gradient-text">comparison</span></h2>
           <p class="section-desc centered reveal">
             Embedded deployment, sub-microsecond latency, dual Python + Rust APIs,
             and zero ops. No cluster to manage, no infrastructure to maintain.
@@ -1282,7 +1313,7 @@ for batch in db.subscribe("summary"):
           </svg>
           <span>LaminarDB</span>
         </a>
-        <p>The embedded streaming database. Sub-microsecond SQL stream processing in Rust and Python.</p>
+        <p>LaminarDB is an open-source embedded streaming SQL database. Sub-microsecond latency, zero infrastructure, with native Rust and Python APIs. Apache 2.0 licensed.</p>
       </div>
       <div>
         <h4>Resources</h4>
@@ -1316,22 +1347,22 @@ for batch in db.subscribe("summary"):
       <p>
         &copy; 2026 LaminarDB Contributors &middot;
         <a href="https://github.com/laminardb/laminardb/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0 License</a> &middot;
-        v0.15.0
+        v0.18.0
       </p>
     </div>
   </footer>
 
-  <!-- Prism.js -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-sql.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-rust.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
+  <!-- Prism.js (defer for better Core Web Vitals) -->
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-sql.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-rust.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
 
   <!-- Playground -->
-  <script src="js/playground.js"></script>
+  <script defer src="js/playground.js"></script>
 
   <!-- Main JS -->
-  <script src="js/main.js"></script>
+  <script defer src="js/main.js"></script>
 </body>
 </html>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://laminardb.io/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://laminardb.io</loc>
+    <lastmod>2026-03-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://laminardb.io/api/laminar_db/</loc>
+    <lastmod>2026-03-03</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- **Version bump**: All crate versions 0.17.0 → 0.18.0 (root workspace + 9 crate Cargo.tomls, 30 occurrences)
- **Doc humanization**: Removed AI-generated language patterns across 25 markdown files — replaced filler words (seamless, comprehensive, leverages, cutting-edge, world-class) with direct, developer-friendly prose
- **SEO optimization**: Keyword-optimized headings, enhanced structured data, added crawlability files, improved Core Web Vitals

## Changes

### Version Bump (10 Cargo.toml files)
- Root workspace version → 0.18.0
- All inter-crate path dependency versions → 0.18.0
- Version references in README, SECURITY.md, SQL_REFERENCE.md updated

### Documentation Humanization (25 files)
- Replaced "LaminarDB uses/provides/extends" sentence openers with direct descriptions
- Removed marketing language: seamless, comprehensive, leverages, cutting-edge, world-class, production-ready
- Rewrote section openers in ARCHITECTURE.md, README.md, CONTRIBUTING.md to lead with what things do
- Cleaned up crate READMEs, ADRs, feature specs, and audit docs

### SEO Optimization (site/index.html + 2 new files)
- **H1**: Changed from tagline ("Stop stitching. Start streaming.") to keyword-rich ("Embedded Streaming Database. Sub-Microsecond SQL.")
- **Section headings**: Added target keywords to 4 section H2s (use cases, benchmarks, connectors, comparison)
- **Meta tags**: Added `robots`, `author`, `theme-color`, `og:locale`, `og:image:width/height`
- **Keywords**: Expanded from 14 to 20 terms (added streaming-specific phrases)
- **JSON-LD**: Enhanced SoftwareApplication schema (version, dates, pricing, org). Added WebSite schema for sitelinks
- **Crawlability**: New `robots.txt` and `sitemap.xml`
- **Core Web Vitals**: Added `defer` to all 7 script tags to reduce render-blocking
- **Footer**: Keyword-enriched description
- **Stale content**: Fixed v0.15 → v0.18 (3 places), 185 → 189 features (3 places)

## Test plan

- [ ] `cargo build` succeeds with updated versions
- [ ] `cargo clippy --all -- -D warnings` passes
- [ ] Site renders correctly locally (open `site/index.html`)
- [ ] Verify JSON-LD with Google Rich Results Test
- [ ] Verify Open Graph with Facebook Sharing Debugger
- [ ] Check robots.txt accessible at `/robots.txt`
- [ ] Check sitemap.xml accessible at `/sitemap.xml`