### PR TITLE
Refactor site CSS: simplify theme & layout

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1,2134 +1,812 @@
-/* ============================================
-   LaminarDB — v2 Design System
-   Inspired by Supabase, Vercel, Linear, Neon
-   ============================================ */
+/* LaminarDB — Systems-grade design. No gradients, no glass, no glow. */
 
-/* --- Custom Properties --- */
 :root {
-  /* Backgrounds */
-  --bg-deep: #050a18;
-  --bg-primary: #080d1e;
-  --bg-secondary: #0c1229;
-  --bg-tertiary: #111936;
-  --bg-card: rgba(12, 18, 41, 0.6);
-  --bg-code: #0a0f20;
+  --bg: #0a0a0a;
+  --bg-surface: #111111;
+  --bg-code: #0e0e0e;
+  --border: #1e1e1e;
+  --border-bright: #2a2a2a;
 
-  /* Accent colors */
-  --cyan-50: #ecfeff;
-  --cyan-100: #cffafe;
-  --cyan-200: #a5f3fc;
-  --cyan-300: #67e8f9;
-  --cyan-400: #22d3ee;
-  --cyan-500: #06b6d4;
-  --cyan-600: #0891b2;
-  --cyan-glow: rgba(6, 182, 212, 0.15);
-  --cyan-glow-strong: rgba(6, 182, 212, 0.35);
+  --text: #e5e5e5;
+  --text-secondary: #999999;
+  --text-dim: #666666;
 
-  /* Secondary accents */
-  --violet-400: #a78bfa;
-  --violet-500: #8b5cf6;
-  --violet-glow: rgba(139, 92, 246, 0.15);
-  --amber-400: #fbbf24;
-  --amber-500: #f59e0b;
-  --green-400: #4ade80;
-  --green-500: #22c55e;
-  --rose-400: #fb7185;
-  --rose-500: #f43f5e;
+  --accent: #00b4d8;
+  --accent-bright: #38cbeb;
+  --accent-dim: rgba(0, 180, 216, 0.12);
 
-  /* Text */
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-tertiary: #64748b;
-  --text-muted: #475569;
+  --green: #22c55e;
+  --green-dim: rgba(34, 197, 94, 0.12);
+  --yellow: #eab308;
+  --red: #ef4444;
 
-  /* Glass */
-  --glass-bg: rgba(15, 23, 50, 0.5);
-  --glass-border: rgba(148, 163, 184, 0.08);
-  --glass-border-hover: rgba(6, 182, 212, 0.25);
-  --glass-glow: 0 0 0 1px rgba(6, 182, 212, 0.1), 0 8px 40px -8px rgba(6, 182, 212, 0.1);
+  --font-mono: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace;
+  --font-body: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 
-  /* Gradients */
-  --gradient-hero: linear-gradient(135deg, #06b6d4 0%, #8b5cf6 50%, #ec4899 100%);
-  --gradient-text: linear-gradient(135deg, #67e8f9, #06b6d4, #8b5cf6);
-  --gradient-text-warm: linear-gradient(135deg, #fbbf24, #f59e0b, #ef4444);
-  --gradient-card-border: linear-gradient(135deg, rgba(6, 182, 212, 0.3), rgba(139, 92, 246, 0.1));
-  --gradient-surface: linear-gradient(180deg, rgba(6, 182, 212, 0.03) 0%, transparent 100%);
-
-  /* Typography */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
-  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-
-  /* Layout */
-  --max-width: 1200px;
-  --max-width-narrow: 900px;
-  --section-gap: 8rem;
-  --radius: 16px;
-  --radius-sm: 10px;
-  --radius-xs: 6px;
-
-  /* Motion */
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
-  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
-  --duration: 0.4s;
-  --duration-slow: 0.8s;
+  --max-width: 960px;
+  --gap: 2rem;
 }
 
-/* --- Reset & Base --- */
+/* --- Reset --- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html {
-  scroll-behavior: smooth;
-  font-size: 16px;
-  overflow-x: hidden;
-  -webkit-text-size-adjust: 100%;
-}
+html { font-size: 16px; scroll-behavior: smooth; }
 body {
-  font-family: var(--font-sans);
-  background: var(--bg-deep);
+  font-family: var(--font-body);
+  background: var(--bg);
   color: var(--text-secondary);
-  line-height: 1.7;
-  overflow-x: hidden;
+  line-height: 1.65;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-a {
-  color: var(--cyan-400);
-  text-decoration: none;
-  transition: color var(--duration) var(--ease-out);
-}
-a:hover { color: var(--cyan-300); }
+a { color: var(--accent-bright); text-decoration: none; }
+a:hover { color: var(--text); }
 img { max-width: 100%; display: block; }
-ul, ol { list-style: none; }
-code {
-  font-family: var(--font-mono);
-  font-size: 0.875em;
-}
+code { font-family: var(--font-mono); }
+strong { color: var(--text); font-weight: 600; }
 
-/* --- Utilities --- */
+/* --- Layout --- */
 .container {
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 0 1.5rem;
-}
-.text-center { text-align: center; }
-
-.gradient-text {
-  background: var(--gradient-text);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  display: inline;
+  padding: 0 24px;
 }
 
-.section-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--cyan-400);
-  margin-bottom: 1rem;
+section {
+  padding: 5rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+section:last-of-type { border-bottom: none; }
+
+/* --- Typography --- */
+h1, h2, h3, h4 {
   font-family: var(--font-mono);
-}
-.section-label::before {
-  content: '';
-  display: inline-block;
-  width: 24px;
-  height: 1px;
-  background: var(--cyan-500);
-}
-
-.section-title {
-  font-family: var(--font-display);
-  font-size: clamp(2rem, 5vw, 3.25rem);
-  font-weight: 800;
-  color: var(--text-primary);
-  line-height: 1.15;
-  letter-spacing: -0.03em;
-  margin-bottom: 1rem;
-}
-
-.section-desc {
-  font-size: 1.125rem;
-  color: var(--text-secondary);
-  max-width: 640px;
-  line-height: 1.7;
-}
-.section-desc.centered {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.section-header {
-  margin-bottom: 4rem;
-}
-
-/* --- Scroll Reveal --- */
-.reveal {
-  opacity: 0;
-  transform: translateY(24px);
-  transition: opacity 0.7s var(--ease-out), transform 0.7s var(--ease-out);
-}
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-.reveal-delay-1 { transition-delay: 0.08s; }
-.reveal-delay-2 { transition-delay: 0.16s; }
-.reveal-delay-3 { transition-delay: 0.24s; }
-.reveal-delay-4 { transition-delay: 0.32s; }
-.reveal-delay-5 { transition-delay: 0.40s; }
-.reveal-delay-6 { transition-delay: 0.48s; }
-
-/* --- Buttons --- */
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.7rem 1.5rem;
-  border-radius: var(--radius-sm);
-  font-size: 0.9rem;
-  font-weight: 600;
-  font-family: var(--font-sans);
-  border: none;
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
-  white-space: nowrap;
-  text-decoration: none;
-  line-height: 1.4;
-}
-.btn svg {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-.btn-primary {
-  background: var(--cyan-500);
-  color: #000;
-  font-weight: 700;
-}
-.btn-primary:hover {
-  background: var(--cyan-400);
-  color: #000;
-  transform: translateY(-1px);
-  box-shadow: 0 0 0 1px var(--cyan-400), 0 8px 32px -4px rgba(6, 182, 212, 0.4);
-}
-.btn-secondary {
-  background: transparent;
-  color: var(--text-primary);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-}
-.btn-secondary:hover {
-  border-color: var(--cyan-500);
-  color: var(--cyan-400);
-  background: rgba(6, 182, 212, 0.05);
-}
-.btn-ghost {
-  background: transparent;
-  color: var(--text-secondary);
-  padding: 0.7rem 1rem;
-}
-.btn-ghost:hover {
-  color: var(--cyan-400);
-}
-.btn-lg {
-  padding: 0.85rem 2rem;
-  font-size: 1rem;
-  border-radius: var(--radius);
-}
-.btn-sm {
-  padding: 0.45rem 1rem;
-  font-size: 0.82rem;
-  border-radius: var(--radius-xs);
-}
-
-/* ================================================
-   STICKY TOP BAR
-   ================================================ */
-.sticky-bar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1100;
-  transform: translateY(-100%);
-  transition: transform 0.4s var(--ease-out);
-  background: rgba(5, 10, 24, 0.92);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border-bottom: 1px solid var(--glass-border);
-}
-.sticky-bar.visible {
-  transform: translateY(0);
-}
-.sticky-bar-inner {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1.25rem;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0.5rem 1.5rem;
-}
-.sticky-bar-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: 700;
-  font-size: 0.9rem;
-  color: var(--text-primary);
+  color: var(--text);
+  line-height: 1.3;
   letter-spacing: -0.01em;
 }
-.sticky-bar-brand:hover { color: var(--text-primary); }
-.sticky-bar-install {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
-  background: var(--bg-code);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-xs);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
-}
-.sticky-bar-install:hover {
-  border-color: rgba(6, 182, 212, 0.2);
-}
-.sticky-bar-install .prompt { color: var(--cyan-500); user-select: none; }
-.sticky-bar-install .cmd { color: var(--text-primary); }
 
-/* ================================================
-   NAVIGATION
-   ================================================ */
+h1 { font-size: 2.25rem; font-weight: 700; }
+h2 { font-size: 1.5rem; font-weight: 500; margin-bottom: 1.25rem; }
+h3 { font-size: 1.05rem; font-weight: 500; margin-bottom: 0.5rem; }
+h4 { font-size: 0.9rem; font-weight: 500; }
+
+p { margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+
+.section-desc {
+  color: var(--text-dim);
+  font-size: 0.9rem;
+  margin-bottom: 2.5rem;
+  max-width: 600px;
+}
+
+/* --- Nav --- */
 .nav {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  padding: 0.75rem 0;
-  transition: all var(--duration) var(--ease-out);
+  z-index: 100;
+  background: rgba(10, 10, 10, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+  height: 56px;
 }
-.nav.scrolled {
-  background: rgba(5, 10, 24, 0.82);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border-bottom: 1px solid var(--glass-border);
-}
+
 .nav-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 0 1.5rem;
-  gap: 1rem;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 1.5rem;
 }
+
 .nav-brand {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  font-weight: 700;
-  font-size: 1.15rem;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-  flex-shrink: 0;
-}
-.nav-brand:hover { color: var(--text-primary); }
-.nav-brand img,
-.nav-brand svg.logo-icon {
-  height: 32px;
-  width: auto;
-}
-.nav-brand svg.logo-icon {
-  transition: filter var(--duration) var(--ease-out);
-}
-.nav-brand:hover svg.logo-icon {
-  filter: drop-shadow(0 0 8px rgba(6, 182, 212, 0.5));
-}
-.nav-brand .version-badge {
-  font-size: 0.65rem;
-  font-weight: 600;
-  padding: 0.15rem 0.45rem;
-  background: rgba(6, 182, 212, 0.12);
-  border: 1px solid rgba(6, 182, 212, 0.2);
-  border-radius: 100px;
-  color: var(--cyan-400);
+  gap: 8px;
+  color: var(--text);
   font-family: var(--font-mono);
-  line-height: 1;
+  font-weight: 700;
+  font-size: 1rem;
+  white-space: nowrap;
+  text-decoration: none;
 }
+
+.nav-brand:hover { color: var(--text); }
+
+.nav-brand svg { flex-shrink: 0; }
+
+.version-badge {
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--accent);
+  border: 1px solid rgba(212, 145, 42, 0.3);
+  padding: 1px 6px;
+  border-radius: 3px;
+  line-height: 1.4;
+}
+
 .nav-links {
   display: flex;
-  gap: 0.25rem;
   align-items: center;
+  gap: 1.25rem;
+  margin-left: auto;
+  font-size: 0.85rem;
 }
+
 .nav-links a {
-  color: var(--text-tertiary);
-  font-size: 0.875rem;
-  font-weight: 500;
-  padding: 0.4rem 0.75rem;
-  border-radius: var(--radius-xs);
-  white-space: nowrap;
-  transition: all var(--duration) var(--ease-out);
+  color: var(--text-dim);
+  transition: color 0.15s;
 }
-.nav-links a:hover { color: var(--text-primary); background: rgba(148, 163, 184, 0.06); }
-.nav-links a.active { color: var(--text-primary); }
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-shrink: 0;
-}
-.github-btn {
+
+.nav-links a:hover { color: var(--text); }
+
+.nav-links .github-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.12);
-  border-radius: var(--radius-sm);
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-  transition: all var(--duration) var(--ease-out);
+  gap: 4px;
 }
-.github-btn:hover {
-  border-color: var(--cyan-500);
-  color: var(--text-primary);
-  background: rgba(6, 182, 212, 0.05);
-}
-.github-btn svg { width: 18px; height: 18px; }
 
-/* Mobile nav */
-.mobile-menu { display: none; }
+.nav-links .github-link svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
 .nav-toggle {
   display: none;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.5rem;
-  z-index: 1001;
+  padding: 4px;
+  margin-left: auto;
 }
+
 .nav-toggle span {
   display: block;
-  width: 20px;
+  width: 18px;
   height: 2px;
-  background: var(--text-primary);
-  margin: 5px 0;
-  border-radius: 2px;
-  transition: all var(--duration) var(--ease-out);
+  background: var(--text-secondary);
+  margin: 4px 0;
+  transition: transform 0.2s, opacity 0.2s;
 }
-.nav-toggle.open span:nth-child(1) { transform: rotate(45deg) translate(5px, 5px); }
+
+.nav-toggle.open span:nth-child(1) { transform: rotate(45deg) translate(3px, 4px); }
 .nav-toggle.open span:nth-child(2) { opacity: 0; }
-.nav-toggle.open span:nth-child(3) { transform: rotate(-45deg) translate(5px, -5px); }
+.nav-toggle.open span:nth-child(3) { transform: rotate(-45deg) translate(3px, -4px); }
 
-/* ================================================
-   HERO
-   ================================================ */
-.hero {
-  position: relative;
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 8rem 1.5rem 6rem;
-  overflow: hidden;
-}
-
-/* Animated gradient mesh background */
-.hero-glow {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  z-index: 0;
-}
-.hero-glow::before {
-  content: '';
-  position: absolute;
-  top: -20%;
-  left: -10%;
-  width: 60%;
-  height: 80%;
-  background: radial-gradient(ellipse, rgba(6, 182, 212, 0.12) 0%, transparent 70%);
-  animation: glow-drift 15s ease-in-out infinite alternate;
-}
-.hero-glow::after {
-  content: '';
-  position: absolute;
-  bottom: -30%;
-  right: -15%;
-  width: 70%;
-  height: 90%;
-  background: radial-gradient(ellipse, rgba(139, 92, 246, 0.08) 0%, transparent 70%);
-  animation: glow-drift 20s ease-in-out infinite alternate-reverse;
-}
-@keyframes glow-drift {
-  0% { transform: translate(0, 0) scale(1); }
-  100% { transform: translate(40px, -30px) scale(1.1); }
+.mobile-menu {
+  display: none;
+  position: fixed;
+  top: 56px;
+  left: 0;
+  right: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 99;
 }
 
-/* Grid pattern overlay */
-.hero-grid {
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
-  background-size: 64px 64px;
-  mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 100%);
-  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 30%, transparent 100%);
-  z-index: 0;
-}
+.mobile-menu.open { display: flex; }
 
-/* Floating particles */
-.hero-particles {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  overflow: hidden;
-}
-.particle {
-  position: absolute;
-  width: 2px;
-  height: 2px;
-  background: var(--cyan-400);
-  border-radius: 50%;
-  opacity: 0;
-  animation: particle-float linear infinite;
-}
-@keyframes particle-float {
-  0% { opacity: 0; transform: translateY(100vh) translateX(0); }
-  10% { opacity: 0.6; }
-  90% { opacity: 0.6; }
-  100% { opacity: 0; transform: translateY(-10vh) translateX(30px); }
-}
-
-.hero-content {
-  position: relative;
-  z-index: 1;
-  max-width: 840px;
-}
-
-.hero-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 1rem 0.4rem 0.5rem;
-  background: rgba(6, 182, 212, 0.06);
-  border: 1px solid rgba(6, 182, 212, 0.12);
-  border-radius: 100px;
-  font-size: 0.82rem;
+.mobile-menu a {
   color: var(--text-secondary);
-  margin-bottom: 2rem;
-  font-weight: 500;
-  transition: all var(--duration) var(--ease-out);
-}
-.hero-eyebrow:hover {
-  border-color: rgba(6, 182, 212, 0.25);
-  background: rgba(6, 182, 212, 0.08);
-}
-.hero-eyebrow .eyebrow-badge {
-  font-size: 0.7rem;
-  font-weight: 700;
-  padding: 0.2rem 0.55rem;
-  background: var(--cyan-500);
-  color: #000;
-  border-radius: 100px;
-  line-height: 1.2;
-}
-.hero-eyebrow .eyebrow-arrow {
-  margin-left: 0.25rem;
-  transition: transform var(--duration) var(--ease-out);
-}
-.hero-eyebrow:hover .eyebrow-arrow {
-  transform: translateX(2px);
+  font-size: 0.9rem;
+  padding: 4px 0;
 }
 
