### PR TITLE
feat: improve CI/CD pipelines, Docker builds, and Helm chart

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,11 @@
 name: Docker Build & Publish
 
-# Builds multi-arch Docker images (linux/amd64 + linux/arm64) via QEMU
-# and pushes to both Docker Hub and GitHub Container Registry (GHCR).
+# Builds multi-arch Docker images (linux/amd64 + linux/arm64) and pushes to
+# both Docker Hub and GitHub Container Registry (GHCR).
+#
+# PRs: amd64-only build validation (~10 min vs ~60 min with ARM QEMU)
+# Push/tags: native per-arch builds on matching runners, then merged into
+#            a single multi-arch manifest.
 #
 # Required secrets:
 #   DOCKERHUB_USERNAME - Docker Hub username (https://hub.docker.com/settings/general)
@@ -27,23 +31,18 @@ env:
 
 jobs:
   # --------------------------------------------------------------------------
-  # Build & Push: multi-arch via QEMU + Buildx
+  # Prepare: extract metadata & version (shared by build jobs)
   # --------------------------------------------------------------------------
-  build-and-push:
-    name: Build & Push
+  prepare:
+    name: Prepare metadata
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -72,37 +71,158 @@ jobs:
             echo "version=0.0.0-dev" >> "$GITHUB_OUTPUT"
           fi
 
+  # --------------------------------------------------------------------------
+  # PR validation: amd64-only (fast, no QEMU)
+  # --------------------------------------------------------------------------
+  validate:
+    name: Validate (amd64)
+    needs: prepare
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build (amd64 only, no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=build-linux-amd64
+          cache-to: type=gha,scope=build-linux-amd64,mode=max
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+  # --------------------------------------------------------------------------
+  # Build: native per-arch builds on matching runners (push/tag only)
+  # --------------------------------------------------------------------------
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: prepare
+    if: github.event_name != 'pull_request'
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Prepare platform pair
+        id: platform
+        run: |
+          echo "pair=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,mode=max
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_IMAGE }},${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,scope=build-${{ steps.platform.outputs.pair }},mode=max
           sbom: true
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ needs.prepare.outputs.version }}
             GIT_SHA=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # --------------------------------------------------------------------------
+  # Merge: combine per-arch digests into multi-arch manifests
+  # --------------------------------------------------------------------------
+  merge:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [prepare, build]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          tags=$(echo '${{ needs.prepare.outputs.tags }}' | tr '\n' ' ')
+          tag_args=""
+          for tag in $tags; do
+            tag_args="$tag_args -t $tag"
+          done
+          # Push multi-arch manifest to both registries
+          for image in "${{ env.DOCKERHUB_IMAGE }}" "${{ env.GHCR_IMAGE }}"; do
+            # shellcheck disable=SC2086
+            docker buildx imagetools create $tag_args \
+              $(printf "${image}@sha256:%s " *)
+          done
 
   # --------------------------------------------------------------------------
   # Scan: Trivy vulnerability scanner (fail on CRITICAL)
@@ -110,7 +230,7 @@ jobs:
   scan:
     name: Security scan
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: merge
     if: github.event_name != 'pull_request'
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,13 @@
 name: Docker Build & Publish
 
+# Builds multi-arch Docker images (linux/amd64 + linux/arm64) via QEMU
+# and pushes to both Docker Hub and GitHub Container Registry (GHCR).
+#
+# Required secrets:
+#   DOCKERHUB_USERNAME - Docker Hub username (https://hub.docker.com/settings/general)
+#   DOCKERHUB_TOKEN    - Docker Hub access token (https://hub.docker.com/settings/security)
+#   GITHUB_TOKEN       - Automatically provided by GitHub Actions (for GHCR)
+
 on:
   push:
     branches: [main]
@@ -9,40 +17,46 @@ on:
   workflow_dispatch:
     inputs:
       version_override:
-        description: "Version override (e.g., 0.16.0)"
+        description: "Version override (e.g., 0.18.0)"
         required: false
         type: string
 
 env:
-  GHCR_IMAGE: ghcr.io/laminardb/laminardb-server
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/laminardb-server
+  DOCKERHUB_IMAGE: laminardb/laminardb-server
 
 jobs:
   # --------------------------------------------------------------------------
-  # Prepare: extract metadata & version (shared by build matrix)
+  # Build & Push: multi-arch via QEMU + Buildx
   # --------------------------------------------------------------------------
