### PR TITLE
fix(connectors): PostgreSQL CDC production correctness fixes

### DIFF
--- a/crates/laminar-connectors/src/cdc/postgres/postgres_io.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/postgres_io.rs
@@ -185,7 +185,6 @@ fn validate_pg_identifier(value: &str, field: &str) -> Result<(), ConnectorError
 
 /// Builds the `START_REPLICATION` SQL command.
 ///
-/// This returns the query string to be sent via the `CopyBoth` protocol.
 /// Returns the query string to be sent via the `CopyBoth` protocol.
 ///
 /// # Errors

--- a/crates/laminar-connectors/src/cdc/postgres/source.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/source.rs
@@ -9,13 +9,11 @@
 //! - **Ring 1**: WAL consumption, pgoutput parsing, Arrow conversion
 //! - **Ring 2**: Slot management, schema discovery, health checks
 
-use std::collections::VecDeque;
-use std::sync::Arc;
-use std::time::Instant;
-
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::Arc;
 use tokio::sync::Notify;
 
 use crate::checkpoint::SourceCheckpoint;
@@ -75,9 +73,10 @@ pub struct PostgresCdcSource {
     /// Write LSN (latest position received from server).
     write_lsn: Lsn,
 
-    /// Last time a keepalive was received (used by production I/O path via `process_wal_payload`).
-    #[allow(dead_code)] // updated in process_wal_payload (feature = "postgres-cdc")
-    last_keepalive: Instant,
+    /// Polled LSN — tracks the latest position drained into a batch.
+    /// Decoupled from `confirmed_flush_lsn` so the PG replication slot
+    /// is only advanced when the pipeline actually checkpoints.
+    polled_lsn: Lsn,
 
     /// Pending WAL messages to process (for testing and batch processing).
     pending_messages: VecDeque<Vec<u8>>,
@@ -100,13 +99,17 @@ pub struct PostgresCdcSource {
     /// Shutdown signal for the background reader task.
     #[cfg(feature = "postgres-cdc")]
     reader_shutdown: Option<tokio::sync::watch::Sender<bool>>,
+
+    /// Sender for feeding confirmed flush LSN back to the reader task.
+    /// The reader uses this to call `update_applied_lsn` only for
+    /// durably-checkpointed positions (prevents at-least-once violation).
+    #[cfg(feature = "postgres-cdc")]
+    confirmed_lsn_tx: Option<tokio::sync::watch::Sender<u64>>,
 }
 
 /// In-progress transaction state.
 #[derive(Debug, Clone)]
 struct TransactionState {
-    /// Transaction ID.
-    _xid: u32,
     /// Final LSN of the transaction.
     final_lsn: Lsn,
     /// Commit timestamp in milliseconds.
@@ -135,6 +138,8 @@ enum WalPayload {
     KeepAlive {
         wal_end: u64,
     },
+    /// Fatal error from the reader task (e.g. reconnect exhaustion).
+    Error(String),
 }
 
 impl PostgresCdcSource {
@@ -151,7 +156,7 @@ impl PostgresCdcSource {
             current_txn: None,
             confirmed_flush_lsn: Lsn::ZERO,
             write_lsn: Lsn::ZERO,
-            last_keepalive: Instant::now(),
+            polled_lsn: Lsn::ZERO,
             pending_messages: VecDeque::new(),
             data_ready: Arc::new(Notify::new()),
             #[cfg(feature = "postgres-cdc")]
@@ -162,6 +167,8 @@ impl PostgresCdcSource {
             reader_handle: None,
             #[cfg(feature = "postgres-cdc")]
             reader_shutdown: None,
+            #[cfg(feature = "postgres-cdc")]
+            confirmed_lsn_tx: None,
         }
     }
 
@@ -239,7 +246,6 @@ impl PostgresCdcSource {
         match msg {
             WalMessage::Begin(begin) => {
                 self.current_txn = Some(TransactionState {
-                    _xid: begin.xid,
                     final_lsn: begin.final_lsn,
                     commit_ts_ms: begin.commit_ts_ms,
                     events: Vec::new(),
@@ -247,10 +253,7 @@ impl PostgresCdcSource {
             }
             WalMessage::Commit(commit) => {
                 if let Some(txn) = self.current_txn.take() {
-                    // Flush transaction events to the output buffer
-                    for event in txn.events {
-                        self.event_buffer.push_back(event);
-                    }
+                    self.event_buffer.extend(txn.events);
                     self.write_lsn = commit.end_lsn;
                     self.metrics.record_transaction();
                     self.metrics
@@ -276,8 +279,24 @@ impl PostgresCdcSource {
             WalMessage::Delete(del) => {
                 self.process_delete(del.relation_id, &del.old_tuple)?;
             }
-            WalMessage::Truncate(_) | WalMessage::Origin(_) | WalMessage::Type(_) => {
-                // Truncate, Origin, and Type messages are noted but don't
+            WalMessage::Truncate(trunc) => {
+                let table_names: Vec<String> = trunc
+                    .relation_ids
+                    .iter()
+                    .map(|id| {
+                        self.relation_cache
+                            .get(*id)
+                            .map_or_else(|| format!("oid:{id}"), RelationInfo::full_name)
+                    })
+                    .collect();
+                return Err(ConnectorError::ReadError(format!(
+                    "TRUNCATE received on table(s): {}. \
+                     Cannot produce retraction events — restart the pipeline with a fresh snapshot.",
+                    table_names.join(", ")
+                )));
+            }
+            WalMessage::Origin(_) | WalMessage::Type(_) => {
+                // Origin and Type messages are noted but don't
                 // produce change events in the current implementation.
             }
         }
@@ -289,14 +308,14 @@ impl PostgresCdcSource {
         relation_id: u32,
         new_tuple: &super::decoder::TupleData,
     ) -> Result<(), ConnectorError> {
-        let relation = self.get_relation(relation_id)?;
+        let relation = self.require_relation(relation_id)?;
         let table = relation.full_name();
 
         if !self.config.should_include_table(&table) {
             return Ok(());
         }
 
-        let after_json = tuple_to_json(new_tuple, &relation);
+        let after_json = tuple_to_json(new_tuple, relation);
         let (lsn, ts_ms) = self.current_txn_context();
 
         let event = ChangeEvent {
@@ -319,15 +338,15 @@ impl PostgresCdcSource {
         old_tuple: Option<&super::decoder::TupleData>,
         new_tuple: &super::decoder::TupleData,
     ) -> Result<(), ConnectorError> {
-        let relation = self.get_relation(relation_id)?;
+        let relation = self.require_relation(relation_id)?;
         let table = relation.full_name();
 
         if !self.config.should_include_table(&table) {
             return Ok(());
         }
 
-        let before_json = old_tuple.map(|t| tuple_to_json(t, &relation));
-        let after_json = tuple_to_json(new_tuple, &relation);
+        let before_json = old_tuple.map(|t| tuple_to_json(t, relation));
+        let after_json = tuple_to_json(new_tuple, relation);
         let (lsn, ts_ms) = self.current_txn_context();
 
         let event = ChangeEvent {
@@ -349,14 +368,14 @@ impl PostgresCdcSource {
         relation_id: u32,
         old_tuple: &super::decoder::TupleData,
     ) -> Result<(), ConnectorError> {
-        let relation = self.get_relation(relation_id)?;
+        let relation = self.require_relation(relation_id)?;
         let table = relation.full_name();
 
         if !self.config.should_include_table(&table) {
             return Ok(());
         }
 
-        let before_json = tuple_to_json(old_tuple, &relation);
+        let before_json = tuple_to_json(old_tuple, relation);
         let (lsn, ts_ms) = self.current_txn_context();
 
         let event = ChangeEvent {
@@ -373,15 +392,17 @@ impl PostgresCdcSource {
         Ok(())
     }
 
-    fn get_relation(&self, relation_id: u32) -> Result<RelationInfo, ConnectorError> {
-        self.relation_cache
-            .get(relation_id)
-            .cloned()
-            .ok_or_else(|| {
-                ConnectorError::ReadError(format!(
-                    "unknown relation ID {relation_id} (no Relation message received yet)"
-                ))
-            })
+    /// Looks up a relation by ID, returning a reference (no clone).
+    ///
+    /// The caller must extract all needed data (table name, JSON) from
+    /// the reference before calling `push_event` or other `&mut self`
+    /// methods (Rust's borrow rules require disjoint access).
+    fn require_relation(&self, relation_id: u32) -> Result<&RelationInfo, ConnectorError> {
+        self.relation_cache.get(relation_id).ok_or_else(|| {
+            ConnectorError::ReadError(format!(
+                "unknown relation ID {relation_id} (no Relation message received yet)"
+            ))
+        })
     }
 
     fn current_txn_context(&self) -> (Lsn, i64) {
@@ -445,9 +466,9 @@ impl PostgresCdcSource {
             }
             WalPayload::KeepAlive { wal_end } => {
                 self.write_lsn = Lsn::new(wal_end);
-                self.last_keepalive = Instant::now();
                 Ok(())
             }
+            WalPayload::Error(msg) => Err(ConnectorError::ReadError(msg)),
         }
     }
 
@@ -483,6 +504,7 @@ impl SourceConnector for PostgresCdcSource {
         if let Some(lsn) = self.config.start_lsn {
             self.confirmed_flush_lsn = lsn;
             self.write_lsn = lsn;
+            self.polled_lsn = lsn;
         }
 
         // Without postgres-cdc feature, open() must fail loudly to prevent
@@ -517,6 +539,7 @@ impl SourceConnector for PostgresCdcSource {
                 if let Some(lsn) = slot_lsn {
                     self.confirmed_flush_lsn = lsn;
                     self.write_lsn = lsn;
+                    self.polled_lsn = lsn;
                 }
             }
 
@@ -537,78 +560,142 @@ impl SourceConnector for PostgresCdcSource {
             // Spawn background reader task for event-driven wake-up.
             let (wal_tx, wal_rx) = tokio::sync::mpsc::channel(4096);
             let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+            let (confirmed_lsn_tx, mut confirmed_lsn_rx) =
+                tokio::sync::watch::channel(self.confirmed_flush_lsn.as_u64());
             let data_ready = Arc::clone(&self.data_ready);
+            let reader_config = self.config.clone();
 
             let reader_handle = tokio::spawn(async move {
+                const MAX_FAILURES: u32 = 10;
                 let mut repl_client = repl_client;
-                loop {
-                    tokio::select! {
-                        biased;
-                        _ = shutdown_rx.changed() => break,
-                        event = repl_client.recv() => {
-                            match event {
-                                Ok(Some(event)) => {
-                                    let payload = match &event {
-                                        pgwire_replication::ReplicationEvent::Begin {
-                                            final_lsn,
-                                            xid,
-                                            commit_time_micros,
-                                        } => Some(WalPayload::Begin {
-                                            final_lsn: final_lsn.as_u64(),
-                                            commit_ts_us: *commit_time_micros,
-                                            xid: *xid,
-                                        }),
-                                        pgwire_replication::ReplicationEvent::Commit {
-                                            end_lsn,
-                                            commit_time_micros,
-                                            lsn,
-                                        } => {
-                                            repl_client.update_applied_lsn(*end_lsn);
-                                            Some(WalPayload::Commit {
+                let mut consecutive_failures: u32 = 0;
+
+                'reconnect: loop {
+                    // Inner recv loop — processes events from the current connection.
+                    'recv: loop {
+                        // Feed back confirmed LSN to PG (non-blocking check).
+                        // Only positions that the main thread has checkpointed
+                        // are reported as "applied", preserving at-least-once.
+                        if confirmed_lsn_rx.has_changed().unwrap_or(false) {
+                            let confirmed = *confirmed_lsn_rx.borrow_and_update();
+                            if confirmed > 0 {
+                                repl_client.update_applied_lsn(pgwire_replication::Lsn::from_u64(
+                                    confirmed,
+                                ));
+                            }
+                        }
+
+                        tokio::select! {
+                            biased;
+                            _ = shutdown_rx.changed() => break 'reconnect,
+                            event = repl_client.recv() => {
+                                match event {
+                                    Ok(Some(event)) => {
+                                        consecutive_failures = 0;
+                                        let payload = match &event {
+                                            pgwire_replication::ReplicationEvent::Begin {
+                                                final_lsn,
+                                                xid,
+                                                commit_time_micros,
+                                            } => Some(WalPayload::Begin {
+                                                final_lsn: final_lsn.as_u64(),
+                                                commit_ts_us: *commit_time_micros,
+                                                xid: *xid,
+                                            }),
+                                            pgwire_replication::ReplicationEvent::Commit {
+                                                end_lsn,
+                                                commit_time_micros,
+                                                lsn,
+                                            } => Some(WalPayload::Commit {
                                                 end_lsn: end_lsn.as_u64(),
                                                 commit_ts_us: *commit_time_micros,
                                                 lsn: lsn.as_u64(),
-                                            })
+                                            }),
+                                            pgwire_replication::ReplicationEvent::XLogData {
+                                                wal_end,
+                                                data,
+                                                ..
+                                            } => Some(WalPayload::XLogData {
+                                                wal_end: wal_end.as_u64(),
+                                                data: data.to_vec(),
+                                            }),
+                                            pgwire_replication::ReplicationEvent::KeepAlive {
+                                                wal_end,
+                                                ..
+                                            } => Some(WalPayload::KeepAlive {
+                                                wal_end: wal_end.as_u64(),
+                                            }),
+                                            _ => None,
+                                        };
+                                        if let Some(p) = payload {
+                                            if wal_tx.send(p).await.is_err() {
+                                                break 'reconnect;
+                                            }
+                                            data_ready.notify_one();
                                         }
-                                        pgwire_replication::ReplicationEvent::XLogData {
-                                            wal_end,
-                                            data,
-                                            ..
-                                        } => Some(WalPayload::XLogData {
-                                            wal_end: wal_end.as_u64(),
-                                            data: data.to_vec(),
-                                        }),
-                                        pgwire_replication::ReplicationEvent::KeepAlive {
-                                            wal_end,
-                                            ..
-                                        } => Some(WalPayload::KeepAlive {
-                                            wal_end: wal_end.as_u64(),
-                                        }),
-                                        _ => None,
-                                    };
-                                    if let Some(p) = payload {
-                                        if wal_tx.send(p).await.is_err() {
-                                            break;
-                                        }
-                                        data_ready.notify_one();
                                     }
-                                }
-                                Ok(None) => break,
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "WAL reader error");
-                                    break;
+                                    Ok(None) => break 'recv,
+                                    Err(e) => {
+                                        tracing::error!(error = %e, "WAL reader error");
+                                        break 'recv;
+                                    }
                                 }
                             }
                         }
                     }
+
+                    // Shut down old client before reconnecting.
+                    let _ = repl_client.shutdown().await;
+                    consecutive_failures += 1;
+
+                    if consecutive_failures >= MAX_FAILURES {
+                        tracing::error!(
+                            failures = consecutive_failures,
+                            "WAL reader exhausted reconnect attempts"
+                        );
+                        let _ = wal_tx.send(WalPayload::Error(format!(
+                            "WAL reader failed after {consecutive_failures} consecutive reconnect attempts"
+                        ))).await;
+                        data_ready.notify_one();
+                        break 'reconnect;
+                    }
+
+                    // Exponential backoff: 2^n seconds, capped at 30s.
+                    let backoff_secs = (1u64 << consecutive_failures).min(30);
+                    tracing::warn!(
+                        attempt = consecutive_failures,
+                        backoff_secs,
+                        "WAL reader reconnecting"
+                    );
+                    tokio::select! {
+                        biased;
+                        _ = shutdown_rx.changed() => break 'reconnect,
+                        () = tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)) => {}
+                    }
+
+                    // Rebuild replication config with resume LSN from checkpoint.
+                    let resume_lsn = *confirmed_lsn_rx.borrow();
+                    let mut new_config = postgres_io::build_replication_config(&reader_config);
+                    if resume_lsn > 0 {
+                        new_config.start_lsn = pgwire_replication::Lsn::from_u64(resume_lsn);
+                    }
+
+                    match pgwire_replication::ReplicationClient::connect(new_config).await {
+                        Ok(new_client) => {
+                            tracing::info!("WAL reader reconnected");
+                            repl_client = new_client;
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "WAL reader reconnect failed");
+                        }
+                    }
                 }
-                let _ = repl_client.shutdown().await;
             });
 
             self.wal_rx = Some(wal_rx);
             self.reader_handle = Some(reader_handle);
             self.reader_shutdown = Some(shutdown_tx);
-            self.last_keepalive = Instant::now();
+            self.confirmed_lsn_tx = Some(confirmed_lsn_tx);
         }
 
         self.state = ConnectorState::Running;
@@ -627,15 +714,33 @@ impl SourceConnector for PostgresCdcSource {
         }
 
         // Drain WAL events from background reader task.
+        // Collect into a temp vec first to avoid holding a mutable
+        // borrow on self.wal_rx while calling self.process_wal_payload().
         #[cfg(feature = "postgres-cdc")]
-        if let Some(mut rx) = self.wal_rx.take() {
-            while self.event_buffer.len() < max_records {
-                match rx.try_recv() {
-                    Ok(payload) => self.process_wal_payload(payload)?,
-                    Err(_) => break,
+        {
+            let mut payloads = Vec::new();
+            let mut reader_closed = false;
+            if let Some(ref mut rx) = self.wal_rx {
+                while payloads.len() + self.event_buffer.len() < max_records {
+                    match rx.try_recv() {
+                        Ok(payload) => payloads.push(payload),
+                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                            reader_closed = true;
+                            break;
+                        }
+                    }
                 }
             }
-            self.wal_rx = Some(rx);
+            for payload in payloads {
+                self.process_wal_payload(payload)?;
+            }
+            if reader_closed && self.event_buffer.is_empty() {
+                self.state = ConnectorState::Failed;
+                return Err(ConnectorError::ReadError(
+                    "WAL reader task terminated unexpectedly — replication stream lost".to_string(),
+                ));
+            }
         }
 
         // Process any pending WAL messages (test injection path)
@@ -649,6 +754,16 @@ impl SourceConnector for PostgresCdcSource {
         // windowed aggregations that depend on CDC event time.
         match self.drain_events(max_records)? {
             Some(batch) => {
+                // Advance polled_lsn (NOT confirmed_flush_lsn). PG slot
+                // feedback happens in checkpoint(), not here.
+                if self.event_buffer.is_empty() {
+                    self.polled_lsn = self.write_lsn;
+                }
+                self.metrics
+                    .set_confirmed_flush_lsn(self.confirmed_flush_lsn.as_u64());
+                self.metrics
+                    .set_replication_lag_bytes(self.replication_lag_bytes());
+
                 let lsn_str = self.write_lsn.to_string();
                 let partition = PartitionInfo::new(&self.config.slot_name, lsn_str);
                 Ok(Some(SourceBatch::with_partition(batch, partition)))
@@ -663,10 +778,21 @@ impl SourceConnector for PostgresCdcSource {
 
     fn checkpoint(&self) -> SourceCheckpoint {
         let mut cp = SourceCheckpoint::new(0);
-        cp.set_offset("lsn", self.confirmed_flush_lsn.to_string());
+        // polled_lsn = latest position drained into a batch. The PG
+        // slot is only advanced here (not in poll_batch) to prevent
+        // data loss on crash.
+        cp.set_offset("lsn", self.polled_lsn.to_string());
         cp.set_offset("write_lsn", self.write_lsn.to_string());
         cp.set_metadata("slot_name", &self.config.slot_name);
         cp.set_metadata("publication", &self.config.publication);
+
+        // Feed polled LSN to reader task so PG can reclaim WAL.
+        // watch::Sender::send is &self, so this works from checkpoint().
+        #[cfg(feature = "postgres-cdc")]
+        if let Some(ref tx) = self.confirmed_lsn_tx {
+            let _ = tx.send(self.polled_lsn.as_u64());
+        }
+
         cp
     }
 
@@ -676,6 +802,7 @@ impl SourceConnector for PostgresCdcSource {
                 ConnectorError::CheckpointError(format!("invalid LSN in checkpoint: {e}"))
             })?;
             self.confirmed_flush_lsn = lsn;
+            self.polled_lsn = lsn;
             self.metrics.set_confirmed_flush_lsn(lsn.as_u64());
         }
         if let Some(write_lsn_str) = checkpoint.get_offset("write_lsn") {
@@ -721,6 +848,7 @@ impl SourceConnector for PostgresCdcSource {
                 let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
             }
             self.wal_rx = None;
+            self.confirmed_lsn_tx = None;
         }
 
         // Abort the background control-plane connection task.
@@ -823,6 +951,17 @@ impl PostgresCdcSource {
                 }
                 None => buf.push(b'n'),
             }
+        }
+        buf
+    }
+
+    /// Builds a binary pgoutput Truncate message for testing.
+    fn build_truncate_message(relation_ids: &[u32], options: u8) -> Vec<u8> {
+        let mut buf = vec![b'T'];
+        buf.extend_from_slice(&(relation_ids.len() as i32).to_be_bytes());
+        buf.push(options);
+        for id in relation_ids {
+            buf.extend_from_slice(&id.to_be_bytes());
         }
         buf
     }
@@ -951,6 +1090,7 @@ mod tests {
     fn test_checkpoint() {
         let mut src = default_source();
         src.confirmed_flush_lsn = "1/ABCD".parse().unwrap();
+        src.polled_lsn = "1/ABCD".parse().unwrap();
         src.write_lsn = "1/ABCE".parse().unwrap();
 
         let cp = src.checkpoint();
@@ -1410,5 +1550,100 @@ mod tests {
 
         let _ = src.poll_batch(100).await;
         assert_eq!(src.write_lsn().as_u64(), 0x500);
+    }
+
+    // ── TRUNCATE returns error ──
+
+    #[tokio::test]
+    async fn test_truncate_returns_error() {
+        let mut src = running_source();
+
+        // Register relation so the error message includes the table name.
+        src.enqueue_wal_data(PostgresCdcSource::build_relation_message(
+            16384,
+            "public",
+            "users",
+            &[(1, "id", INT8_OID, -1)],
+        ));
+
+        src.enqueue_wal_data(PostgresCdcSource::build_begin_message(0x100, 0, 1));
+        src.enqueue_wal_data(PostgresCdcSource::build_truncate_message(&[16384], 0));
+
+        let result = src.poll_batch(100).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("TRUNCATE"),
+            "error should mention TRUNCATE: {err}"
+        );
+        assert!(
+            err.contains("users"),
+            "error should mention table name: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_truncate_unknown_relation_uses_oid() {
+        let mut src = running_source();
+
+        // No relation registered for ID 99999
+        src.enqueue_wal_data(PostgresCdcSource::build_begin_message(0x100, 0, 1));
+        src.enqueue_wal_data(PostgresCdcSource::build_truncate_message(&[99999], 0));
+
+        let result = src.poll_batch(100).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("oid:99999"), "error should mention oid: {err}");
+    }
+
+    // ── confirmed_flush_lsn not advanced until checkpoint ──
+
+    #[tokio::test]
+    async fn test_confirmed_lsn_not_advanced_until_checkpoint() {
+        let mut src = running_source();
+
+        src.enqueue_wal_data(PostgresCdcSource::build_relation_message(
+            100,
+            "public",
+            "t",
+            &[(1, "id", INT4_OID, -1)],
+        ));
+
+        src.enqueue_wal_data(PostgresCdcSource::build_begin_message(0x100, 0, 1));
+        src.enqueue_wal_data(PostgresCdcSource::build_insert_message(100, &[Some("1")]));
+        src.enqueue_wal_data(PostgresCdcSource::build_commit_message(0x100, 0x500, 0));
+
+        // Before poll: confirmed_flush_lsn is ZERO.
+        assert!(src.confirmed_flush_lsn().is_zero());
+
+        // After poll: confirmed_flush_lsn must NOT have advanced.
+        let _ = src.poll_batch(100).await.unwrap().unwrap();
+        assert!(
+            src.confirmed_flush_lsn().is_zero(),
+            "confirmed_flush_lsn should not advance on poll, got {}",
+            src.confirmed_flush_lsn()
+        );
+
+        // polled_lsn should have advanced.
+        assert_eq!(src.polled_lsn.as_u64(), 0x500);
+
+        // After checkpoint: the checkpoint offset should use polled_lsn.
+        let cp = src.checkpoint();
+        assert_eq!(cp.get_offset("lsn"), Some("0/500"));
+    }
+
+    // ── Restore sets polled_lsn ──
+
+    #[tokio::test]
+    async fn test_restore_sets_polled_lsn() {
+        let mut src = default_source();
+        let mut cp = SourceCheckpoint::new(1);
+        cp.set_offset("lsn", "2/FF00");
+        cp.set_offset("write_lsn", "2/FF10");
+
+        src.restore(&cp).await.unwrap();
+        assert_eq!(src.confirmed_flush_lsn.as_u64(), 0x2_0000_FF00);
+        assert_eq!(src.polled_lsn.as_u64(), 0x2_0000_FF00);
+        assert_eq!(src.write_lsn.as_u64(), 0x2_0000_FF10);
     }
 }


### PR DESCRIPTION
## Summary

- **CRITICAL**: Decouple `polled_lsn` from `confirmed_flush_lsn` so the PG replication slot only advances at checkpoint time, not poll time. Previously a crash after poll but before checkpoint lost data.
- **TRUNCATE** messages now return an error instead of being silently discarded (full-table retraction requires a snapshot, not yet implemented).
- **Reader error propagation**: `WalPayload::Error` variant lets the reader task surface fatal errors to `poll_batch()` instead of silently dying.
- **Reconnect/retry** in WAL reader task: exponential backoff (2^n sec, cap 30s, max 10 attempts), resume from confirmed LSN, clean shutdown via `tokio::select!`.
- Remove duplicate doc line in `postgres_io.rs`.

## Test plan

- [x] `cargo check -p laminar-connectors`
- [x] `cargo clippy -p laminar-connectors -- -D warnings`
- [x] `cargo test -p laminar-connectors --lib` (492 pass)
- [x] `cargo fmt -- --check`
- [x] `cargo doc -p laminar-connectors --no-deps` (no warnings)
- [ ] New tests: `test_truncate_returns_error`, `test_truncate_unknown_relation_uses_oid`, `test_confirmed_lsn_not_advanced_until_checkpoint`, `test_restore_sets_polled_lsn` (require `postgres-cdc` feature to run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer TRUNCATE error messages listing affected tables (or OIDs) and improved propagation of fatal reader errors.
  * WAL slot advancement now aligns more reliably with checkpoint boundaries and batch processing.

* **Tests**
  * Expanded tests for TRUNCATE scenarios and LSN/checkpoint behavior.

* **Documentation**
  * Minor clarification in inline documentation.

* **Behavior**
  * Reduced unnecessary data cloning during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->