### PR TITLE
feat(db): support COUNT, AVG, MIN, MAX over changelog streams

### DIFF
--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -460,6 +460,8 @@ pub(crate) struct AggFuncSpec {
     pub(crate) return_type: DataType,
     /// Whether this is a DISTINCT aggregate (e.g., `COUNT(DISTINCT x)`).
     pub(crate) distinct: bool,
+    /// Whether this is COUNT(*) — uses a dummy boolean input, no real column.
+    pub(crate) is_count_star: bool,
     /// Column index of the FILTER boolean column in pre-agg output, if any.
     pub(crate) filter_col_index: Option<usize>,
 }
@@ -504,6 +506,20 @@ impl AggFuncSpec {
                 self.udf.name()
             ))
         })
+    }
+
+    /// Create a weight-aware retractable accumulator for changelog streams.
+    ///
+    /// These accumulators receive the `__weight` column as the last input
+    /// in `update_batch` and handle retraction internally.
+    pub(crate) fn create_retractable_accumulator(
+        &self,
+    ) -> Result<Box<dyn datafusion_expr::Accumulator>, DbError> {
+        crate::retractable_accumulator::create_retractable(
+            &self.udf.name().to_lowercase(),
+            &self.return_type,
+            self.is_count_star,
+        )
     }
 }
 
