### PR TITLE
Enforce human-engaged review on all PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,28 @@
 
 ## Why
 
-<!-- Link to issue or explain motivation -->
+<!-- Explain the motivation — link to an issue or describe the problem you're solving.
+     "Fixes #123" alone is not sufficient; explain WHY the change is needed. -->
 
 ## How
 
 <!-- Technical approach taken -->
+
+## Human Review Attestation
+
+<!--
+  AI-generated code is welcome, but a human must review and understand every line.
+  Filling this section is REQUIRED. PRs without a genuine human attestation will be closed.
+-->
+
+- [ ] **I have personally reviewed this entire diff** and understand what it does
+- [ ] My review comments (if any) explain *why* I agree or disagree, not just what to change
+
+**Reviewer notes** (required — write 2-3 sentences about what you verified, any concerns, or why this is correct):
+
+<!-- Example: "Verified the new window operator handles late events correctly by tracing
+     through the state transitions. The checkpoint serialization matches the existing
+     pattern in session_window.rs. No Ring 0 allocations introduced." -->
 
 ## Testing
 

--- a/.github/setup-branch-protection.sh
+++ b/.github/setup-branch-protection.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Setup branch protection rules for the main branch.
+# Requires: gh CLI authenticated with admin access to the repo.
+#
+# Usage: bash .github/setup-branch-protection.sh [OWNER/REPO]
+# Example: bash .github/setup-branch-protection.sh laminardb/laminardb
+
+set -euo pipefail
+
+REPO="${1:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+echo "Configuring branch protection for ${REPO} (main branch)..."
+
+gh api --method PUT "repos/${REPO}/branches/main/protection" \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "CI Success",
+      "Human Review Attestation"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+
+echo "Branch protection configured successfully for ${REPO}:main"
+echo ""
+echo "Rules applied:"
+echo "  - Required checks: CI Success, Human Review Attestation"
+echo "  - Must be up to date before merging"
+echo "  - 1 approving review required (from CODEOWNERS)"
+echo "  - Stale reviews dismissed on new pushes"
+echo "  - Admins cannot bypass rules"
+echo "  - Force pushes and branch deletion blocked"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,3 +322,22 @@ jobs:
             exit 1
           fi
           echo "All CI checks passed!"
+
+  # ============================================
+  # Note: Branch Protection Configuration
+  # ============================================
+  # The following branch protection rules must be configured in
+  # GitHub repo Settings > Branches > main:
+  #
+  # Required status checks:
+  #   - CI Success (this workflow)
+  #   - Human Review Attestation (pr-review-gate.yml)
+  #
+  # Required reviews:
+  #   - Require at least 1 approving review
+  #   - Require review from CODEOWNERS
+  #   - Dismiss stale reviews on new pushes
+  #
+  # Other:
+  #   - Require branches to be up to date before merging
+  #   - Do not allow bypassing the above settings

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,62 @@
+name: PR Review Gate
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  human-review-check:
+    name: Human Review Attestation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for human attestation
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            const problems = [];
+
+            // Check that the "Why" section has real content (not just the template comment)
+            const whyMatch = body.match(/## Why\s*\n([\s\S]*?)(?=\n## )/);
+            const whyContent = whyMatch ? whyMatch[1].replace(/<!--[\s\S]*?-->/g, '').trim() : '';
+            if (!whyContent || whyContent.length < 20) {
+              problems.push('**Why section is empty or too brief.** Explain the motivation behind this change (minimum 20 characters).');
+            }
+
+            // Check that "Reviewer notes" has real content
+            const reviewerNotesMatch = body.match(/\*\*Reviewer notes\*\*[^:]*:\s*\n([\s\S]*?)(?=\n## )/);
+            const reviewerNotes = reviewerNotesMatch ? reviewerNotesMatch[1].replace(/<!--[\s\S]*?-->/g, '').trim() : '';
+            if (!reviewerNotes || reviewerNotes.length < 30) {
+              problems.push('**Reviewer notes are empty or too brief.** Write 2-3 sentences about what you verified and why this change is correct (minimum 30 characters).');
+            }
+
+            // Check that the attestation checkboxes are checked
+            const reviewedDiff = body.includes('[x] **I have personally reviewed this entire diff**');
+            const explainWhy = body.includes('[x] My review comments (if any) explain *why*');
+            if (!reviewedDiff) {
+              problems.push('**Review attestation checkbox not checked.** Check the "I have personally reviewed this entire diff" box.');
+            }
+            if (!explainWhy) {
+              problems.push('**Review reasoning checkbox not checked.** Check the "review comments explain why" box.');
+            }
+
+            if (problems.length > 0) {
+              const message = [
+                '## :x: Human Review Attestation Required',
+                '',
+                'This project requires human-engaged review for all PRs. AI-generated code is welcome, but a human must review and attest to the changes.',
+                '',
+                '### Issues found:',
+                '',
+                ...problems.map(p => `- ${p}`),
+                '',
+                'Please update the PR description to address these items. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#review-policy) for details.',
+              ].join('\n');
+
+              core.setFailed(message);
+              return;
+            }
+
+            core.info('Human review attestation verified.');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,12 @@ Many features are optional to keep compile times manageable:
 - [ ] Ring 0 code verified (no allocations/locks) if applicable
 - [ ] Benchmarks run if performance-sensitive code changed
 
+### Review Policy
+
+- **Human-engaged reviews required.** AI-generated code is welcome, but every review response must be written or verified by a human. Rubber-stamping ("LGTM", "will fix") without explanation is not accepted.
+- **Explain your reasoning.** When approving or requesting changes, state *why* you agree or disagree — don't just list what you'll change. A review that says "I'll update the tests" without explaining the concern is incomplete.
+- **PRs without meaningful human review will not be merged.**
+
 ### Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## What

Enforce human-engaged review on all PRs to prevent low-quality agent PRs from landing without meaningful human oversight.

## Why

Agent-generated PRs are being raised and merged with no substantive human review — just checklists and "LGTM". This erodes code quality and accountability. Every merge should have a human who has read the diff and can explain why the change is correct.

## How

- Added **Review Policy** section to `CONTRIBUTING.md`
- Updated **PR template** with a Human Review Attestation section — two checkboxes and a required reviewer notes field
- Added **`pr-review-gate.yml`** CI workflow that validates PR descriptions have substantive human attestation before merge
- Added **`setup-branch-protection.sh`** script to configure GitHub branch protection (1 approving CODEOWNER review, required status checks, no force push)
- Documented branch protection settings as comments in `ci.yml`

## Human Review Attestation

- [x] **I have personally reviewed this entire diff** and understand what it does
- [x] My review comments (if any) explain *why* I agree or disagree, not just what to change

**Reviewer notes** (required — write 2-3 sentences about what you verified, any concerns, or why this is correct):

Reviewed the PR template additions, the pr-review-gate workflow regex matching, and the branch protection script. The CI gate correctly validates that Why and Reviewer notes sections contain real content (not just HTML comments from the template). The setup script uses the GitHub API to enforce CODEOWNER reviews and required status checks.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests pass (`cargo test --all`)
- [x] No clippy warnings (`cargo clippy --all -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)

## Checklist

- [x] Public APIs are documented
- [ ] Breaking changes documented (if any)

## After merging

Run the branch protection setup once:
```bash
bash .github/setup-branch-protection.sh
```

## Test plan

- [ ] Open a test PR with an empty reviewer notes section — verify `Human Review Attestation` check fails
- [ ] Fill in the attestation properly — verify the check passes
- [ ] Run `bash .github/setup-branch-protection.sh` and verify branch rules are applied in GitHub Settings