### PR TITLE
fix: wire WebSocket ping/pong heartbeats for idle client detection

### DIFF
--- a/crates/laminar-connectors/src/websocket/sink.rs
+++ b/crates/laminar-connectors/src/websocket/sink.rs
@@ -163,7 +163,6 @@ impl SinkConnector for WebSocketSinkServer {
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let fanout = Arc::clone(&self.fanout);
         let metrics = Arc::clone(&self.metrics);
-        let _ = (ping_interval, ping_timeout); // reserved for heartbeat
 
         let handle = tokio::spawn(async move {
             let mut shutdown_rx = shutdown_rx;
@@ -183,6 +182,8 @@ impl SinkConnector for WebSocketSinkServer {
                                 let fanout = Arc::clone(&fanout);
                                 let metrics = metrics.clone();
                                 let mut client_shutdown = shutdown_rx.clone();
+                                let client_ping_interval = ping_interval;
+                                let client_ping_timeout = ping_timeout;
 
                                 tokio::spawn(async move {
                                     let ws_stream = match tokio_tungstenite::accept_async(stream).await {
@@ -252,7 +253,12 @@ impl SinkConnector for WebSocketSinkServer {
                                         }
                                     }
 
-                                    // Fan-out loop: forward messages to this client.
+                                    // Fan-out loop with ping/pong heartbeats.
+                                    let mut ping_ticker = tokio::time::interval(client_ping_interval);
+                                    ping_ticker.tick().await; // consume initial immediate tick
+                                    let mut awaiting_pong = false;
+                                    let mut last_ping_sent = tokio::time::Instant::now();
+
                                     loop {
                                         tokio::select! {
                                             Some(data) = rx.recv() => {
@@ -265,8 +271,10 @@ impl SinkConnector for WebSocketSinkServer {
                                             msg = read.next() => {
                                                 match msg {
                                                     Some(Ok(tungstenite::Message::Close(_))) | None => break,
+                                                    Some(Ok(tungstenite::Message::Pong(_))) => {
+                                                        awaiting_pong = false;
+                                                    }
                                                     Some(Ok(tungstenite::Message::Text(text))) => {
-                                                        // Handle unsubscribe.
                                                         if let Ok(ClientMessage::Unsubscribe { .. }) =
                                                             serde_json::from_str::<ClientMessage>(text.as_ref())
                                                         {
@@ -275,6 +283,18 @@ impl SinkConnector for WebSocketSinkServer {
                                                     }
                                                     _ => {}
                                                 }
+                                            }
+                                            _ = ping_ticker.tick() => {
+                                                if awaiting_pong && last_ping_sent.elapsed() > client_ping_timeout {
+                                                    debug!(addr = %addr, "ping timeout — disconnecting");
+                                                    metrics.record_ping_timeout();
+                                                    break;
+                                                }
+                                                if write.send(tungstenite::Message::Ping(bytes::Bytes::new())).await.is_err() {
+                                                    break;
+                                                }
+                                                awaiting_pong = true;
+                                                last_ping_sent = tokio::time::Instant::now();
                                             }
                                             _ = client_shutdown.changed() => break,
                                         }

--- a/crates/laminar-connectors/src/websocket/sink_metrics.rs
+++ b/crates/laminar-connectors/src/websocket/sink_metrics.rs
@@ -27,6 +27,8 @@ pub struct WebSocketSinkMetrics {
     pub client_disconnects: AtomicU64,
     /// Total replay requests received from clients.
     pub replay_requests: AtomicU64,
+    /// Total clients disconnected due to ping timeout.
+    pub ping_timeouts: AtomicU64,
 }
 
 impl WebSocketSinkMetrics {
@@ -40,6 +42,7 @@ impl WebSocketSinkMetrics {
             connected_clients: AtomicU64::new(0),
             client_disconnects: AtomicU64::new(0),
             replay_requests: AtomicU64::new(0),
+            ping_timeouts: AtomicU64::new(0),
         }
     }
 
@@ -76,6 +79,11 @@ impl WebSocketSinkMetrics {
         self.replay_requests.fetch_add(1, Ordering::Relaxed);
     }
 
+    /// Records a client disconnected due to ping timeout.
+    pub fn record_ping_timeout(&self) {
+        self.ping_timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Converts to the SDK's [`ConnectorMetrics`].
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
@@ -102,6 +110,10 @@ impl WebSocketSinkMetrics {
         m.add_custom(
             "ws.messages_dropped_slow_client",
             self.messages_dropped_slow_client.load(Ordering::Relaxed) as f64,
+        );
+        m.add_custom(
+            "ws.ping_timeouts",
+            self.ping_timeouts.load(Ordering::Relaxed) as f64,
         );
         m
     }
@@ -202,7 +214,7 @@ mod tests {
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
         assert_eq!(cm.errors_total, 0);
-        assert_eq!(cm.custom.len(), 4);
+        assert_eq!(cm.custom.len(), 5);
     }
 
     #[test]
@@ -210,7 +222,7 @@ mod tests {
         let m = WebSocketSinkMetrics::new();
         let cm = m.to_connector_metrics();
         // Should have exactly 4 custom metrics
-        assert_eq!(cm.custom.len(), 4);
+        assert_eq!(cm.custom.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ping_interval` and `ping_timeout` were parsed from config then immediately discarded (`let _ = ...`). Idle clients were never detected or cleaned up.
- Each per-client task now runs a `tokio::time::interval` ping ticker:
  - Sends `Ping` frame at `ping_interval` (default 30s)
  - Tracks `awaiting_pong` state and `last_ping_sent` timestamp
  - On next tick, if pong not received within `ping_timeout`, disconnects
  - Handles `Pong` frames in the read match arm
- Added `ping_timeouts` counter to `WebSocketSinkMetrics`

## Test plan

- [x] `cargo test -p laminar-connectors --features websocket` — 726 passed
- [x] `cargo clippy -p laminar-connectors --features websocket -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] **AI slop**: no restating comments, three local variables instead of a PingState struct
- [x] **Redundant code**: ping/pong is distinct from slow client policy (liveness vs throughput)
- [x] **No test-only code in production**
- [x] **Performance**: Ping frames are 2 bytes, once per `ping_interval` per client. `Bytes::new()` is zero-alloc. The `tokio::select!` branch adds no cost when not triggered.