@@ -889,6 +905,7 @@ impl IncrementalAggState {
                     output_name,
                     return_type,
                     distinct: is_distinct,
+                    is_count_star: agg_func.params.args.is_empty(),
                     filter_col_index,
                 });
             } else {
@@ -913,17 +930,22 @@ impl IncrementalAggState {
         };
 
         let weight_col_idx = if source_has_weight {
-            // Only SUM is mathematically correct with Z-set weight
-            // multiplication (SUM(x * w)). COUNT ignores weights,
-            // AVG's internal count doesn't account for weights, and
-            // MIN/MAX can't retract without full state.
+            // Validate that all aggregates support retractable changelog
+            // semantics. Retractable accumulators handle the weight column
+            // internally (SUM, COUNT, AVG, MIN, MAX).
             for spec in &agg_specs {
+                if spec.distinct {
+                    return Err(DbError::Pipeline(format!(
+                        "DISTINCT aggregates are not supported over changelog streams \
+                         ({}(DISTINCT ...) requires per-value tracking not yet implemented).",
+                        spec.udf.name()
+                    )));
+                }
                 let name = spec.udf.name().to_lowercase();
-                if !matches!(name.as_str(), "sum") {
+                if !matches!(name.as_str(), "sum" | "count" | "avg" | "min" | "max") {
                     return Err(DbError::Pipeline(format!(
                         "Cannot compute {}() over a changelog stream. \
-                         Only SUM is supported for cascaded changelog aggregation. \
-                         Use EMIT ON WINDOW CLOSE or a non-updating source.",
+                         Supported: SUM, COUNT, AVG, MIN, MAX.",
                         spec.udf.name()
                     )));
                 }
@@ -1139,7 +1161,12 @@ impl IncrementalAggState {
                 }
                 let mut accs = Vec::with_capacity(self.agg_specs.len());
                 for spec in &self.agg_specs {
-                    accs.push(spec.create_accumulator()?);
+                    let acc = if self.weight_col_idx.is_some() {
+                        spec.create_retractable_accumulator()?
+                    } else {
+                        spec.create_accumulator()?
+                    };
+                    accs.push(acc);
                 }
                 self.groups.insert(
                     row_key.clone(),
@@ -1175,7 +1202,12 @@ impl IncrementalAggState {
         if !self.groups.contains_key(&empty_key) {
             let mut accs = Vec::with_capacity(self.agg_specs.len());
             for spec in &self.agg_specs {
-                accs.push(spec.create_accumulator()?);
+                let acc = if self.weight_col_idx.is_some() {
+                    spec.create_retractable_accumulator()?
+                } else {
+                    spec.create_accumulator()?
+                };
+                accs.push(acc);
             }
             self.groups.insert(
                 empty_key.clone(),
@@ -1229,7 +1261,8 @@ impl IncrementalAggState {
                 input_arrays.push(arr);
             }
 
-            if let Some(filter_idx) = spec.filter_col_index {
+            // Apply per-accumulator FILTER mask.
+            let filtered_weight = if let Some(filter_idx) = spec.filter_col_index {
                 let filter_arr = compute::take(batch.column(filter_idx), &index_array, None)
                     .map_err(|e| DbError::Pipeline(format!("filter take: {e}")))?;
                 if let Some(mask) = filter_arr
@@ -1244,18 +1277,24 @@ impl IncrementalAggState {
                         );
                     }
                     input_arrays = filtered;
+                    // Also filter weight array through the same mask.
+                    weight_arr
+                        .as_ref()
+                        .map(|w| {
+                            compute::filter(w, mask)
+                                .map_err(|e| DbError::Pipeline(format!("weight filter: {e}")))
+                        })
+                        .transpose()?
+                } else {
+                    weight_arr.clone()
                 }
-            }
+            } else {
+                weight_arr.clone()
+            };
 
-            // Z-set: multiply each input by __weight. SUM(x * w) is the
-            // weighted sum; COUNT(*) becomes SUM(w).
-            if let Some(ref w) = weight_arr {
-                for arr in &mut input_arrays {
-                    if arr.data_type().is_numeric() {
-                        *arr = arrow::compute::kernels::numeric::mul(arr, w)
-                            .map_err(|e| DbError::Pipeline(format!("weight mul: {e}")))?;
-                    }
-                }
+            // Retractable accumulators receive weight as the last input.
+            if let Some(w) = &filtered_weight {
+                input_arrays.push(Arc::clone(w));
             }
 
             accs[i]
@@ -1516,7 +1555,11 @@ impl IncrementalAggState {
 
             let mut accs = Vec::with_capacity(self.agg_specs.len());
             for (i, spec) in self.agg_specs.iter().enumerate() {
-                let mut acc = spec.create_accumulator()?;
+                let mut acc = if self.weight_col_idx.is_some() {
+                    spec.create_retractable_accumulator()?
+                } else {
+                    spec.create_accumulator()?
+                };
                 if i < gc.acc_states.len() {
                     let state_scalars: Result<Vec<ScalarValue>, _> =
                         gc.acc_states[i].iter().map(json_to_scalar).collect();
@@ -3648,7 +3691,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_min_rejected_over_changelog_upstream() {
+    async fn test_min_accepted_over_changelog_upstream() {
+        // MIN is now supported over changelog streams via retractable accumulators.
         let ctx = SessionContext::new();
         let schema = Arc::new(Schema::new(vec![
             Field::new("symbol", DataType::Utf8, false),
@@ -3673,12 +3717,501 @@ mod tests {
             false,
         )
         .await;
+        assert!(result.is_ok(), "MIN should be accepted over changelog");
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_agg_rejected_over_changelog() {
+        // STDDEV is NOT supported over changelog streams.
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("symbol", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let result = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT symbol, STDDEV(price) AS sd FROM upstream GROUP BY symbol",
+            false,
+        )
+        .await;
         match result {
             Err(e) => {
                 let msg = e.to_string();
                 assert!(msg.contains("Cannot compute"), "got: {msg}");
             }
-            Ok(_) => panic!("expected error for MIN over changelog upstream"),
+            Ok(_) => panic!("expected error for STDDEV over changelog upstream"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_cascaded_count_star_over_changelog() {
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("amount", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT region, COUNT(*) AS cnt FROM upstream GROUP BY region",
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(state.weight_col_idx.is_some());
+
+        // Cycle 1: insert 3 rows.
+        // Pre-agg schema for COUNT(*): [region, TRUE (dummy bool), __weight].
+        let b1 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("__agg_input_1", DataType::Boolean, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US", "EU"])),
+                Arc::new(arrow::array::BooleanArray::from(vec![true, true, true])),
+                Arc::new(arrow::array::Int64Array::from(vec![1, 1, 1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        assert_eq!(r1[0].num_rows(), 2);
+
+        // Cycle 2: retract one US row
+        let b2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("__agg_input_1", DataType::Boolean, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US"])),
+                Arc::new(arrow::array::BooleanArray::from(vec![true])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b2, 2000).unwrap();
+        let r2 = state.emit().unwrap();
+        let counts = r2[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let regions = r2[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        for i in 0..r2[0].num_rows() {
+            match regions.value(i) {
+                "US" => assert_eq!(counts.value(i), 1, "US count should be 1 after retraction"),
+                "EU" => assert_eq!(counts.value(i), 1, "EU count should remain 1"),
+                other => panic!("unexpected region: {other}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cascaded_avg_over_changelog() {
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("price", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT region, AVG(price) AS avg_price FROM upstream GROUP BY region",
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Insert: 10, 20, 30 for "US" -> avg = 20
+        let b1 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])),
+                Arc::new(arrow::array::Int64Array::from(vec![1, 1, 1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        let avg = r1[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        assert!((avg.value(0) - 20.0).abs() < 0.001, "avg should be 20.0");
+
+        // Retract 10 -> {20, 30} -> avg = 25
+        let b2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b2, 2000).unwrap();
+        let r2 = state.emit().unwrap();
+        let avg2 = r2[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        assert!(
+            (avg2.value(0) - 25.0).abs() < 0.001,
+            "avg should be 25.0 after retraction"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cascaded_min_over_changelog() {
+        // Single MIN aggregate — pre-agg schema: [region, price, __weight]
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("price", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT region, MIN(price) AS lo FROM upstream GROUP BY region",
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Insert 10, 20, 30
+        let b1 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])),
+                Arc::new(arrow::array::Int64Array::from(vec![1, 1, 1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        let mins = r1[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(mins.value(0), 10);
+
+        // Retract current min (10) -> new min = 20
+        let b2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b2, 2000).unwrap();
+        let r2 = state.emit().unwrap();
+        let mins2 = r2[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(mins2.value(0), 20, "min should be 20 after retracting 10");
+
+        // Retract 20, retract 30 -> empty -> NULL
+        let b3 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![20, 30])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1, -1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b3, 3000).unwrap();
+        let r3 = state.emit().unwrap();
+        assert!(
+            r3[0].column(1).is_null(0),
+            "min should be NULL after all values retracted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cascaded_max_retract_over_changelog() {
+        // Single MAX aggregate — pre-agg schema: [region, price, __weight]
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("price", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT region, MAX(price) AS hi FROM upstream GROUP BY region",
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Insert 10, 20, 30
+        let b1 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])),
+                Arc::new(arrow::array::Int64Array::from(vec![1, 1, 1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        let maxs = r1[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(maxs.value(0), 30);
+
+        // Retract current max (30) -> new max = 20
+        let b2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("price", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![30])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b2, 2000).unwrap();
+        let r2 = state.emit().unwrap();
+        let maxs2 = r2[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(maxs2.value(0), 20, "max should be 20 after retracting 30");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_cascaded_mixed_aggregates_over_changelog() {
+        // Mixed: SUM + COUNT(*) + AVG + MIN + MAX on same column.
+        // Pre-agg schema: [region, amount(SUM), TRUE(COUNT), amount(AVG),
+        //                   amount(MIN), amount(MAX), __weight] = 7 columns.
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("amount", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        ctx.register_table("upstream", Arc::new(mem)).unwrap();
+
+        let result = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT region, SUM(amount) AS total, COUNT(*) AS cnt, \
+             AVG(amount) AS avg_amt, MIN(amount) AS lo, MAX(amount) AS hi \
+             FROM upstream GROUP BY region",
+            false,
+        )
+        .await;
+        assert!(result.is_ok(), "mixed aggregates should be accepted");
+        let mut state = result.unwrap().unwrap();
+
+        // Pre-agg has 7 cols: [region, amt, TRUE, amt, amt, amt, __weight].
+        // Build matching batch.
+        let b1 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("__agg_input_1", DataType::Int64, true),
+                Field::new("__agg_input_2", DataType::Boolean, true),
+                Field::new("__agg_input_3", DataType::Int64, true),
+                Field::new("__agg_input_4", DataType::Int64, true),
+                Field::new("__agg_input_5", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])), // SUM input
+                Arc::new(arrow::array::BooleanArray::from(vec![true, true, true])), // COUNT(*)
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])), // AVG input
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])), // MIN input
+                Arc::new(arrow::array::Int64Array::from(vec![10, 20, 30])), // MAX input
+                Arc::new(arrow::array::Int64Array::from(vec![1, 1, 1])),    // weight
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        assert_eq!(r1[0].num_rows(), 1);
+
+        // Retract 10, insert 40.
+        let b2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("region", DataType::Utf8, true),
+                Field::new("__agg_input_1", DataType::Int64, true),
+                Field::new("__agg_input_2", DataType::Boolean, true),
+                Field::new("__agg_input_3", DataType::Int64, true),
+                Field::new("__agg_input_4", DataType::Int64, true),
+                Field::new("__agg_input_5", DataType::Int64, true),
+                Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["US", "US"])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 40])),
+                Arc::new(arrow::array::BooleanArray::from(vec![true, true])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 40])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 40])),
+                Arc::new(arrow::array::Int64Array::from(vec![10, 40])),
+                Arc::new(arrow::array::Int64Array::from(vec![-1, 1])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b2, 2000).unwrap();
+        let r2 = state.emit().unwrap();
+        // {20, 30, 40}: SUM=90, COUNT=3, AVG=30, MIN=20, MAX=40
+        let b = &r2[0];
+        let sum_col = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let cnt_col = b
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let avg_col = b
+            .column(3)
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .unwrap();
+        let min_col = b
+            .column(4)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let max_col = b
+            .column(5)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(sum_col.value(0), 90, "SUM should be 90");
+        assert_eq!(cnt_col.value(0), 3, "COUNT should be 3");
+        assert!((avg_col.value(0) - 30.0).abs() < 0.001, "AVG should be 30");
+        assert_eq!(min_col.value(0), 20, "MIN should be 20");
+        assert_eq!(max_col.value(0), 40, "MAX should be 40");
     }
 }

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -474,6 +474,7 @@ impl CoreWindowState {
                     output_name,
                     return_type,
                     distinct: is_distinct,
+                    is_count_star: agg_func.params.args.is_empty(),
                     filter_col_index,
                 });
             } else {
@@ -1614,6 +1615,7 @@ mod tests {
             output_name: "total".to_string(),
             return_type: DataType::Int64,
             distinct: false,
+            is_count_star: false,
             filter_col_index: None,
         }];
 
@@ -1663,6 +1665,7 @@ mod tests {
                 output_name: "total".to_string(),
                 return_type: DataType::Int64,
                 distinct: false,
+                is_count_star: false,
                 filter_col_index: None,
             },
             AggFuncSpec {
@@ -1672,6 +1675,7 @@ mod tests {
                 output_name: "cnt".to_string(),
                 return_type: DataType::Int64,
                 distinct: false,
+                is_count_star: false,
                 filter_col_index: None,
             },
         ];
@@ -1721,6 +1725,7 @@ mod tests {
             output_name: "total".to_string(),
             return_type: DataType::Int64,
             distinct: false,
+            is_count_star: false,
             filter_col_index: None,
         }];
 
@@ -1770,6 +1775,7 @@ mod tests {
             output_name: "total".to_string(),
             return_type: DataType::Int64,
             distinct: false,
+            is_count_star: false,
             filter_col_index: None,
         }];
 

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -429,6 +429,7 @@ impl IncrementalEowcState {
                     output_name,
                     return_type,
                     distinct: is_distinct,
+                    is_count_star: agg_func.params.args.is_empty(),
                     filter_col_index,
                 });
             } else {
@@ -1146,6 +1147,7 @@ mod tests {
             output_name: "total".to_string(),
             return_type: DataType::Int64,
             distinct: false,
+            is_count_star: false,
             filter_col_index: None,
         }];
 

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -66,6 +66,7 @@ mod pipeline_lifecycle;
 pub mod profile;
 /// Unified recovery manager.
 pub mod recovery_manager;
+mod retractable_accumulator;
 mod show_commands;
 mod sink_task;
 mod sql_analysis;

--- a/crates/laminar-db/src/retractable_accumulator.rs
+++ b/crates/laminar-db/src/retractable_accumulator.rs
@@ -1,0 +1,833 @@
+//! Weight-aware accumulators for Z-set changelog aggregation.
+//!
+//! When aggregating over a changelog stream (one with a `__weight` column),
+//! standard `DataFusion` accumulators produce incorrect results because they
+//! are purely additive — they have no concept of retraction.
+//!
+//! This module provides [`datafusion_expr::Accumulator`] implementations that
+//! receive the weight as the **last element** of `update_batch` inputs and
+//! handle retraction internally.
+//!
+//! # Supported aggregates
+//!
+//! | Function | Strategy | State | Retract |
+//! |----------|----------|-------|---------|
+//! | SUM | `SUM(value * weight)` | `(sum, count)` | O(1) |
+//! | COUNT(\*) | `SUM(weight)` | `count` | O(1) |
+//! | COUNT(col) | `SUM(weight)` where col IS NOT NULL | `count` | O(1) |
+//! | AVG | `SUM(value * weight) / SUM(weight)` | `(sum, wt_sum)` | O(1) |
+//! | MIN | Counted multiset, result = first key | `BTreeMap` | O(log n) |
+//! | MAX | Counted multiset, result = last key | `BTreeMap` | O(log n) |
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use arrow::array::{Array, ArrayRef, AsArray};
+use arrow::datatypes::DataType;
+use datafusion_common::ScalarValue;
+use datafusion_expr::Accumulator;
+
+use crate::error::DbError;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Extract `i64` weights from the last array in the inputs slice.
+fn weight_array(values: &[ArrayRef]) -> &arrow::array::Int64Array {
+    values
+        .last()
+        .expect("retractable accumulator requires weight as last input")
+        .as_primitive::<arrow::datatypes::Int64Type>()
+}
+
+/// Cast a numeric array element at `row` to `f64`.
+fn to_f64(arr: &ArrayRef, row: usize) -> Option<f64> {
+    if arr.is_null(row) {
+        return None;
+    }
+    match arr.data_type() {
+        DataType::Int8 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::Int8Type>().value(row),
+        )),
+        DataType::Int16 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::Int16Type>().value(row),
+        )),
+        DataType::Int32 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::Int32Type>().value(row),
+        )),
+        DataType::Int64 =>
+        {
+            #[allow(clippy::cast_precision_loss)]
+            Some(arr.as_primitive::<arrow::datatypes::Int64Type>().value(row) as f64)
+        }
+        DataType::UInt8 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::UInt8Type>().value(row),
+        )),
+        DataType::UInt16 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::UInt16Type>()
+                .value(row),
+        )),
+        DataType::UInt32 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::UInt32Type>()
+                .value(row),
+        )),
+        DataType::UInt64 =>
+        {
+            #[allow(clippy::cast_precision_loss)]
+            Some(
+                arr.as_primitive::<arrow::datatypes::UInt64Type>()
+                    .value(row) as f64,
+            )
+        }
+        DataType::Float32 => Some(f64::from(
+            arr.as_primitive::<arrow::datatypes::Float32Type>()
+                .value(row),
+        )),
+        DataType::Float64 => Some(
+            arr.as_primitive::<arrow::datatypes::Float64Type>()
+                .value(row),
+        ),
+        _ => None,
+    }
+}
+
+/// Encode an `f64` as `i64` for deterministic `BTreeMap` ordering.
+///
+/// Uses IEEE 754 total-order encoding: negative floats get all bits flipped,
+/// positive floats get the sign bit set. A final XOR shifts from u64 ordering
+/// to i64 ordering so `BTreeMap<i64, _>` iteration matches numeric order.
+#[allow(clippy::cast_possible_wrap)]
+fn f64_to_sortable_i64(v: f64) -> i64 {
+    let bits = v.to_bits();
+    let sortable = if (bits >> 63) != 0 {
+        !bits // negative: flip all bits (reverses order)
+    } else {
+        bits | (1_u64 << 63) // positive: set sign bit (places after negatives)
+    };
+    // Shift from u64 ordering to i64 ordering.
+    (sortable ^ (1_u64 << 63)) as i64
+}
+
+/// Decode the sortable `i64` back to `f64`.
+fn sortable_i64_to_f64(encoded: i64) -> f64 {
+    #[allow(clippy::cast_sign_loss)]
+    let sortable = (encoded as u64) ^ (1_u64 << 63);
+    let bits = if (sortable >> 63) != 0 {
+        sortable & !(1_u64 << 63) // was positive: clear the sign bit we set
+    } else {
+        !sortable // was negative: undo the flip
+    };
+    f64::from_bits(bits)
+}
+
+/// Convert an `f64` value back to the target `ScalarValue` type.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+fn f64_to_scalar(v: f64, dt: &DataType) -> ScalarValue {
+    match dt {
+        DataType::Int8 => ScalarValue::Int8(Some(v as i8)),
+        DataType::Int16 => ScalarValue::Int16(Some(v as i16)),
+        DataType::Int32 => ScalarValue::Int32(Some(v as i32)),
+        DataType::Int64 => ScalarValue::Int64(Some(v as i64)),
+        DataType::UInt8 => ScalarValue::UInt8(Some(v as u8)),
+        DataType::UInt16 => ScalarValue::UInt16(Some(v as u16)),
+        DataType::UInt32 => ScalarValue::UInt32(Some(v as u32)),
+        DataType::UInt64 => ScalarValue::UInt64(Some(v as u64)),
+        DataType::Float32 => ScalarValue::Float32(Some(v as f32)),
+        _ => ScalarValue::Float64(Some(v)),
+    }
+}
+
+// ── Factory ─────────────────────────────────────────────────────────
+
+/// Create a retractable accumulator for the given aggregate function name.
+///
+/// Returns `Ok(accumulator)` for supported functions, or `Err` for unsupported.
+/// The `return_type` is the expected output data type (used for casting on
+/// evaluate).
+pub(crate) fn create_retractable(
+    func_name: &str,
+    return_type: &DataType,
+    is_count_star: bool,
+) -> Result<Box<dyn Accumulator>, DbError> {
+    match func_name {
+        "sum" => Ok(Box::new(RetractableSumAccum::new(return_type.clone()))),
+        "count" => {
+            if is_count_star {
+                Ok(Box::new(RetractableCountStarAccum::default()))
+            } else {
+                Ok(Box::new(RetractableCountAccum::default()))
+            }
+        }
+        "avg" => Ok(Box::new(RetractableAvgAccum::default())),
+        "min" => Ok(Box::new(RetractableExtremumAccum::new(
+            return_type.clone(),
+            Extremum::Min,
+        ))),
+        "max" => Ok(Box::new(RetractableExtremumAccum::new(
+            return_type.clone(),
+            Extremum::Max,
+        ))),
+        other => Err(DbError::Pipeline(format!(
+            "Cannot compute {other}() over a changelog stream. \
+             Supported: SUM, COUNT, AVG, MIN, MAX.",
+        ))),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SUM
+// ═══════════════════════════════════════════════════════════════════
+
+/// Retractable SUM: `SUM(value * weight)`.
+#[derive(Debug)]
+struct RetractableSumAccum {
+    sum: f64,
+    count: i64,
+    return_type: DataType,
+}
+
+impl RetractableSumAccum {
+    fn new(return_type: DataType) -> Self {
+        Self {
+            sum: 0.0,
+            count: 0,
+            return_type,
+        }
+    }
+}
+
+impl Accumulator for RetractableSumAccum {
+    /// Inputs: `[value_col, weight_col]`.
+    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let weights = weight_array(values);
+        let value_arr = &values[0];
+        for row in 0..value_arr.len() {
+            if let Some(v) = to_f64(value_arr, row) {
+                let w = weights.value(row);
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    self.sum += v * w as f64;
+                }
+                self.count += w;
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> datafusion_common::Result<ScalarValue> {
+        if self.count == 0 {
+            return ScalarValue::try_from(&self.return_type);
+        }
+        Ok(f64_to_scalar(self.sum, &self.return_type))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
+        Ok(vec![
+            ScalarValue::Float64(Some(self.sum)),
+            ScalarValue::Int64(Some(self.count)),
+        ])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let sums = states[0].as_primitive::<arrow::datatypes::Float64Type>();
+        let counts = states[1].as_primitive::<arrow::datatypes::Int64Type>();
+        for row in 0..sums.len() {
+            if !sums.is_null(row) {
+                self.sum += sums.value(row);
+            }
+            if !counts.is_null(row) {
+                self.count += counts.value(row);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// COUNT(*)
+// ═══════════════════════════════════════════════════════════════════
+
+/// Retractable COUNT(\*): `SUM(weight)`.
+///
+/// The dummy boolean input column is ignored. Only the weight column matters.
+#[derive(Debug, Default)]
+struct RetractableCountStarAccum {
+    count: i64,
+}
+
+impl Accumulator for RetractableCountStarAccum {
+    /// Inputs: `[dummy_bool, weight_col]`.
+    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let weights = weight_array(values);
+        for row in 0..weights.len() {
+            self.count += weights.value(row);
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> datafusion_common::Result<ScalarValue> {
+        Ok(ScalarValue::Int64(Some(self.count)))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
+        Ok(vec![ScalarValue::Int64(Some(self.count))])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let counts = states[0].as_primitive::<arrow::datatypes::Int64Type>();
+        for row in 0..counts.len() {
+            if !counts.is_null(row) {
+                self.count += counts.value(row);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// COUNT(col)
+// ═══════════════════════════════════════════════════════════════════
+
+/// Retractable COUNT(col): `SUM(weight)` where col IS NOT NULL.
+#[derive(Debug, Default)]
+struct RetractableCountAccum {
+    count: i64,
+}
+
+impl Accumulator for RetractableCountAccum {
+    /// Inputs: `[value_col, weight_col]`.
+    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let weights = weight_array(values);
+        let value_arr = &values[0];
+        for row in 0..value_arr.len() {
+            if !value_arr.is_null(row) {
+                self.count += weights.value(row);
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> datafusion_common::Result<ScalarValue> {
+        Ok(ScalarValue::Int64(Some(self.count)))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
+        Ok(vec![ScalarValue::Int64(Some(self.count))])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let counts = states[0].as_primitive::<arrow::datatypes::Int64Type>();
+        for row in 0..counts.len() {
+            if !counts.is_null(row) {
+                self.count += counts.value(row);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// AVG
+// ═══════════════════════════════════════════════════════════════════
+
+/// Retractable AVG: `SUM(value * weight) / SUM(weight)`.
+#[derive(Debug, Default)]
+struct RetractableAvgAccum {
+    weighted_sum: f64,
+    weight_sum: i64,
+}
+
+impl Accumulator for RetractableAvgAccum {
+    /// Inputs: `[value_col, weight_col]`.
+    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let weights = weight_array(values);
+        let value_arr = &values[0];
+        for row in 0..value_arr.len() {
+            if let Some(v) = to_f64(value_arr, row) {
+                let w = weights.value(row);
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    self.weighted_sum += v * w as f64;
+                }
+                self.weight_sum += w;
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> datafusion_common::Result<ScalarValue> {
+        if self.weight_sum == 0 {
+            return Ok(ScalarValue::Float64(None));
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let avg = self.weighted_sum / self.weight_sum as f64;
+        Ok(ScalarValue::Float64(Some(avg)))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
+        Ok(vec![
+            ScalarValue::Float64(Some(self.weighted_sum)),
+            ScalarValue::Int64(Some(self.weight_sum)),
+        ])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let sums = states[0].as_primitive::<arrow::datatypes::Float64Type>();
+        let wts = states[1].as_primitive::<arrow::datatypes::Int64Type>();
+        for row in 0..sums.len() {
+            if !sums.is_null(row) {
+                self.weighted_sum += sums.value(row);
+            }
+            if !wts.is_null(row) {
+                self.weight_sum += wts.value(row);
+            }
+        }
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// MIN / MAX (shared implementation)
+// ═══════════════════════════════════════════════════════════════════
+
+/// Whether the extremum accumulator tracks the minimum or maximum.
+#[derive(Debug, Clone, Copy)]
+enum Extremum {
+    Min,
+    Max,
+}
+
+/// Retractable MIN/MAX using a counted multiset (`BTreeMap<sortable_bits, count>`).
+///
+/// On insert (weight > 0): increment count for value.
+/// On retract (weight < 0): decrement count; remove entry when zero.
+/// Result: first key (MIN) or last key (MAX).
+#[derive(Debug)]
+struct RetractableExtremumAccum {
+    /// `value_bits` (sortable encoding) -> net count
+    counts: BTreeMap<i64, i64>,
+    return_type: DataType,
+    direction: Extremum,
+}
+
+impl RetractableExtremumAccum {
+    fn new(return_type: DataType, direction: Extremum) -> Self {
+        Self {
+            counts: BTreeMap::new(),
+            return_type,
+            direction,
+        }
+    }
+}
+
+impl Accumulator for RetractableExtremumAccum {
+    /// Inputs: `[value_col, weight_col]`.
+    fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let weights = weight_array(values);
+        let value_arr = &values[0];
+        for row in 0..value_arr.len() {
+            if let Some(v) = to_f64(value_arr, row) {
+                let bits = f64_to_sortable_i64(v);
+                let w = weights.value(row);
+                let entry = self.counts.entry(bits).or_insert(0);
+                *entry += w;
+                if *entry == 0 {
+                    self.counts.remove(&bits);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn evaluate(&mut self) -> datafusion_common::Result<ScalarValue> {
+        let pair = match self.direction {
+            Extremum::Min => self.counts.first_key_value(),
+            Extremum::Max => self.counts.last_key_value(),
+        };
+        match pair {
+            Some((&bits, _)) => {
+                let v = sortable_i64_to_f64(bits);
+                Ok(f64_to_scalar(v, &self.return_type))
+            }
+            None => ScalarValue::try_from(&self.return_type),
+        }
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.counts.len() * (std::mem::size_of::<i64>() * 2 + 64)
+        // BTreeMap node overhead
+    }
+
+    fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
+        let keys: Vec<ScalarValue> = self
+            .counts
+            .keys()
+            .map(|k| ScalarValue::Int64(Some(*k)))
+            .collect();
+        let vals: Vec<ScalarValue> = self
+            .counts
+            .values()
+            .map(|c| ScalarValue::Int64(Some(*c)))
+            .collect();
+        Ok(vec![
+            ScalarValue::List(ScalarValue::new_list(&keys, &DataType::Int64, true)),
+            ScalarValue::List(ScalarValue::new_list(&vals, &DataType::Int64, true)),
+        ])
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> datafusion_common::Result<()> {
+        let keys_list = states[0].as_list::<i32>();
+        let vals_list = states[1].as_list::<i32>();
+        for row in 0..keys_list.len() {
+            let keys = keys_list.value(row);
+            let vals = vals_list.value(row);
+            let k_arr = keys.as_primitive::<arrow::datatypes::Int64Type>();
+            let v_arr = vals.as_primitive::<arrow::datatypes::Int64Type>();
+            for i in 0..k_arr.len() {
+                let bits = k_arr.value(i);
+                let cnt = v_arr.value(i);
+                let entry = self.counts.entry(bits).or_insert(0);
+                *entry += cnt;
+                if *entry == 0 {
+                    self.counts.remove(&bits);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use arrow::array::{BooleanArray, Float64Array, Int64Array};
+
+    fn i64_arr(vals: &[i64]) -> ArrayRef {
+        Arc::new(Int64Array::from(vals.to_vec()))
+    }
+
+    fn f64_arr(vals: &[f64]) -> ArrayRef {
+        Arc::new(Float64Array::from(vals.to_vec()))
+    }
+
+    fn bool_arr(vals: &[bool]) -> ArrayRef {
+        Arc::new(BooleanArray::from(vals.to_vec()))
+    }
+
+    fn nullable_i64_arr(vals: &[Option<i64>]) -> ArrayRef {
+        Arc::new(Int64Array::from(vals.to_vec()))
+    }
+
+    // ── SUM ─────────────────────────────────────────────────────
+
+    #[test]
+    fn sum_basic_insert_retract() {
+        let mut acc = RetractableSumAccum::new(DataType::Int64);
+        // Insert: 10 (+1), 20 (+1)
+        acc.update_batch(&[i64_arr(&[10, 20]), i64_arr(&[1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(30)));
+
+        // Retract 10 (-1), insert 30 (+1)
+        acc.update_batch(&[i64_arr(&[10, 30]), i64_arr(&[-1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(50)));
+    }
+
+    #[test]
+    fn sum_checkpoint_roundtrip() {
+        let mut acc = RetractableSumAccum::new(DataType::Int64);
+        acc.update_batch(&[i64_arr(&[10, 20]), i64_arr(&[1, 1])])
+            .unwrap();
+
+        let state = acc.state().unwrap();
+        let mut restored = RetractableSumAccum::new(DataType::Int64);
+        let arrays: Vec<ArrayRef> = state.iter().map(|s| s.to_array().unwrap()).collect();
+        restored.merge_batch(&arrays).unwrap();
+        assert_eq!(restored.evaluate().unwrap(), ScalarValue::Int64(Some(30)));
+    }
+
+    #[test]
+    fn sum_empty_returns_null() {
+        let mut acc = RetractableSumAccum::new(DataType::Int64);
+        let result = acc.evaluate().unwrap();
+        assert!(result.is_null());
+    }
+
+    // ── COUNT(*) ────────────────────────────────────────────────
+
+    #[test]
+    fn count_star_basic() {
+        let mut acc = RetractableCountStarAccum::default();
+        // 3 inserts
+        acc.update_batch(&[bool_arr(&[true, true, true]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(3)));
+
+        // Retract 1
+        acc.update_batch(&[bool_arr(&[true]), i64_arr(&[-1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(2)));
+    }
+
+    #[test]
+    fn count_star_checkpoint() {
+        let mut acc = RetractableCountStarAccum::default();
+        acc.update_batch(&[bool_arr(&[true, true]), i64_arr(&[1, 1])])
+            .unwrap();
+        let state = acc.state().unwrap();
+        let mut restored = RetractableCountStarAccum::default();
+        let arrays: Vec<ArrayRef> = state.iter().map(|s| s.to_array().unwrap()).collect();
+        restored.merge_batch(&arrays).unwrap();
+        assert_eq!(restored.evaluate().unwrap(), ScalarValue::Int64(Some(2)));
+    }
+
+    // ── COUNT(col) ──────────────────────────────────────────────
+
+    #[test]
+    fn count_col_skips_nulls() {
+        let mut acc = RetractableCountAccum::default();
+        // 3 rows: value present, NULL, value present
+        acc.update_batch(&[
+            nullable_i64_arr(&[Some(10), None, Some(30)]),
+            i64_arr(&[1, 1, 1]),
+        ])
+        .unwrap();
+        // Only 2 non-null rows counted
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(2)));
+    }
+
+    #[test]
+    fn count_col_retract() {
+        let mut acc = RetractableCountAccum::default();
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(3)));
+
+        acc.update_batch(&[i64_arr(&[10]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(2)));
+    }
+
+    // ── AVG ─────────────────────────────────────────────────────
+
+    #[test]
+    fn avg_basic() {
+        let mut acc = RetractableAvgAccum::default();
+        // Insert 10, 20, 30
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Float64(Some(20.0)));
+    }
+
+    #[test]
+    fn avg_retract() {
+        let mut acc = RetractableAvgAccum::default();
+        // Insert 10, 20, 30 -> avg = 20
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        // Retract 10 -> {20, 30} -> avg = 25
+        acc.update_batch(&[i64_arr(&[10]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Float64(Some(25.0)));
+    }
+
+    #[test]
+    fn avg_empty_returns_null() {
+        let mut acc = RetractableAvgAccum::default();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Float64(None));
+    }
+
+    #[test]
+    fn avg_checkpoint() {
+        let mut acc = RetractableAvgAccum::default();
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        let state = acc.state().unwrap();
+        let mut restored = RetractableAvgAccum::default();
+        let arrays: Vec<ArrayRef> = state.iter().map(|s| s.to_array().unwrap()).collect();
+        restored.merge_batch(&arrays).unwrap();
+        assert_eq!(
+            restored.evaluate().unwrap(),
+            ScalarValue::Float64(Some(20.0))
+        );
+    }
+
+    // ── MIN ─────────────────────────────────────────────────────
+
+    #[test]
+    fn min_basic() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        acc.update_batch(&[i64_arr(&[30, 10, 20]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(10)));
+    }
+
+    #[test]
+    fn min_retract_current_min() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(10)));
+
+        acc.update_batch(&[i64_arr(&[10]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(20)));
+    }
+
+    #[test]
+    fn min_empty_returns_null() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        assert!(acc.evaluate().unwrap().is_null());
+    }
+
+    #[test]
+    fn min_retract_all() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        acc.update_batch(&[i64_arr(&[10, 20]), i64_arr(&[1, 1])])
+            .unwrap();
+        acc.update_batch(&[i64_arr(&[10, 20]), i64_arr(&[-1, -1])])
+            .unwrap();
+        assert!(acc.evaluate().unwrap().is_null());
+    }
+
+    #[test]
+    fn min_duplicate_values() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        acc.update_batch(&[i64_arr(&[10, 10, 20]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        acc.update_batch(&[i64_arr(&[10]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(10)));
+
+        acc.update_batch(&[i64_arr(&[10]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(20)));
+    }
+
+    #[test]
+    fn min_checkpoint_roundtrip() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        acc.update_batch(&[i64_arr(&[30, 10, 20]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+
+        let state = acc.state().unwrap();
+        let mut restored = RetractableExtremumAccum::new(DataType::Int64, Extremum::Min);
+        let arrays: Vec<ArrayRef> = state.iter().map(|s| s.to_array().unwrap()).collect();
+        restored.merge_batch(&arrays).unwrap();
+        assert_eq!(restored.evaluate().unwrap(), ScalarValue::Int64(Some(10)));
+    }
+
+    // ── MAX ─────────────────────────────────────────────────────
+
+    #[test]
+    fn max_basic() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Max);
+        acc.update_batch(&[i64_arr(&[10, 30, 20]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(30)));
+    }
+
+    #[test]
+    fn max_retract_current_max() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Max);
+        acc.update_batch(&[i64_arr(&[10, 20, 30]), i64_arr(&[1, 1, 1])])
+            .unwrap();
+        acc.update_batch(&[i64_arr(&[30]), i64_arr(&[-1])]).unwrap();
+        assert_eq!(acc.evaluate().unwrap(), ScalarValue::Int64(Some(20)));
+    }
+
+    #[test]
+    fn max_empty_returns_null() {
+        let mut acc = RetractableExtremumAccum::new(DataType::Int64, Extremum::Max);
+        assert!(acc.evaluate().unwrap().is_null());
+    }
+
+    // ── Float support ───────────────────────────────────────────
+
+    #[test]
+    fn min_max_float64() {
+        let mut min_acc = RetractableExtremumAccum::new(DataType::Float64, Extremum::Min);
+        let mut max_acc = RetractableExtremumAccum::new(DataType::Float64, Extremum::Max);
+
+        let vals = f64_arr(&[3.25, 1.41, 2.72]);
+        let wts = i64_arr(&[1, 1, 1]);
+
+        min_acc.update_batch(&[vals.clone(), wts.clone()]).unwrap();
+        max_acc.update_batch(&[vals, wts]).unwrap();
+
+        assert_eq!(
+            min_acc.evaluate().unwrap(),
+            ScalarValue::Float64(Some(1.41))
+        );
+        assert_eq!(
+            max_acc.evaluate().unwrap(),
+            ScalarValue::Float64(Some(3.25))
+        );
+    }
+
+    // ── Sortable encoding ───────────────────────────────────────
+
+    #[test]
+    fn sortable_encoding_roundtrip() {
+        let values = [-100.0, -1.0, -0.0, 0.0, 1.0, 100.0, f64::INFINITY];
+        for v in values {
+            let bits = f64_to_sortable_i64(v);
+            let back = sortable_i64_to_f64(bits);
+            assert_eq!(v.to_bits(), back.to_bits(), "roundtrip failed for {v}");
+        }
+    }
+
+    #[test]
+    fn sortable_encoding_preserves_order() {
+        let values = [-100.0, -1.0, 0.0, 1.0, 100.0];
+        let encoded: Vec<i64> = values.iter().map(|v| f64_to_sortable_i64(*v)).collect();
+        for i in 0..encoded.len() - 1 {
+            assert!(
+                encoded[i] < encoded[i + 1],
+                "order not preserved: {} ({}) >= {} ({})",
+                values[i],
+                encoded[i],
+                values[i + 1],
+                encoded[i + 1]
+            );
+        }
+    }
+
+    // ── Mixed aggregates (factory) ──────────────────────────────
+
+    #[test]
+    fn factory_supported_functions() {
+        assert!(create_retractable("sum", &DataType::Int64, false).is_ok());
+        assert!(create_retractable("count", &DataType::Int64, true).is_ok());
+        assert!(create_retractable("count", &DataType::Int64, false).is_ok());
+        assert!(create_retractable("avg", &DataType::Float64, false).is_ok());
+        assert!(create_retractable("min", &DataType::Int64, false).is_ok());
+        assert!(create_retractable("max", &DataType::Int64, false).is_ok());
+    }
+
+    #[test]
+    fn factory_unsupported_function() {
+        assert!(create_retractable("stddev", &DataType::Float64, false).is_err());
+    }
+}


### PR DESCRIPTION
## What

Lifts the SUM-only restriction on cascaded changelog aggregation. Adds weight-aware `DataFusion Accumulator` implementations for COUNT(*), COUNT(col), AVG, MIN, and MAX over Z-set changelog streams.

## Why

Cascaded aggregation — aggregating over a stream that itself carries `__weight` retraction markers — was hard-coded to reject anything other than SUM. Real-world streaming queries routinely need `SELECT region, COUNT(*), AVG(price), MIN(price), MAX(price) FROM upstream GROUP BY region` over changelog streams. This is table-stakes functionality that Flink, Materialize, and RisingWave all support.

The root cause was a single weight-handling strategy (multiply all numeric inputs by weight) that only works for SUM. COUNT ignores weights, AVG's internal count isn't weighted, and MIN/MAX produce nonsense when multiplied by -1.

## How

**New module `retractable_accumulator.rs`** — weight-aware `Accumulator` implementations where the `__weight` column is passed as the last element of `update_batch` inputs:

| Aggregate | Strategy | Retract Cost |
|-----------|----------|-------------|
| SUM | `SUM(value * weight)` | O(1) |
| COUNT(\*) | `SUM(weight)` | O(1) |
| COUNT(col) | `SUM(weight)` where col IS NOT NULL | O(1) |
| AVG | `SUM(value * weight) / SUM(weight)` | O(1) |
| MIN/MAX | `BTreeMap<sortable_bits, net_count>` multiset | O(log n) |

MIN/MAX use a counted multiset — retracting the current extremum correctly produces the new extremum without re-scanning.

**Pipeline change in `aggregate_state.rs`** — `update_group_accumulators` now passes weight as the last input array to retractable accumulators instead of multiplying all numeric inputs by weight. This also fixes a latent bug where FILTER + weight would produce a length mismatch.

**`is_count_star` on `AggFuncSpec`** — propagates `args.is_empty()` from the parser to distinguish COUNT(\*) from COUNT(bool_col). The previous heuristic (input_type == Boolean) would misclassify COUNT on a nullable boolean column.

## Human Review Attestation

- [x] **I have personally reviewed this entire diff** and understand what it does
- [x] My review comments (if any) explain *why* I agree or disagree, not just what to change

**Reviewer notes** (required — write 2-3 sentences about what you verified, any concerns, or why this is correct):

Verified the retractable accumulator contract: weight is always the last input array, only appended when weight_col_idx is set, and all three accumulator creation sites (grouped, global, restore) create retractable accumulators under that condition. The sortable f64 encoding has roundtrip and order-preservation unit tests covering negative values, zero, and positive values. MIN/MAX retraction of the current extremum is tested — retracting the min correctly promotes the next-smallest value. The FILTER+weight interaction now filters both through the same boolean mask, fixing a latent length-mismatch bug in the old multiply-by-weight path. Known tradeoff: f64 precision loss for Int64 values > 2^53, same as the Ring 0 retractable accumulators in changelog.rs.

## Testing

- [x] Unit tests added/updated (25 unit tests in retractable_accumulator.rs)
- [x] Integration tests pass (6 cascaded agg tests including mixed 5-aggregate GROUP BY)
- [x] No clippy warnings (`cargo clippy -p laminar-db -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)

## Ring 0 (if applicable)

Not applicable — retractable accumulators operate in Ring 1 (SQL/DataFusion path). The hot-path `update_group_accumulators` change is a branch replacement (weight-as-input vs multiply-inputs), not a new allocation.

## Checklist

- [x] Public APIs are documented
- [x] Breaking changes documented (if any) — `AggFuncSpec` gains `is_count_star: bool` field (crate-internal, not public)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retractable, weight-aware aggregate support so SUM, COUNT, COUNT(*), AVG, MIN, and MAX properly handle changelog retractions.
  * Automatic detection of COUNT(*) semantics.

* **Bug Fixes**
  * Aggregation over changelog streams now enforces supported aggregate set and rejects unsupported ones with clearer errors.

* **Tests**
  * Updated coverage for accepted/rejected aggregates and retraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->