-.hero h1 {
-  font-family: var(--font-display);
-  font-size: clamp(2.75rem, 7vw, 5rem);
-  font-weight: 800;
-  letter-spacing: -0.04em;
-  line-height: 1.05;
-  color: var(--text-primary);
+/* --- Hero --- */
+.hero {
+  padding: 4rem 0 3rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.hero-tagline {
+  font-size: 2.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero-desc {
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  max-width: 560px;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.hero-install-group {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
   margin-bottom: 1.5rem;
 }
-.hero h1 .gradient-text {
-  background: var(--gradient-hero);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
 
-.hero-subtitle {
-  font-size: clamp(1.05rem, 2vw, 1.25rem);
-  color: var(--text-secondary);
-  max-width: 600px;
-  margin: 0 auto 2.5rem;
-  line-height: 1.7;
-}
-
-.hero-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-bottom: 2.5rem;
-}
-
-/* Install snippet with language toggle */
-.hero-install-wrapper {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  margin-bottom: 3rem;
-}
-.hero-install-tabs {
-  display: flex;
-  gap: 0;
+.hero-install-group .hero-install {
   margin-bottom: 0;
-  background: rgba(10, 15, 32, 0.6);
-  border: 1px solid var(--glass-border);
-  border-bottom: none;
-  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
-  overflow: hidden;
-}
-.install-tab {
-  padding: 0.4rem 1.25rem;
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
-  border-right: 1px solid var(--glass-border);
-}
-.install-tab:last-child { border-right: none; }
-.install-tab:hover { color: var(--text-secondary); }
-.install-tab.active {
-  color: var(--cyan-400);
-  background: rgba(6, 182, 212, 0.08);
 }
 
 .hero-install {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem 0.75rem 1.25rem;
-  background: var(--bg-code);
-  border: 1px solid var(--glass-border);
-  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-  font-family: var(--font-mono);
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
-  min-width: 320px;
-  justify-content: center;
-}
-.hero-install:hover {
-  border-color: rgba(6, 182, 212, 0.2);
-  background: rgba(10, 15, 32, 0.9);
-}
-.hero-install .prompt { color: var(--cyan-500); user-select: none; }
-.hero-install .cmd { color: var(--text-primary); }
-.hero-install .copy-hint {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  padding: 0.15rem 0.5rem;
-  border: 1px solid var(--glass-border);
+  gap: 8px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 4px;
-  font-family: var(--font-sans);
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s;
+  margin-bottom: 1.5rem;
+}
+
+.hero-install:hover { border-color: var(--border-bright); }
+
+.hero-install .prompt {
+  color: var(--accent);
   user-select: none;
 }
 
-/* Hero metrics strip */
+.hero-install .cmd { color: var(--text); }
+
+.hero-install .copy-hint {
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  margin-left: 8px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 2rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #0a0a0a;
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-bright);
+  border-color: var(--accent-bright);
+  color: #0a0a0a;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-bright);
+}
+
+.btn-secondary:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.btn svg { width: 14px; height: 14px; fill: currentColor; }
+
+.hero-code {
+  margin-bottom: 2rem;
+}
+
 .hero-metrics {
   display: flex;
-  gap: 2rem;
-  justify-content: center;
+  gap: 2.5rem;
   flex-wrap: wrap;
 }
+
 .hero-metric {
   display: flex;
   flex-direction: column;
-  align-items: center;
 }
+
 .hero-metric-value {
-  font-size: 1.75rem;
-  font-weight: 800;
   font-family: var(--font-mono);
-  color: var(--text-primary);
-  line-height: 1;
-  letter-spacing: -0.02em;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.2;
 }
+
 .hero-metric-value .unit {
-  font-size: 0.7em;
-  color: var(--cyan-400);
-  font-weight: 600;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--accent);
 }
+
 .hero-metric-label {
   font-size: 0.75rem;
-  color: var(--text-tertiary);
-  margin-top: 0.35rem;
-  font-weight: 500;
+  color: var(--text-dim);
 }
 
-/* ================================================
-   SOCIAL PROOF / TECH BADGES
-   ================================================ */
-.tech-strip {
-  padding: 4rem 1.5rem;
-  border-top: 1px solid var(--glass-border);
-  border-bottom: 1px solid var(--glass-border);
-}
-.tech-strip-inner {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3rem;
-  flex-wrap: wrap;
-  max-width: var(--max-width);
-  margin: 0 auto;
-}
-.tech-badge {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
-  color: var(--text-tertiary);
-  font-weight: 500;
-  transition: color var(--duration) var(--ease-out);
-}
-.tech-badge:hover { color: var(--text-secondary); }
-.tech-badge svg { width: 20px; height: 20px; opacity: 0.6; }
-.tech-badge .tech-name { font-weight: 600; color: var(--text-secondary); }
-
-/* ================================================
-   POSITIONING / WHY SECTION
-   ================================================ */
-.why-section {
-  padding: var(--section-gap) 1.5rem;
-}
-.why-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-top: 3rem;
-}
-.why-card {
-  position: relative;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  padding: 2rem;
-  transition: all var(--duration) var(--ease-out);
-  overflow: hidden;
-}
-.why-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: var(--radius);
-  padding: 1px;
-  background: linear-gradient(135deg, rgba(6, 182, 212, 0.15), transparent 50%);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  -webkit-mask-composite: xor;
-  opacity: 0;
-  transition: opacity var(--duration) var(--ease-out);
-  pointer-events: none;
-}
-.why-card:hover {
-  transform: translateY(-2px);
-  border-color: var(--glass-border-hover);
-  box-shadow: var(--glass-glow);
-}
-.why-card:hover::before { opacity: 1; }
-
-.why-card-icon {
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-sm);
-  margin-bottom: 1.25rem;
-  font-size: 1.25rem;
-}
-.why-card-icon.cyan { background: rgba(6, 182, 212, 0.1); color: var(--cyan-400); }
-.why-card-icon.violet { background: rgba(139, 92, 246, 0.1); color: var(--violet-400); }
-.why-card-icon.amber { background: rgba(251, 191, 36, 0.1); color: var(--amber-400); }
-.why-card-icon.green { background: rgba(74, 222, 128, 0.1); color: var(--green-400); }
-.why-card-icon svg { width: 22px; height: 22px; }
-
-.why-card h3 {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.01em;
-}
-.why-card p {
-  font-size: 0.925rem;
-  color: var(--text-secondary);
-  line-height: 1.65;
-}
-.why-card .card-stat {
-  display: inline-block;
-  margin-top: 1rem;
-  padding: 0.25rem 0.6rem;
-  background: rgba(6, 182, 212, 0.06);
-  border: 1px solid rgba(6, 182, 212, 0.1);
-  border-radius: 100px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--cyan-400);
+.hero-metric-source {
+  font-size: 0.65rem;
+  color: var(--text-dim);
   font-family: var(--font-mono);
 }
 
-/* ================================================
-   USE CASES V2 — Marketing Cards
-   ================================================ */
-.use-cases-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-.use-cases-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
+.hero-metric-source a {
+  color: var(--text-dim);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
-.use-cases-grid-v2 {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-top: 3rem;
-}
-.use-case-card-v2 {
-  position: relative;
-  padding: 2rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  transition: all var(--duration) var(--ease-out);
-  display: flex;
-  flex-direction: column;
-}
-.use-case-card-v2:hover {
-  border-color: var(--glass-border-hover);
-  transform: translateY(-2px);
-  box-shadow: var(--glass-glow);
-}
-.use-case-card-icon {
-  width: 44px;
-  height: 44px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-sm);
-  margin-bottom: 1.25rem;
-}
-.use-case-card-icon svg { width: 22px; height: 22px; }
-.use-case-card-v2 h3 {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.01em;
-}
-.use-case-card-v2 p {
-  font-size: 0.925rem;
-  color: var(--text-secondary);
-  line-height: 1.65;
-  flex: 1;
-}
-.use-case-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  margin-top: 1.25rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--cyan-400);
-  transition: all var(--duration) var(--ease-out);
-}
-.use-case-link:hover {
-  color: var(--cyan-300);
-}
-.use-case-link span {
-  transition: transform var(--duration) var(--ease-out);
-}
-.use-case-link:hover span {
-  transform: translateX(3px);
-}
-
-/* ================================================
-   PERFORMANCE METRICS
-   ================================================ */
-.perf-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-.perf-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
-}
-
-.perf-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1.5rem;
-  margin-top: 3rem;
-}
-.perf-card {
-  text-align: center;
-  padding: 2rem 1.5rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  transition: all var(--duration) var(--ease-out);
-  position: relative;
-  overflow: hidden;
-}
-.perf-card::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 10%;
-  right: 10%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--cyan-500), transparent);
-  opacity: 0;
-  transition: opacity var(--duration) var(--ease-out);
-}
-.perf-card:hover {
-  border-color: var(--glass-border-hover);
-  transform: translateY(-2px);
-}
-.perf-card:hover::after { opacity: 1; }
-
-.perf-value {
-  font-size: 2.5rem;
-  font-weight: 800;
-  font-family: var(--font-mono);
-  background: var(--gradient-text);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  line-height: 1;
-  margin-bottom: 0.5rem;
-  letter-spacing: -0.02em;
-}
-.perf-label {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-.perf-sublabel {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-top: 0.25rem;
-  font-family: var(--font-mono);
-}
-
-/* ================================================
-   CODE EXAMPLES
-   ================================================ */
-.code-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-
-.code-container {
-  max-width: 860px;
-  margin: 3rem auto 0;
-}
+/* --- Code Blocks --- */
 .code-block {
   background: var(--bg-code);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  border-radius: 6px;
   overflow: hidden;
-  transition: all var(--duration) var(--ease-out);
-}
-.code-block:hover {
-  border-color: rgba(6, 182, 212, 0.15);
-  box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.05), 0 24px 64px -12px rgba(0, 0, 0, 0.5);
 }
 
 .code-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 0.5rem;
-  border-bottom: 1px solid var(--glass-border);
-  background: rgba(15, 23, 50, 0.4);
+  padding: 0 12px;
+  height: 36px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(17, 17, 17, 0.5);
 }
-.tab-buttons {
+
+.code-tabs {
   display: flex;
   gap: 0;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
 }
-.tab-buttons::-webkit-scrollbar { display: none; }
-.tab-btn {
-  padding: 0.75rem 1.15rem;
+
+.code-tab {
   background: none;
   border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-muted);
-  font-family: var(--font-sans);
-  font-size: 0.82rem;
-  font-weight: 500;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  padding: 6px 12px;
   cursor: pointer;
-  white-space: nowrap;
-  transition: all var(--duration) var(--ease-out);
-}
-.tab-btn:hover { color: var(--text-secondary); }
-.tab-btn.active {
-  color: var(--cyan-400);
-  border-bottom-color: var(--cyan-400);
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s;
 }
 
-.code-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding-right: 0.5rem;
-}
+.code-tab:hover { color: var(--text-secondary); }
+.code-tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
 .copy-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.6rem;
-  background: transparent;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-xs);
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  font-family: var(--font-sans);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
+  gap: 4px;
+  transition: all 0.15s;
 }
-.copy-btn:hover {
-  border-color: var(--cyan-500);
-  color: var(--cyan-400);
-}
+
+.copy-btn:hover { color: var(--text-secondary); border-color: var(--border-bright); }
+
 .copy-btn.copied {
-  color: var(--green-400);
-  border-color: var(--green-400);
-}
-.copy-btn svg {
-  width: 14px;
-  height: 14px;
+  color: var(--green);
+  border-color: var(--green);
 }
 
-.tab-panel {
-  display: none;
-}
-.tab-panel.active { display: block; }
-.tab-panel pre {
+.copy-btn svg { width: 12px; height: 12px; }
+
+.code-body { overflow-x: auto; }
+
+.code-body pre {
   margin: 0;
-  padding: 1.5rem;
-  overflow-x: auto;
-  font-size: 0.85rem;
-  line-height: 1.75;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: var(--bg-tertiary) transparent;
-}
-.tab-panel code {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
+  padding: 16px;
+  background: transparent !important;
 }
 
-/* Prism overrides */
-.tab-panel code[class*="language-"],
-.tab-panel pre[class*="language-"] {
-  background: transparent;
-  text-shadow: none;
-  font-family: var(--font-mono);
-}
-.token.comment { color: var(--text-muted); font-style: italic; }
-.token.keyword { color: var(--violet-400); }
-.token.string { color: var(--green-400); }
-.token.function { color: var(--cyan-300); }
-.token.number { color: var(--amber-400); }
-.token.operator { color: var(--cyan-400); }
-.token.punctuation { color: var(--text-tertiary); }
-.token.class-name { color: var(--amber-400); }
-.token.property { color: var(--cyan-300); }
-.token.boolean { color: var(--amber-400); }
-
-/* ================================================
-   PYTHON API SECTION
-   ================================================ */
-.python-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-  background: linear-gradient(180deg, rgba(6, 182, 212, 0.02) 0%, transparent 40%, rgba(139, 92, 246, 0.02) 100%);
-}
-.python-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
-}
-
-.python-showcase {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2.5rem;
-  margin-top: 3rem;
-  align-items: start;
-}
-.python-code-side {
-  position: sticky;
-  top: 5rem;
-}
-.python-code-side .code-block {
-  margin: 0;
-}
-
-.python-features-side {
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-}
-.python-feature {
-  display: flex;
-  gap: 1rem;
-  align-items: flex-start;
-}
-.python-feature-icon {
-  width: 40px;
-  height: 40px;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(6, 182, 212, 0.1);
-  border-radius: var(--radius-xs);
-  color: var(--cyan-400);
-}
-.python-feature-icon svg { width: 20px; height: 20px; }
-.python-feature h4 {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.3rem;
-  letter-spacing: -0.01em;
-}
-.python-feature p {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.python-install-cta {
-  display: flex;
-  justify-content: center;
-  margin-top: 2.5rem;
-}
-.python-install-cta .hero-install {
-  border-radius: var(--radius-sm);
-}
-
-/* ================================================
-   ARCHITECTURE
-   ================================================ */
-.arch-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-
-.arch-visual {
-  max-width: 800px;
-  margin: 3rem auto 0;
-}
-
-.ring-layer {
-  position: relative;
-  border: 1px solid;
-  border-radius: var(--radius);
-  padding: 1.75rem;
-  margin-bottom: 2px;
-  transition: all var(--duration) var(--ease-out);
-}
-.ring-layer:hover {
-  transform: scale(1.005);
-}
-
-.ring-layer.ring-0 {
-  border-color: rgba(6, 182, 212, 0.3);
-  background: linear-gradient(180deg, rgba(6, 182, 212, 0.06) 0%, rgba(6, 182, 212, 0.02) 100%);
-  z-index: 3;
-}
-.ring-layer.ring-1 {
-  border-color: rgba(139, 92, 246, 0.2);
-  background: linear-gradient(180deg, rgba(139, 92, 246, 0.04) 0%, rgba(139, 92, 246, 0.01) 100%);
-  z-index: 2;
-}
-.ring-layer.ring-2 {
-  border-color: rgba(148, 163, 184, 0.1);
-  background: linear-gradient(180deg, rgba(148, 163, 184, 0.03) 0%, transparent 100%);
-  z-index: 1;
-}
-
-.ring-label {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1rem;
-}
-.ring-name {
+.code-body code {
   font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  line-height: 1.55;
+  background: transparent !important;
 }
-.ring-0 .ring-name { color: var(--cyan-400); }
-.ring-1 .ring-name { color: var(--violet-400); }
-.ring-2 .ring-name { color: var(--text-tertiary); }
+
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* --- Architecture Rings --- */
+.arch-rings {
+  margin: 2rem 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.ring {
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  margin-bottom: 0;
+}
+
+.ring-0 { border-color: var(--accent); }
+.ring-1 { border-color: var(--border-bright); }
+.ring-2 { border-color: var(--border); }
+
+.ring-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ring-name {
+  color: var(--text);
+  font-weight: 500;
+  font-size: 0.8rem;
+}
 
 .ring-constraint {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
+  color: var(--text-dim);
+  font-size: 0.7rem;
 }
 
 .ring-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 6px;
 }
+
 .ring-chip {
-  padding: 0.4rem 0.85rem;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: var(--radius-xs);
-  font-size: 0.82rem;
-  font-weight: 500;
-  color: var(--text-primary);
-  transition: all var(--duration) var(--ease-out);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
 }
-.ring-0 .ring-chip:hover { border-color: var(--cyan-500); background: rgba(6, 182, 212, 0.06); }
-.ring-1 .ring-chip:hover { border-color: var(--violet-500); background: rgba(139, 92, 246, 0.06); }
-.ring-2 .ring-chip:hover { border-color: rgba(148, 163, 184, 0.2); }
 
 .ring-divider {
   text-align: center;
-  padding: 0.35rem 0;
-}
-.ring-divider span {
-  display: inline-block;
-  padding: 0.2rem 0.75rem;
-  font-size: 0.7rem;
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-  background: var(--bg-deep);
-  border: 1px solid var(--glass-border);
-  border-radius: 100px;
-}
-
-/* Architecture detail cards */
-.arch-details {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
-  margin-top: 3rem;
-}
-.arch-detail {
-  padding: 1.5rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  transition: all var(--duration) var(--ease-out);
-}
-.arch-detail:hover {
-  border-color: var(--glass-border-hover);
-}
-.arch-detail-icon {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--cyan-glow);
-  border-radius: var(--radius-xs);
-  color: var(--cyan-400);
-  margin-bottom: 1rem;
-}
-.arch-detail-icon svg { width: 18px; height: 18px; }
-.arch-detail h4 {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 0.35rem;
-}
-.arch-detail p {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-/* ================================================
-   CONNECTORS
-   ================================================ */
-.connectors-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-
-.connectors-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 1rem;
-  margin-top: 3rem;
-}
-.connector-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1.5rem 1rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  text-align: center;
-  transition: all var(--duration) var(--ease-out);
-}
-.connector-card:hover {
-  border-color: var(--glass-border-hover);
-  transform: translateY(-2px);
-  box-shadow: var(--glass-glow);
-}
-.connector-icon {
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-sm);
-  font-size: 1.1rem;
-  font-weight: 800;
-  font-family: var(--font-mono);
-}
-.connector-icon.kafka { background: rgba(6, 182, 212, 0.1); color: var(--cyan-400); }
-.connector-icon.postgres { background: rgba(139, 92, 246, 0.1); color: var(--violet-400); }
-.connector-icon.mysql { background: rgba(251, 191, 36, 0.1); color: var(--amber-400); }
-.connector-icon.delta { background: rgba(74, 222, 128, 0.1); color: var(--green-400); }
-.connector-icon.iceberg { background: rgba(56, 189, 248, 0.1); color: var(--cyan-300); }
-.connector-icon.websocket { background: rgba(251, 113, 133, 0.1); color: var(--rose-400); }
-
-.connector-name {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-.connector-type {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-.connector-badge {
+  padding: 4px 0;
+  color: var(--text-dim);
   font-size: 0.65rem;
-  font-weight: 600;
-  padding: 0.15rem 0.45rem;
-  border-radius: 100px;
-}
-.connector-badge.impl {
-  background: rgba(74, 222, 128, 0.1);
-  color: var(--green-400);
-  border: 1px solid rgba(74, 222, 128, 0.15);
-}
-
-/* ================================================
-   FEATURES GRID
-   ================================================ */
-.features-section {
-  padding: var(--section-gap) 1.5rem;
-}
-.features-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-  margin-top: 3rem;
-}
-.feature-card {
-  padding: 1.75rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  transition: all var(--duration) var(--ease-out);
   position: relative;
 }
-.feature-card:hover {
-  border-color: var(--glass-border-hover);
-  transform: translateY(-1px);
+
+.ring-divider::before {
+  content: '│';
+  display: block;
+  color: var(--border-bright);
 }
-.feature-card-icon {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-xs);
+
+/* --- What It Is / Text Sections --- */
+.text-block {
+  max-width: 680px;
+}
+
+.text-block p {
   margin-bottom: 1rem;
-  font-size: 1rem;
-}
-.feature-card h3 {
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.4rem;
-  letter-spacing: -0.01em;
-}
-.feature-card p {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-/* ================================================
-   COMPARISON TABLE
-   ================================================ */
-.comparison-section {
-  padding: var(--section-gap) 1.5rem;
-}
-
-/* Comparison highlights row */
-.comparison-highlights {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  margin-bottom: 3rem;
-}
-.comparison-hl-card {
-  text-align: center;
-  padding: 1.25rem 1rem;
-  background: var(--bg-card);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  transition: all var(--duration) var(--ease-out);
-}
-.comparison-hl-card:hover {
-  border-color: var(--glass-border-hover);
-}
-.comparison-hl-value {
-  font-size: 1.1rem;
-  font-weight: 800;
-  color: var(--cyan-400);
-  font-family: var(--font-mono);
-  margin-bottom: 0.25rem;
-  letter-spacing: -0.01em;
-}
-.comparison-hl-desc {
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  line-height: 1.4;
-}
-
-.comparison-wrapper {
-  max-width: var(--max-width);
-  margin: 0 auto;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  scrollbar-width: thin;
-  scrollbar-color: var(--bg-tertiary) transparent;
-}
-.comparison-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.875rem;
-  min-width: 800px;
-}
-.comparison-table th,
-.comparison-table td {
-  padding: 0.85rem 1.25rem;
-  text-align: center;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-}
-.comparison-table th {
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  font-weight: 600;
-  font-size: 0.82rem;
-  letter-spacing: 0.02em;
-  position: sticky;
-  top: 0;
-}
-.comparison-table td:first-child {
-  text-align: left;
-  font-weight: 500;
-  color: var(--text-primary);
-}
-.comparison-table th.hl,
-.comparison-table td.hl {
-  background: rgba(6, 182, 212, 0.04);
-}
-.comparison-table th.hl {
-  color: var(--cyan-400);
-  background: rgba(6, 182, 212, 0.08);
-  font-weight: 700;
-  position: relative;
-}
-.comparison-table th.hl::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: var(--cyan-500);
-}
-.comparison-table tbody tr {
-  transition: background var(--duration) var(--ease-out);
-}
-.comparison-table tbody tr:hover td {
-  background: rgba(255, 255, 255, 0.015);
-}
-.comparison-table tbody tr:hover td.hl {
-  background: rgba(6, 182, 212, 0.06);
-}
-.comparison-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.check { color: var(--green-400); font-weight: 700; }
-.cross { color: var(--rose-400); opacity: 0.6; }
-.comparison-note {
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  text-align: center;
-  margin-top: 1rem;
-  font-style: italic;
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
-  line-height: 1.6;
-}
-
-/* ================================================
-   DEVELOPER EXPERIENCE (GET STARTED)
-   ================================================ */
-.dx-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-.dx-section::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse 60% 40% at 50% 100%, rgba(6, 182, 212, 0.05), transparent);
-  pointer-events: none;
-}
-
-.dx-steps {
-  max-width: 740px;
-  margin: 3rem auto 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2.5rem;
-  position: relative;
-}
-.dx-steps::before {
-  content: '';
-  position: absolute;
-  left: 24px;
-  top: 50px;
-  bottom: 50px;
-  width: 2px;
-  background: linear-gradient(180deg, var(--cyan-500), var(--violet-500), rgba(6, 182, 212, 0.1));
-  border-radius: 2px;
-}
-
-.dx-step {
-  display: flex;
-  gap: 1.5rem;
-  align-items: flex-start;
-  position: relative;
-}
-.dx-step-num {
-  width: 50px;
-  height: 50px;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--bg-deep);
-  border: 2px solid var(--cyan-500);
-  border-radius: 50%;
-  font-size: 1.1rem;
-  font-weight: 800;
-  color: var(--cyan-400);
-  font-family: var(--font-mono);
-  z-index: 1;
-  box-shadow: 0 0 20px rgba(6, 182, 212, 0.15);
-}
-.dx-step-body {
-  flex: 1;
-  padding-top: 0.5rem;
-}
-.dx-step-body h3 {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.35rem;
-  letter-spacing: -0.02em;
-}
-.dx-step-body p {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.75rem;
-  line-height: 1.6;
-}
-.dx-step-body pre {
-  background: var(--bg-code);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
-  padding: 1rem 1.25rem;
-  overflow-x: auto;
-  font-size: 0.85rem;
   line-height: 1.7;
 }
