### PR TITLE
fix(kafka): backpressure livelock preventing data flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "anyhow",
  "axum",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-storage"
-version = "0.18.9"
+version = "0.18.10"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.18.9"
+version = "0.18.10"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,5 @@
 {
-  "latest_version": "0.18.9",
+  "latest_version": "0.18.10",
   "abi_version": 1,
   "released_at": "2026-03-18T16:34:42Z",
   "minimum_supported": "0.1.0",
@@ -10,5 +10,5 @@
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc"
   ],
-  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.9"
+  "download_base_url": "https://github.com/laminardb/laminardb/releases/download/v0.18.10"
 }

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,8 +11,8 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.18.9" }
-laminar-storage = { path = "../laminar-storage", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.10" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -645,18 +645,13 @@ impl SourceConnector for KafkaSource {
             });
         }
 
-        // Check backpressure.
+        // Update backpressure state — never skip the drain below (deadlocks).
         if self.backpressure.should_pause() {
             self.backpressure.set_paused(true);
             debug!("backpressure: pausing consumption");
-            return Ok(None);
-        }
-        if self.backpressure.should_resume() {
+        } else if self.backpressure.should_resume() {
             self.backpressure.set_paused(false);
             debug!("backpressure: resuming consumption");
-        }
-        if self.backpressure.is_paused() {
-            return Ok(None);
         }
 
         // Lazily spawn the background reader task on first poll.

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -35,10 +35,10 @@ gcs = ["laminar-storage/gcs"]
 azure = ["laminar-storage/azure"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.18.9" }
-laminar-sql = { path = "../laminar-sql", version = "0.18.9" }
-laminar-storage = { path = "../laminar-storage", version = "0.18.9" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10" }
+laminar-sql = { path = "../laminar-sql", version = "0.18.10" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.10" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.10" }
 
 # Arrow
 arrow = { workspace = true }
@@ -86,8 +86,8 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = { workspace = true }
-laminar-derive = { path = "../laminar-derive", version = "0.18.9" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.18.9", features = ["testing"] }
+laminar-derive = { path = "../laminar-derive", version = "0.18.10" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.10", features = ["testing"] }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -21,5 +21,5 @@ proc-macro2 = "1.0"
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.18.9" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.10" }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/main.rs"
 
 [dependencies]
 # All LaminarDB crates
-laminar-core = { path = "../laminar-core", version = "0.18.9", features = ["delta"] }
-laminar-sql = { path = "../laminar-sql", version = "0.18.9" }
-laminar-storage = { path = "../laminar-storage", version = "0.18.9" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.18.9" }
-laminar-db = { path = "../laminar-db", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10", features = ["delta"] }
+laminar-sql = { path = "../laminar-sql", version = "0.18.10" }
+laminar-storage = { path = "../laminar-storage", version = "0.18.10" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.18.10" }
+laminar-db = { path = "../laminar-db", version = "0.18.10" }
 
 # CLI and configuration
 clap = { version = "4.6", features = ["derive", "env"] }

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -11,7 +11,7 @@ description = "SQL layer for LaminarDB with streaming extensions"
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10" }
 
 # DataFusion for SQL processing
 datafusion = { workspace = true }

--- a/crates/laminar-storage/Cargo.toml
+++ b/crates/laminar-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage layer for LaminarDB - WAL, checkpointing, and lakehouse i
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.18.9" }
+laminar-core = { path = "../laminar-core", version = "0.18.10" }
 
 # Storage
 object_store = "0.13"  # For cloud storage

--- a/examples/binance-ws/Cargo.toml
+++ b/examples/binance-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-ws"
-version = "0.18.9"
+version = "0.18.10"
 edition = "2021"
 publish = false
 description = "Binance VWAP signals: minimal LaminarDB streaming example"
@@ -10,8 +10,8 @@ name = "binance-ws"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.9", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.9" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.10", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.10" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb-demo"
-version = "0.18.9"
+version = "0.18.10"
 edition = "2021"
 publish = false
 description = "Market Data Demo: Real-time analytics with Ratatui TUI for LaminarDB"
@@ -23,9 +23,9 @@ default = []
 kafka = ["laminar-db/kafka", "dep:rdkafka", "dep:serde", "dep:serde_json"]
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.9" }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.9" }
-laminar-core = { path = "../../crates/laminar-core", version = "0.18.9" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.10" }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.10" }
+laminar-core = { path = "../../crates/laminar-core", version = "0.18.10" }
 
 # Arrow
 arrow = "57.2"

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microstructure"
-version = "0.18.9"
+version = "0.18.10"
 edition = "2021"
 publish = false
 description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
@@ -10,8 +10,8 @@ name = "microstructure"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.18.9", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.9" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.18.10", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.18.10" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"


### PR DESCRIPTION
## Summary

- **Fix backpressure deadlock in Kafka source**: `poll_batch()` returned `Ok(None)` when backpressure was active, but it was the only consumer of the internal reader channel. `channel_len` never decreased, `should_resume()` never fired, and the pipeline permanently starved — no data flowed, Kafka consumer group got evicted (`max.poll.interval.ms` timeout), and barrier checkpoints failed repeatedly with increasing checkpoint IDs.
- **Root cause**: Three early-return paths in `poll_batch()` skipped the `rx.try_recv()` drain loop when paused. Backpressure state is now tracked for observability but never blocks the drain.
- Bump version to 0.18.10.

## Test plan

- [ ] `cargo test --lib -p laminar-connectors` — 499 tests pass
- [ ] `cargo test --lib -p laminar-db` — 509 tests pass
- [ ] `cargo clippy -p laminar-connectors -- -D warnings` — clean
- [ ] Deploy with Kafka source + Delta Lake sink, verify data flows without "barrier checkpoint failed" warnings
- [ ] Verify Kafka consumer group stays alive under sustained load (no `max.poll.interval.ms` eviction)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.18.10

* **Bug Fixes**
  * Improved backpressure handling in Kafka connectors for more reliable state management and data flow during pause/resume cycles.

* **Chores**
  * Version bump to 0.18.10 across all workspace components and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->