### PR TITLE
fix: wire delivery guarantee from config and close connector on restore failure

### DIFF
--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -137,6 +137,16 @@ impl LaminarDbBuilder {
         self
     }
 
+    /// Set the end-to-end delivery guarantee for the pipeline.
+    #[must_use]
+    pub fn delivery_guarantee(
+        mut self,
+        guarantee: laminar_connectors::connector::DeliveryGuarantee,
+    ) -> Self {
+        self.config.delivery_guarantee = guarantee;
+        self
+    }
+
     /// Register a custom scalar UDF with the database.
     ///
     /// The UDF will be available in SQL queries after `build()`.

--- a/crates/laminar-db/src/config.rs
+++ b/crates/laminar-db/src/config.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use laminar_connectors::connector::DeliveryGuarantee;
 use laminar_core::streaming::{BackpressureStrategy, StreamCheckpointConfig};
 
 /// SQL identifier case sensitivity mode.
@@ -118,6 +119,8 @@ pub struct LaminarConfig {
     pub tiering: Option<TieringConfig>,
     /// Thread-per-core runtime configuration (`None` = use tokio mode).
     pub tpc: Option<TpcRuntimeConfig>,
+    /// End-to-end delivery guarantee (default: at-least-once).
+    pub delivery_guarantee: DeliveryGuarantee,
 }
 
 impl Default for LaminarConfig {
@@ -132,6 +135,7 @@ impl Default for LaminarConfig {
             object_store_options: HashMap::new(),
             tiering: None,
             tpc: None,
+            delivery_guarantee: DeliveryGuarantee::default(),
         }
     }
 }

--- a/crates/laminar-db/src/pipeline/source_adapter.rs
+++ b/crates/laminar-db/src/pipeline/source_adapter.rs
@@ -267,6 +267,13 @@ fn source_io_main(
                             "[LDB-5030] source checkpoint restore failed under exactly-once \
                              — cannot guarantee delivery semantics"
                         );
+                        if let Err(close_err) = connector.close().await {
+                            tracing::warn!(
+                                source = %name,
+                                error = %close_err,
+                                "error closing connector after restore failure"
+                            );
+                        }
                         return None;
                     }
                     tracing::warn!(

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -793,7 +793,7 @@ impl LaminarDB {
                 std::time::Duration::ZERO
             },
             barrier_alignment_timeout: std::time::Duration::from_secs(30),
-            delivery_guarantee: laminar_connectors::connector::DeliveryGuarantee::default(),
+            delivery_guarantee: self.config.delivery_guarantee,
         };
 
         // Validate delivery guarantee constraints.


### PR DESCRIPTION
## Summary
- `delivery_guarantee` was hard-coded to `AtLeastOnce` in `pipeline_lifecycle.rs`, making all exactly-once validation and barrier-checkpoint code paths unreachable
- Added `delivery_guarantee` field to `LaminarConfig` and a builder method on `LaminarDbBuilder` so callers can select `ExactlyOnce`
- Wired `self.config.delivery_guarantee` through to `PipelineConfig` instead of `DeliveryGuarantee::default()`
- Fixed resource leak in `source_adapter.rs`: when `restore()` fails under exactly-once, the already-opened connector is now closed before returning

## Test plan
- [x] `cargo check -p laminar-db` passes
- [x] `cargo clippy -p laminar-db -- -D warnings` clean
- [x] `cargo test -p laminar-db --lib` — 495 tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo doc --no-deps -p laminar-db` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable delivery guarantees for database initialization, enabling exactly-once or at-least-once semantics based on application requirements.

* **Bug Fixes**
  * Improved resource cleanup and error handling during recovery failures in exactly-once delivery mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->