-.dx-step-body code {
-  font-family: var(--font-mono);
+
+.not-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
 }
 
-.dx-cta {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 3rem;
+.not-list li {
+  padding: 4px 0;
+  font-size: 0.9rem;
 }
 
-/* ================================================
-   CTA BANNER
-   ================================================ */
-.cta-section {
-  padding: var(--section-gap) 1.5rem;
-}
-.cta-box {
-  max-width: 800px;
-  margin: 0 auto;
-  text-align: center;
-  padding: 4rem 2rem;
-  background: linear-gradient(180deg, rgba(6, 182, 212, 0.04) 0%, rgba(12, 18, 41, 0.6) 100%);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  position: relative;
-  overflow: hidden;
-}
-.cta-box::before {
-  content: '';
-  position: absolute;
-  top: -1px;
-  left: 10%;
-  right: 10%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--cyan-500), var(--violet-500), transparent);
-}
-.cta-box h2 {
-  font-size: clamp(1.75rem, 4vw, 2.5rem);
-  font-weight: 800;
-  color: var(--text-primary);
-  margin-bottom: 1rem;
-  letter-spacing: -0.03em;
-}
-.cta-box p {
-  font-size: 1.05rem;
-  color: var(--text-secondary);
-  margin-bottom: 2rem;
-  max-width: 500px;
-  margin-left: auto;
-  margin-right: auto;
-}
-.cta-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-.cta-community {
-  margin-top: 1.5rem;
-}
-.cta-community-link {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  transition: color var(--duration) var(--ease-out);
-}
-.cta-community-link:hover {
-  color: var(--cyan-400);
-}
-.cta-built-with {
-  display: flex;
-  gap: 2rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 2.5rem;
-  padding-top: 2rem;
-  border-top: 1px solid var(--glass-border);
-}
-.cta-built-item {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  color: var(--text-muted);
-  font-weight: 500;
+.not-list li::before {
+  content: '—';
+  color: var(--text-dim);
+  margin-right: 8px;
 }
 
-/* ================================================
-   FOOTER
-   ================================================ */
-.footer {
-  padding: 4rem 1.5rem 2rem;
-  border-top: 1px solid var(--glass-border);
-}
-.footer-grid {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
-  gap: 3rem;
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding-bottom: 3rem;
-}
-.footer-brand p {
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  margin-top: 0.75rem;
-  max-width: 280px;
-  line-height: 1.6;
-}
-.footer h4 {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 1rem;
-}
-.footer-links {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-.footer-links a {
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  transition: color var(--duration) var(--ease-out);
-}
-.footer-links a:hover { color: var(--text-primary); }
-.footer-bottom {
-  text-align: center;
-  padding-top: 2rem;
-  border-top: 1px solid var(--glass-border);
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  max-width: var(--max-width);
-  margin: 0 auto;
-}
-.footer-bottom a { color: var(--text-muted); }
-.footer-bottom a:hover { color: var(--cyan-400); }
-
-/* ================================================
-   DATA FLOW PLAYGROUND
-   ================================================ */
-.playground-section {
-  padding: var(--section-gap) 1.5rem;
-  position: relative;
-}
-.playground-section::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--glass-border), transparent);
+/* --- Connector Table --- */
+.connector-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-.playground-container {
-  max-width: var(--max-width);
-  margin: 3rem auto 0;
-}
-
-.playground-canvas-wrapper {
-  position: relative;
-  background: linear-gradient(180deg, rgba(5, 10, 24, 0.8) 0%, rgba(8, 13, 30, 0.9) 100%);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  overflow: hidden;
-  transition: border-color var(--duration) var(--ease-out);
-}
-.playground-canvas-wrapper:hover {
-  border-color: rgba(6, 182, 212, 0.15);
-  box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.05), 0 24px 64px -12px rgba(0, 0, 0, 0.4);
-}
-
-#playground-canvas {
-  display: block;
+.connector-table {
   width: 100%;
-  cursor: default;
+  border-collapse: collapse;
+  font-size: 0.85rem;
 }
 
-.playground-controls {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem 1.25rem;
-  background: rgba(15, 23, 50, 0.5);
-  border-top: 1px solid var(--glass-border);
-  flex-wrap: wrap;
-}
-
-.playground-controls-left,
-.playground-controls-right {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.playground-speed-control {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.playground-speed-control label {
-  font-size: 0.75rem;
-  color: var(--text-muted);
+.connector-table th {
+  text-align: left;
+  font-family: var(--font-mono);
   font-weight: 500;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-bright);
   white-space: nowrap;
 }
 
-#playground-speed {
-  width: 80px;
-  height: 4px;
-  -webkit-appearance: none;
-  appearance: none;
-  background: rgba(148, 163, 184, 0.1);
-  border-radius: 4px;
-  outline: none;
-  cursor: pointer;
-}
-#playground-speed::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--cyan-500);
-  cursor: pointer;
-  border: 2px solid var(--bg-deep);
-  box-shadow: 0 0 8px rgba(6, 182, 212, 0.4);
-}
-#playground-speed::-moz-range-thumb {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--cyan-500);
-  cursor: pointer;
-  border: 2px solid var(--bg-deep);
-  box-shadow: 0 0 8px rgba(6, 182, 212, 0.4);
+.connector-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
 }
 
-.playground-speed-value {
-  font-size: 0.75rem;
-  font-family: var(--font-mono);
-  color: var(--cyan-400);
-  font-weight: 600;
-  min-width: 2.5em;
-}
+.connector-table tr:last-child td { border-bottom: none; }
 
-.playground-eps {
-  font-size: 0.75rem;
+.connector-table td:first-child {
   font-family: var(--font-mono);
-  color: var(--text-muted);
   font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
 }
 
-.playground-add-btn {
+.status-impl {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.12);
-  border-radius: var(--radius-xs);
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-  font-family: var(--font-sans);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
-  white-space: nowrap;
-}
-.playground-add-btn:hover {
-  border-color: var(--cyan-500);
-  color: var(--cyan-400);
-  background: rgba(6, 182, 212, 0.05);
-}
-.playground-add-btn svg {
-  width: 12px;
-  height: 12px;
+  gap: 5px;
+  color: var(--green);
+  font-size: 0.8rem;
 }
 
-.playground-hint {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2rem;
-  padding: 0.6rem 1rem;
-  flex-wrap: wrap;
-}
-.playground-hint span {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  white-space: nowrap;
-}
-.playground-hint-dot {
-  display: inline-block;
+.status-impl::before {
+  content: '';
   width: 6px;
   height: 6px;
+  background: var(--green);
   border-radius: 50%;
-  background: var(--cyan-500);
-  opacity: 0.5;
+  flex-shrink: 0;
 }
 
-/* Preset buttons */
-.playground-presets {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
-  background: rgba(15, 23, 50, 0.5);
-  border-bottom: 1px solid var(--glass-border);
-  flex-wrap: wrap;
+.feature-flag {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  background: var(--bg-surface);
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
 }
 
-.preset-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.9rem;
-  background: transparent;
-  border: 1px solid rgba(148, 163, 184, 0.1);
-  border-radius: 100px;
-  color: var(--text-muted);
-  font-family: var(--font-sans);
-  font-size: 0.78rem;
+/* --- Deployment --- */
+.deploy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.deploy-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1.25rem;
+}
+
+.deploy-card h3 {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.deploy-card p {
+  font-size: 0.85rem;
+  margin-bottom: 0.75rem;
+}
+
+.deploy-card code {
+  font-size: 0.8rem;
+  color: var(--accent);
+}
+
+.deploy-card .label-planned {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--yellow);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-bottom: 8px;
+}
+
+/* --- Comparison Table --- */
+.comparison-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-bottom: 2rem;
+}
+
+.comparison-table {
+  width: 100%;
+  min-width: 700px;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.comparison-table th {
+  text-align: left;
+  font-family: var(--font-mono);
   font-weight: 500;
-  cursor: pointer;
-  transition: all var(--duration) var(--ease-out);
+  font-size: 0.75rem;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-bright);
+  white-space: nowrap;
+  color: var(--text-dim);
+}
+
+.comparison-table th.hl {
+  color: var(--accent);
+}
+
+.comparison-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
   white-space: nowrap;
 }
 
