### PR TITLE
fix(connectors): Delta Lake sink/source production hardening

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.18.7"
+version = "0.18.8"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,5 @@
 {
-  "latest_version": "0.18.7",
+  "latest_version": "0.18.8",
   "abi_version": 1,
   "released_at": "2026-03-17T08:43:20Z",
   "minimum_supported": "0.1.0",
@@ -10,5 +10,5 @@
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc"
   ],
-  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.7"
+  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.8"
 }

--- a/crates/laminar-connectors/src/lakehouse/delta.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta.rs
@@ -123,6 +123,11 @@ pub struct DeltaLakeSink {
     /// Handle for the background compaction task.
     #[cfg(feature = "delta-lake")]
     compaction_handle: Option<tokio::task::JoinHandle<()>>,
+    /// When true, Delta table init is deferred until the first `write_batch()`
+    /// provides a schema. This happens when Unity Catalog auto-create is
+    /// configured but the pipeline schema is not yet available at `open()` time.
+    #[cfg(feature = "delta-lake")]
+    needs_deferred_delta_init: bool,
 }
 
 impl DeltaLakeSink {
@@ -156,6 +161,8 @@ impl DeltaLakeSink {
             compaction_cancel: None,
             #[cfg(feature = "delta-lake")]
             compaction_handle: None,
+            #[cfg(feature = "delta-lake")]
+            needs_deferred_delta_init: false,
         }
     }
 
@@ -165,6 +172,100 @@ impl DeltaLakeSink {
         let mut sink = Self::new(config);
         sink.schema = Some(schema);
         sink
+    }
+
+    /// Initializes the Delta table: auto-creates in Unity Catalog if needed,
+    /// resolves the catalog path, opens or creates the Delta table, and spawns
+    /// the compaction loop. Called from `open()` or deferred to the first
+    /// `write_batch()` when the schema is not yet available at open time.
+    #[cfg(feature = "delta-lake")]
+    async fn init_delta_table(&mut self) -> Result<(), ConnectorError> {
+        use super::delta_io;
+
+        // For uc:// tables, pre-create in Unity Catalog if needed.
+        // Must run before resolve_catalog_options which calls GET on the table.
+        #[cfg(feature = "delta-lake-unity")]
+        ensure_uc_table_exists(&self.config, self.schema.as_ref()).await?;
+
+        // Resolve catalog path: for Unity this calls GET to get the
+        // storage_location, bypassing delta-rs credential vending.
+        let (resolved_path, merged_options) = delta_io::resolve_catalog_options(
+            &self.config.catalog_type,
+            self.config.catalog_database.as_deref(),
+            self.config.catalog_name.as_deref(),
+            self.config.catalog_schema.as_deref(),
+            &self.config.table_path,
+            &self.config.storage_options,
+        )
+        .await?;
+
+        // Inject default connection timeouts if not explicitly set.
+        // Azure load balancers close idle connections after ~4 minutes.
+        // Without these, a stale connection causes writes to hang forever.
+        let mut merged_options = merged_options;
+        merged_options
+            .entry("timeout".to_string())
+            .or_insert_with(|| "120s".to_string());
+        merged_options
+            .entry("connect_timeout".to_string())
+            .or_insert_with(|| "30s".to_string());
+        merged_options
+            .entry("pool_idle_timeout".to_string())
+            .or_insert_with(|| "60s".to_string());
+
+        // Persist resolved values for reopen_table() on conflict retry.
+        self.resolved_table_path.clone_from(&resolved_path);
+        self.resolved_storage_options.clone_from(&merged_options);
+
+        let table = delta_io::open_or_create_table(
+            &resolved_path,
+            merged_options.clone(),
+            self.schema.as_ref(),
+        )
+        .await?;
+
+        // Read schema from existing table if we don't have one.
+        if self.schema.is_none() {
+            if let Ok(schema) = delta_io::get_table_schema(&table) {
+                self.schema = Some(schema);
+            }
+        }
+
+        // Resolve last committed epoch for exactly-once recovery.
+        if self.config.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+            self.last_committed_epoch =
+                delta_io::get_last_committed_epoch(&table, &self.config.writer_id).await;
+            if self.last_committed_epoch > 0 {
+                info!(
+                    writer_id = %self.config.writer_id,
+                    last_committed_epoch = self.last_committed_epoch,
+                    "recovered last committed epoch from Delta Lake txn metadata"
+                );
+            }
+        }
+
+        // Store the Delta version.
+        #[allow(clippy::cast_sign_loss)]
+        {
+            self.delta_version = table.version().unwrap_or(0) as u64;
+        }
+        self.table = Some(table);
+
+        // Spawn background compaction task if enabled.
+        if self.config.compaction.enabled {
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let handle = tokio::spawn(compaction_loop(
+                resolved_path.clone(),
+                Arc::new(merged_options),
+                self.config.compaction.clone(),
+                self.config.vacuum_retention,
+                cancel.clone(),
+            ));
+            self.compaction_cancel = Some(cancel);
+            self.compaction_handle = Some(handle);
+        }
+
+        Ok(())
     }
 
     /// Returns the current connector state.
