### PR TITLE
fix: resolve Avro schemas from Schema Registry before deserialization

### DIFF
--- a/crates/laminar-connectors/src/kafka/avro.rs
+++ b/crates/laminar-connectors/src/kafka/avro.rs
@@ -173,6 +173,10 @@ impl RecordDeserializer for AvroDeserializer {
     fn format(&self) -> Format {
         Format::Avro
     }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
 }
 
 impl std::fmt::Debug for AvroDeserializer {

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -467,6 +467,24 @@ impl SourceConnector for KafkaSource {
             None
         };
 
+        // Resolve Avro schemas from Schema Registry before deserialization.
+        if let Some(avro_deser) = self
+            .deserializer
+            .as_any_mut()
+            .and_then(|any| any.downcast_mut::<AvroDeserializer>())
+        {
+            for &(start, len) in &payload_offsets {
+                if let Some(schema_id) =
+                    AvroDeserializer::extract_confluent_id(&payload_buf[start..start + len])
+                {
+                    avro_deser
+                        .ensure_schema_registered(schema_id)
+                        .await
+                        .map_err(ConnectorError::Serde)?;
+                }
+            }
+        }
+
         let refs: Vec<&[u8]> = payload_offsets
             .iter()
             .map(|&(start, len)| &payload_buf[start..start + len])

--- a/crates/laminar-connectors/src/serde/mod.rs
+++ b/crates/laminar-connectors/src/serde/mod.rs
@@ -130,6 +130,11 @@ pub trait RecordDeserializer: Send + Sync {
 
     /// Returns the format this deserializer handles.
     fn format(&self) -> Format;
+
+    /// Downcasts to concrete type (e.g., for Avro schema resolution).
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        None
+    }
 }
 
 /// Trait for serializing Arrow `RecordBatch` into raw bytes.


### PR DESCRIPTION
## Summary

- `KafkaSource::poll_batch()` called `deserialize_batch()` without resolving Confluent schema IDs first, causing `arrow-avro`'s `build_decoder()` to fail on an empty schema store
- Added `as_any_mut()` to `RecordDeserializer` trait for downcasting to `AvroDeserializer`
- Before deserialization, extract schema IDs from Confluent wire format payloads and call `ensure_schema_registered()` to populate the schema store

## Test plan

- [ ] Run Kafka Avro pipeline with Confluent Schema Registry and verify messages decode successfully
- [ ] Verify non-Avro formats (JSON, CSV) are unaffected (`as_any_mut` returns `None`)
- [ ] `cargo test -p laminar-connectors --features kafka`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Avro schema handling in Kafka connectors through pre-resolution of schemas from the Schema Registry. Schemas are now registered and resolved before batch deserialization operations occur, enabling improved early error detection and enhanced overall reliability when processing Avro-encoded messages from Kafka topics. This change strengthens schema management in production workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->