### PR TITLE
chore: bump version to 0.18.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "binance-ws"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arrow",
  "crossterm",
@@ -4337,7 +4337,7 @@ checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "laminar-connectors"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4472,7 +4472,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-storage"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "anyhow",
  "backoff",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "laminardb-demo"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "microstructure"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arrow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.18.6"
+version = "0.18.7"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,5 @@
 {
-  "latest_version": "0.18.6",
+  "latest_version": "0.18.7",
   "abi_version": 1,
   "released_at": "2026-03-16T09:33:51Z",
   "minimum_supported": "0.1.0",
@@ -10,5 +10,5 @@
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc"
   ],
-  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.6"
+  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.7"
 }

--- a/examples/binance-ws/Cargo.toml
+++ b/examples/binance-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-ws"
-version = "0.18.6"
+version = "0.18.7"
 edition = "2021"
 publish = false
 description = "Binance VWAP signals: minimal LaminarDB streaming example"
@@ -10,8 +10,8 @@ name = "binance-ws"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.6", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.6" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.7", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.7" }
 arrow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 crossterm = "0.29"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb-demo"
-version = "0.18.6"
+version = "0.18.7"
 edition = "2021"
 publish = false
 description = "Market Data Demo: Real-time analytics with Ratatui TUI for LaminarDB"
@@ -23,9 +23,9 @@ default = []
 kafka = ["laminar-db/kafka", "dep:rdkafka", "dep:serde", "dep:serde_json"]
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.6" }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.6" }
-laminar-core = { path = "../../crates/laminar-core", version = "0.18.6" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.7" }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.7" }
+laminar-core = { path = "../../crates/laminar-core", version = "0.18.7" }
 
 # Arrow
 arrow = { workspace = true }

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microstructure"
-version = "0.18.6"
+version = "0.18.7"
 edition = "2021"
 publish = false
 description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
@@ -10,8 +10,8 @@ name = "microstructure"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.6", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.6" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.7", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.7" }
 arrow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 crossterm = "0.29"


### PR DESCRIPTION
## Summary
- Bump workspace and example crate versions from 0.18.6 to 0.18.7
- Update `compatibility.json` (latest_version + download URL)
- Regenerate `Cargo.lock`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.18.7 across the workspace, updating the public release/compatibility metadata and synchronizing example package versions to match the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->