-.preset-btn:hover {
-  border-color: rgba(6, 182, 212, 0.25);
-  color: var(--text-secondary);
-  background: rgba(6, 182, 212, 0.04);
+.comparison-table td.hl {
+  color: var(--text);
 }
 
-.preset-btn.active {
-  border-color: rgba(6, 182, 212, 0.4);
-  color: var(--cyan-400);
-  background: rgba(6, 182, 212, 0.08);
-  box-shadow: 0 0 12px -2px rgba(6, 182, 212, 0.2), inset 0 0 0 1px rgba(6, 182, 212, 0.05);
-  font-weight: 600;
+.comparison-table tr:last-child td { border-bottom: none; }
+
+.comparison-table .win {
+  color: var(--text);
+  font-weight: 500;
 }
 
-.preset-icon {
+.comparison-note {
   font-size: 0.85rem;
-  line-height: 1;
+  color: var(--text-dim);
+  margin-bottom: 2rem;
+  font-style: italic;
 }
 
-/* Tooltip */
-#playground-tooltip {
-  display: none;
-  position: fixed;
-  z-index: 1100;
-  max-width: 240px;
-  padding: 0.75rem 1rem;
-  background: rgba(12, 18, 41, 0.95);
-  border: 1px solid rgba(6, 182, 212, 0.2);
-  border-radius: var(--radius-sm);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  pointer-events: none;
-  box-shadow: 0 12px 40px -8px rgba(0, 0, 0, 0.6);
+.alternatives {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
 }
-.playground-tooltip-title {
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.25rem;
+
+.alt-card {
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
 }
-.playground-tooltip-desc {
-  font-size: 0.75rem;
+
+.alt-card h4 {
+  color: var(--text);
+  margin-bottom: 0.35rem;
+}
+
+.alt-card p {
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+/* --- Status --- */
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.status-col h3 {
+  font-size: 0.85rem;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-col.stable h3 { color: var(--green); }
+.status-col.experimental h3 { color: var(--yellow); }
+.status-col.unimplemented h3 { color: var(--text-dim); }
+
+.status-col ul {
+  list-style: none;
+  padding: 0;
+}
+
+.status-col li {
+  font-size: 0.85rem;
+  padding: 3px 0;
   color: var(--text-secondary);
-  line-height: 1.5;
 }
 
-/* ================================================
-   TOUCH / HOVER HINT VARIANTS
-   ================================================ */
-.hint-touch { display: none; }
-.hint-desktop { display: inline; }
-
-@media (hover: none), (pointer: coarse) {
-  .hint-touch { display: inline; }
-  .hint-desktop { display: none; }
-  .hint-hover { display: none !important; }
+/* --- Contributing --- */
+.contrib-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-/* ================================================
-   RESPONSIVE
-   ================================================ */
-@media (max-width: 1024px) {
-  :root {
-    --section-gap: 6rem;
-  }
-  .perf-grid { grid-template-columns: repeat(2, 1fr); }
-  .features-grid { grid-template-columns: repeat(2, 1fr); }
-  .footer-grid { grid-template-columns: 2fr 1fr 1fr; }
-  .comparison-highlights { grid-template-columns: repeat(2, 1fr); }
-  .python-showcase { grid-template-columns: 1fr; }
-  .python-code-side { position: static; }
+/* --- Footer --- */
+.footer {
+  padding: 2rem 0;
+  border-top: 1px solid var(--border);
 }
 
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer-left {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+
+.footer-left a { color: var(--text-dim); }
+.footer-left a:hover { color: var(--text-secondary); }
+
+.footer-links {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.8rem;
+}
+
+.footer-links a { color: var(--text-dim); }
+.footer-links a:hover { color: var(--text-secondary); }
+
+/* --- Responsive --- */
 @media (max-width: 768px) {
-  .nav-links, .nav-actions { display: none; }
-  .nav-toggle { display: block; }
-  .mobile-menu {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: rgba(5, 10, 24, 0.97);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    border-bottom: 1px solid var(--glass-border);
-    padding: 1rem 1.5rem 1.5rem;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  .mobile-menu.open { display: flex; }
-  .mobile-menu a {
-    padding: 0.65rem 0;
-    font-size: 1rem;
-    color: var(--text-secondary);
-  }
-  .mobile-menu .btn {
-    margin-top: 0.5rem;
-    text-align: center;
-    justify-content: center;
-  }
+  h1 { font-size: 1.75rem; }
+  h2 { font-size: 1.25rem; }
 
-  .hero { padding: 7rem 1rem 4rem; min-height: auto; }
-  .hero h1 { font-size: 2.25rem; }
-  .hero-subtitle { font-size: 1rem; }
+  section { padding: 3rem 0; }
 
-  .why-grid { grid-template-columns: 1fr; }
-  .use-cases-grid-v2 { grid-template-columns: 1fr; }
-  .perf-grid { grid-template-columns: repeat(2, 1fr); }
-  .features-grid { grid-template-columns: 1fr; }
-  .arch-details { grid-template-columns: 1fr; }
-  .footer-grid { grid-template-columns: 1fr; gap: 2rem; }
-  .comparison-highlights { grid-template-columns: 1fr 1fr; }
-
-  .section-title { font-size: 1.75rem; }
-  .section-desc { font-size: 1rem; }
-
-  .ring-label { flex-direction: column; gap: 0.25rem; align-items: flex-start; }
-  .ring-chips { gap: 0.35rem; }
-  .ring-chip { padding: 0.35rem 0.65rem; font-size: 0.78rem; }
+  .hero { padding: 2.5rem 0 2rem; }
 
   .hero-metrics { gap: 1.5rem; }
-  .hero-metric-value { font-size: 1.5rem; }
 
-  .dx-step { flex-direction: column; gap: 0.75rem; }
-  .dx-steps::before { display: none; }
+  .nav-links { display: none; }
+  .nav-toggle { display: block; }
 
-  .comparison-table { font-size: 0.78rem; min-width: 700px; }
-  .connectors-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+  .deploy-grid { grid-template-columns: 1fr; }
+  .status-grid { grid-template-columns: 1fr; }
+  .alternatives { grid-template-columns: 1fr; }
 
-  .sticky-bar-inner { gap: 0.75rem; font-size: 0.82rem; }
-  .sticky-bar-install { display: none; }
-
-  /* Playground mobile adjustments at 768px */
-  .playground-controls { flex-direction: column; align-items: stretch; gap: 0.5rem; }
-  .playground-controls-left,
-  .playground-controls-right { justify-content: center; }
-  .playground-presets { gap: 0.35rem; padding: 0.6rem 0.75rem; }
-  .preset-btn { padding: 0.35rem 0.7rem; font-size: 0.72rem; }
-  .playground-hint { gap: 1rem; }
-  .hint-hover { display: none; }
+  .footer-inner { flex-direction: column; align-items: flex-start; }
 }
 
 @media (max-width: 480px) {
-  :root { --section-gap: 4rem; }
-  .container { padding: 0 1rem; }
-  .hero { padding: 6rem 1rem 3rem; }
-  .hero h1 { font-size: 1.75rem; letter-spacing: -0.03em; }
-  .hero-subtitle { font-size: 0.95rem; }
-  .hero-actions { flex-direction: column; align-items: stretch; }
-  .hero-install { font-size: 0.8rem; min-width: 0; }
-  .hero-install-wrapper { width: 100%; }
+  h1 { font-size: 1.5rem; }
+
+  .container { padding: 0 16px; }
+
+  .hero-actions { flex-direction: column; }
   .hero-metrics { flex-direction: column; gap: 1rem; }
-  .perf-grid { grid-template-columns: 1fr 1fr; }
-  .perf-value { font-size: 1.75rem; }
-  .cta-box { padding: 2.5rem 1.5rem; }
-  .tab-btn { padding: 0.6rem 0.75rem; font-size: 0.75rem; }
-  .tab-panel pre { padding: 1rem; font-size: 0.78rem; }
-  .connectors-grid { grid-template-columns: repeat(2, 1fr); gap: 0.75rem; }
-  .connector-card { padding: 1rem 0.75rem; }
-  .dx-cta { flex-direction: column; align-items: stretch; }
-  .dx-cta .btn { justify-content: center; }
-  .playground-hint { gap: 0.5rem; padding: 0.5rem 0.75rem; }
-  .playground-hint span { font-size: 0.65rem; }
-  .playground-presets { gap: 0.25rem; padding: 0.5rem 0.5rem; }
-  .preset-btn { padding: 0.3rem 0.55rem; font-size: 0.68rem; gap: 0.25rem; }
-  .preset-icon { font-size: 0.75rem; }
-  .playground-speed-control label { font-size: 0.7rem; }
-  .playground-eps { font-size: 0.7rem; }
-  #playground-speed { width: 60px; }
-  .comparison-highlights { grid-template-columns: 1fr; }
+
+  .code-body code { font-size: 0.75rem; }
 }
+
+/* --- Prism overrides --- */
+pre[class*="language-"] { background: transparent !important; margin: 0 !important; }
+code[class*="language-"] { background: transparent !important; }

--- a/site/index.html
+++ b/site/index.html
@@ -3,211 +3,161 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LaminarDB — The Embedded Streaming Database | Real-Time SQL Processing</title>
-  <meta name="description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, streams like Flink. Python and Rust APIs. Apache 2.0 open source.">
-  <meta name="keywords" content="streaming database, embedded database, real-time analytics, stream processing, Rust database, Python streaming, SQL stream processing, Apache Arrow, DataFusion, sub-microsecond latency, Kafka connector, CDC, Delta Lake, PyArrow, tumbling window, session window, ASOF join, embedded analytics, event processing, streaming SQL engine">
-  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <meta name="author" content="LaminarDB Contributors">
-  <meta name="theme-color" content="#0a0a1a">
+  <title>LaminarDB — Streaming SQL Engine</title>
+  <meta name="description" content="The streaming engine that starts embedded. Sub-microsecond SQL over event streams. Embed in Rust or Python, run standalone, or scale to a cluster. Arrow, DataFusion. Apache 2.0.">
+  <meta name="keywords" content="streaming database, embedded database, stream processing, Rust, SQL, Apache Arrow, DataFusion, Kafka, CDC, Delta Lake, sub-microsecond, ASOF join, tumbling window, session window">
+  <meta name="robots" content="index, follow">
+  <meta name="theme-color" content="#0a0a0a">
   <link rel="canonical" href="https://laminardb.io">
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="LaminarDB — The Embedded Streaming Database | Real-Time SQL Processing">
-  <meta property="og:description" content="Process streaming data with sub-microsecond latency using familiar SQL. Embedded like SQLite, streams like Flink. Python and Rust APIs.">
+  <meta property="og:title" content="LaminarDB — Streaming SQL Engine">
+  <meta property="og:description" content="The streaming engine that starts embedded. Sub-microsecond SQL over event streams. Embed in Rust or Python, run standalone, or scale to a cluster.">
   <meta property="og:image" content="https://laminardb.io/img/logo.jpg">
   <meta property="og:url" content="https://laminardb.io">
   <meta property="og:type" content="website">
-  <meta property="og:site_name" content="LaminarDB">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
 
-  <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="LaminarDB — The Embedded Streaming Database">
-  <meta name="twitter:description" content="Sub-microsecond SQL stream processing. No cluster required. Python + Rust. Apache 2.0.">
+  <meta name="twitter:title" content="LaminarDB — Streaming SQL Engine">
+  <meta name="twitter:description" content="The streaming engine that starts embedded. Sub-microsecond SQL. Embed in Rust or Python, run standalone, or scale to a cluster.">
   <meta name="twitter:image" content="https://laminardb.io/img/logo.jpg">
 
-  <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
 
-  <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 
-  <!-- Prism.js -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
-
-  <!-- Styles -->
   <link rel="stylesheet" href="css/style.css">
 
-  <!-- JSON-LD: SoftwareApplication -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "LaminarDB",
-    "description": "High-performance embedded streaming SQL database with sub-microsecond latency. Process streaming data with familiar SQL, zero infrastructure, and Python or Rust APIs.",
+    "description": "Embedded streaming SQL engine with sub-microsecond latency. Process event streams using SQL, Rust, Apache Arrow, and DataFusion.",
     "applicationCategory": "Database",
-    "applicationSubCategory": "Streaming Database",
     "operatingSystem": "Linux, macOS, Windows",
     "license": "https://opensource.org/licenses/Apache-2.0",
     "url": "https://laminardb.io",
     "codeRepository": "https://github.com/laminardb/laminardb",
     "programmingLanguage": ["Rust", "Python", "SQL"],
-    "softwareVersion": "0.18.0",
-    "datePublished": "2026-01-01",
-    "dateModified": "2026-03-03",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD"
-    },
+    "softwareVersion": "0.18.1",
     "author": {
       "@type": "Organization",
       "name": "LaminarDB Contributors",
       "url": "https://github.com/laminardb"
-    },
-    "keywords": "streaming database, embedded database, real-time SQL, stream processing, Apache Arrow, DataFusion"
-  }
-  </script>
-  <!-- JSON-LD: WebSite (enables sitelinks search box) -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "LaminarDB",
-    "url": "https://laminardb.io",
-    "description": "The embedded streaming SQL database. Sub-microsecond latency, zero infrastructure, Python and Rust APIs."
+    }
   }
   </script>
 </head>
 <body>
 
-  <!-- ======== Sticky Top Bar (appears on scroll) ======== -->
-  <div class="sticky-bar" id="sticky-bar" aria-hidden="true">
-    <div class="sticky-bar-inner">
-      <a href="#" class="sticky-bar-brand" aria-label="LaminarDB home">
-        <svg class="logo-icon" viewBox="0 0 40 40" width="24" height="24" aria-hidden="true">
-          <defs><linearGradient id="sticky-lg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#06b6d4"/><stop offset="100%" stop-color="#8b5cf6"/></linearGradient></defs>
-          <path d="M0 20 C8 20,14 17,22 17 C30 17,32 21,40 21" stroke="url(#sticky-lg)" stroke-width="3" fill="none" stroke-linecap="round"/>
-        </svg>
-        <span>LaminarDB</span>
-      </a>
-      <div class="sticky-bar-install" role="button" tabindex="0" aria-label="Copy install command">
-        <span class="prompt">$</span>
-        <span class="cmd">pip install laminardb</span>
-      </div>
-      <a href="#get-started" class="btn btn-primary btn-sm">Get Started</a>
-    </div>
-  </div>
-
-  <!-- ======== Navigation ======== -->
+  <!-- Nav -->
   <header class="nav" role="banner">
     <div class="nav-inner">
       <a href="#" class="nav-brand" aria-label="LaminarDB home">
-        <svg class="logo-icon" viewBox="0 0 40 40" width="32" height="32" aria-hidden="true">
-          <defs><linearGradient id="nav-lg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#06b6d4"/><stop offset="100%" stop-color="#8b5cf6"/></linearGradient></defs>
-          <path d="M4 8 C12 8,14 6,22 6 C30 6,32 10,36 10" stroke="url(#nav-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".5"/>
-          <path d="M2 14 C10 14,14 11,22 11 C30 11,32 15,38 15" stroke="url(#nav-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".7"/>
-          <path d="M0 20 C8 20,14 17,22 17 C30 17,32 21,40 21" stroke="url(#nav-lg)" stroke-width="3" fill="none" stroke-linecap="round"/>
-          <path d="M2 26 C10 26,14 23,22 23 C30 23,32 27,38 27" stroke="url(#nav-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".7"/>
-          <path d="M4 32 C12 32,14 30,22 30 C30 30,32 34,36 34" stroke="url(#nav-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".5"/>
+        <svg viewBox="0 0 40 40" width="28" height="28" aria-hidden="true">
+          <defs><linearGradient id="logo-g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#00b4d8"/><stop offset="100%" stop-color="#38cbeb"/></linearGradient></defs>
+          <path d="M4 8 C12 8,14 6,22 6 C30 6,32 10,36 10" stroke="url(#logo-g)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".4"/>
+          <path d="M2 14 C10 14,14 11,22 11 C30 11,32 15,38 15" stroke="url(#logo-g)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".6"/>
+          <path d="M0 20 C8 20,14 17,22 17 C30 17,32 21,40 21" stroke="url(#logo-g)" stroke-width="3" fill="none" stroke-linecap="round"/>
+          <path d="M2 26 C10 26,14 23,22 23 C30 23,32 27,38 27" stroke="url(#logo-g)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".6"/>
+          <path d="M4 32 C12 32,14 30,22 30 C30 30,32 34,36 34" stroke="url(#logo-g)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".4"/>
         </svg>
         <span>LaminarDB</span>
-        <span class="version-badge">v0.18</span>
+        <span class="version-badge">v0.18.1</span>
       </a>
 
       <nav class="nav-links" aria-label="Main navigation">
-        <a href="#why">Why</a>
-        <a href="#use-cases">Use Cases</a>
-        <a href="#performance">Performance</a>
-        <a href="#code">Code</a>
-        <a href="#python">Python</a>
-        <a href="#architecture">Architecture</a>
-        <a href="#playground">Playground</a>
+        <a href="#quick-start">Quick Start</a>
+        <a href="#connectors">Connectors</a>
+        <a href="#comparison">Comparison</a>
+        <a href="#status">Status</a>
         <a href="https://laminardb.io/api/laminar_db/" target="_blank" rel="noopener">Docs</a>
-      </nav>
-
-      <div class="nav-actions">
-        <a href="https://github.com/laminardb/laminardb" class="github-btn" target="_blank" rel="noopener" aria-label="Star on GitHub">
-          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-          <span>Star on GitHub</span>
+        <a href="https://github.com/laminardb/laminardb" class="github-link" target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          GitHub
         </a>
-        <a href="#get-started" class="btn btn-primary">Get Started</a>
-      </div>
+      </nav>
 
       <button class="nav-toggle" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
 
       <div class="mobile-menu">
-        <a href="#why">Why LaminarDB</a>
-        <a href="#use-cases">Use Cases</a>
-        <a href="#performance">Performance</a>
-        <a href="#code">Code Examples</a>
-        <a href="#python">Python</a>
-        <a href="#architecture">Architecture</a>
-        <a href="#playground">Playground</a>
+        <a href="#quick-start">Quick Start</a>
         <a href="#connectors">Connectors</a>
-        <a href="#features">Features</a>
         <a href="#comparison">Comparison</a>
+        <a href="#status">Status</a>
         <a href="https://laminardb.io/api/laminar_db/" target="_blank" rel="noopener">API Docs</a>
-        <a href="https://github.com/laminardb/laminardb" class="btn btn-secondary" target="_blank" rel="noopener">GitHub</a>
-        <a href="#get-started" class="btn btn-primary">Get Started</a>
+        <a href="https://github.com/laminardb/laminardb" target="_blank" rel="noopener">GitHub</a>
       </div>
     </div>
   </header>
 
   <main>
-    <!-- ======== Hero ======== -->
+
+    <!-- Hero -->
     <section class="hero" id="hero">
-      <div class="hero-glow" aria-hidden="true"></div>
-      <div class="hero-grid" aria-hidden="true"></div>
-      <div class="hero-particles" aria-hidden="true"></div>
-
-      <div class="hero-content">
-        <a href="https://github.com/laminardb/laminardb/releases" class="hero-eyebrow" target="_blank" rel="noopener">
-          <span class="eyebrow-badge">v0.18</span>
-          <span>Delta Lake, checkpoint barriers, and 189 features shipped</span>
-          <span class="eyebrow-arrow">&rarr;</span>
-        </a>
-
-        <h1>
-          <span class="gradient-text">Embedded Streaming Database.</span><br>
-          Sub-Microsecond SQL.
-        </h1>
-
-        <p class="hero-subtitle">
-          Replace Kafka + Flink + a database with one embedded engine.
-          Sub-microsecond SQL, minimal allocations, no JVM, no cluster &mdash; just
-          add a dependency and go.
+      <div class="container">
+        <h1 class="hero-tagline">The streaming engine that starts embedded</h1>
+        <p class="hero-desc">
+          Sub-microsecond SQL over event streams.
+          Embed in Rust or Python, run as a standalone server,
+          or scale to a cluster. No JVM.
         </p>
 
+        <div class="hero-install-group">
+          <div class="hero-install" role="button" tabindex="0" aria-label="Copy Rust install command">
+            <span class="prompt">$</span>
+            <span class="cmd">cargo add laminar-db</span>
+            <span class="copy-hint">copy</span>
+          </div>
+          <div class="hero-install" role="button" tabindex="0" aria-label="Copy Python install command">
+            <span class="prompt">$</span>
+            <span class="cmd">pip install laminardb</span>
+            <span class="copy-hint">copy</span>
+          </div>
+        </div>
+
         <div class="hero-actions">
-          <a href="#get-started" class="btn btn-primary btn-lg">Get Started &mdash; It's Free</a>
-          <a href="https://github.com/laminardb/laminardb" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-            Star on GitHub
+          <a href="#quick-start" class="btn btn-primary">Quick Start</a>
+          <a href="https://github.com/laminardb/laminardb" class="btn btn-secondary" target="_blank" rel="noopener">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+            View on GitHub
           </a>
         </div>
 
-        <!-- Language toggle install snippet -->
-        <div class="hero-install-wrapper">
-          <div class="hero-install-tabs">
-            <button class="install-tab active" data-install="rust">Rust</button>
-            <button class="install-tab" data-install="python">Python</button>
-          </div>
-          <div class="hero-install" role="button" tabindex="0" aria-label="Copy install command" data-install-panel="rust">
-            <span class="prompt">$</span>
-            <span class="cmd">cargo add laminar-db</span>
-            <span class="copy-hint">Click to copy</span>
-          </div>
-          <div class="hero-install" role="button" tabindex="0" aria-label="Copy install command" data-install-panel="python" style="display: none;">
-            <span class="prompt">$</span>
-            <span class="cmd">pip install laminardb</span>
-            <span class="copy-hint">Click to copy</span>
+        <div class="hero-code">
+          <div class="code-block">
+            <div class="code-header">
+              <span style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-dim);">main.rs</span>
+              <button class="copy-btn" aria-label="Copy code">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                Copy
+              </button>
+            </div>
+            <div class="code-body">
+              <div class="tab-panel active">
+                <pre><code class="language-rust">let db = LaminarDB::open()?;
+
+db.execute("CREATE SOURCE trades (
+    symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT
+)").await?;
+
+db.execute("CREATE STREAM vwap AS
+    SELECT symbol,
+           SUM(price * CAST(volume AS DOUBLE))
+             / SUM(CAST(volume AS DOUBLE)) AS vwap
+    FROM trades
+    GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
+    EMIT ON WINDOW CLOSE
+").await?;
+
+db.start().await?;</code></pre>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -215,455 +165,227 @@
           <div class="hero-metric">
             <div class="hero-metric-value">&lt;500<span class="unit">ns</span></div>
             <div class="hero-metric-label">state lookup p99</div>
+            <div class="hero-metric-source"><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/state_bench.rs" target="_blank" rel="noopener">state_bench.rs</a></div>
           </div>
           <div class="hero-metric">
-            <div class="hero-metric-value">2.24<span class="unit">M</span></div>
-            <div class="hero-metric-label">events/sec per core</div>
-          </div>
-          <div class="hero-metric">
-            <div class="hero-metric-value">189</div>
-            <div class="hero-metric-label">features shipped</div>
+            <div class="hero-metric-value">1M+<span class="unit">/s</span></div>
+            <div class="hero-metric-label">events per core</div>
+            <div class="hero-metric-source"><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/throughput_bench.rs" target="_blank" rel="noopener">throughput_bench.rs</a></div>
           </div>
           <div class="hero-metric">
             <div class="hero-metric-value">0</div>
-            <div class="hero-metric-label">allocations on hot path</div>
+            <div class="hero-metric-label">hot-path allocations</div>
+            <div class="hero-metric-source"><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/tests/zero_alloc_integration.rs" target="_blank" rel="noopener">zero_alloc_integration.rs</a></div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- ======== Data Flow Playground ======== -->
-    <section class="playground-section" id="playground">
+    <!-- What It Is -->
+    <section id="what">
       <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Interactive</div>
-          <h2 class="section-title reveal">Data Flow <span class="gradient-text">Playground</span></h2>
-          <p class="section-desc centered reveal">
-            See how LaminarDB processes streaming data in real-time. Click operators to toggle, drag to rearrange.
+        <h2>What it is</h2>
+        <div class="text-block">
+          <p>
+            LaminarDB is a streaming SQL engine.
+            Write SQL queries over event streams &mdash; windows, joins, aggregations &mdash;
+            and the engine evaluates them continuously as events arrive.
+            Built on <a href="https://arrow.apache.org/" target="_blank" rel="noopener">Apache Arrow 57</a>
+            and <a href="https://datafusion.apache.org/" target="_blank" rel="noopener">DataFusion 52</a>.
+          </p>
+          <p>
+            <strong>Three deployment modes.</strong>
+            Embed it in your application &mdash; Rust (<code>cargo add laminar-db</code>) or Python (<code>pip install laminardb</code>).
+            Run it as a standalone server (<code>laminardb</code> binary) with Kafka, CDC, and Delta Lake connectors.
+            Or deploy as a cluster &mdash; distributed mode is coming soon.
+          </p>
+          <p>
+            It is not a message broker (it consumes from Kafka, doesn't replace it)
+            and it is not a general-purpose OLTP/OLAP database &mdash; it processes streams.
           </p>
         </div>
 
-        <div class="playground-container reveal">
-          <div class="playground-canvas-wrapper">
-            <div class="playground-presets">
-              <button class="preset-btn active" data-preset="fraud" aria-label="Switch to Fraud Detection pipeline">
-                <span class="preset-icon" aria-hidden="true">&#x1f6e1;&#xfe0f;</span>
-                <span>Fraud Detection</span>
-              </button>
-              <button class="preset-btn" data-preset="join" aria-label="Switch to Stream Join pipeline">
-                <span class="preset-icon" aria-hidden="true">&#x1f517;</span>
-                <span>Stream Join</span>
-              </button>
-              <button class="preset-btn" data-preset="asof" aria-label="Switch to ASOF Join pipeline">
-                <span class="preset-icon" aria-hidden="true">&#x23f1;&#xfe0f;</span>
-                <span>ASOF Join</span>
-              </button>
+        <div class="arch-rings">
+          <div class="ring ring-0">
+            <div class="ring-header">
+              <span class="ring-name">Ring 0 &mdash; Hot Path</span>
+              <span class="ring-constraint">&lt;500ns &middot; zero alloc &middot; no locks</span>
             </div>
-            <canvas id="playground-canvas" aria-label="Interactive data flow visualization showing particles flowing through streaming pipeline operators"></canvas>
-            <div class="playground-controls">
-              <div class="playground-controls-left">
-                <div class="playground-speed-control">
-                  <label for="playground-speed">Speed</label>
-                  <input type="range" id="playground-speed" min="0.2" max="3" step="0.1" value="1">
-                  <span class="playground-speed-value" id="playground-speed-label">1.0x</span>
-                </div>
-                <span class="playground-eps" id="playground-eps">0 events/sec</span>
-              </div>
-              <div class="playground-controls-right">
-                <button class="playground-add-btn" id="playground-add-event" aria-label="Inject five events into the pipeline">
-                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="3" x2="8" y2="13"/><line x1="3" y1="8" x2="13" y2="8"/></svg>
-                  Add Events
-                </button>
-              </div>
+            <div class="ring-chips">
+              <span class="ring-chip">Reactor</span>
+              <span class="ring-chip">Operators</span>
+              <span class="ring-chip">State Store</span>
+              <span class="ring-chip">JIT</span>
             </div>
-            <div class="playground-hint">
-              <span><span class="playground-hint-dot"></span> <span class="hint-desktop">Click</span><span class="hint-touch">Tap</span> operators to toggle on/off</span>
-              <span><span class="playground-hint-dot"></span> Drag operators to rearrange</span>
-              <span class="hint-hover"><span class="playground-hint-dot"></span> Hover for details</span>
+          </div>
+          <div class="ring-divider">SPSC queues</div>
+          <div class="ring ring-1">
+            <div class="ring-header">
+              <span class="ring-name">Ring 1 &mdash; Background I/O</span>
+              <span class="ring-constraint">async &middot; bounded latency impact</span>
+            </div>
+            <div class="ring-chips">
+              <span class="ring-chip">WAL</span>
+              <span class="ring-chip">Checkpoints</span>
+              <span class="ring-chip">Connectors</span>
+              <span class="ring-chip">Recovery</span>
+            </div>
+          </div>
+          <div class="ring-divider">Bounded channels</div>
+          <div class="ring ring-2">
+            <div class="ring-header">
+              <span class="ring-name">Ring 2 &mdash; Control Plane</span>
+              <span class="ring-constraint">no latency requirements</span>
+            </div>
+            <div class="ring-chips">
+              <span class="ring-chip">REST API</span>
+              <span class="ring-chip">Metrics</span>
+              <span class="ring-chip">Config</span>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Playground tooltip (positioned fixed, outside flow) -->
-    <div id="playground-tooltip" role="tooltip" aria-hidden="true">
-      <div class="playground-tooltip-title"></div>
-      <div class="playground-tooltip-desc"></div>
-    </div>
-
-    <!-- ======== Built With Strip ======== -->
-    <div class="tech-strip">
-      <div class="tech-strip-inner">
-        <div class="tech-badge">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M23.687 11.709l-.995-.959a1.397 1.397 0 0 1 0-1.922l.995-.96a.537.537 0 0 0-.161-.878l-1.281-.56a1.397 1.397 0 0 1-.735-1.727l.436-1.323a.537.537 0 0 0-.558-.707l-1.386.108a1.397 1.397 0 0 1-1.444-1.162l-.219-1.372a.537.537 0 0 0-.808-.399l-1.147.808a1.397 1.397 0 0 1-1.854-.274L8.07.068a.537.537 0 0 0-.89.099L5.949 1.58a1.397 1.397 0 0 1-1.709.694l-1.296-.461a.537.537 0 0 0-.72.548l.096 1.387a1.397 1.397 0 0 1-1.197 1.425l-1.377.192a.537.537 0 0 0-.417.799l.794 1.156a1.397 1.397 0 0 1-.308 1.848L-.14 8.11a.537.537 0 0 0 .087.89l1.171.752c.578.372.845 1.066.654 1.705l-.459 1.264a.537.537 0 0 0 .538.724l1.386-.13a1.397 1.397 0 0 1 1.465 1.128l.239 1.37a.537.537 0 0 0 .799.406l1.164-.787a1.397 1.397 0 0 1 1.851.239l.894.961a.537.537 0 0 0 .884-.115l.545-1.38a1.397 1.397 0 0 1 1.697-.732l1.308.425a.537.537 0 0 0 .729-.534l-.068-1.387a1.397 1.397 0 0 1 1.225-1.405l1.381-.165a.537.537 0 0 0 .43-.789l-.769-1.172a1.397 1.397 0 0 1 .343-1.84z"/></svg>
-          Built with <span class="tech-name">Rust</span>
-        </div>
-        <div class="tech-badge">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-          <span class="tech-name">Apache Arrow</span>
-        </div>
-        <div class="tech-badge">
-          <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/></svg>
-          <span class="tech-name">DataFusion</span>
-        </div>
-        <div class="tech-badge">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20z"/></svg>
-          <span class="tech-name">Cranelift JIT</span>
-        </div>
-        <div class="tech-badge">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/><path d="M12 6v6l4 2"/></svg>
-          <span class="tech-name">Python + Rust</span>
-        </div>
-        <div class="tech-badge">
-          Apache 2.0 License
-        </div>
-      </div>
-    </div>
-
-    <!-- ======== Why LaminarDB ======== -->
-    <section class="why-section" id="why">
+    <!-- Quick Start -->
+    <section id="quick-start">
       <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Why LaminarDB</div>
-          <h2 class="section-title reveal">Your streaming stack is <span class="gradient-text">too complex</span></h2>
-          <p class="section-desc centered reveal">
-            You shouldn't need Kafka, Flink, and a database just to aggregate a stream.
-            LaminarDB embeds a full streaming engine directly in your application &mdash;
-            one dependency, zero infrastructure.
-          </p>
-        </div>
+        <h2>Quick start</h2>
+        <p class="section-desc">Add the dependency and write your first streaming query.</p>
 
-        <div class="why-grid">
-          <div class="why-card reveal reveal-delay-1">
-            <div class="why-card-icon cyan">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        <div class="code-block">
+          <div class="code-header">
+            <div class="code-tabs">
+              <button class="code-tab active" data-tab="qs-rust">Rust Library</button>
+              <button class="code-tab" data-tab="qs-sql">SQL Examples</button>
+              <button class="code-tab" data-tab="qs-server">Standalone Server</button>
+              <button class="code-tab" data-tab="qs-kafka">Kafka Pipeline</button>
             </div>
-            <h3>Sub-Microsecond Latency</h3>
-            <p>Minimal allocations on the hot path. No GC pauses, no JVM warmup, no serialization overhead. 325ns measured through a 3-node DAG pipeline.</p>
-            <span class="card-stat">325ns measured &bull; &lt;500ns p99</span>
+            <button class="copy-btn" aria-label="Copy code">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+              Copy
+            </button>
           </div>
+          <div class="code-body">
+            <div class="tab-panel active" id="qs-rust">
+              <pre><code class="language-rust">// Cargo.toml: laminar-db = "0.18", tokio = { version = "1", features = ["full"] }
 
-          <div class="why-card reveal reveal-delay-2">
-            <div class="why-card-icon violet">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-            </div>
-            <h3>Zero Infrastructure</h3>
-            <p>Single binary, no cluster, no external dependencies. Embed in your application like SQLite. Add a dependency, not infrastructure.</p>
-            <span class="card-stat">cargo add laminar-db</span>
-          </div>
-
-          <div class="why-card reveal reveal-delay-3">
-            <div class="why-card-icon green">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-            </div>
-            <h3>SQL You Already Know</h3>
-            <p>DataFusion-powered SQL with streaming extensions: TUMBLE, HOP, SESSION windows, ASOF/temporal/lookup joins, EMIT strategies, and 30+ aggregates.</p>
-            <span class="card-stat">DataFusion 52 + Arrow 57</span>
-          </div>
-
-          <div class="why-card reveal reveal-delay-4">
-            <div class="why-card-icon amber">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-            </div>
-            <h3>Never Lose an Event</h3>
-            <p>Write-ahead log, full-state checkpointing, two-phase commit, and barrier-based coordination. Production-grade durability without a cluster.</p>
-            <span class="card-stat">WAL + 2PC + epoch tracking</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Use Cases ======== -->
-    <section class="use-cases-section" id="use-cases">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Use Cases</div>
-          <h2 class="section-title reveal">Real-time stream processing <span class="gradient-text">use cases</span></h2>
-          <p class="section-desc centered reveal">
-            From fraud detection to live dashboards, LaminarDB powers real-time workloads
-            that used to require a distributed cluster.
-          </p>
-        </div>
-
-        <div class="use-cases-grid-v2">
-          <div class="use-case-card-v2 reveal reveal-delay-1">
-            <div class="use-case-card-icon" style="background: rgba(251,113,133,0.1); color: var(--rose-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>
-            </div>
-            <h3>Real-Time Fraud Detection</h3>
-            <p>Detect suspicious patterns in payment streams with sub-microsecond windowed aggregations. Flag anomalies before the transaction completes.</p>
-            <a href="#code" class="use-case-link">See example code <span>&rarr;</span></a>
-          </div>
-
-          <div class="use-case-card-v2 reveal reveal-delay-2">
-            <div class="use-case-card-icon" style="background: rgba(74,222,128,0.1); color: var(--green-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-            </div>
-            <h3>IoT Analytics at the Edge</h3>
-            <p>Process millions of sensor readings per second with exactly-once guarantees. Runs embedded on a single machine, no cloud dependency required.</p>
-            <a href="#architecture" class="use-case-link">Explore architecture <span>&rarr;</span></a>
-          </div>
-
-          <div class="use-case-card-v2 reveal reveal-delay-3">
-            <div class="use-case-card-icon" style="background: rgba(6,182,212,0.1); color: var(--cyan-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 20V10M12 20V4M6 20v-6"/></svg>
-            </div>
-            <h3>Live Dashboards</h3>
-            <p>Power real-time dashboards with continuous SQL queries over streaming data. WebSocket sinks push updates the instant they happen.</p>
-            <a href="#connectors" class="use-case-link">View connectors <span>&rarr;</span></a>
-          </div>
-
-          <div class="use-case-card-v2 reveal reveal-delay-4">
-            <div class="use-case-card-icon" style="background: rgba(139,92,246,0.1); color: var(--violet-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-            </div>
-            <h3>Event-Driven Microservices</h3>
-            <p>Replace complex event choreography with declarative SQL pipelines. CDC connectors keep your services in sync without custom integration code.</p>
-            <a href="#code" class="use-case-link">See CDC example <span>&rarr;</span></a>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Performance ======== -->
-    <section class="perf-section" id="performance">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Performance</div>
-          <h2 class="section-title reveal">Streaming database <span class="gradient-text">benchmarks</span></h2>
-          <p class="section-desc centered reveal">
-            Criterion benchmarks from <code>cargo bench</code>. Thread-per-core architecture
-            with CPU pinning, lock-free SPSC queues, and arena allocators.
-          </p>
-        </div>
-
-        <div class="perf-grid">
-          <div class="perf-card reveal reveal-delay-1">
-            <div class="perf-value">&lt;500ns</div>
-            <div class="perf-label">State lookup p99</div>
-            <div class="perf-sublabel">AHashMap, cache-aligned</div>
-          </div>
-          <div class="perf-card reveal reveal-delay-2">
-            <div class="perf-value">2.24M</div>
-            <div class="perf-label">Events/sec per core</div>
-            <div class="perf-sublabel">linear pipeline</div>
-          </div>
-          <div class="perf-card reveal reveal-delay-3">
-            <div class="perf-value">325ns</div>
-            <div class="perf-label">3-node DAG latency</div>
-            <div class="perf-sublabel">routing + state + emit</div>
-          </div>
-          <div class="perf-card reveal reveal-delay-4">
-            <div class="perf-value">4.8ns</div>
-            <div class="perf-label">SPSC queue operation</div>
-            <div class="perf-sublabel">lock-free, minimal-alloc</div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Code Examples ======== -->
-    <section class="code-section" id="code">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Code</div>
-          <h2 class="section-title reveal">Write SQL, get <span class="gradient-text">real-time results</span></h2>
-          <p class="section-desc centered reveal">
-            Streaming SQL, real-time joins, CDC pipelines, and lakehouse sinks &mdash; all from a single binary.
-          </p>
-        </div>
-
-        <div class="code-container reveal">
-          <div class="code-block">
-            <div class="code-header">
-              <div class="tab-buttons">
-                <button class="tab-btn active" data-tab="tab-rust">Rust API</button>
-                <button class="tab-btn" data-tab="tab-sql">Streaming SQL</button>
-                <button class="tab-btn" data-tab="tab-python">Python</button>
-                <button class="tab-btn" data-tab="tab-kafka">Kafka Pipeline</button>
-                <button class="tab-btn" data-tab="tab-joins">Stream Joins</button>
-                <button class="tab-btn" data-tab="tab-cdc">CDC</button>
-              </div>
-              <div class="code-actions">
-                <button class="copy-btn" aria-label="Copy code">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                  Copy
-                </button>
-              </div>
-            </div>
-
-            <div class="tab-panel active" id="tab-rust">
-              <pre><code class="language-rust">use laminar_db::LaminarDB;
-use laminar_derive::{Record, FromRow};
-
-#[derive(Record)]
-struct Trade {
-    symbol: String,
-    price: f64,
-    volume: i64,
-    #[event_time]
-    ts: i64,
-}
-
-#[derive(FromRow)]
-struct OhlcBar {
-    symbol: String,
-    window_start: i64,
-    open: f64,
-    high: f64,
-    low: f64,
-    close: f64,
-    volume: i64,
-}
+use laminar_db::LaminarDB;
 
 #[tokio::main]
-async fn main() -> Result&lt;(), Box&lt;dyn std::error::Error&gt;&gt; {
+async fn main() -&gt; anyhow::Result&lt;()&gt; {
     let db = LaminarDB::open()?;
 
-    db.execute("CREATE SOURCE trades (
-        symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT
+    db.execute("CREATE SOURCE events (
+        key VARCHAR, value DOUBLE, ts BIGINT
     )").await?;
 
-    db.execute("CREATE STREAM ohlc_1m AS
-        SELECT symbol,
-               CAST(tumble(ts, INTERVAL '1' MINUTE) AS BIGINT) AS window_start,
-               first_value(price) AS open,
-               MAX(price) AS high, MIN(price) AS low,
-               last_value(price) AS close,
-               SUM(volume) AS volume
-        FROM trades
-        GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
+    db.execute("CREATE STREAM summary AS
+        SELECT key, COUNT(*) AS total, AVG(value) AS avg
+        FROM events
+        GROUP BY key, tumble(ts, INTERVAL '1' MINUTE)
         EMIT ON WINDOW CLOSE
     ").await?;
 
-    let source = db.source::&lt;Trade&gt;("trades")?;
-    let sub = db.subscribe::&lt;OhlcBar&gt;("ohlc_1m")?;
-
     db.start().await?;
 
-    // Push events and consume results
-    source.push(Trade { symbol: "AAPL".into(), price: 150.0, volume: 100, ts: 1700000000000 });
-    source.watermark(1700000060000); // Advance past window boundary
+    // Push events into the source (typed via derive macro)
+    let source = db.source::&lt;Event&gt;("events")?;
+    source.push(Event { key: "sensor-1".into(), value: 42.0, ts: 1700000000000 });
 
-    while let Some(bars) = sub.poll() {
-        for bar in &amp;bars {
-            println!("{}: O={:.2} H={:.2} L={:.2} C={:.2}", bar.symbol, bar.open, bar.high, bar.low, bar.close);
+    // Subscribe to streaming results
+    let sub = db.subscribe::&lt;Summary&gt;("summary")?;
+    while let Some(rows) = sub.poll() {
+        for row in &amp;rows {
+            println!("{}: count={}, avg={:.2}", row.key, row.total, row.avg);
         }
     }
+
     Ok(())
 }</code></pre>
             </div>
 
-            <div class="tab-panel" id="tab-sql">
-              <pre><code class="language-sql">-- Real-time OHLC bars with tumbling windows
+            <div class="tab-panel" id="qs-sql">
+              <pre><code class="language-sql">-- Tumbling window: 1-minute OHLC bars
 CREATE STREAM ohlc_1m AS
 SELECT symbol,
-       CAST(tumble(ts, INTERVAL '1' MINUTE) AS BIGINT) AS window_start,
        first_value(price) AS open,
-       MAX(price) AS high,
-       MIN(price) AS low,
+       MAX(price) AS high, MIN(price) AS low,
        last_value(price) AS close,
        SUM(volume) AS volume
 FROM trades
 GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
 EMIT ON WINDOW CLOSE;
 
--- Cascading MV: roll up 1-minute bars to 1-hour bars
-CREATE MATERIALIZED VIEW ohlc_1h AS
-SELECT symbol,
-       first_value(open) AS open,
-       MAX(high) AS high,
-       MIN(low) AS low,
-       last_value(close) AS close
-FROM ohlc_1m
-GROUP BY symbol, tumble(window_start, INTERVAL '1' HOUR);
-
--- Session windows: detect activity bursts
-CREATE STREAM user_sessions AS
-SELECT user_id,
-       COUNT(*) AS clicks,
+-- Session window: detect activity bursts
+CREATE STREAM sessions AS
+SELECT user_id, COUNT(*) AS clicks,
        MAX(ts) - MIN(ts) AS duration_ms
 FROM clickstream
 GROUP BY user_id, session(ts, INTERVAL '30' SECOND)
 EMIT ON WINDOW CLOSE;
 
--- Hopping windows: rolling 10-second average
-CREATE STREAM rolling_avg AS
-SELECT symbol,
-       AVG(price) AS avg_price,
-       SUM(volume) AS total_volume
-FROM trades
-GROUP BY symbol, HOP(ts, INTERVAL '2' SECOND, INTERVAL '10' SECOND);</code></pre>
+-- ASOF join: enrich trades with closest preceding quote
+SELECT t.symbol, t.price, q.bid, q.ask,
+       t.price - q.bid AS spread
+FROM trades t
+ASOF JOIN quotes q
+    ON t.symbol = q.symbol AND t.ts &gt;= q.ts;
+
+-- Stream-stream join with time bounds
+CREATE STREAM matched AS
+SELECT t.symbol, t.price, o.order_id
+FROM trades t
+INNER JOIN orders o ON t.symbol = o.symbol
+    AND o.ts BETWEEN t.ts - 10000 AND t.ts + 10000;</code></pre>
             </div>
 
-            <div class="tab-panel" id="tab-python">
-              <pre><code class="language-python">import laminardb
-import pyarrow as pa
+            <div class="tab-panel" id="qs-server">
+              <pre><code class="language-bash"># Install the standalone server
+cargo install laminar-server
 
-# Open an in-memory streaming database
-db = laminardb.open()
+# Run with a config file (see examples/ directory)
+laminardb --config laminardb.toml
 
-# Define source and streaming query
-db.execute("""CREATE SOURCE trades (
-    symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT
-)""")
+# Or run with Docker
+docker compose up
 
-db.execute("""CREATE STREAM vwap AS
-    SELECT symbol,
-           SUM(price * CAST(volume AS DOUBLE)) / SUM(CAST(volume AS DOUBLE)) AS vwap,
-           COUNT(*) AS trade_count
-    FROM trades
-    GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
-    EMIT ON WINDOW CLOSE
-""")
+# Docker Compose includes:
+#   - laminardb (port 8080)
+#   - Redpanda/Kafka (port 19092)
+#   - Schema Registry (port 18081)
+#   - Prometheus + Grafana (optional)
 
-db.start()
-
-# Insert data (dict or PyArrow RecordBatch -- zero-copy)
-db.insert("trades", {
-    "symbol": "AAPL", "price": 150.25,
-    "volume": 100, "ts": 1700000000000
-})
-
-# Query results as PyArrow Table
-result = db.query("SELECT * FROM vwap")
-print(result.to_pandas())
-
-# Subscribe for streaming updates
-sub = db.subscribe("vwap")
-for batch in sub:
-    print(batch.to_pandas())
-
-# pip install laminardb</code></pre>
+# Example configs in the repo:
+#   examples/laminardb.toml          — full config
+#   examples/laminardb-minimal.toml  — minimal
+#   examples/laminardb-delta.toml    — Delta Lake</code></pre>
             </div>
 
-            <div class="tab-panel" id="tab-kafka">
-              <pre><code class="language-sql">-- Kafka source with SASL/SSL and Schema Registry
+            <div class="tab-panel" id="qs-kafka">
+              <pre><code class="language-sql">-- Kafka source with Avro and Schema Registry
 CREATE SOURCE trades (
     symbol VARCHAR, price DOUBLE, volume BIGINT, ts BIGINT
 ) FROM KAFKA (
-    brokers = '${KAFKA_BROKERS}',
+    brokers = 'localhost:9092',
     topic = 'market-trades',
     group_id = 'laminar-analytics',
     format = 'avro',
-    schema.registry.url = 'http://schema-registry:8081',
-    offset_reset = 'earliest'
+    schema.registry.url = 'http://schema-registry:8081'
 );
 
 -- Real-time aggregation
 CREATE STREAM trade_summary AS
-SELECT symbol,
-       COUNT(*) AS trades,
-       SUM(price * CAST(volume AS DOUBLE)) AS notional,
-       AVG(price) AS avg_price
+SELECT symbol, COUNT(*) AS trades,
+       AVG(price) AS avg_price,
+       SUM(volume) AS total_volume
 FROM trades
 GROUP BY symbol, tumble(ts, INTERVAL '1' MINUTE)
 EMIT ON WINDOW CLOSE;
 
 -- Kafka sink with exactly-once delivery
 CREATE SINK output INTO KAFKA (
-    brokers = '${KAFKA_BROKERS}',
+    brokers = 'localhost:9092',
     topic = 'trade-summaries',
     format = 'json',
     delivery.guarantee = 'exactly-once'
@@ -676,693 +398,438 @@ CREATE SINK lake INTO DELTA_LAKE (
     delivery.guarantee = 'exactly-once'
 ) AS SELECT * FROM trade_summary;</code></pre>
             </div>
-
-            <div class="tab-panel" id="tab-joins">
-              <pre><code class="language-sql">-- ASOF JOIN: enrich trades with closest preceding quote
-SELECT t.symbol,
-       t.price AS trade_price,
-       t.volume,
-       q.bid, q.ask,
-       t.price - q.bid AS spread
-FROM trades t
-ASOF JOIN quotes q
-    ON t.symbol = q.symbol
-    AND t.ts >= q.ts;
-
--- Stream-stream join with time bounds
-CREATE STREAM enriched_orders AS
-SELECT t.symbol,
-       t.price AS trade_price,
-       o.order_id, o.account_id,
-       t.price - o.price AS price_diff
-FROM trades t
-INNER JOIN orders o
-    ON t.symbol = o.symbol
-    AND o.ts BETWEEN t.ts - 10000 AND t.ts + 10000;
-
--- Lookup join against a reference table
-CREATE LOOKUP TABLE instruments FROM POSTGRES (
-    hostname = 'db.example.com', port = '5432',
-    database = 'market', query = 'SELECT * FROM instruments'
-);
-
-SELECT t.symbol, t.price, i.sector, i.exchange
-FROM trades t
-JOIN instruments i ON t.symbol = i.symbol;</code></pre>
-            </div>
-
-            <div class="tab-panel" id="tab-cdc">
-              <pre><code class="language-sql">-- PostgreSQL CDC via logical replication
-CREATE SOURCE orders_cdc (
-    id INT, customer_id INT, amount DOUBLE,
-    status VARCHAR, ts BIGINT
-) FROM POSTGRES_CDC (
-    hostname = 'db.example.com',
-    port = '5432',
-    database = 'shop',
-    slot.name = 'laminar_orders',
-    publication = 'laminar_pub'
-);
-
--- MySQL CDC via binlog
-CREATE SOURCE products_cdc (
-    id INT, name VARCHAR, price DOUBLE, updated_at BIGINT
-) FROM MYSQL_CDC (
-    hostname = 'mysql.example.com',
-    port = '3306',
-    database = 'inventory',
-    table = 'products',
-    server_id = '12345'
-);
-
--- Aggregate CDC changes with Z-set changelog
-CREATE STREAM customer_totals AS
-SELECT customer_id,
-       COUNT(*) AS total_orders,
-       SUM(amount) AS total_spent
-FROM orders_cdc
-WHERE _op IN ('I', 'U')
-GROUP BY customer_id
-EMIT CHANGES;</code></pre>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Python API ======== -->
-    <section class="python-section" id="python">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Python</div>
-          <h2 class="section-title reveal">First-class <span class="gradient-text">Python</span> support</h2>
-          <p class="section-desc centered reveal">
-            Use LaminarDB from Python with a Pythonic API.
-            No Rust knowledge required. Same engine, same performance.
-          </p>
-        </div>
-
-        <div class="python-showcase reveal">
-          <div class="python-code-side">
-            <div class="code-block">
-              <div class="code-header">
-                <div class="tab-buttons">
-                  <button class="tab-btn active" style="cursor: default;">python</button>
-                </div>
-                <div class="code-actions">
-                  <button class="copy-btn" aria-label="Copy code">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                    Copy
-                  </button>
-                </div>
-              </div>
-              <div class="tab-panel active" id="tab-python-showcase">
-                <pre><code class="language-python">from laminardb import Pipeline, KafkaSource, DeltaSink
-
-pipeline = Pipeline()
-
-# Define a streaming SQL query
-pipeline.sql("""
-    SELECT
-        user_id,
-        COUNT(*) as event_count,
-        SUM(amount) as total_amount
-    FROM TUMBLE(payments, interval '1 minute')
-    GROUP BY user_id
-    HAVING total_amount > 10000
-""")
-
-# Connect source and sink
-pipeline.source(KafkaSource(
-    "payments",
-    broker="localhost:9092"
-))
-pipeline.sink(DeltaSink(
-    "s3://warehouse/fraud_alerts"
-))
-
-# Run the pipeline
-pipeline.run()</code></pre>
-              </div>
-            </div>
-          </div>
-
-          <div class="python-features-side">
-            <div class="python-feature">
-              <div class="python-feature-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-              </div>
-              <div>
-                <h4>Zero-Copy Data Sharing</h4>
-                <p>Arrow memory is shared directly between the Rust engine and Python. No serialization, no copies, no overhead.</p>
-              </div>
-            </div>
-            <div class="python-feature">
-              <div class="python-feature-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-              </div>
-              <div>
-                <h4>Native PyArrow Integration</h4>
-                <p>Query results arrive as PyArrow Tables. Works directly with pandas, Polars, DuckDB, and the rest of the PyData stack.</p>
-              </div>
-            </div>
-            <div class="python-feature">
-              <div class="python-feature-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-              </div>
-              <div>
-                <h4>Jupyter Notebook Support</h4>
-                <p>Prototype streaming queries interactively. Push data, inspect results, and iterate in real time from a notebook cell.</p>
-              </div>
-            </div>
-            <div class="python-feature">
-              <div class="python-feature-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-              </div>
-              <div>
-                <h4>Async/Await Compatible</h4>
-                <p>Full asyncio support for non-blocking pipelines. Works natively with FastAPI, Starlette, and modern async Python.</p>
-              </div>
-            </div>
           </div>
         </div>
 
-        <div class="python-install-cta reveal">
-          <div class="hero-install" role="button" tabindex="0" aria-label="Copy install command">
-            <span class="prompt">$</span>
-            <span class="cmd">pip install laminardb</span>
-            <span class="copy-hint">Click to copy</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Architecture ======== -->
-    <section class="arch-section" id="architecture">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Architecture</div>
-          <h2 class="section-title reveal">Three-ring <span class="gradient-text">isolation</span></h2>
-          <p class="section-desc centered reveal">
-            Strict separation between the hot path, background I/O, and control plane.
-            Each ring has its own latency budget and allocation policy.
-          </p>
-        </div>
-
-        <div class="arch-visual reveal">
-          <div class="ring-layer ring-0">
-            <div class="ring-label">
-              <span class="ring-name">Ring 0 &mdash; Hot Path</span>
-              <span class="ring-constraint">&lt; 500ns &middot; minimal alloc &middot; no locks</span>
-            </div>
-            <div class="ring-chips">
-              <span class="ring-chip">Reactor Loop</span>
-              <span class="ring-chip">DAG Executor</span>
-              <span class="ring-chip">State Store</span>
-              <span class="ring-chip">Window Ops</span>
-              <span class="ring-chip">Join Ops</span>
-              <span class="ring-chip">JIT Compiler</span>
-            </div>
-          </div>
-
-          <div class="ring-divider"><span>SPSC Queues (~4.8ns)</span></div>
-
-          <div class="ring-layer ring-1">
-            <div class="ring-label">
-              <span class="ring-name">Ring 1 &mdash; Background</span>
-              <span class="ring-constraint">async I/O &middot; bounded latency impact</span>
-            </div>
-            <div class="ring-chips">
-              <span class="ring-chip">Per-Core WAL</span>
-              <span class="ring-chip">Checkpointing</span>
-              <span class="ring-chip">Connectors</span>
-              <span class="ring-chip">io_uring</span>
-              <span class="ring-chip">Recovery</span>
-            </div>
-          </div>
-
-          <div class="ring-divider"><span>Bounded Channels</span></div>
-
-          <div class="ring-layer ring-2">
-            <div class="ring-label">
-              <span class="ring-name">Ring 2 &mdash; Control Plane</span>
-              <span class="ring-constraint">full flexibility &middot; no latency requirements</span>
-            </div>
-            <div class="ring-chips">
-              <span class="ring-chip">Admin API</span>
-              <span class="ring-chip">Metrics</span>
-              <span class="ring-chip">Auth</span>
-              <span class="ring-chip">Config</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="arch-details reveal">
-          <div class="arch-detail">
-            <div class="arch-detail-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-            </div>
-            <h4>Thread-per-Core</h4>
-            <p>Each CPU core runs its own reactor, state store, and WAL segment. No cross-core locks. NUMA-aware memory allocation.</p>
-          </div>
-          <div class="arch-detail">
-            <div class="arch-detail-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-            </div>
-            <h4>Exactly-Once Delivery</h4>
-            <p>Barrier-based checkpoints, two-phase commit, and epoch-aligned sinks ensure exactly-once semantics end-to-end.</p>
-          </div>
-          <div class="arch-detail">
-            <div class="arch-detail-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-            </div>
-            <h4>Adaptive JIT</h4>
-            <p>Cranelift compiles SQL plans to native code in the background. Hot-swaps from interpreted to compiled with zero downtime.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Connectors ======== -->
-    <section class="connectors-section" id="connectors">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Connectors</div>
-          <h2 class="section-title reveal">Data source and sink <span class="gradient-text">connectors</span></h2>
-          <p class="section-desc centered reveal">
-            Feature-gated connectors with exactly-once semantics via two-phase commit.
-            Build custom connectors with the SDK.
-          </p>
-        </div>
-
-        <div class="connectors-grid reveal">
-          <div class="connector-card">
-            <div class="connector-icon kafka">K</div>
-            <div class="connector-name">Kafka</div>
-            <div class="connector-type">Source + Sink</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon postgres">P</div>
-            <div class="connector-name">PostgreSQL CDC</div>
-            <div class="connector-type">Source</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon postgres">P</div>
-            <div class="connector-name">PostgreSQL</div>
-            <div class="connector-type">Sink</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon mysql">M</div>
-            <div class="connector-name">MySQL CDC</div>
-            <div class="connector-type">Source</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon delta">D</div>
-            <div class="connector-name">Delta Lake</div>
-            <div class="connector-type">Source + Sink</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon iceberg">F</div>
-            <div class="connector-name">File Sources</div>
-            <div class="connector-type">Sink</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card">
-            <div class="connector-icon websocket">W</div>
-            <div class="connector-name">WebSocket</div>
-            <div class="connector-type">Source + Sink</div>
-            <span class="connector-badge impl">Implemented</span>
-          </div>
-          <div class="connector-card" style="opacity: 0.5;">
-            <div class="connector-icon" style="background: rgba(148,163,184,0.06); color: var(--text-muted);">+</div>
-            <div class="connector-name" style="color: var(--text-muted);">Custom</div>
-            <div class="connector-type">Connector SDK</div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Features ======== -->
-    <section class="features-section" id="features">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Features</div>
-          <h2 class="section-title reveal">189 features. <span class="gradient-text">76% complete.</span></h2>
-          <p class="section-desc centered reveal">
-            From core engine primitives to distributed delta mode. Every feature is specified,
-            implemented, and tested.
-          </p>
-        </div>
-
-        <div class="features-grid">
-          <div class="feature-card reveal reveal-delay-1">
-            <div class="feature-card-icon" style="background: var(--cyan-glow); color: var(--cyan-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-            </div>
-            <h3>Window Functions</h3>
-            <p>Tumbling, sliding, hopping, and session windows with configurable EMIT strategies and merge support.</p>
-          </div>
-          <div class="feature-card reveal reveal-delay-2">
-            <div class="feature-card-icon" style="background: var(--violet-glow); color: var(--violet-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M18 20V10M12 20V4M6 20v-6"/></svg>
-            </div>
-            <h3>Stream Joins</h3>
-            <p>Stream-stream, ASOF, temporal, and lookup joins with time bounds and foyer-cached dimension tables.</p>
-          </div>
-          <div class="feature-card reveal reveal-delay-3">
-            <div class="feature-card-icon" style="background: rgba(251,191,36,0.1); color: var(--amber-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M4 4h16v16H4z"/><path d="M4 12h16M12 4v16"/></svg>
-            </div>
-            <h3>JIT Compilation</h3>
-            <p>Cranelift compiles SQL plans to native x86/ARM code. Adaptive warmup with zero-downtime hot-swap.</p>
-          </div>
-          <div class="feature-card reveal reveal-delay-4">
-            <div class="feature-card-icon" style="background: rgba(74,222,128,0.1); color: var(--green-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-            </div>
-            <h3>Checkpointing</h3>
-            <p>Per-core WAL, barrier-based checkpoints, and full state recovery.</p>
-          </div>
-          <div class="feature-card reveal reveal-delay-5">
-            <div class="feature-card-icon" style="background: rgba(251,113,133,0.1); color: var(--rose-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-            </div>
-            <h3>Schema Framework</h3>
-            <p>Pluggable format decoders (JSON, CSV, Avro, Parquet), schema inference, evolution, and dead letter queues.</p>
-          </div>
-          <div class="feature-card reveal reveal-delay-6">
-            <div class="feature-card-icon" style="background: var(--cyan-glow); color: var(--cyan-400);">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-            </div>
-            <h3>Distributed Mode</h3>
-            <p>Gossip discovery, Raft consensus, epoch-fenced partitions, and cross-node gRPC. Delta architecture.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ======== Comparison ======== -->
-    <section class="comparison-section" id="comparison">
-      <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Comparison</div>
-          <h2 class="section-title reveal">LaminarDB vs Flink vs Kafka Streams <span class="gradient-text">comparison</span></h2>
-          <p class="section-desc centered reveal">
-            Embedded deployment, sub-microsecond latency, dual Python + Rust APIs,
-            and zero ops. No cluster to manage, no infrastructure to maintain.
-          </p>
-        </div>
-
-        <div class="comparison-highlights reveal">
-          <div class="comparison-hl-card">
-            <div class="comparison-hl-value">Embedded</div>
-            <div class="comparison-hl-desc">No infrastructure to deploy or manage</div>
-          </div>
-          <div class="comparison-hl-card">
-            <div class="comparison-hl-value">Sub-&micro;s</div>
-            <div class="comparison-hl-desc">325ns measured through a 3-node DAG</div>
-          </div>
-          <div class="comparison-hl-card">
-            <div class="comparison-hl-value">Python + Rust</div>
-            <div class="comparison-hl-desc">Dual language APIs, one engine</div>
-          </div>
-          <div class="comparison-hl-card">
-            <div class="comparison-hl-value">Zero ops</div>
-            <div class="comparison-hl-desc">No cluster, no JVM, no tuning</div>
-          </div>
-        </div>
-
-        <div class="comparison-wrapper reveal">
-          <table class="comparison-table">
-            <thead>
-              <tr>
-                <th>Feature</th>
-                <th class="hl">LaminarDB</th>
-                <th>Flink</th>
-                <th>Kafka Streams</th>
-                <th>RisingWave</th>
-                <th>Materialize</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Deployment</td>
-                <td class="hl"><strong>Embedded</strong></td>
-                <td>Distributed</td>
-                <td>Embedded</td>
-                <td>Distributed</td>
-                <td>Distributed</td>
-              </tr>
-              <tr>
-                <td>Architecture</td>
-                <td class="hl"><strong>Embedded (&lt; 1&micro;s)</strong></td>
-                <td>Distributed (ms)</td>
-                <td>Embedded (~1ms)</td>
-                <td>Distributed (ms)</td>
-                <td>Distributed (ms)</td>
-              </tr>
-              <tr>
-                <td>SQL support</td>
-                <td class="hl"><span class="check">&#10003;</span> Full</td>
-                <td>Limited</td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="check">&#10003;</span> Full</td>
-                <td><span class="check">&#10003;</span> Full</td>
-              </tr>
-              <tr>
-                <td>Python API</td>
-                <td class="hl"><span class="check">&#10003;</span> Native</td>
-                <td>PyFlink</td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-              </tr>
-              <tr>
-                <td>Exactly-once</td>
-                <td class="hl"><span class="check">&#10003;</span></td>
-                <td><span class="check">&#10003;</span></td>
-                <td><span class="check">&#10003;</span></td>
-                <td><span class="check">&#10003;</span></td>
-                <td><span class="check">&#10003;</span></td>
-              </tr>
-              <tr>
-                <td>Thread-per-core</td>
-                <td class="hl"><span class="check">&#10003;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-              </tr>
-              <tr>
-                <td>JIT compilation</td>
-                <td class="hl"><span class="check">&#10003;</span> Cranelift</td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-              </tr>
-              <tr>
-                <td>Lakehouse sinks</td>
-                <td class="hl"><span class="check">&#10003;</span> Delta Lake</td>
-                <td>Limited</td>
-                <td><span class="cross">&#10007;</span></td>
-                <td><span class="check">&#10003;</span></td>
-                <td><span class="cross">&#10007;</span></td>
-              </tr>
-              <tr>
-                <td>Language</td>
-                <td class="hl"><strong>Rust + Python</strong></td>
-                <td>Java</td>
-                <td>Java</td>
-                <td>Rust</td>
-                <td>Rust / C++</td>
-              </tr>
-              <tr>
-                <td>License</td>
-                <td class="hl"><strong>Apache 2.0</strong></td>
-                <td>Apache 2.0</td>
-                <td>Apache 2.0</td>
-                <td>Apache 2.0</td>
-                <td>BSL</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p class="comparison-note reveal">
-          Flink, RisingWave, and Materialize are distributed systems designed for cluster-scale workloads.
-          LaminarDB is an embedded engine optimized for single-node, in-process use cases.
-          Different architectures serve different needs &mdash; we believe both have a place.
+        <p style="margin-top: 1rem; font-size: 0.85rem; color: var(--text-dim);">
+          More examples:
+          <a href="https://github.com/laminardb/laminardb/tree/main/examples" target="_blank" rel="noopener">examples/</a> &middot;
+          <a href="https://laminardb.io/api/laminar_db/" target="_blank" rel="noopener">API reference</a> &middot;
+          <a href="https://github.com/laminardb/laminardb/blob/main/docs/SQL_REFERENCE.md" target="_blank" rel="noopener">SQL reference</a>
         </p>
       </div>
     </section>
 
-    <!-- ======== Developer Experience: Zero to Streaming ======== -->
-    <section class="dx-section" id="get-started">
+    <!-- Connectors -->
+    <section id="connectors">
       <div class="container">
-        <div class="section-header text-center">
-          <div class="section-label reveal">Developer Experience</div>
-          <h2 class="section-title reveal">From zero to streaming in <span class="gradient-text">60 seconds</span></h2>
+        <h2>Connectors</h2>
+        <p class="section-desc">
+          All connectors are feature-gated. Compile only what you use.
+          Enable via <code>cargo add laminar-db --features kafka,delta-lake</code>.
+        </p>
+
+        <div class="connector-table-wrapper">
+          <table class="connector-table">
+            <thead>
+              <tr>
+                <th>Connector</th>
+                <th>Direction</th>
+                <th>Status</th>
+                <th>Feature Flag</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Kafka</td>
+                <td>Source + Sink</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">kafka</code></td>
+                <td>Avro, JSON, CSV. Confluent Schema Registry. Exactly-once via 2PC.</td>
+              </tr>
+              <tr>
+                <td>PostgreSQL CDC</td>
+                <td>Source</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">postgres-cdc</code></td>
+                <td>Logical replication via pgoutput. LSN-based checkpoint tracking.</td>
+              </tr>
+              <tr>
+                <td>PostgreSQL Sink</td>
+                <td>Sink</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">postgres-sink</code></td>
+                <td>COPY BINARY (append) or INSERT ON CONFLICT (upsert).</td>
+              </tr>
+              <tr>
+                <td>MySQL CDC</td>
+                <td>Source</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">mysql-cdc</code></td>
+                <td>Binlog replication. GTID or file+position modes.</td>
+              </tr>
+              <tr>
+                <td>Delta Lake</td>
+                <td>Source + Sink</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">delta-lake</code></td>
+                <td>S3, Azure, GCS, Unity, Glue catalogs. Exactly-once epoch tracking.</td>
+              </tr>
+              <tr>
+                <td>WebSocket</td>
+                <td>Source + Sink</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">websocket</code></td>
+                <td>Client and server modes. JSON/CSV serialization.</td>
+              </tr>
+              <tr>
+                <td>File Auto-Loader</td>
+                <td>Source + Sink</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">files</code></td>
+                <td>CSV, JSON Lines, Parquet, plain text. Schema inference and evolution.</td>
+              </tr>
+              <tr>
+                <td>Parquet Lookup</td>
+                <td>Source</td>
+                <td><span class="status-impl">Implemented</span></td>
+                <td><code class="feature-flag">parquet-lookup</code></td>
+                <td>Object-store-backed dimension tables for lookup joins.</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
 
-        <div class="dx-steps">
-          <div class="dx-step reveal reveal-delay-1">
-            <div class="dx-step-num">1</div>
-            <div class="dx-step-body">
-              <h3>Install</h3>
-              <p>One command. No containers, no clusters, no config files.</p>
-              <pre><code class="language-bash"># Python
-pip install laminardb
+        <p style="margin-top: 1rem; font-size: 0.85rem; color: var(--text-dim);">
+          Custom connectors: implement the
+          <a href="https://laminardb.io/api/laminar_connectors/connector/trait.SourceConnector.html" target="_blank" rel="noopener">SourceConnector</a> /
+          <a href="https://laminardb.io/api/laminar_connectors/connector/trait.SinkConnector.html" target="_blank" rel="noopener">SinkConnector</a>
+          traits.
+        </p>
+      </div>
+    </section>
 
-# Rust
-cargo add laminar-db</code></pre>
-            </div>
+    <!-- Deployment Modes -->
+    <section id="deployment">
+      <div class="container">
+        <h2>Deployment</h2>
+
+        <div class="deploy-grid">
+          <div class="deploy-card">
+            <h3>Embedded</h3>
+            <p>
+              Rust: <code>cargo add laminar-db</code>.
+              Python: <code>pip install laminardb</code>.
+              The engine runs in your process &mdash; push events, subscribe to results.
+            </p>
+            <p>Good fit for edge processing, embedded analytics, and latency-sensitive apps.</p>
           </div>
-
-          <div class="dx-step reveal reveal-delay-2">
-            <div class="dx-step-num">2</div>
-            <div class="dx-step-body">
-              <h3>Write SQL</h3>
-              <p>Define your streaming query using familiar SQL syntax.</p>
-              <pre><code class="language-sql">CREATE SOURCE events (
-    key VARCHAR, value DOUBLE, ts BIGINT
-);
-
-CREATE STREAM summary AS
-    SELECT key, COUNT(*) AS total, AVG(value) AS avg
-    FROM events
-    GROUP BY key, tumble(ts, INTERVAL '1' MINUTE)
-    EMIT ON WINDOW CLOSE;</code></pre>
-            </div>
+          <div class="deploy-card">
+            <h3>Standalone Server</h3>
+            <p>
+              Run the <code>laminardb</code> binary with a TOML config.
+              REST API on port 8080. Connects to Kafka, databases, Delta Lake.
+              Docker image and Helm chart available.
+            </p>
+            <p>Use for: CDC pipelines, stream-to-lakehouse, event routing.</p>
           </div>
-
-          <div class="dx-step reveal reveal-delay-3">
-            <div class="dx-step-num">3</div>
-            <div class="dx-step-body">
-              <h3>Run</h3>
-              <p>Push data and get real-time results. That's it.</p>
-              <pre><code class="language-python">import laminardb
-
-db = laminardb.open()
-# ... execute SQL from step 2 ...
-db.start()
-
-db.insert("events", {"key": "sensor-1", "value": 42.0, "ts": 1700000000000})
-
-for batch in db.subscribe("summary"):
-    print(batch.to_pandas())</code></pre>
-            </div>
+          <div class="deploy-card">
+            <h3>Cluster</h3>
+            <span class="label-planned">Coming Soon</span>
+            <p>
+              Multi-node deployment using Raft consensus and gossip discovery.
+              Core primitives are in the workspace &mdash; cluster mode is being wired into the server.
+            </p>
+            <p><a href="https://github.com/laminardb/laminardb/blob/main/docs/ROADMAP.md" target="_blank" rel="noopener">Track progress on the roadmap</a></p>
           </div>
-        </div>
-
-        <div class="dx-cta reveal">
-          <a href="https://laminardb.io/api/laminar_db/" class="btn btn-primary btn-lg" target="_blank" rel="noopener">Read the Docs</a>
-          <a href="https://crates.io/crates/laminar-db" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">Crates.io</a>
-          <a href="https://github.com/laminardb/laminardb-python" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">Python Package</a>
         </div>
       </div>
     </section>
 
-    <!-- ======== CTA Banner ======== -->
-    <section class="cta-section">
+    <!-- Comparison -->
+    <section id="comparison">
       <div class="container">
-        <div class="cta-box reveal">
-          <h2>Ready to process your <span class="gradient-text">first stream</span>?</h2>
-          <p>LaminarDB is free, open source, and Apache 2.0 licensed. Get started in under a minute.</p>
-          <div class="cta-actions">
-            <a href="https://laminardb.io/api/laminar_db/" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
-              Read the Docs
-            </a>
-            <a href="https://github.com/laminardb/laminardb" class="btn btn-secondary btn-lg" target="_blank" rel="noopener">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-              Star on GitHub
-            </a>
+        <h2>How it compares</h2>
+        <p class="section-desc">
+          Different tools for different problems.
+          LaminarDB targets low-latency, single-node workloads today &mdash; cluster mode is coming.
+        </p>
+
+        <div class="comparison-wrapper">
+          <table class="comparison-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th class="hl">LaminarDB</th>
+                <th>Apache Flink</th>
+                <th>Kafka Streams</th>
+                <th>Arroyo</th>
+                <th>kdb+</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Type</td>
+                <td class="hl">SQL engine</td>
+                <td>Distributed framework</td>
+                <td>Stream library (JVM)</td>
+                <td>Distributed engine</td>
+                <td>Timeseries DB</td>
+              </tr>
+              <tr>
+                <td>Language</td>
+                <td class="hl">Rust + Python</td>
+                <td>Java / Scala</td>
+                <td>Java</td>
+                <td>Rust</td>
+                <td>q/k (proprietary)</td>
+              </tr>
+              <tr>
+                <td>SQL</td>
+                <td class="hl">DataFusion</td>
+                <td>Flink SQL</td>
+                <td>None</td>
+                <td>DataFusion</td>
+                <td>q language</td>
+              </tr>
+              <tr>
+                <td>Deployment</td>
+                <td class="hl">Embedded, server, cluster (soon)</td>
+                <td class="win">Cluster (YARN/K8s)</td>
+                <td>In-app (JVM)</td>
+                <td class="win">Kubernetes</td>
+                <td>Single process</td>
+              </tr>
+              <tr>
+                <td>Latency target</td>
+                <td class="hl">&lt;1&micro;s state lookup</td>
+                <td>~10ms</td>
+                <td>~1ms</td>
+                <td>~10ms</td>
+                <td>&lt;1&micro;s</td>
+              </tr>
+              <tr>
+                <td>Horizontal scale</td>
+                <td class="hl">No (single node)</td>
+                <td class="win">Yes</td>
+                <td class="win">Via Kafka partitions</td>
+                <td class="win">Yes</td>
+                <td>No</td>
+              </tr>
+              <tr>
+                <td>Exactly-once</td>
+                <td class="hl">Barrier checkpoints</td>
+                <td>Barrier checkpoints</td>
+                <td>Kafka transactions</td>
+                <td>Barrier checkpoints</td>
+                <td>N/A</td>
+              </tr>
+              <tr>
+                <td>Connectors</td>
+                <td class="hl">8</td>
+                <td class="win">100+</td>
+                <td>Kafka only</td>
+                <td class="win">15+</td>
+                <td>Custom</td>
+              </tr>
+              <tr>
+                <td>Ops overhead</td>
+                <td class="hl">None (lib) / low</td>
+                <td>High (cluster, JVM)</td>
+                <td>Low</td>
+                <td>Medium (K8s)</td>
+                <td>Low</td>
+              </tr>
+              <tr>
+                <td>License</td>
+                <td class="hl">Apache 2.0</td>
+                <td>Apache 2.0</td>
+                <td>Apache 2.0</td>
+                <td>Apache 2.0</td>
+                <td>Proprietary</td>
+              </tr>
+              <tr>
+                <td>Maturity</td>
+                <td class="hl">Pre-1.0 (v0.18.1)</td>
+                <td class="win">Production (10+ yrs)</td>
+                <td class="win">Production (8+ yrs)</td>
+                <td class="win">Production (~2 yrs)</td>
+                <td class="win">Production (30+ yrs)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p class="comparison-note">
+          Bold cells show where a competitor has a clear advantage.
+          LaminarDB wins on latency and deployment flexibility.
+          It loses on maturity, horizontal scale (until cluster ships), and ecosystem breadth.
+        </p>
+
+        <h3 style="margin-bottom: 1rem;">When to choose something else</h3>
+        <div class="alternatives">
+          <div class="alt-card">
+            <h4>Apache Flink</h4>
+            <p>Need to scale across a cluster? Flink handles 100+ connectors and complex event processing. Trade-off: heavyweight JVM footprint and operational overhead.</p>
           </div>
-          <div class="cta-community">
-            <a href="https://github.com/laminardb/laminardb/discussions" class="cta-community-link" target="_blank" rel="noopener">
-              Join the community on GitHub Discussions &rarr;
-            </a>
+          <div class="alt-card">
+            <h4>Kafka Streams</h4>
+            <p>Strictly Kafka in/out and already running JVM services? Streams is the simplest fit. No SQL though.</p>
           </div>
-          <div class="cta-built-with">
-            <div class="cta-built-item">Built with Rust</div>
-            <div class="cta-built-item">Apache Arrow</div>
-            <div class="cta-built-item">DataFusion</div>
-            <div class="cta-built-item">Cranelift</div>
+          <div class="alt-card">
+            <h4>Arroyo</h4>
+            <p>Distributed streaming in Rust with a web UI. Runs on Kubernetes. Shares the DataFusion SQL foundation with LaminarDB.</p>
+          </div>
+          <div class="alt-card">
+            <h4>kdb+</h4>
+            <p>Finance teams with q/k expertise and sub-microsecond timeseries analytics. 30+ years of production track record. Licensing is steep.</p>
           </div>
         </div>
       </div>
     </section>
+
+    <!-- Benchmarks -->
+    <section id="benchmarks">
+      <div class="container">
+        <h2>Benchmarks</h2>
+        <p class="section-desc">
+          Criterion benchmarks run on an AMD Ryzen AI 7 350 laptop.
+          These are not server numbers. Dedicated hardware with isolated cores will perform better.
+          <a href="https://github.com/laminardb/laminardb/blob/main/docs/BENCHMARKS.md" target="_blank" rel="noopener">Full results</a>.
+        </p>
+
+        <div class="connector-table-wrapper">
+          <table class="connector-table">
+            <thead>
+              <tr>
+                <th>Metric</th>
+                <th>Target</th>
+                <th>Measured</th>
+                <th>Benchmark File</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>State lookup (AHash get_ref)</td>
+                <td>&lt;500ns</td>
+                <td>10&ndash;16ns (zero-copy)</td>
+                <td><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/state_bench.rs" target="_blank" rel="noopener">state_bench.rs</a></td>
+              </tr>
+              <tr>
+                <td>Throughput / core</td>
+                <td>500K events/s</td>
+                <td>1.1&ndash;3.17M events/s</td>
+                <td><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/throughput_bench.rs" target="_blank" rel="noopener">throughput_bench.rs</a></td>
+              </tr>
+              <tr>
+                <td>p99 latency</td>
+                <td>&lt;10&micro;s</td>
+                <td>0.55&ndash;1.16&micro;s</td>
+                <td><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/latency_bench.rs" target="_blank" rel="noopener">latency_bench.rs</a></td>
+              </tr>
+              <tr>
+                <td>Checkpoint recovery</td>
+                <td>&lt;10s</td>
+                <td>1.39ms</td>
+                <td><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-core/benches/checkpoint_bench.rs" target="_blank" rel="noopener">checkpoint_bench.rs</a></td>
+              </tr>
+              <tr>
+                <td>WAL append</td>
+                <td>&lt;1&micro;s</td>
+                <td>541ns</td>
+                <td><a href="https://github.com/laminardb/laminardb/blob/main/crates/laminar-storage/benches/wal_bench.rs" target="_blank" rel="noopener">wal_bench.rs</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p style="margin-top: 1rem; font-size: 0.85rem; color: var(--text-dim);">
+          Reproduce: <code>cargo bench --bench state_bench</code>,
+          <code>cargo bench --bench throughput_bench</code>,
+          <code>cargo bench --bench latency_bench</code>.
+          All benchmarks use <a href="https://github.com/bheisler/criterion.rs" target="_blank" rel="noopener">Criterion</a> for statistical analysis.
+        </p>
+      </div>
+    </section>
+
+    <!-- Status -->
+    <section id="status">
+      <div class="container">
+        <h2>Status</h2>
+        <p class="section-desc">
+          Current version: <strong>0.18.1</strong> (pre-1.0).
+          <a href="https://github.com/laminardb/laminardb/releases" target="_blank" rel="noopener">Releases</a> &middot;
+          <a href="https://github.com/laminardb/laminardb/blob/main/docs/ROADMAP.md" target="_blank" rel="noopener">Roadmap</a>
+        </p>
+
+        <div class="status-grid">
+          <div class="status-col stable">
+            <h3>Stable</h3>
+            <ul>
+              <li>Core engine (reactor, state stores, DAG executor)</li>
+              <li>Window functions (tumbling, sliding, hopping, session)</li>
+              <li>Joins (stream-stream, ASOF, temporal, lookup)</li>
+              <li>All 8 connectors (Kafka, CDC, Delta, WS, files)</li>
+              <li>Barrier-based checkpointing and recovery</li>
+              <li>Per-core WAL with exactly-once semantics</li>
+              <li>Standalone server with REST API</li>
+              <li>Docker and Helm chart deployment</li>
+              <li>JIT compilation via Cranelift</li>
+            </ul>
+          </div>
+          <div class="status-col experimental">
+            <h3>Experimental</h3>
+            <ul>
+              <li>io_uring storage (Linux only)</li>
+              <li>Incremental checkpoints</li>
+              <li>Cross-partition aggregation (gossip)</li>
+            </ul>
+          </div>
+          <div class="status-col unimplemented">
+            <h3>Not yet implemented</h3>
+            <ul>
+              <li>Cluster / multi-node deployment (coming soon)</li>
+              <li>PostgreSQL wire protocol (planned)</li>
+              <li>MongoDB, Redis connectors</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Contributing -->
+    <section id="contributing">
+      <div class="container">
+        <h2>Contributing</h2>
+        <p style="max-width: 600px; margin-bottom: 1.5rem;">
+          LaminarDB is Apache 2.0 licensed. Contributions welcome.
+          Rust 1.85+ required. See the contribution guide for Ring 0 constraints
+          (no allocations, no locks, no syscalls on the hot path).
+        </p>
+        <div class="contrib-links">
+          <a href="https://github.com/laminardb/laminardb/blob/main/CONTRIBUTING.md" class="btn btn-secondary" target="_blank" rel="noopener">Contribution Guide</a>
+          <a href="https://github.com/laminardb/laminardb/discussions" class="btn btn-secondary" target="_blank" rel="noopener">Discussions</a>
+          <a href="https://github.com/laminardb/laminardb/labels/good%20first%20issue" class="btn btn-secondary" target="_blank" rel="noopener">Good First Issues</a>
+        </div>
+      </div>
+    </section>
+
   </main>
 
-  <!-- ======== Footer ======== -->
+  <!-- Footer -->
   <footer class="footer">
-    <div class="footer-grid">
-      <div class="footer-brand">
-        <a href="#" class="nav-brand">
-          <svg class="logo-icon" viewBox="0 0 40 40" width="32" height="32" aria-hidden="true">
-            <defs><linearGradient id="footer-lg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#06b6d4"/><stop offset="100%" stop-color="#8b5cf6"/></linearGradient></defs>
-            <path d="M4 8 C12 8,14 6,22 6 C30 6,32 10,36 10" stroke="url(#footer-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".5"/>
-            <path d="M2 14 C10 14,14 11,22 11 C30 11,32 15,38 15" stroke="url(#footer-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".7"/>
-            <path d="M0 20 C8 20,14 17,22 17 C30 17,32 21,40 21" stroke="url(#footer-lg)" stroke-width="3" fill="none" stroke-linecap="round"/>
-            <path d="M2 26 C10 26,14 23,22 23 C30 23,32 27,38 27" stroke="url(#footer-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".7"/>
-            <path d="M4 32 C12 32,14 30,22 30 C30 30,32 34,36 34" stroke="url(#footer-lg)" stroke-width="2.5" fill="none" stroke-linecap="round" opacity=".5"/>
-          </svg>
-          <span>LaminarDB</span>
-        </a>
-        <p>LaminarDB is an open-source embedded streaming SQL database. Sub-microsecond latency, zero infrastructure, with native Rust and Python APIs. Apache 2.0 licensed.</p>
-      </div>
-      <div>
-        <h4>Resources</h4>
+    <div class="container">
+      <div class="footer-inner">
+        <div class="footer-left">
+          LaminarDB &middot;
+          <a href="https://github.com/laminardb/laminardb/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0</a> &middot;
+          v0.18.1
+        </div>
         <div class="footer-links">
-          <a href="https://laminardb.io/api/laminar_db/" target="_blank" rel="noopener">API Docs</a>
           <a href="https://github.com/laminardb/laminardb" target="_blank" rel="noopener">GitHub</a>
           <a href="https://crates.io/crates/laminar-db" target="_blank" rel="noopener">Crates.io</a>
+          <a href="https://laminardb.io/api/laminar_db/" target="_blank" rel="noopener">API Docs</a>
           <a href="https://github.com/laminardb/laminardb/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
         </div>
       </div>
-      <div>
-        <h4>Product</h4>
-        <div class="footer-links">
-          <a href="#features">Features</a>
-          <a href="#performance">Performance</a>
-          <a href="#architecture">Architecture</a>
-          <a href="#connectors">Connectors</a>
-          <a href="#python">Python API</a>
-        </div>
-      </div>
-      <div>
-        <h4>Bindings</h4>
-        <div class="footer-links">
-          <a href="https://crates.io/crates/laminar-db" target="_blank" rel="noopener">Rust (primary)</a>
-          <a href="https://github.com/laminardb/laminardb-python" target="_blank" rel="noopener">Python (PyO3)</a>
-          <a href="https://github.com/laminardb/laminardb" target="_blank" rel="noopener">C FFI</a>
-        </div>
-      </div>
-    </div>
-    <div class="footer-bottom">
-      <p>
-        &copy; 2026 LaminarDB Contributors &middot;
-        <a href="https://github.com/laminardb/laminardb/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0 License</a> &middot;
-        v0.18.0
-      </p>
     </div>
   </footer>
 
-  <!-- Prism.js (defer for better Core Web Vitals) -->
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-sql.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-rust.min.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
-
-  <!-- Playground -->
-  <script defer src="js/playground.js"></script>
-
-  <!-- Main JS -->
   <script defer src="js/main.js"></script>
 </body>
 </html>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,77 +1,18 @@
-/* ============================================
-   LaminarDB v2 — Interactivity & Animations
-   ============================================ */
+/* LaminarDB — Minimal interactivity. No animations, no particles. */
 
 document.addEventListener('DOMContentLoaded', () => {
 
-  // ---- Navigation scroll effect ----
-  const nav = document.querySelector('.nav');
-  const onScroll = () => {
-    nav.classList.toggle('scrolled', window.scrollY > 40);
-  };
-  window.addEventListener('scroll', onScroll, { passive: true });
-  onScroll();
-
-  // ---- Sticky top bar (appears after scrolling past hero) ----
-  const stickyBar = document.getElementById('sticky-bar');
-  const heroSection = document.getElementById('hero');
-  if (stickyBar && heroSection) {
-    const stickyObserver = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            stickyBar.classList.remove('visible');
-            stickyBar.setAttribute('aria-hidden', 'true');
-          } else {
-            stickyBar.classList.add('visible');
-            stickyBar.setAttribute('aria-hidden', 'false');
-          }
-        });
-      },
-      { threshold: 0, rootMargin: '-80px 0px 0px 0px' }
-    );
-    stickyObserver.observe(heroSection);
-
-    // Copy on click for sticky bar install
-    const stickyInstall = stickyBar.querySelector('.sticky-bar-install');
-    if (stickyInstall) {
-      stickyInstall.addEventListener('click', () => {
-        const cmd = stickyInstall.querySelector('.cmd')?.textContent || '';
-        navigator.clipboard.writeText(cmd).then(() => {
-          const cmdEl = stickyInstall.querySelector('.cmd');
-          if (cmdEl) {
-            const original = cmdEl.textContent;
-            cmdEl.textContent = 'Copied!';
-            cmdEl.style.color = 'var(--green-400)';
-            setTimeout(() => {
-              cmdEl.textContent = original;
-              cmdEl.style.color = '';
-            }, 1500);
-          }
-        });
-      });
-    }
+  // --- Mobile nav toggle ---
+  const navToggle = document.querySelector('.nav-toggle');
+  const mobileMenu = document.querySelector('.mobile-menu');
+  if (navToggle && mobileMenu) {
+    navToggle.addEventListener('click', () => {
+      navToggle.classList.toggle('open');
+      mobileMenu.classList.toggle('open');
+    });
   }
 
-  // ---- Active nav link highlight ----
-  const sections = document.querySelectorAll('section[id]');
-  const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');
-  const highlightNav = () => {
-    const scrollY = window.scrollY + 120;
-    sections.forEach((section) => {
-      const top = section.offsetTop;
-      const height = section.offsetHeight;
-      const id = section.getAttribute('id');
-      if (scrollY >= top && scrollY < top + height) {
-        navLinks.forEach((link) => {
-          link.classList.toggle('active', link.getAttribute('href') === '#' + id);
-        });
-      }
-    });
-  };
-  window.addEventListener('scroll', highlightNav, { passive: true });
-
-  // ---- Smooth scroll ----
+  // --- Smooth scroll for anchor links ---
   document.querySelectorAll('a[href^="#"]').forEach((link) => {
     link.addEventListener('click', (e) => {
       const href = link.getAttribute('href');
@@ -80,94 +21,38 @@ document.addEventListener('DOMContentLoaded', () => {
       if (target) {
         e.preventDefault();
         target.scrollIntoView({ behavior: 'smooth' });
-        mobileMenu?.classList.remove('open');
-        navToggle?.classList.remove('open');
-      }
-    });
-  });
-
-  // ---- Mobile nav ----
-  const navToggle = document.querySelector('.nav-toggle');
-  const mobileMenu = document.querySelector('.mobile-menu');
-  navToggle?.addEventListener('click', () => {
-    navToggle.classList.toggle('open');
-    mobileMenu?.classList.toggle('open');
-  });
-
-  // ---- Scroll reveal (IntersectionObserver) ----
-  const revealElements = document.querySelectorAll('.reveal');
-  if (revealElements.length > 0) {
-    const revealObserver = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
-            revealObserver.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.1, rootMargin: '0px 0px -40px 0px' }
-    );
-    revealElements.forEach((el) => revealObserver.observe(el));
-  }
-
-  // ---- Animated counters ----
-  function animateCounter(el, from, to, duration, suffix) {
-    const start = performance.now();
-    suffix = suffix || '';
-    const step = (now) => {
-      const elapsed = now - start;
-      const progress = Math.min(elapsed / duration, 1);
-      // Ease-out expo
-      const eased = progress === 1 ? 1 : 1 - Math.pow(2, -10 * progress);
-      const current = Math.round(from + (to - from) * eased);
-      el.textContent = current.toLocaleString() + suffix;
-      if (progress < 1) {
-        requestAnimationFrame(step);
-      }
-    };
-    requestAnimationFrame(step);
-  }
-
-  // Observe counter elements
-  document.querySelectorAll('[data-count-to]').forEach((el) => {
-    let counted = false;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !counted) {
-          counted = true;
-          const to = parseInt(el.dataset.countTo, 10);
-          const from = parseInt(el.dataset.countFrom || '0', 10);
-          const duration = parseInt(el.dataset.countDuration || '2000', 10);
-          const suffix = el.dataset.countSuffix || '';
-          animateCounter(el, from, to, duration, suffix);
-          observer.unobserve(el);
+        // Close mobile menu if open
+        if (mobileMenu) {
+          mobileMenu.classList.remove('open');
+          navToggle?.classList.remove('open');
         }
-      },
-      { threshold: 0.5 }
-    );
-    observer.observe(el);
-  });
-
-  // ---- Code tabs ----
-  const tabButtons = document.querySelectorAll('.tab-btn');
-  tabButtons.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const target = btn.dataset.tab;
-      if (!target) return; // Skip buttons without a data-tab (e.g., Python showcase static tab)
-      const container = btn.closest('.code-block');
-      const buttons = container.querySelectorAll('.tab-btn');
-      const panels = container.querySelectorAll('.tab-panel');
-      buttons.forEach((b) => b.classList.toggle('active', b === btn));
-      panels.forEach((p) => p.classList.toggle('active', p.id === target));
+      }
     });
   });
 
-  // ---- Copy code button ----
+  // --- Code tabs ---
+  document.querySelectorAll('.code-tab').forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const targetId = tab.dataset.tab;
+      if (!targetId) return;
+      const block = tab.closest('.code-block');
+      if (!block) return;
+
+      block.querySelectorAll('.code-tab').forEach((t) => {
+        t.classList.toggle('active', t === tab);
+      });
+      block.querySelectorAll('.tab-panel').forEach((panel) => {
+        panel.classList.toggle('active', panel.id === targetId);
+      });
+    });
+  });
+
+  // --- Copy code button ---
   document.querySelectorAll('.copy-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
-      const container = btn.closest('.code-block');
-      const activePanel = container?.querySelector('.tab-panel.active');
+      const block = btn.closest('.code-block');
+      if (!block) return;
+      const activePanel = block.querySelector('.tab-panel.active');
       const code = activePanel?.querySelector('code')?.textContent || '';
       navigator.clipboard.writeText(code).then(() => {
         const original = btn.innerHTML;
@@ -181,78 +66,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // ---- Install snippet copy (all .hero-install elements) ----
-  document.querySelectorAll('.hero-install').forEach((installSnippet) => {
-    installSnippet.addEventListener('click', () => {
-      const cmd = installSnippet.querySelector('.cmd')?.textContent || '';
+  // --- Hero install command copy ---
+  document.querySelectorAll('.hero-install').forEach((el) => {
+    el.addEventListener('click', () => {
+      const cmd = el.querySelector('.cmd')?.textContent || '';
       navigator.clipboard.writeText(cmd).then(() => {
-        const hint = installSnippet.querySelector('.copy-hint');
+        const hint = el.querySelector('.copy-hint');
         if (hint) {
           const original = hint.textContent;
-          hint.textContent = 'Copied!';
-          hint.style.color = 'var(--green-400)';
-          hint.style.borderColor = 'var(--green-400)';
+          hint.textContent = 'copied!';
+          hint.style.color = '#22c55e';
           setTimeout(() => {
             hint.textContent = original;
             hint.style.color = '';
-            hint.style.borderColor = '';
-          }, 2000);
+          }, 1500);
         }
       });
     });
-  });
-
-  // ---- Install language tabs (Rust/Python toggle in hero) ----
-  document.querySelectorAll('.install-tab').forEach((tab) => {
-    tab.addEventListener('click', () => {
-      const lang = tab.dataset.install;
-      const wrapper = tab.closest('.hero-install-wrapper');
-      if (!wrapper) return;
-
-      // Toggle tab active state
-      wrapper.querySelectorAll('.install-tab').forEach((t) => {
-        t.classList.toggle('active', t === tab);
-      });
-
-      // Toggle install panels
-      wrapper.querySelectorAll('.hero-install[data-install-panel]').forEach((panel) => {
-        panel.style.display = panel.dataset.installPanel === lang ? 'inline-flex' : 'none';
-      });
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        el.click();
+      }
     });
   });
 
-  // ---- Floating particles ----
-  const particlesContainer = document.querySelector('.hero-particles');
-  if (particlesContainer) {
-    const count = 20;
-    for (let i = 0; i < count; i++) {
-      const particle = document.createElement('div');
-      particle.className = 'particle';
-      particle.style.left = Math.random() * 100 + '%';
-      particle.style.animationDuration = (8 + Math.random() * 12) + 's';
-      particle.style.animationDelay = (Math.random() * 10) + 's';
-      particle.style.width = (1 + Math.random() * 2) + 'px';
-      particle.style.height = particle.style.width;
-      particle.style.opacity = 0;
-      particlesContainer.appendChild(particle);
-    }
-  }
-
-  // ---- Subtle parallax on hero ----
-  const heroGlow = document.querySelector('.hero-glow');
-  if (heroGlow && window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
-    let ticking = false;
-    window.addEventListener('scroll', () => {
-      if (!ticking) {
-        requestAnimationFrame(() => {
-          const scrollY = window.scrollY;
-          if (scrollY < window.innerHeight) {
-            heroGlow.style.transform = `translateY(${scrollY * 0.15}px)`;
-          }
-          ticking = false;
-        });
-        ticking = true;
-      }
-    }, { passive: true });
-  }
 });

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://laminardb.io</loc>
-    <lastmod>2026-03-03</lastmod>
+    <lastmod>2026-03-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://laminardb.io/api/laminar_db/</loc>
-    <lastmod>2026-03-03</lastmod>
+    <lastmod>2026-03-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Large rewrite of site/css/style.css to simplify and modernize the design system. Replaces the previous LaminarDB gradient/glass-heavy theme with a compact, systems-grade dark theme (new CSS variables like --bg, --accent, --text, etc.), consolidates fonts and spacing, and reduces max-width. Simplifies components and utilities: unified .btn styles with .btn-primary/.btn-secondary, restyled nav (sticky, compact), mobile menu, hero, code blocks and copy buttons, and tightened typography and section spacing. Removed numerous decorative effects (gradients, glows, complex animations) and deprecated many old variables/classes — review templates for any class/variable name changes.

## What

<!-- Brief description of changes -->

## Why

<!-- Link to issue or explain motivation -->

## How

<!-- Technical approach taken -->

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests pass (`cargo test --all`)
- [ ] No clippy warnings (`cargo clippy --all -- -D warnings`)
- [ ] Code is formatted (`cargo fmt`)

## Ring 0 (if applicable)

- [ ] No heap allocations on hot path
- [ ] No locks on hot path
- [ ] Benchmarks run before and after

## Checklist

- [ ] Public APIs are documented
- [ ] Breaking changes documented (if any)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation menu toggle
  * Added copy-to-clipboard buttons for code examples
  * Added tabbed code snippet switching

* **Style**
  * Redesigned color and typography system
  * Simplified navigation and hero section layouts
  * Improved responsive design for mobile and tablet screens

* **Refactor**
  * Removed unnecessary animation effects
  * Streamlined overall interaction patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->