@@ -349,6 +450,11 @@ impl DeltaLakeSink {
                 Some(self.config.partition_columns.as_slice())
             };
 
+            // Create a Delta Lake checkpoint every N commits for read performance.
+            let should_checkpoint = self.config.checkpoint_interval > 0
+                && self.delta_version > 0
+                && (self.delta_version + 1).is_multiple_of(self.config.checkpoint_interval);
+
             super::delta_io::write_batches(
                 table,
                 batches,
@@ -357,6 +463,8 @@ impl DeltaLakeSink {
                 save_mode,
                 partition_cols,
                 self.config.schema_evolution,
+                Some(self.config.target_file_size),
+                should_checkpoint,
             )
             .await
             .map(|(t, _version)| t)
@@ -396,7 +504,25 @@ impl DeltaLakeSink {
                     actual: "table not initialized".into(),
                 })?;
 
-            match self.attempt_delta_write(table).await {
+            // Timeout the write to prevent hanging on stale connections.
+            // Azure LB drops idle connections after ~4 min; without this,
+            // a dead connection blocks the sink task forever.
+            let write_result = tokio::time::timeout(
+                std::time::Duration::from_secs(300),
+                self.attempt_delta_write(table),
+            )
+            .await;
+
+            // Convert timeout to a write error. The table handle was consumed
+            // by attempt_delta_write; the retry loop will reopen via reopen_table().
+            let write_result = match write_result {
+                Ok(inner) => inner,
+                Err(_elapsed) => Err(ConnectorError::WriteError(
+                    "Delta write timed out after 300s".into(),
+                )),
+            };
+
+            match write_result {
                 Ok(table) => {
                     // ── Success: commit state ──
                     #[allow(clippy::cast_sign_loss)]
@@ -500,7 +626,7 @@ impl DeltaLakeSink {
                 ConnectorError::ConfigurationError("'_op' column must be String (Utf8) type".into())
             })?;
 
-        // Build boolean masks (compact bit-buffers, no per-element heap allocation).
+        // Build boolean masks for insert vs delete rows.
         let len = op_array.len();
         let mut insert_mask = Vec::with_capacity(len);
         let mut delete_mask = Vec::with_capacity(len);
@@ -706,80 +832,28 @@ impl SinkConnector for DeltaLakeSink {
         );
 
         // When delta-lake feature is enabled, open/create the actual table.
+        // If Unity Catalog auto-create is configured but no schema is available
+        // yet, defer initialization to the first write_batch() call.
         #[cfg(feature = "delta-lake")]
         {
-            use super::delta_io;
+            let should_defer = matches!(
+                self.config.catalog_type,
+                super::delta_config::DeltaCatalogType::Unity { .. }
+            ) && self.config.catalog_storage_location.is_some()
+                && self.schema.is_none();
 
-            // For uc:// tables, pre-create in Unity Catalog if needed.
-            // Must run before resolve_catalog_options which calls GET on the table.
-            #[cfg(feature = "delta-lake-unity")]
-            ensure_uc_table_exists(&self.config, self.schema.as_ref()).await?;
-
-            // Resolve catalog path: for Unity this calls GET to get the
-            // storage_location, bypassing delta-rs credential vending.
-            let (resolved_path, merged_options) = delta_io::resolve_catalog_options(
-                &self.config.catalog_type,
-                self.config.catalog_database.as_deref(),
-                self.config.catalog_name.as_deref(),
-                self.config.catalog_schema.as_deref(),
-                &self.config.table_path,
-                &self.config.storage_options,
-            )
-            .await?;
-
-            // Persist resolved values for reopen_table() on conflict retry.
-            self.resolved_table_path.clone_from(&resolved_path);
-            self.resolved_storage_options.clone_from(&merged_options);
-
-            let table = delta_io::open_or_create_table(
-                &resolved_path,
-                merged_options.clone(),
-                self.schema.as_ref(),
-            )
-            .await?;
-
-            // Read schema from existing table if we don't have one.
-            if self.schema.is_none() {
-                if let Ok(schema) = delta_io::get_table_schema(&table) {
-                    self.schema = Some(schema);
-                }
+            if should_defer {
+                info!(
+                    "Unity Catalog auto-create configured but pipeline schema not yet \
+                     available — deferring Delta table init to first begin_epoch"
+                );
+                self.needs_deferred_delta_init = true;
+                // Stay in Initializing until init completes in begin_epoch().
+                self.state = ConnectorState::Initializing;
+                return Ok(());
             }
 
-            // Resolve last committed epoch for exactly-once recovery.
-            if self.config.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
-                self.last_committed_epoch =
-                    delta_io::get_last_committed_epoch(&table, &self.config.writer_id).await;
-                if self.last_committed_epoch > 0 {
-                    info!(
-                        writer_id = %self.config.writer_id,
-                        last_committed_epoch = self.last_committed_epoch,
-                        "recovered last committed epoch from Delta Lake txn metadata"
-                    );
-                }
-            }
-
-            // Store the Delta version.
-            // Note: Delta Lake uses i64 for version, but our version is u64.
-            // Versions are always non-negative, so this is safe.
-            #[allow(clippy::cast_sign_loss)]
-            {
-                self.delta_version = table.version().unwrap_or(0) as u64;
-            }
-            self.table = Some(table);
-
-            // Spawn background compaction task if enabled.
-            if self.config.compaction.enabled {
-                let cancel = tokio_util::sync::CancellationToken::new();
-                let handle = tokio::spawn(compaction_loop(
-                    resolved_path.clone(),
-                    Arc::new(merged_options),
-                    self.config.compaction.clone(),
-                    self.config.vacuum_retention,
-                    cancel.clone(),
-                ));
-                self.compaction_cancel = Some(cancel);
-                self.compaction_handle = Some(handle);
-            }
+            self.init_delta_table().await?;
         }
 
         #[cfg(not(feature = "delta-lake"))]
@@ -801,7 +875,8 @@ impl SinkConnector for DeltaLakeSink {
     }
 
     async fn write_batch(&mut self, batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
-        if self.state != ConnectorState::Running {
+        // Accept both Running and Initializing (deferred init in progress).
+        if self.state != ConnectorState::Running && self.state != ConnectorState::Initializing {
             return Err(ConnectorError::InvalidState {
                 expected: "Running".into(),
                 actual: self.state.to_string(),
@@ -820,6 +895,25 @@ impl SinkConnector for DeltaLakeSink {
         // (_op, _ts_ms) so the Delta table isn't created with changelog columns.
         if self.schema.is_none() {
             self.schema = Some(Self::target_schema(&batch.schema(), self.config.write_mode));
+        }
+
+        // Fallback for deferred init: if begin_epoch() couldn't complete
+        // init (schema was still None), complete it now that the first
+        // batch provides a schema.
+        #[cfg(feature = "delta-lake")]
+        if self.needs_deferred_delta_init {
+            info!("schema now available from first batch — completing deferred Delta table init");
+            match self.init_delta_table().await {
+                Ok(()) => {
+                    self.needs_deferred_delta_init = false;
+                    self.state = ConnectorState::Running;
+                    info!("Delta Lake sink connector opened successfully (deferred)");
+                }
+                Err(e) => {
+                    self.state = ConnectorState::Failed;
+                    return Err(e);
+                }
+            }
         }
 
         let num_rows = batch.num_rows();
@@ -845,6 +939,33 @@ impl SinkConnector for DeltaLakeSink {
     }
 
     async fn begin_epoch(&mut self, epoch: u64) -> Result<(), ConnectorError> {
+        // Complete deferred Delta table init on the first epoch.
+        // This must run BEFORE the epoch skip check so that
+        // last_committed_epoch is resolved from the Delta log.
+        // Without this, exactly-once recovery would miss already-committed
+        // epochs and produce duplicates.
+        #[cfg(feature = "delta-lake")]
+        if self.needs_deferred_delta_init {
+            // Schema may not be available yet on the very first epoch.
+            // If so, buffer the epoch — the write_batch will provide it.
+            // But if the pipeline provided a schema via with_schema() or a
+            // previous epoch's write_batch set it, complete init now.
+            if self.schema.is_some() {
+                info!("schema available — completing deferred Delta table init");
+                match self.init_delta_table().await {
+                    Ok(()) => {
+                        self.needs_deferred_delta_init = false;
+                        self.state = ConnectorState::Running;
+                        info!("Delta Lake sink connector opened successfully (deferred)");
+                    }
+                    Err(e) => {
+                        self.state = ConnectorState::Failed;
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
         // For exactly-once, skip epochs already committed.
         if self.config.delivery_guarantee == DeliveryGuarantee::ExactlyOnce
             && epoch <= self.last_committed_epoch
@@ -988,8 +1109,38 @@ impl SinkConnector for DeltaLakeSink {
     }
 
     async fn flush(&mut self) -> Result<(), ConnectorError> {
-        // Coalesce buffered batches to reduce memory fragmentation.
-        // Actual Delta write is deferred to commit_epoch().
+        // For at-least-once delivery, flush() is the only commit trigger
+        // because the checkpoint coordinator skips begin_epoch/pre_commit/
+        // commit_epoch for non-exactly-once sinks. Write directly to Delta.
+        #[cfg(feature = "delta-lake")]
+        if self.config.delivery_guarantee != DeliveryGuarantee::ExactlyOnce {
+            // Retry any orphaned staged data from a prior failed flush
+            // before moving new data in, to prevent silent data loss.
+            // flush_staged_to_delta handles table == None via reopen_table().
+            if !self.staged_batches.is_empty() {
+                self.flush_staged_to_delta().await?;
+            }
+
+            // Stage new buffered data and flush to Delta.
+            if !self.buffer.is_empty() {
+                self.staged_batches = std::mem::take(&mut self.buffer);
+                self.staged_rows = self.buffered_rows;
+                self.staged_bytes = self.buffered_bytes;
+                self.buffered_rows = 0;
+                self.buffered_bytes = 0;
+                self.buffer_start_time = None;
+
+                self.flush_staged_to_delta().await?;
+            }
+            return Ok(());
+        }
+
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        // For exactly-once, just coalesce in memory — the 2PC path
+        // (pre_commit + commit_epoch) handles the actual Delta write.
         if self.buffer.len() > 1 {
             let schema = self.buffer[0].schema();
             let combined = arrow_select::concat::concat_batches(&schema, &self.buffer)
@@ -1003,7 +1154,18 @@ impl SinkConnector for DeltaLakeSink {
     async fn close(&mut self) -> Result<(), ConnectorError> {
         info!("closing Delta Lake sink connector");
 
-        // Commit any remaining buffered data before closing.
+        // Commit any remaining data before closing.
+        // For at-least-once, use flush() which handles both orphaned
+        // staged data and buffered data. For exactly-once, use 2PC.
+        #[cfg(feature = "delta-lake")]
+        if self.config.delivery_guarantee != DeliveryGuarantee::ExactlyOnce {
+            self.flush().await?;
+        } else if !self.buffer.is_empty() {
+            self.pre_commit(self.current_epoch).await?;
+            self.commit_epoch(self.current_epoch).await?;
+        }
+
+        #[cfg(not(feature = "delta-lake"))]
         if !self.buffer.is_empty() {
             self.pre_commit(self.current_epoch).await?;
             self.commit_epoch(self.current_epoch).await?;
@@ -1084,6 +1246,7 @@ fn filter_and_project(
 #[allow(clippy::cast_precision_loss)]
 #[allow(clippy::float_cmp)]
 mod tests {
+    use super::super::delta_config::DeltaCatalogType;
     use super::*;
     use arrow_array::{Float64Array, Int64Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
@@ -1149,6 +1312,118 @@ mod tests {
         let sink = DeltaLakeSink::new(test_config());
         let schema = sink.schema();
         assert_eq!(schema.fields().len(), 0);
+    }
+
+    #[test]
+    fn test_deferred_init_flag_default_false() {
+        let sink = DeltaLakeSink::new(test_config());
+        assert!(!sink.needs_deferred_delta_init);
+    }
+
+    fn unity_config() -> DeltaLakeSinkConfig {
+        let mut config = test_config();
+        config.catalog_type = DeltaCatalogType::Unity {
+            workspace_url: "https://test.azuredatabricks.net".to_string(),
+            access_token: "dapi123".to_string(),
+        };
+        config.catalog_name = Some("main".to_string());
+        config.catalog_schema = Some("default".to_string());
+        config.catalog_storage_location = Some("abfss://c@acct.dfs.core.windows.net/t".to_string());
+        config
+    }
+
+    #[cfg(feature = "delta-lake")]
+    #[tokio::test]
+    async fn test_open_defers_init_for_unity_no_schema() {
+        use crate::config::ConnectorConfig;
+
+        let config = unity_config();
+        let mut sink = DeltaLakeSink::new(config);
+
+        // open() with empty ConnectorConfig (simulates factory path)
+        let connector_config = ConnectorConfig::new("delta-lake");
+        // open() will re-parse but table.path is "/tmp/delta_test" (local),
+        // so it won't actually reach UC REST. However from_config requires
+        // table.path, so we use the sink's existing config by passing empty.
+        // The sink skips re-parse when properties are empty.
+        let result = sink.open(&connector_config).await;
+        assert!(result.is_ok());
+
+        // Should be in Initializing state with deferred flag set.
+        assert!(sink.needs_deferred_delta_init);
+        assert_eq!(sink.state(), ConnectorState::Initializing);
+        assert!(sink.schema.is_none());
+    }
+
+    #[cfg(feature = "delta-lake")]
+    #[tokio::test]
+    async fn test_deferred_init_transitions_to_failed_on_error() {
+        // When deferred init fails, the sink must transition to Failed
+        // to prevent an unbounded retry storm.
+        let mut sink = DeltaLakeSink::new(test_config());
+        sink.state = ConnectorState::Initializing;
+        sink.needs_deferred_delta_init = true;
+        sink.schema = Some(test_schema());
+
+        // begin_epoch will try init_delta_table() which will fail
+        // (no real Delta table at /tmp/delta_test). The sink should
+        // transition to Failed.
+        let result = sink.begin_epoch(1).await;
+        assert!(result.is_err());
+        assert_eq!(sink.state(), ConnectorState::Failed);
+        // Flag may still be set, but Failed state prevents further usage.
+    }
+
+    #[cfg(feature = "delta-lake")]
+    #[tokio::test]
+    async fn test_write_batch_accepts_initializing_state() {
+        // During deferred init, write_batch must accept Initializing state
+        // so the first batch can provide the schema.
+        let mut sink = DeltaLakeSink::new(test_config());
+        sink.state = ConnectorState::Initializing;
+        sink.needs_deferred_delta_init = true;
+
+        let batch = test_batch(5);
+        // write_batch sets schema, then tries init_delta_table which fails.
+        // Sink transitions to Failed.
+        let result = sink.write_batch(&batch).await;
+        assert!(result.is_err());
+        assert_eq!(sink.state(), ConnectorState::Failed);
+        // Schema was set before init was attempted.
+        assert!(sink.schema.is_some());
+    }
+
+    #[test]
+    fn test_no_deferred_init_without_catalog_storage_location() {
+        // Unity catalog without catalog.storage.location should NOT defer.
+        let mut config = unity_config();
+        config.catalog_storage_location = None;
+        let sink = DeltaLakeSink::new(config);
+
+        let should_defer = matches!(sink.config.catalog_type, DeltaCatalogType::Unity { .. })
+            && sink.config.catalog_storage_location.is_some()
+            && sink.schema.is_none();
+        assert!(!should_defer);
+    }
+
+    #[test]
+    fn test_no_deferred_init_with_schema() {
+        // Unity catalog with schema already set should NOT defer.
+        let config = unity_config();
+        let sink = DeltaLakeSink::with_schema(config, test_schema());
+
+        let should_defer = matches!(sink.config.catalog_type, DeltaCatalogType::Unity { .. })
+            && sink.config.catalog_storage_location.is_some()
+            && sink.schema.is_none();
+        assert!(!should_defer);
+    }
+
+    #[test]
+    fn test_health_check_initializing_during_deferred() {
+        let mut sink = DeltaLakeSink::new(test_config());
+        sink.state = ConnectorState::Initializing;
+        // During deferred init, health should NOT report Healthy.
+        assert!(matches!(sink.health_check(), HealthStatus::Unknown));
     }
 
     // ── Batch size estimation ──
@@ -1476,7 +1751,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_flush_coalesces_buffer() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut config = test_config();
+        config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
+        config.writer_id = "test-writer".to_string();
+        let mut sink = DeltaLakeSink::new(config);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);

--- a/crates/laminar-connectors/src/lakehouse/delta_config.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_config.rs
@@ -209,6 +209,19 @@ impl DeltaLakeSinkConfig {
                 ConnectorError::ConfigurationError(format!("invalid compaction.min-files: '{v}'"))
             })?;
         }
+        if let Some(v) = config.get("compaction.check-interval.ms") {
+            let ms: u64 = v.parse().map_err(|_| {
+                ConnectorError::ConfigurationError(format!(
+                    "invalid compaction.check-interval.ms: '{v}'"
+                ))
+            })?;
+            if ms == 0 {
+                return Err(ConnectorError::ConfigurationError(
+                    "compaction.check-interval.ms must be > 0".into(),
+                ));
+            }
+            cfg.compaction.check_interval = Duration::from_millis(ms);
+        }
         if let Some(v) = config.get("vacuum.retention.hours") {
             let hours: u64 = v.parse().map_err(|_| {
                 ConnectorError::ConfigurationError(format!("invalid vacuum.retention.hours: '{v}'"))
@@ -308,11 +321,25 @@ impl DeltaLakeSinkConfig {
                 "checkpoint.interval must be > 0".into(),
             ));
         }
+        if self.compaction.check_interval.is_zero() {
+            return Err(ConnectorError::ConfigurationError(
+                "compaction.check-interval.ms must be > 0".into(),
+            ));
+        }
 
         // Validate catalog-specific requirements.
+        // Fail-fast if the required feature is not compiled in, rather than
+        // deferring the error to runtime when resolve_catalog_options is called.
         match &self.catalog_type {
             DeltaCatalogType::None => {}
             DeltaCatalogType::Glue => {
+                #[cfg(not(feature = "delta-lake-glue"))]
+                return Err(ConnectorError::ConfigurationError(
+                    "Glue catalog requires the 'delta-lake-glue' feature. \
+                     Build with: cargo build --features delta-lake-glue"
+                        .into(),
+                ));
+                #[cfg(feature = "delta-lake-glue")]
                 if self.catalog_database.is_none() {
                     return Err(ConnectorError::ConfigurationError(
                         "Glue catalog requires 'catalog.database' to be set".into(),
@@ -323,25 +350,45 @@ impl DeltaLakeSinkConfig {
                 workspace_url,
                 access_token,
             } => {
-                if workspace_url.is_empty() {
+                #[cfg(not(feature = "delta-lake-unity"))]
+                {
+                    // Suppress unused-variable warnings for the destructured fields.
+                    let _ = (workspace_url, access_token);
                     return Err(ConnectorError::ConfigurationError(
-                        "Unity catalog requires 'catalog.workspace_url' to be set".into(),
+                        "Unity catalog requires the 'delta-lake-unity' feature. \
+                         Build with: cargo build --features delta-lake-unity"
+                            .into(),
                     ));
                 }
-                if access_token.is_empty() {
-                    return Err(ConnectorError::ConfigurationError(
-                        "Unity catalog requires 'catalog.access_token' to be set".into(),
-                    ));
-                }
-                if self.catalog_name.is_none() {
-                    return Err(ConnectorError::ConfigurationError(
-                        "Unity catalog requires 'catalog.name' to be set".into(),
-                    ));
-                }
-                if self.catalog_schema.is_none() {
-                    return Err(ConnectorError::ConfigurationError(
-                        "Unity catalog requires 'catalog.schema' to be set".into(),
-                    ));
+                #[cfg(feature = "delta-lake-unity")]
+                {
+                    if workspace_url.is_empty() {
+                        return Err(ConnectorError::ConfigurationError(
+                            "Unity catalog requires 'catalog.workspace_url' to be set".into(),
+                        ));
+                    }
+                    if access_token.is_empty() {
+                        return Err(ConnectorError::ConfigurationError(
+                            "Unity catalog requires 'catalog.access_token' to be set".into(),
+                        ));
+                    }
+                    // catalog.name and catalog.schema are only required when
+                    // auto-create is enabled (catalog.storage.location is set).
+                    // Without auto-create, the table name is derived from table_path.
+                    if self.catalog_storage_location.is_some() {
+                        if self.catalog_name.is_none() {
+                            return Err(ConnectorError::ConfigurationError(
+                                "Unity catalog auto-create requires 'catalog.name' to be set"
+                                    .into(),
+                            ));
+                        }
+                        if self.catalog_schema.is_none() {
+                            return Err(ConnectorError::ConfigurationError(
+                                "Unity catalog auto-create requires 'catalog.schema' to be set"
+                                    .into(),
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -924,6 +971,7 @@ mod tests {
         assert!(cfg.catalog_storage_location.is_none());
     }
 
+    #[cfg(feature = "delta-lake-glue")]
     #[test]
     fn test_catalog_glue_valid() {
         let mut pairs = required_pairs();
@@ -937,6 +985,7 @@ mod tests {
         assert_eq!(cfg.catalog_database.as_deref(), Some("my_database"));
     }
 
+    #[cfg(feature = "delta-lake-glue")]
     #[test]
     fn test_catalog_glue_missing_database() {
         let mut pairs = required_pairs();

--- a/crates/laminar-connectors/src/lakehouse/delta_io.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_io.rs
@@ -193,6 +193,7 @@ pub async fn open_or_create_table(
 ///
 /// Returns `ConnectorError::WriteError` if the write fails.
 #[cfg(feature = "delta-lake")]
+#[allow(clippy::too_many_arguments)]
 pub async fn write_batches(
     table: DeltaTable,
     batches: Vec<RecordBatch>,
@@ -201,6 +202,8 @@ pub async fn write_batches(
     save_mode: SaveMode,
     partition_columns: Option<&[String]>,
     schema_evolution: bool,
+    target_file_size: Option<usize>,
+    create_checkpoint: bool,
 ) -> Result<(DeltaTable, i64), ConnectorError> {
     if batches.is_empty() {
         debug!("no batches to write, skipping");
@@ -229,8 +232,15 @@ pub async fn write_batches(
         .with_save_mode(save_mode)
         .with_commit_properties(
             CommitProperties::default()
-                .with_application_transaction(Transaction::new(writer_id, epoch_i64)),
+                .with_application_transaction(Transaction::new(writer_id, epoch_i64))
+                .with_create_checkpoint(create_checkpoint),
         );
+
+    // Forward target file size to delta-rs so Parquet files match the
+    // user's configured size, not just the internal default.
+    if let Some(size) = target_file_size {
+        write_builder = write_builder.with_target_file_size(size);
+    }
 
     // Enable schema evolution (additive column merge) if requested.
     if schema_evolution {
@@ -1382,6 +1392,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1423,6 +1435,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1461,6 +1475,8 @@ mod tests {
                 writer_id,
                 epoch,
                 SaveMode::Append,
+                None,
+                false,
                 None,
                 false,
             )
@@ -1516,6 +1532,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1545,6 +1563,8 @@ mod tests {
             "multi-batch-writer",
             1,
             SaveMode::Append,
+            None,
+            false,
             None,
             false,
         )
@@ -1616,6 +1636,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1646,6 +1668,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1658,6 +1682,8 @@ mod tests {
             "writer",
             2,
             SaveMode::Append,
+            None,
+            false,
             None,
             false,
         )
@@ -1754,6 +1780,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1763,6 +1791,8 @@ mod tests {
             "writer",
             2,
             SaveMode::Append,
+            None,
+            false,
             None,
             false,
         )
@@ -1868,6 +1898,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1880,6 +1912,8 @@ mod tests {
             writer_id,
             2,
             SaveMode::Append,
+            None,
+            false,
             None,
             false,
         )
@@ -1933,6 +1967,8 @@ mod tests {
             SaveMode::Append,
             None,
             true, // schema_evolution enabled
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -1960,6 +1996,8 @@ mod tests {
             SaveMode::Append,
             None,
             true,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -2001,6 +2039,8 @@ mod tests {
                 "compaction-writer",
                 epoch,
                 SaveMode::Append,
+                None,
+                false,
                 None,
                 false,
             )
@@ -2069,6 +2109,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -2134,6 +2176,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();
@@ -2197,6 +2241,8 @@ mod tests {
             "merge-writer",
             1,
             SaveMode::Append,
+            None,
+            false,
             None,
             false,
         )

--- a/crates/laminar-connectors/src/lakehouse/delta_source.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_source.rs
@@ -187,7 +187,7 @@ impl SourceConnector for DeltaSource {
             use super::delta_io;
 
             // Open the existing table (source requires the table to exist).
-            let table = delta_io::open_or_create_table(
+            let mut table = delta_io::open_or_create_table(
                 &self.config.table_path,
                 self.config.storage_options.clone(),
                 None,
@@ -204,6 +204,36 @@ impl SourceConnector for DeltaSource {
             #[allow(clippy::cast_possible_wrap)]
             if let Some(start) = self.config.starting_version {
                 self.current_version = start;
+            } else if self.config.read_mode == DeltaReadMode::Incremental && table_version > 0 {
+                // No explicit starting_version in incremental mode: read a
+                // snapshot of the current table state first, then switch to
+                // incremental for subsequent versions. Without this, the
+                // source would start at current_version + 1 and silently
+                // skip all existing data.
+                // NOTE: For very large tables this buffers all rows in memory.
+                // Set `starting_version` explicitly to skip the initial snapshot
+                // if memory is a concern. Streaming backpressure is tracked as D007.
+                let batches =
+                    delta_io::read_batches_at_version(&mut table, table_version, usize::MAX)
+                        .await?;
+                for batch in batches {
+                    if batch.num_rows() > 0 {
+                        self.pending_batches.push_back(batch);
+                    }
+                }
+                if self.pending_batches.is_empty() {
+                    self.current_version = table_version;
+                } else {
+                    self.inflight_version = Some(table_version);
+                }
+                info!(
+                    table_version,
+                    batches_buffered = self.pending_batches.len(),
+                    "Delta Lake source: loaded initial snapshot"
+                );
+                // current_version is set to table_version once the
+                // snapshot batches are fully drained via poll_batch().
+                // Subsequent polls will read table_version + 1 onward.
             } else {
                 self.current_version = table_version;
             }

--- a/crates/laminar-connectors/src/lakehouse/delta_table_provider.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_table_provider.rs
@@ -134,6 +134,8 @@ mod tests {
             SaveMode::Append,
             None,
             false,
+            None,
+            false,
         )
         .await
         .unwrap();

--- a/crates/laminar-connectors/src/lakehouse/mod.rs
+++ b/crates/laminar-connectors/src/lakehouse/mod.rs
@@ -175,6 +175,11 @@ fn delta_lake_config_keys() -> Vec<ConfigKeySpec> {
             "10",
         ),
         ConfigKeySpec::optional(
+            "compaction.check-interval.ms",
+            "How often to check if compaction is needed (milliseconds)",
+            "3600000",
+        ),
+        ConfigKeySpec::optional(
             "vacuum.retention.hours",
             "Hours to retain old files during VACUUM",
             "168",


### PR DESCRIPTION
## Summary

- Fix at-least-once delivery silently buffering data forever (flush now writes to Delta)
- Fix Unity Catalog auto-create when schema not available at open time (deferred init)
- Fix new incremental source skipping entire initial table state (snapshot-first)
- Wire `checkpoint_interval` to delta-rs checkpoint creation
- Wire `target_file_size` to delta-rs write builder
- Fix orphaned staged data from failed flushes being silently dropped
- Add `compaction.check-interval.ms` config key
- Fail-fast on catalog type when required feature not compiled
- Bump version to 0.18.8

## Test plan

- [x] All 151 delta tests pass (`cargo test -- delta`)
- [x] clippy clean with all features
- [x] cargo fmt clean
- [x] cargo doc clean
- [ ] Manual: verify at-least-once sink writes appear in Databricks within flush interval
- [ ] Manual: verify Unity Catalog auto-create with Azure ADLS Gen2
- [ ] Manual: verify new incremental source reads initial table state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.18.8

* **New Features**
  * Deferred Delta Lake table initialization for Unity Catalog so startup can proceed before schema is available
  * New compaction check-interval configuration option
  * Incremental Delta reads preload initial snapshots to preserve buffered data
  * Write operations accept target file size and an option to create checkpoints

* **Bug Fixes**
  * Improved flush/close behavior to preserve delivery guarantees during deferred initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->