### PR TITLE
Fix aarch64 cross-compilation OpenSSL discovery

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -5,11 +5,14 @@
 # CMake's cross-compilation toolchain restricts library search to the GCC sysroot
 # (/usr/aarch64-linux-gnu/), but dpkg multi-arch installs to /usr/lib/aarch64-linux-gnu/.
 # We symlink into the sysroot so CMake's Find* modules can locate headers and libraries.
+# The toolchain.cmake BOTH override lets cmake also search CMAKE_PREFIX_PATH, which is
+# where openssl-sys (vendored) puts its output -- without this, FindOpenSSL fails.
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get --assume-yes install protobuf-compiler zlib1g-dev:$CROSS_DEB_ARCH libcurl4-openssl-dev:$CROSS_DEB_ARCH perl make",
-    "mkdir -p /usr/aarch64-linux-gnu/lib /usr/aarch64-linux-gnu/include && ln -sf /usr/lib/aarch64-linux-gnu/libz.* /usr/aarch64-linux-gnu/lib/ && cp /usr/include/zlib.h /usr/include/zconf.h /usr/aarch64-linux-gnu/include/ && ln -sf /usr/lib/aarch64-linux-gnu/libcurl.* /usr/aarch64-linux-gnu/lib/ && cp -r /usr/include/aarch64-linux-gnu/curl /usr/aarch64-linux-gnu/include/ 2>/dev/null || cp -r /usr/include/curl /usr/aarch64-linux-gnu/include/"
+    "mkdir -p /usr/aarch64-linux-gnu/lib /usr/aarch64-linux-gnu/include && ln -sf /usr/lib/aarch64-linux-gnu/libz.* /usr/aarch64-linux-gnu/lib/ && cp /usr/include/zlib.h /usr/include/zconf.h /usr/aarch64-linux-gnu/include/ && ln -sf /usr/lib/aarch64-linux-gnu/libcurl.* /usr/aarch64-linux-gnu/lib/ && cp -r /usr/include/aarch64-linux-gnu/curl /usr/aarch64-linux-gnu/include/ 2>/dev/null || cp -r /usr/include/curl /usr/aarch64-linux-gnu/include/",
+    "printf '\\nset(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)\\nset(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)\\nset(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)\\n' >> /opt/toolchain.cmake || true"
 ]
 
 # x86_64 Linux (musl) -- install system libs for rdkafka-sys cmake build.


### PR DESCRIPTION
## Summary

The aarch64 release build was failing because cmake's `FindOpenSSL` couldn't locate the vendored OpenSSL that `openssl-sys` compiled from source.

**Root cause**: The cross-rs toolchain file (`/opt/toolchain.cmake`) sets `CMAKE_FIND_ROOT_PATH_MODE_*` to `ONLY`, which restricts cmake's `find_*` to the GCC sysroot. The vendored OpenSSL output lives in the cargo build directory and is passed via `CMAKE_PREFIX_PATH`, but that gets ignored under `ONLY` mode.

**Fix**: Append `BOTH` overrides to the toolchain file for aarch64, exactly like the musl target already does (and has been working). This lets cmake search both the sysroot and `CMAKE_PREFIX_PATH`.

```
FindOpenSSL error (before):
  Could NOT find OpenSSL (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR)
```

## Test plan

- [x] The musl target uses the identical fix and builds successfully
- [ ] Verify aarch64 release build passes on next tag push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced aarch64 build target configuration to improve library and package discovery during cross-compilation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->