### PR TITLE
fix: wire WebSocket event_time_field for watermark extraction

### DIFF
--- a/crates/laminar-connectors/src/websocket/parser.rs
+++ b/crates/laminar-connectors/src/websocket/parser.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use arrow_array::builder::{BinaryBuilder, StringBuilder};
-use arrow_array::RecordBatch;
+use arrow_array::{Array, RecordBatch};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 
 use crate::error::ConnectorError;
@@ -159,6 +159,34 @@ impl MessageParser {
                 "failed to build CSV RecordBatch: {e}"
             )))
         })
+    }
+}
+
+/// Extracts the maximum event time (as epoch milliseconds) from a named column.
+///
+/// Supports `Int64` and `TimestampMillisecond` column types. Returns `None`
+/// if the column is missing, has an unsupported type, or is entirely null.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn extract_max_event_time(batch: &RecordBatch, field: &str) -> Option<i64> {
+    let col_idx = batch.schema().index_of(field).ok()?;
+    let col = batch.column(col_idx);
+
+    if let Some(arr) = col.as_any().downcast_ref::<arrow_array::Int64Array>() {
+        (0..arr.len())
+            .filter(|&i| !arr.is_null(i))
+            .map(|i| arr.value(i))
+            .max()
+    } else if let Some(arr) = col
+        .as_any()
+        .downcast_ref::<arrow_array::TimestampMillisecondArray>()
+    {
+        (0..arr.len())
+            .filter(|&i| !arr.is_null(i))
+            .map(|i| arr.value(i))
+            .max()
+    } else {
+        None
     }
 }
 
@@ -408,5 +436,41 @@ mod tests {
         assert_eq!(active_field.data_type(), &DataType::Boolean);
         let score_field = schema.field_with_name("score").unwrap();
         assert_eq!(score_field.data_type(), &DataType::Float64);
+    }
+
+    #[test]
+    fn test_extract_max_event_time_int64() {
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, false)]));
+        let ts = arrow_array::Int64Array::from(vec![1000, 3000, 2000]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ts)]).unwrap();
+
+        assert_eq!(extract_max_event_time(&batch, "ts"), Some(3000));
+    }
+
+    #[test]
+    fn test_extract_max_event_time_missing_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let ids = arrow_array::Int64Array::from(vec![1, 2, 3]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids)]).unwrap();
+
+        assert_eq!(extract_max_event_time(&batch, "ts"), None);
+    }
+
+    #[test]
+    fn test_extract_max_event_time_with_nulls() {
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Int64, true)]));
+        let ts = arrow_array::Int64Array::from(vec![Some(1000), None, Some(3000), None]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ts)]).unwrap();
+
+        assert_eq!(extract_max_event_time(&batch, "ts"), Some(3000));
+    }
+
+    #[test]
+    fn test_extract_max_event_time_unsupported_type() {
+        let schema = Arc::new(Schema::new(vec![Field::new("ts", DataType::Utf8, false)]));
+        let ts = arrow_array::StringArray::from(vec!["2026-01-01"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ts)]).unwrap();
+
+        assert_eq!(extract_max_event_time(&batch, "ts"), None);
     }
 }

--- a/crates/laminar-connectors/src/websocket/source_server.rs
+++ b/crates/laminar-connectors/src/websocket/source_server.rs
@@ -312,10 +312,17 @@ impl SourceConnector for WebSocketSourceServer {
         let num_rows = batch.num_rows();
         self.message_buffer.clear();
 
-        self.checkpoint_state.watermark = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
+        // Use event time from batch data if configured, otherwise wall-clock.
+        if let Some(ref field) = self.config.event_time_field {
+            if let Some(max_ts) = super::parser::extract_max_event_time(&batch, field) {
+                self.checkpoint_state.watermark = max_ts;
+            }
+        } else {
+            self.checkpoint_state.watermark = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+        }
 
         debug!(
             records = num_rows,

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -566,6 +566,18 @@ impl LaminarDB {
                      are degraded to at-most-once for this source"
                 );
             }
+            // Wire event.time.column from connector config to the core Source
+            // so SourceWatermarkState can extract watermarks from batch data.
+            if let Some(entry) = self.catalog.get_source(name) {
+                if entry.source.event_time_column().is_none() {
+                    if let Some(col) = config.get("event.time.column") {
+                        entry.source.set_event_time_column(col);
+                    } else if let Some(col) = config.get("event.time.field") {
+                        entry.source.set_event_time_column(col);
+                    }
+                }
+            }
+
             sources.push(SourceRegistration {
                 name: name.clone(),
                 connector: source,


### PR DESCRIPTION
## Summary

- WebSocket `source_server` set checkpoint watermark to wall-clock time, ignoring `event_time_field` and `event_time_format` config options
- Now `poll_batch()` extracts max event time from the configured batch column for accurate checkpoint watermarks
- Pipeline startup wires `event.time.field` / `event.time.column` from connector config to `set_event_time_column()` so the existing `SourceWatermarkState` machinery handles pipeline-level watermarks automatically
- Added `extract_max_event_time()` helper in `parser.rs` supporting `Int64` and `TimestampMillisecond` columns

## Test plan

- [x] `cargo test -p laminar-connectors --features websocket` — 723 passed (4 new)
- [x] `cargo test -p laminar-db` — 504 passed
- [x] `cargo clippy -p laminar-connectors -p laminar-db -- -D warnings` — clean
- [x] No AI slop: `extract_max_event_time` is self-documenting, only doc explains return semantics
- [x] No redundant code: manual iterator max avoids adding `arrow-ord` dependency; does not duplicate `EventTimeExtractor` in laminar-core (different purpose: checkpoint vs pipeline watermark)
- [x] No test-only code in production paths
- [x] Performance: O(n) scan over batch column, runs once per `poll_batch()` in Ring 1. No heap allocation.