### PR TITLE
fix: exclude microstructure example from release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,11 +151,11 @@ jobs:
 
       - name: Build (cross)
         if: matrix.cross
-        run: cross build --workspace --exclude laminardb-demo --exclude binance-ws --release ${{ matrix.features }} --target ${{ matrix.target }}
+        run: cross build --workspace --exclude laminardb-demo --exclude binance-ws --exclude microstructure --release ${{ matrix.features }} --target ${{ matrix.target }}
 
       - name: Build (native)
         if: "!matrix.cross"
-        run: cargo build --workspace --exclude laminardb-demo --exclude binance-ws --release ${{ matrix.features }} --target ${{ matrix.target }}
+        run: cargo build --workspace --exclude laminardb-demo --exclude binance-ws --exclude microstructure --release ${{ matrix.features }} --target ${{ matrix.target }}
 
       - name: Package artifacts
         shell: bash


### PR DESCRIPTION
## Summary
- Add `--exclude microstructure` to both cross and native build commands in the release workflow
- Fixes aarch64 cross-compilation OOM (SIGKILL) caused by linking the microstructure demo binary under fat LTO on memory-constrained CI runners
- All three example crates (`laminardb-demo`, `binance-ws`, `microstructure`) are now consistently excluded