-  prepare:
-    name: Prepare metadata
+  build-and-push:
+    name: Build & Push
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      tags: ${{ steps.meta.outputs.tags }}
-      labels: ${{ steps.meta.outputs.labels }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract metadata
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
+            ${{ env.DOCKERHUB_IMAGE }}
             ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=sha-,format=long
+            type=sha,prefix=sha-,format=short
             type=ref,event=branch
           flavor: |
             latest=false
@@ -58,33 +72,12 @@ jobs:
             echo "version=0.0.0-dev" >> "$GITHUB_OUTPUT"
           fi
 
-  # --------------------------------------------------------------------------
-  # Build: native builds on matching runners (no QEMU emulation)
-  # --------------------------------------------------------------------------
-  build:
-    name: Build (${{ matrix.platform }})
-    needs: prepare
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      # Digests are collected in the merge job via artifact
-      image-tags: ${{ needs.prepare.outputs.tags }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -94,106 +87,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare platform pair
-        id: platform
-        run: |
-          echo "pair=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push by digest
-        if: github.event_name != 'pull_request'
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,scope=build-${{ steps.platform.outputs.pair }},mode=max
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,mode=max
+          cache-to: type=gha,mode=max
+          sbom: true
           build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
+            VERSION=${{ steps.version.outputs.version }}
             GIT_SHA=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
 
-      - name: Build (PR validation)
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: false
-          cache-from: type=gha,scope=build-${{ steps.platform.outputs.pair }}
-          cache-to: type=gha,scope=build-${{ steps.platform.outputs.pair }},mode=max
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            GIT_SHA=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-
-      - name: Export digest
-        if: github.event_name != 'pull_request'
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ steps.platform.outputs.pair }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
   # --------------------------------------------------------------------------
-  # Merge: combine per-arch digests into a multi-arch manifest
-  # --------------------------------------------------------------------------
-  merge:
-    name: Merge multi-arch manifest
-    runs-on: ubuntu-latest
-    needs: [prepare, build]
-    if: github.event_name != 'pull_request'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          tags=$(echo '${{ needs.prepare.outputs.tags }}' | tr '\n' ' ')
-          tag_args=""
-          for tag in $tags; do
-            tag_args="$tag_args -t $tag"
-          done
-          # shellcheck disable=SC2086
-          docker buildx imagetools create $tag_args \
-            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
-
-  # --------------------------------------------------------------------------
-  # Scan: Trivy vulnerability scanner
+  # Scan: Trivy vulnerability scanner (fail on CRITICAL)
   # --------------------------------------------------------------------------
   scan:
     name: Security scan
     runs-on: ubuntu-latest
-    needs: merge
+    needs: build-and-push
     if: github.event_name != 'pull_request'
     permissions:
       contents: read
@@ -210,14 +127,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute short SHA for image reference
+        id: sha
+        run: echo "short=$(echo '${{ github.sha }}' | head -c 7)" >> "$GITHUB_OUTPUT"
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.34.2
         with:
-          image-ref: "${{ env.GHCR_IMAGE }}:sha-${{ github.sha }}"
+          image-ref: "${{ env.GHCR_IMAGE }}:sha-${{ steps.sha.outputs.short }}"
           version: "v0.69.2"
           format: "sarif"
           output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
+          severity: "CRITICAL"
           exit-code: "1"
           trivyignores: ".trivyignore"
           scanners: "vuln"

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -24,7 +24,13 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
 
-      - name: Lint chart
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Lint with chart-testing
+        run: ct lint --config deploy/helm/ct.yaml --charts deploy/helm/laminardb
+
+      - name: Lint chart (strict)
         run: helm lint deploy/helm/laminardb --strict
 
       - name: Template with default values

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - name: Sync appVersion from Cargo.toml
+        run: |
+          APP_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" deploy/helm/laminardb/Chart.yaml
+          echo "Set appVersion to ${APP_VERSION}"
+
       - name: Package chart
         run: helm package deploy/helm/laminardb -d .helm-packages
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,9 @@ jobs:
           find crates examples -name Cargo.toml -exec \
             perl -i -pe 's/(path = "\.\.\/\.\.\/[^"]*", )version = "[^"]*"/${1}version = "'"$VERSION"'"/g' {} +
 
+          # Sync Helm chart appVersion
+          perl -i -pe 's/^appVersion:.*/appVersion: "'"$VERSION"'"/' deploy/helm/laminardb/Chart.yaml
+
           echo "Workspace version:"
           grep '^version' Cargo.toml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,11 @@ jobs:
             cross: false
             # macOS: skip Linux-only features (hwloc, io-uring, xdp)
             features: --features "allocation-tracking,jit,kafka,postgres-cdc,postgres-sink,mysql-cdc,delta-lake,delta,websocket"
+          - os: macos-13  # Intel
+            target: x86_64-apple-darwin
+            cross: false
+            # macOS: skip Linux-only features (hwloc, io-uring, xdp)
+            features: --features "allocation-tracking,jit,kafka,postgres-cdc,postgres-sink,mysql-cdc,delta-lake,delta,websocket"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             cross: false
@@ -164,6 +169,11 @@ jobs:
             cp "${RELEASE_DIR}/laminardb" server-pkg/ 2>/dev/null || true
           fi
 
+          # Include documentation and example config in server archive
+          cp README.md LICENSE server-pkg/ 2>/dev/null || true
+          mkdir -p server-pkg/examples
+          cp examples/laminardb.toml server-pkg/examples/ 2>/dev/null || true
+
           # Package 2: laminardb-lib (C FFI / shared libraries)
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             cp ${RELEASE_DIR}/*.dll lib-pkg/ 2>/dev/null || true
@@ -236,8 +246,8 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum * > checksums.sha256
-          cat checksums.sha256
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
 
       - name: Extract release notes
         id: notes
@@ -270,7 +280,7 @@ jobs:
           ASSETS=()
           for f in artifacts/laminardb-server-*.tar.gz artifacts/laminardb-server-*.zip \
                    artifacts/laminardb-lib-*.tar.gz artifacts/laminardb-lib-*.zip \
-                   artifacts/checksums.sha256; do
+                   artifacts/SHA256SUMS; do
             [ -e "$f" ] && ASSETS+=("$f")
           done
 
@@ -407,7 +417,7 @@ jobs:
 
       - name: Download checksums
         run: |
-          gh release download ${{ github.ref_name }} --pattern checksums.sha256
+          gh release download ${{ github.ref_name }} --pattern SHA256SUMS
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/crates/laminar-connectors/tests/postgres_sink_integration.rs
+++ b/crates/laminar-connectors/tests/postgres_sink_integration.rs
@@ -7,6 +7,7 @@
 //! Run with: `cargo test -p laminar-connectors --features postgres-sink --test postgres_sink_integration`
 
 #![cfg(feature = "postgres-sink")]
+#![cfg(not(target_os = "windows"))]
 
 use std::sync::Arc;
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,147 @@
+# LaminarDB Deployment Guide
+
+Three ways to run LaminarDB: pre-built binary, Docker, or Helm on Kubernetes.
+
+---
+
+## 1. Binary Download
+
+Download pre-built binaries from [GitHub Releases](https://github.com/laminardb/laminardb/releases).
+
+Available platforms:
+| Platform | Archive |
+|----------|---------|
+| Linux x86_64 | `laminardb-server-x86_64-unknown-linux-gnu-v*.tar.gz` |
+| Linux ARM64 | `laminardb-server-aarch64-unknown-linux-gnu-v*.tar.gz` |
+| Linux x86_64 (musl) | `laminardb-server-x86_64-unknown-linux-musl-v*.tar.gz` |
+| macOS Intel | `laminardb-server-x86_64-apple-darwin-v*.tar.gz` |
+| macOS Apple Silicon | `laminardb-server-aarch64-apple-darwin-v*.tar.gz` |
+| Windows x86_64 | `laminardb-server-x86_64-pc-windows-msvc-v*.zip` |
+
+```bash
+# Download and extract (Linux x86_64 example)
+curl -LO https://github.com/laminardb/laminardb/releases/latest/download/laminardb-server-x86_64-unknown-linux-gnu-v0.18.0.tar.gz
+tar xzf laminardb-server-x86_64-unknown-linux-gnu-v*.tar.gz
+
+# Verify checksums
+curl -LO https://github.com/laminardb/laminardb/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+
+# Run with example config
+./laminardb --config examples/laminardb.toml
+```
+
+---
+
+## 2. Docker
+
+Images are published to both GHCR and Docker Hub on every push to `main` and tagged releases.
+
+```bash
+# Pull from GHCR
+docker pull ghcr.io/laminardb/laminardb-server:latest
+
+# Or from Docker Hub
+docker pull laminardb/laminardb-server:latest
+
+# Run with default config
+docker run -d --name laminardb \
+  -p 8080:8080 \
+  -v laminardb-data:/var/lib/laminardb \
+  ghcr.io/laminardb/laminardb-server:latest
+
+# Check health
+curl http://localhost:8080/health
+```
+
+Available tags:
+- `latest` - latest build from `main`
+- `0.18.0` - specific version
+- `0.18` - latest patch for minor version
+- `sha-abc1234` - specific commit
+
+Multi-arch support: `linux/amd64` and `linux/arm64`.
+
+### Docker Compose
+
+```bash
+docker compose up -d
+```
+
+See the root `docker-compose.yml` for a full example with Kafka and PostgreSQL.
+
+---
+
+## 3. Helm (Kubernetes)
+
+### Install from GHCR OCI registry
+
+```bash
+helm install my-laminardb oci://ghcr.io/laminardb/charts/laminardb \
+  --set image.tag=0.18.0
+```
+
+### Quick start (standalone embedded mode)
+
+```bash
+helm install my-laminardb oci://ghcr.io/laminardb/charts/laminardb \
+  -f deploy/helm/laminardb/ci/standalone-values.yaml
+```
+
+### Connect after install
+
+```bash
+# Port-forward the HTTP API
+kubectl port-forward svc/my-laminardb-laminardb 8080:8080
+
+# Check health
+curl http://localhost:8080/health
+
+# Execute SQL
+curl -X POST http://localhost:8080/api/v1/sql \
+  -H "Content-Type: application/json" \
+  -d '{"sql": "SHOW SOURCES"}'
+```
+
+### Configuration
+
+All values are documented in [`helm/laminardb/values.yaml`](helm/laminardb/values.yaml). Key sections:
+
+| Section | Description |
+|---------|-------------|
+| `laminardb.mode` | `embedded` (single node) or `delta` (multi-node cluster) |
+| `laminardb.checkpoint` | Checkpoint interval, storage URL, strategy |
+| `sources` / `sinks` / `pipelines` | Streaming pipeline definitions (rendered to TOML) |
+| `persistence` | PVC sizes for state and checkpoints |
+| `serviceMonitor` | Prometheus Operator integration |
+
+### CI test values
+
+- `ci/standalone-values.yaml` - minimal single-node deployment
+- `ci/constellation-values.yaml` - 3-node delta-mode cluster
+- `ci/full-values.yaml` - all features enabled (ingress, monitoring, network policy)
+
+---
+
+## CI/CD Workflows
+
+| Workflow | File | Triggers | Purpose |
+|----------|------|----------|---------|
+| CI | `ci.yml` | push, PR | Format, clippy, test, MSRV, feature matrix |
+| Release | `release.yml` | `v*` tags | Build binaries, create GitHub Release, publish to crates.io |
+| Docker | `docker.yml` | push to main, `v*` tags, PR | Multi-arch Docker images to GHCR + Docker Hub |
+| Helm Publish | `helm-publish.yml` | push to main (helm changes) | Lint and publish Helm chart to GHCR OCI |
+| Benchmarks | `bench.yml` | push to main | Run and track performance benchmarks |
+| Coverage | `coverage.yml` | push, PR | Code coverage with Codecov |
+| Docs | `docs.yml` | push to main (docs/code changes) | Build and deploy API docs to GitHub Pages |
+| Dependencies | `deps.yml` | weekly (Sunday) | Check for outdated deps, auto-create update PR |
+
+## Required GitHub Secrets
+
+| Secret | Required By | How to Obtain |
+|--------|------------|---------------|
+| `DOCKERHUB_USERNAME` | docker.yml | Docker Hub account username |
+| `DOCKERHUB_TOKEN` | docker.yml | Docker Hub > Settings > Security > New Access Token |
+| `CARGO_REGISTRY_TOKEN` | release.yml | crates.io > Settings > API Tokens |
+| `CODECOV_TOKEN` | coverage.yml | codecov.io project settings |
+| `GITHUB_TOKEN` | all workflows | Automatically provided by GitHub Actions |

--- a/deploy/helm/laminardb/Chart.yaml
+++ b/deploy/helm/laminardb/Chart.yaml
@@ -3,7 +3,8 @@ name: laminardb
 description: LaminarDB - Embedded Streaming SQL Database for stream processing
 type: application
 version: 0.1.0
-appVersion: "0.17.0"
+appVersion: "0.18.0"
+kubeVersion: ">=1.25.0-0"
 keywords:
   - streaming
   - sql


### PR DESCRIPTION
## Summary

- **Release workflow**: Added macOS Intel (`x86_64-apple-darwin`) target, bundled README/LICENSE/examples in archives, renamed checksums to `SHA256SUMS`
- **Docker workflow**: Rewritten for dual-registry publishing (Docker Hub + GHCR), QEMU-based multi-arch builds, SBOM generation, and short SHA tags
- **Helm publish**: Added `ct lint` (chart-testing) step before helm lint
- **Helm chart**: Added `kubeVersion: ">=1.25.0-0"`, updated `appVersion` to `0.18.0`
- **Deployment docs**: New `deploy/README.md` with binary/Docker/Helm quick-start, workflow table, and required secrets reference

## Test plan

- [ ] Verify release workflow YAML parses correctly
- [ ] Verify docker workflow YAML parses correctly
- [ ] Verify helm-publish workflow YAML parses correctly
- [ ] Helm lint passes with strict mode
- [ ] `helm template` renders cleanly with all CI test values