### PR TITLE
fix: defer Kafka sink Avro schema registration to first write

### DIFF
--- a/crates/laminar-connectors/src/kafka/sink.rs
+++ b/crates/laminar-connectors/src/kafka/sink.rs
@@ -216,33 +216,21 @@ impl KafkaSink {
         batch_schema: &SchemaRef,
     ) -> Result<(), ConnectorError> {
         let schema_changed = self.schema != *batch_schema;
-        if schema_changed {
-            debug!(
-                old = ?self.schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>(),
-                new = ?batch_schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>(),
-                "sink schema updated from incoming batch"
-            );
-            self.schema = batch_schema.clone();
-            self.serializer = select_serializer(
-                self.config.format,
-                &self.schema,
-                Arc::clone(&self.avro_schema_id),
-                self.schema_registry.clone(),
-            );
-        }
-
-        // Register on first write (schema_id still 0) or after schema change.
-        if self.config.format == Format::Avro
+        let needs_registration = self.config.format == Format::Avro
             && (schema_changed
                 || self
                     .avro_schema_id
                     .load(std::sync::atomic::Ordering::Relaxed)
-                    == 0)
-        {
+                    == 0);
+
+        // Register with SR *before* advancing schema/serializer so a failure
+        // doesn't leave avro_schema_id stale while the serializer already
+        // encodes with the new schema.
+        if needs_registration {
             if let Some(ref sr) = self.schema_registry {
                 let subject = format!("{}-value", self.config.topic);
                 let avro_schema =
-                    super::schema_registry::arrow_to_avro_schema(&self.schema, &self.config.topic)
+                    super::schema_registry::arrow_to_avro_schema(batch_schema, &self.config.topic)
                         .map_err(ConnectorError::Serde)?;
                 let schema_id = sr
                     .register_schema(
@@ -261,6 +249,21 @@ impl KafkaSink {
                     .store(schema_id as u32, std::sync::atomic::Ordering::Relaxed);
                 info!(subject = %subject, schema_id, "registered Avro schema");
             }
+        }
+
+        if schema_changed {
+            debug!(
+                old = ?self.schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>(),
+                new = ?batch_schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>(),
+                "sink schema updated from incoming batch"
+            );
+            self.schema = batch_schema.clone();
+            self.serializer = select_serializer(
+                self.config.format,
+                &self.schema,
+                Arc::clone(&self.avro_schema_id),
+                self.schema_registry.clone(),
+            );
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Kafka sink factory creates sinks with a placeholder `{key, value}` schema. Registering this during `open()` causes `write_batch()` to fail with "Schema of RecordBatch differs from Writer schema" because the actual pipeline output schema doesn't match.
- Moved Avro schema registration from `open()` to a lazy `ensure_schema_ready()` in `write_batch()` that fires on first write (`schema_id == 0`) or on schema change (evolution).
- Prevents the placeholder schema from polluting Schema Registry and breaking BACKWARD/FORWARD/FULL compatibility checks.

## Scenarios covered

| Scenario | Behavior |
|----------|----------|
| New topic | Schema registered on first `write_batch` with real pipeline schema |
| Existing topic | Same — real schema registered, SR deduplicates if unchanged |
| Schema evolution | `ensure_schema_ready` detects mismatch, re-registers new schema |
| DDL-provided schema (no mismatch) | `schema_id == 0` triggers registration on first write |
| No Schema Registry configured | Only serializer updated, no SR calls |

## Test plan

- [ ] Kafka source → `SELECT *` → Kafka sink with Avro format (the failing case from the bug report)
- [ ] Verify Schema Registry shows the correct schema, not the `{key, value}` placeholder
- [ ] Verify BACKWARD compatibility mode doesn't reject the real schema
- [ ] Verify schema evolution (add column to source) propagates to sink SR registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Avro Schema Registry registration is deferred until the first write and whenever the output schema changes, rather than happening eagerly on startup.
  * Each write now ensures the current batch schema is prepared and serializer updated before sending, preserving schema compatibility settings.
  * No public API or signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->