### PR TITLE
Fix storage crate correctness and durability issues

### DIFF
--- a/crates/laminar-storage/src/changelog_drainer.rs
+++ b/crates/laminar-storage/src/changelog_drainer.rs
@@ -60,12 +60,24 @@ impl ChangelogDrainer {
 
     /// Drains available entries from the buffer into the pending batch.
     ///
-    /// If `pending` would exceed `max_pending`, older entries are discarded
-    /// first to keep memory bounded. Returns the number of entries drained.
+    /// If `pending` is at the `max_pending` limit, the oldest half of
+    /// pending entries are discarded to make room. Returns the number
+    /// of new entries drained from the buffer.
     pub fn drain(&mut self) -> usize {
-        // Enforce max_pending: if we're at the limit, clear to make room.
+        // Enforce max_pending: if we're at the limit, shed the oldest half
+        // to make room while preserving recent entries. This is preferable
+        // to clearing everything — the newest entries are most likely to
+        // be needed for the next checkpoint.
         if self.pending.len() >= self.max_pending {
-            self.pending.clear();
+            let keep = self.max_pending / 2;
+            let drop_count = self.pending.len() - keep;
+            tracing::warn!(
+                dropped = drop_count,
+                kept = keep,
+                max_pending = self.max_pending,
+                "changelog drainer pending buffer at limit, shedding oldest entries"
+            );
+            self.pending.drain(..drop_count);
         }
 
         let room = self.max_pending.saturating_sub(self.pending.len());
@@ -269,18 +281,27 @@ mod tests {
             buf.push(StateChangelogEntry::put(1, i, 0, 1));
         }
 
-        // Create drainer with max_pending = 5
-        let mut drainer = ChangelogDrainer::new(buf.clone(), 100).with_max_pending(5);
+        // Create drainer with max_pending = 6
+        let mut drainer = ChangelogDrainer::new(buf.clone(), 100).with_max_pending(6);
 
-        // First drain: gets 5 (limited by max_pending room)
+        // First drain: gets 5 (room = 6 - 0 - 1, but actually 6 entries fit with room=6)
         let count = drainer.drain();
-        assert_eq!(count, 5);
-        assert_eq!(drainer.pending_count(), 5);
+        assert_eq!(count, 6);
+        assert_eq!(drainer.pending_count(), 6);
 
-        // Second drain: pending is at max_pending, so clear first then drain
+        // Second drain: pending is at max_pending (6 >= 6), so shed oldest half (3),
+        // keeping 3 recent entries. Then drain remaining 4 from buffer, but room is
+        // only 6-3=3, so only 3 more are drained.
         let count2 = drainer.drain();
-        assert_eq!(count2, 5); // remaining 5 entries
-        assert_eq!(drainer.pending_count(), 5);
+        assert_eq!(count2, 3);
+        assert_eq!(drainer.pending_count(), 6); // 3 kept + 3 new
+        assert_eq!(drainer.total_drained(), 9);
+
+        // Third drain: again at limit, shed oldest half (3), keep 3,
+        // drain remaining 1 from buffer.
+        let count3 = drainer.drain();
+        assert_eq!(count3, 1);
+        assert_eq!(drainer.pending_count(), 4); // 3 kept + 1 new
         assert_eq!(drainer.total_drained(), 10);
     }
 

--- a/crates/laminar-storage/src/object_store_factory.rs
+++ b/crates/laminar-storage/src/object_store_factory.rs
@@ -112,7 +112,10 @@ fn build_s3(
     let mut builder = AmazonS3Builder::from_env().with_url(url);
 
     for (key, value) in options {
-        builder = builder.with_config(key.parse()?, value);
+        let config_key = key.parse().map_err(|e: object_store::Error| {
+            ObjectStoreFactoryError::Build(format!("invalid S3 config key '{key}': {e}"))
+        })?;
+        builder = builder.with_config(config_key, value);
     }
 
     let store = builder.build()?;
@@ -144,7 +147,10 @@ fn build_gcs(
     let mut builder = GoogleCloudStorageBuilder::from_env().with_url(url);
 
     for (key, value) in options {
-        builder = builder.with_config(key.parse()?, value);
+        let config_key = key.parse().map_err(|e: object_store::Error| {
+            ObjectStoreFactoryError::Build(format!("invalid GCS config key '{key}': {e}"))
+        })?;
+        builder = builder.with_config(config_key, value);
     }
 
     let store = builder.build()?;
@@ -176,7 +182,10 @@ fn build_azure(
     let mut builder = MicrosoftAzureBuilder::from_env().with_url(url);
 
     for (key, value) in options {
-        builder = builder.with_config(key.parse()?, value);
+        let config_key = key.parse().map_err(|e: object_store::Error| {
+            ObjectStoreFactoryError::Build(format!("invalid Azure config key '{key}': {e}"))
+        })?;
+        builder = builder.with_config(config_key, value);
     }
 
     let store = builder.build()?;

--- a/crates/laminar-storage/src/per_core_wal/entry.rs
+++ b/crates/laminar-storage/src/per_core_wal/entry.rs
@@ -222,13 +222,12 @@ impl PerCoreWalEntry {
     /// Call once and pass the result to entry constructors to avoid
     /// repeated `SystemTime::now()` syscalls in tight loops.
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)] // i64 ns won't overflow for ~292 years
     pub fn now_ns() -> i64 {
         use std::time::{SystemTime, UNIX_EPOCH};
-        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-            #[allow(clippy::cast_possible_truncation)] // i64 ns won't overflow for ~292 years
-            let ns = d.as_nanos() as i64;
-            ns
-        })
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos() as i64)
     }
 }
 

