### PR TITLE
fix: auto-wire CDC watermark propagation via _ts_ms event time column

### DIFF
--- a/crates/laminar-connectors/src/cdc/postgres/mod.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/mod.rs
@@ -113,6 +113,12 @@ fn postgres_cdc_config_keys() -> Vec<ConfigKeySpec> {
         ConfigKeySpec::optional("ssl.sni.hostname", "SNI hostname for SSL connections", ""),
         // Replication start position
         ConfigKeySpec::optional("start.lsn", "Starting LSN for replication", ""),
+        // Watermark
+        ConfigKeySpec::optional(
+            "event.time.column",
+            "Column for watermark extraction (default: _ts_ms)",
+            "_ts_ms",
+        ),
     ]
 }
 

--- a/crates/laminar-connectors/src/cdc/postgres/source.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/source.rs
@@ -631,11 +631,9 @@ impl SourceConnector for PostgresCdcSource {
         self.process_pending_messages()?;
 
         // Drain buffered events into a RecordBatch.
-        // Watermark advancement: the batch contains `_ts_ms` (commit timestamp)
-        // which downstream pipeline watermark extractors should use. The LSN
-        // in PartitionInfo tracks replication progress for offset management.
-        // TODO: extract max(_ts_ms) and expose as source-level watermark for
-        // windowed aggregations that depend on CDC event time.
+        // Watermark: the pipeline auto-wires _ts_ms as event time column for
+        // CDC sources, so SourceWatermarkState extracts max(_ts_ms) per batch.
+        // The LSN in PartitionInfo tracks replication progress for offsets.
         match self.drain_events(max_records)? {
             Some(batch) => {
                 let lsn_str = self.write_lsn.to_string();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -566,6 +566,24 @@ impl LaminarDB {
                      are degraded to at-most-once for this source"
                 );
             }
+
+            // Auto-wire event_time_column for CDC sources so downstream
+            // windowed aggregations receive watermark progress without
+            // requiring a SQL WATERMARK clause. The CDC envelope always
+            // contains _ts_ms (commit timestamp in milliseconds).
+            if let Some(entry) = self.catalog.get_source(name) {
+                if entry.source.event_time_column().is_none() {
+                    let ct = config.connector_type().to_lowercase();
+                    if ct == "postgres-cdc" || ct == "mysql-cdc" {
+                        entry.source.set_event_time_column("_ts_ms");
+                    }
+                    // Also honor explicit event.time.column from WITH clause
+                    if let Some(col) = config.get("event.time.column") {
+                        entry.source.set_event_time_column(col);
+                    }
+                }
+            }
+
             sources.push(SourceRegistration {
                 name: name.clone(),
                 connector: source,


### PR DESCRIPTION
## Summary

- CDC sources emit `_ts_ms` (commit timestamp) in every batch but it was never wired for watermark advancement — downstream windowed aggregations stalled indefinitely
- Pipeline startup now auto-sets `event_time_column` to `_ts_ms` for `postgres-cdc` and `mysql-cdc` connectors, unless a SQL `WATERMARK` clause already exists
- Reuses existing `SourceWatermarkState` + `EventTimeExtractor` machinery (zero new watermark logic)
- Users can override via `WITH ('event.time.column' = 'custom_col')`
- Added `event.time.column` to CDC config keys for discoverability

## Test plan

- [x] `cargo test -p laminar-connectors` — 582 passed
- [x] `cargo test -p laminar-db` — 504 passed
- [x] `cargo clippy -p laminar-db -- -D warnings` — clean
- [x] No AI slop: no restating comments, no `.unwrap()`, error messages preserved
- [x] No redundant code: reuses existing watermark machinery, no new extraction logic
- [x] No test-only code in production paths
- [x] Performance: `set_event_time_column` is OnceLock (Ring 2, once per source). Watermark extraction in `SourceWatermarkState` is Ring 1, SIMD-optimized via `arrow::compute::max`