### PR TITLE
chore: exclude examples from Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,5 +31,8 @@ nul
 Thumbs.db
 .DS_Store
 
+# Examples (not needed in server image)
+examples/
+
 # Logs
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ ENV CARGO_PROFILE_RELEASE_LTO=thin \
 # Copy workspace Cargo files first so dependency builds are cached.
 COPY Cargo.toml Cargo.lock ./
 
+# Strip example crates from workspace members (not needed for server build)
+RUN sed -i '/"examples\//d' Cargo.toml
+
 # Copy all crate Cargo.toml files (preserving directory structure)
 COPY crates/laminar-core/Cargo.toml crates/laminar-core/Cargo.toml
 COPY crates/laminar-sql/Cargo.toml crates/laminar-sql/Cargo.toml
@@ -57,18 +60,15 @@ RUN mkdir -p crates/laminar-core/src && echo "pub fn _dummy() {}" > crates/lamin
     && mkdir -p crates/laminar-connectors/src && echo "pub fn _dummy() {}" > crates/laminar-connectors/src/lib.rs \
     && mkdir -p crates/laminar-db/src && echo "pub fn _dummy() {}" > crates/laminar-db/src/lib.rs \
     && mkdir -p crates/laminar-derive/src && echo "pub fn _dummy() {}" > crates/laminar-derive/src/lib.rs \
-    && mkdir -p crates/laminar-server/src && echo "fn main() {}" > crates/laminar-server/src/main.rs \
-    && mkdir -p examples/demo/src && echo "fn main() {}" > examples/demo/src/main.rs \
-    && mkdir -p examples/binance-ws/src && echo "fn main() {}" > examples/binance-ws/src/main.rs
+    && mkdir -p crates/laminar-server/src && echo "fn main() {}" > crates/laminar-server/src/main.rs
 
 # Build dependencies only (this layer is cached)
 RUN cargo build --release -p laminar-server 2>/dev/null || true
 
 # --- Real source build ---
 # Remove dummy sources and copy real code
-RUN rm -rf crates/ examples/
+RUN rm -rf crates/
 COPY crates/ crates/
-COPY examples/ examples/
 
 # Touch main.rs to invalidate the binary cache but keep dep cache
 RUN touch crates/laminar-server/src/main.rs


### PR DESCRIPTION
## Summary

- Add `examples/` to `.dockerignore` to exclude example crates from the build context
- Strip example workspace members from `Cargo.toml` during the Docker build so Cargo doesn't require them
- Remove dummy example source stubs and `COPY examples/` from the Dockerfile

The example crates (demo, binance-ws, microstructure) were being pulled into the Docker build even though only `laminar-server` is compiled. This also fixes a latent issue where `microstructure` was missing from the dummy stubs, which would have broken workspace resolution if not masked by `|| true`.

## Test plan

- [ ] Verify `docker build .` completes successfully
- [ ] Verify the final image contains only the server binary (no example artifacts)
- [ ] Verify local `cargo build` and `cargo test` still work with examples in the workspace