--- a/crates/laminar-storage/src/per_core_wal/manager.rs
+++ b/crates/laminar-storage/src/per_core_wal/manager.rs
@@ -107,14 +107,25 @@ impl PerCoreWalManager {
                 return Err(PerCoreWalError::SegmentNotFound { core_id, path });
             }
 
-            // Read to find last valid position and max epoch
+            // Single pass: read all valid entries, tracking max epoch and
+            // the last valid position. Avoids reading the file twice.
             let mut reader = PerCoreWalReader::open(core_id, &path)?;
-            let valid_end = reader.find_valid_end()?;
-
-            // Read entries to find max epoch
-            let mut reader = PerCoreWalReader::open(core_id, &path)?;
-            for entry in reader.read_all()? {
-                max_epoch = max_epoch.max(entry.epoch);
+            let mut valid_end = 0u64;
+            loop {
+                let pos_before = reader.position();
+                match reader.read_next()? {
+                    super::reader::WalReadResult::Entry(entry) => {
+                        max_epoch = max_epoch.max(entry.epoch);
+                        valid_end = reader.position();
+                    }
+                    super::reader::WalReadResult::Eof => break,
+                    super::reader::WalReadResult::TornWrite { .. }
+                    | super::reader::WalReadResult::ChecksumMismatch { .. }
+                    | super::reader::WalReadResult::Corrupted { .. } => {
+                        valid_end = pos_before;
+                        break;
+                    }
+                }
             }
 
             let writer = CoreWalWriter::open_at(core_id, &path, valid_end)?;

--- a/crates/laminar-storage/src/per_core_wal/writer.rs
+++ b/crates/laminar-storage/src/per_core_wal/writer.rs
@@ -330,7 +330,10 @@ impl CoreWalWriter {
             .truncate(false)
             .open(&self.path)?;
 
+        // Sync after truncation to make it durable.
+        // Without this, a crash could leave the file at its old length.
         file.set_len(position)?;
+        file.sync_all()?;
 
         // Reopen for append
         let file = OpenOptions::new().append(true).open(&self.path)?;

--- a/crates/laminar-storage/src/wal.rs
+++ b/crates/laminar-storage/src/wal.rs
@@ -332,8 +332,10 @@ impl WriteAheadLog {
             .truncate(false)
             .open(&self.path)?;
 
-        // Truncate file
+        // Truncate file and sync to make the truncation durable.
+        // Without this sync, a crash could leave the file at its old length.
         file.set_len(position)?;
+        file.sync_all()?;
 
         // Reopen for append
         let file = OpenOptions::new().append(true).open(&self.path)?;


### PR DESCRIPTION
## Summary

- **WAL truncate durability**: Added `sync_all()` after `set_len()` in both single-writer and per-core WAL truncate paths — without this a crash could leave the file at its pre-truncation length
- **Changelog drainer backpressure**: Fixed `drain()` dropping *all* pending entries when at `max_pending` limit; now sheds the oldest half and keeps recent entries, with a `tracing::warn` so operators know it happened
- **Per-core WAL open perf**: Merged the double-read in `PerCoreWalManager::open` into a single pass (was opening and reading each segment file twice)
- **Object store factory errors**: Config key parse errors now include the offending key name for S3, GCS, and Azure builders
- **Cleanup**: Simplified `now_ns()` unnecessary let-binding in per-core WAL entry

## Test plan

- [x] All 282 `laminar-storage` unit tests pass
- [x] Clippy clean
- [x] Downstream crates (`laminar-sql`, `laminar-connectors`, `laminar-db`) compile without changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for invalid object store configuration keys across S3, GCS, and Azure backends.
  * Added durability synchronization after write-ahead log truncation to ensure data integrity.

* **Improvements**
  * Optimized WAL segment opening logic to reduce unnecessary file reads.
  * Enhanced pending entry eviction strategy to preserve newer entries while shedding older ones under capacity constraints, with diagnostic warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->