### PR TITLE
feat(metrics): add production-grade Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4552,6 +4552,7 @@ dependencies = [
  "pgpq",
  "pgwire-replication",
  "postgres-types",
+ "prometheus",
  "prost",
  "rdkafka",
  "reqwest 0.13.2",
@@ -4578,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrayvec",
  "arrow",
@@ -4614,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -4634,6 +4635,7 @@ dependencies = [
  "laminar-sql",
  "laminar-storage",
  "parking_lot 0.12.5",
+ "prometheus",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4648,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4662,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4682,6 +4684,7 @@ dependencies = [
  "notify",
  "openssl",
  "parking_lot 0.12.5",
+ "prometheus",
  "regex",
  "serde",
  "serde_json",
@@ -4700,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4727,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-storage"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6174,6 +6177,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot 0.12.5",
+ "procfs",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6222,6 +6264,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"
@@ -97,6 +97,9 @@ base64 = "0.22"
 
 # Randomness
 rand = "0.10"
+
+# Metrics
+prometheus = { version = "0.14", features = ["process"] }
 
 # Apache Iceberg
 iceberg = "0.9.0"

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,7 +11,7 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.20.1" }
+laminar-core = { path = "../laminar-core", version = "0.20.2" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }
@@ -56,6 +56,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
+prometheus = { workspace = true }
 rustc-hash = { workspace = true }
 
 # Arrow for RecordBatch

--- a/crates/laminar-connectors/benches/mongodb_throughput.rs
+++ b/crates/laminar-connectors/benches/mongodb_throughput.rs
@@ -50,7 +50,7 @@ fn source_event_throughput(c: &mut Criterion) {
                 b.iter(|| {
                     let config =
                         MongoDbSourceConfig::new("mongodb://localhost:27017", "bench", "coll");
-                    let mut source = MongoDbCdcSource::new(config);
+                    let mut source = MongoDbCdcSource::new(config, None);
 
                     for i in 0..n {
                         source.enqueue_event(sample_event(i));

--- a/crates/laminar-connectors/src/cdc/mysql/metrics.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/metrics.rs
@@ -1,139 +1,197 @@
 //! MySQL CDC source connector metrics.
 //!
-//! Lock-free atomic counters for CDC event processing statistics.
+//! Prometheus-backed counters/gauges for CDC event processing statistics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
 /// Metrics for MySQL CDC source connector.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone)]
 pub struct MySqlCdcMetrics {
     /// Total number of binlog events received.
-    pub events_received: AtomicU64,
+    pub events_received: IntCounter,
 
     /// Total number of INSERT row events processed.
-    pub inserts: AtomicU64,
+    pub inserts: IntCounter,
 
     /// Total number of UPDATE row events processed.
-    pub updates: AtomicU64,
+    pub updates: IntCounter,
 
     /// Total number of DELETE row events processed.
-    pub deletes: AtomicU64,
+    pub deletes: IntCounter,
 
     /// Total number of transactions seen.
-    pub transactions: AtomicU64,
+    pub transactions: IntCounter,
 
     /// Total number of TABLE_MAP events processed.
-    pub table_maps: AtomicU64,
+    pub table_maps: IntCounter,
 
     /// Total number of bytes received from binlog.
-    pub bytes_received: AtomicU64,
+    pub bytes_received: IntCounter,
 
     /// Total number of errors encountered.
-    pub errors: AtomicU64,
+    pub errors: IntCounter,
 
     /// Total number of heartbeats received.
-    pub heartbeats: AtomicU64,
+    pub heartbeats: IntCounter,
 
     /// Total number of DDL (query) events.
-    pub ddl_events: AtomicU64,
+    pub ddl_events: IntCounter,
 
     /// Current binlog position (low 32 bits).
-    pub binlog_position: AtomicU64,
+    pub binlog_position: IntGauge,
 }
 
 impl MySqlCdcMetrics {
     /// Creates new metrics with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let events_received = IntCounter::new(
+            "mysql_cdc_events_received_total",
+            "Total binlog events received",
+        )
+        .unwrap();
+        let inserts =
+            IntCounter::new("mysql_cdc_inserts_total", "Total INSERT row events").unwrap();
+        let updates =
+            IntCounter::new("mysql_cdc_updates_total", "Total UPDATE row events").unwrap();
+        let deletes =
+            IntCounter::new("mysql_cdc_deletes_total", "Total DELETE row events").unwrap();
+        let transactions =
+            IntCounter::new("mysql_cdc_transactions_total", "Total transactions").unwrap();
+        let table_maps =
+            IntCounter::new("mysql_cdc_table_maps_total", "Total TABLE_MAP events").unwrap();
+        let bytes_received =
+            IntCounter::new("mysql_cdc_bytes_received_total", "Total bytes from binlog").unwrap();
+        let errors = IntCounter::new("mysql_cdc_errors_total", "Total CDC errors").unwrap();
+        let heartbeats =
+            IntCounter::new("mysql_cdc_heartbeats_total", "Total heartbeats received").unwrap();
+        let ddl_events = IntCounter::new("mysql_cdc_ddl_events_total", "Total DDL events").unwrap();
+        let binlog_position =
+            IntGauge::new("mysql_cdc_binlog_position", "Current binlog position").unwrap();
+
+        let _ = reg.register(Box::new(events_received.clone()));
+        let _ = reg.register(Box::new(inserts.clone()));
+        let _ = reg.register(Box::new(updates.clone()));
+        let _ = reg.register(Box::new(deletes.clone()));
+        let _ = reg.register(Box::new(transactions.clone()));
+        let _ = reg.register(Box::new(table_maps.clone()));
+        let _ = reg.register(Box::new(bytes_received.clone()));
+        let _ = reg.register(Box::new(errors.clone()));
+        let _ = reg.register(Box::new(heartbeats.clone()));
+        let _ = reg.register(Box::new(ddl_events.clone()));
+        let _ = reg.register(Box::new(binlog_position.clone()));
+
+        Self {
+            events_received,
+            inserts,
+            updates,
+            deletes,
+            transactions,
+            table_maps,
+            bytes_received,
+            errors,
+            heartbeats,
+            ddl_events,
+            binlog_position,
+        }
     }
 
     /// Increments the binlog events received counter.
     pub fn inc_events_received(&self) {
-        self.events_received.fetch_add(1, Ordering::Relaxed);
+        self.events_received.inc();
     }
 
     /// Increments the INSERT row event counter by `count`.
     pub fn inc_inserts(&self, count: u64) {
-        self.inserts.fetch_add(count, Ordering::Relaxed);
+        self.inserts.inc_by(count);
     }
 
     /// Increments the UPDATE row event counter by `count`.
     pub fn inc_updates(&self, count: u64) {
-        self.updates.fetch_add(count, Ordering::Relaxed);
+        self.updates.inc_by(count);
     }
 
     /// Increments the DELETE row event counter by `count`.
     pub fn inc_deletes(&self, count: u64) {
-        self.deletes.fetch_add(count, Ordering::Relaxed);
+        self.deletes.inc_by(count);
     }
 
     /// Increments the transaction counter.
     pub fn inc_transactions(&self) {
-        self.transactions.fetch_add(1, Ordering::Relaxed);
+        self.transactions.inc();
     }
 
     /// Increments the TABLE_MAP event counter.
     pub fn inc_table_maps(&self) {
-        self.table_maps.fetch_add(1, Ordering::Relaxed);
+        self.table_maps.inc();
     }
 
     /// Adds bytes to the bytes received counter.
     pub fn add_bytes_received(&self, bytes: u64) {
-        self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
+        self.bytes_received.inc_by(bytes);
     }
 
     /// Increments the error counter.
     pub fn inc_errors(&self) {
-        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.errors.inc();
     }
 
     /// Increments the heartbeat counter.
     pub fn inc_heartbeats(&self) {
-        self.heartbeats.fetch_add(1, Ordering::Relaxed);
+        self.heartbeats.inc();
     }
 
     /// Increments the DDL event counter.
     pub fn inc_ddl_events(&self) {
-        self.ddl_events.fetch_add(1, Ordering::Relaxed);
+        self.ddl_events.inc();
     }
 
     /// Updates the current binlog position.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn set_binlog_position(&self, position: u64) {
-        self.binlog_position.store(position, Ordering::Relaxed);
+        self.binlog_position.set(position as i64);
     }
 
     /// Returns the current binlog position.
     #[must_use]
+    #[allow(clippy::cast_sign_loss)]
     pub fn get_binlog_position(&self) -> u64 {
-        self.binlog_position.load(Ordering::Relaxed)
+        self.binlog_position.get() as u64
     }
 
     /// Returns the total number of row events (insert + update + delete).
     #[must_use]
     pub fn total_row_events(&self) -> u64 {
-        self.inserts.load(Ordering::Relaxed)
-            + self.updates.load(Ordering::Relaxed)
-            + self.deletes.load(Ordering::Relaxed)
+        self.inserts.get() + self.updates.get() + self.deletes.get()
     }
 
     /// Returns a snapshot of all metrics.
     #[must_use]
+    #[allow(clippy::cast_sign_loss)]
     pub fn snapshot(&self) -> MetricsSnapshot {
         MetricsSnapshot {
-            events_received: self.events_received.load(Ordering::Relaxed),
-            inserts: self.inserts.load(Ordering::Relaxed),
-            updates: self.updates.load(Ordering::Relaxed),
-            deletes: self.deletes.load(Ordering::Relaxed),
-            transactions: self.transactions.load(Ordering::Relaxed),
-            table_maps: self.table_maps.load(Ordering::Relaxed),
-            bytes_received: self.bytes_received.load(Ordering::Relaxed),
-            errors: self.errors.load(Ordering::Relaxed),
-            heartbeats: self.heartbeats.load(Ordering::Relaxed),
-            ddl_events: self.ddl_events.load(Ordering::Relaxed),
-            binlog_position: self.binlog_position.load(Ordering::Relaxed),
+            events_received: self.events_received.get(),
+            inserts: self.inserts.get(),
+            updates: self.updates.get(),
+            deletes: self.deletes.get(),
+            transactions: self.transactions.get(),
+            table_maps: self.table_maps.get(),
+            bytes_received: self.bytes_received.get(),
+            errors: self.errors.get(),
+            heartbeats: self.heartbeats.get(),
+            ddl_events: self.ddl_events.get(),
+            binlog_position: self.binlog_position.get() as u64,
         }
     }
 
@@ -142,25 +200,16 @@ impl MySqlCdcMetrics {
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         ConnectorMetrics {
             records_total: self.total_row_events(),
-            bytes_total: self.bytes_received.load(Ordering::Relaxed),
-            errors_total: self.errors.load(Ordering::Relaxed),
+            bytes_total: self.bytes_received.get(),
+            errors_total: self.errors.get(),
             ..ConnectorMetrics::default()
         }
     }
+}
 
-    /// Resets all counters to zero.
-    pub fn reset(&self) {
-        self.events_received.store(0, Ordering::Relaxed);
-        self.inserts.store(0, Ordering::Relaxed);
-        self.updates.store(0, Ordering::Relaxed);
-        self.deletes.store(0, Ordering::Relaxed);
-        self.transactions.store(0, Ordering::Relaxed);
-        self.table_maps.store(0, Ordering::Relaxed);
-        self.bytes_received.store(0, Ordering::Relaxed);
-        self.errors.store(0, Ordering::Relaxed);
-        self.heartbeats.store(0, Ordering::Relaxed);
-        self.ddl_events.store(0, Ordering::Relaxed);
-        self.binlog_position.store(0, Ordering::Relaxed);
+impl Default for MySqlCdcMetrics {
+    fn default() -> Self {
+        Self::new(None)
     }
 }
 
@@ -205,23 +254,23 @@ mod tests {
 
     #[test]
     fn test_new_metrics() {
-        let m = MySqlCdcMetrics::new();
-        assert_eq!(m.events_received.load(Ordering::Relaxed), 0);
-        assert_eq!(m.inserts.load(Ordering::Relaxed), 0);
-        assert_eq!(m.errors.load(Ordering::Relaxed), 0);
+        let m = MySqlCdcMetrics::new(None);
+        assert_eq!(m.events_received.get(), 0);
+        assert_eq!(m.inserts.get(), 0);
+        assert_eq!(m.errors.get(), 0);
     }
 
     #[test]
     fn test_inc_events_received() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.inc_events_received();
         m.inc_events_received();
-        assert_eq!(m.events_received.load(Ordering::Relaxed), 2);
+        assert_eq!(m.events_received.get(), 2);
     }
 
     #[test]
     fn test_inc_row_events() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.inc_inserts(5);
         m.inc_updates(3);
         m.inc_deletes(2);
@@ -230,22 +279,22 @@ mod tests {
 
     #[test]
     fn test_add_bytes() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.add_bytes_received(100);
         m.add_bytes_received(50);
-        assert_eq!(m.bytes_received.load(Ordering::Relaxed), 150);
+        assert_eq!(m.bytes_received.get(), 150);
     }
 
     #[test]
     fn test_binlog_position() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.set_binlog_position(12345);
         assert_eq!(m.get_binlog_position(), 12345);
     }
 
     #[test]
     fn test_snapshot() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.inc_inserts(10);
         m.inc_updates(5);
         m.inc_transactions();
@@ -259,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_to_connector_metrics() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
         m.inc_inserts(10);
         m.add_bytes_received(1000);
         m.inc_errors();
@@ -271,22 +320,8 @@ mod tests {
     }
 
     #[test]
-    fn test_reset() {
-        let m = MySqlCdcMetrics::new();
-        m.inc_inserts(10);
-        m.inc_errors();
-        m.set_binlog_position(12345);
-
-        m.reset();
-
-        assert_eq!(m.inserts.load(Ordering::Relaxed), 0);
-        assert_eq!(m.errors.load(Ordering::Relaxed), 0);
-        assert_eq!(m.binlog_position.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
     fn test_inc_all_counters() {
-        let m = MySqlCdcMetrics::new();
+        let m = MySqlCdcMetrics::new(None);
 
         m.inc_events_received();
         m.inc_inserts(1);

--- a/crates/laminar-connectors/src/cdc/mysql/mod.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/mod.rs
@@ -54,8 +54,9 @@ pub fn register_mysql_cdc_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "mysql-cdc",
         info.clone(),
-        Arc::new(|| {
-            Box::new(MySqlCdcSource::new(MySqlCdcConfig::default())) as Box<dyn SourceConnector>
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(MySqlCdcSource::new(MySqlCdcConfig::default(), registry))
+                as Box<dyn SourceConnector>
         }),
     );
 
@@ -63,7 +64,7 @@ pub fn register_mysql_cdc_source(registry: &ConnectorRegistry) {
         "mysql-cdc",
         info,
         Arc::new(|config| {
-            let connector = Box::new(MySqlCdcSource::new(MySqlCdcConfig::default()));
+            let connector = Box::new(MySqlCdcSource::new(MySqlCdcConfig::default(), None));
             Ok(Box::new(crate::lookup::cdc_adapter::CdcTableSource::new(
                 connector,
                 config.clone(),
@@ -195,7 +196,7 @@ mod tests {
         let _config = MySqlCdcConfig::default();
         let _ssl = SslMode::Preferred;
         let _snapshot = SnapshotMode::Initial;
-        let _metrics = MySqlCdcMetrics::new();
+        let _metrics = MySqlCdcMetrics::new(None);
         let _cache = TableCache::new();
         let _op = CdcOperation::Insert;
     }

--- a/crates/laminar-connectors/src/cdc/mysql/source.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/source.rs
@@ -104,7 +104,7 @@ impl std::fmt::Debug for MySqlCdcSource {
 impl MySqlCdcSource {
     /// Creates a new MySQL CDC source with the given configuration.
     #[must_use]
-    pub fn new(config: MySqlCdcConfig) -> Self {
+    pub fn new(config: MySqlCdcConfig, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             connected: false,
@@ -114,7 +114,7 @@ impl MySqlCdcSource {
             current_binlog_file: String::new(),
             current_gtid: None,
             event_buffer: Vec::new(),
-            metrics: MySqlCdcMetrics::new(),
+            metrics: MySqlCdcMetrics::new(registry),
             schema: None,
             last_activity: None,
             data_ready: Arc::new(Notify::new()),
@@ -134,7 +134,7 @@ impl MySqlCdcSource {
     /// Returns error if required configuration keys are missing.
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let mysql_config = MySqlCdcConfig::from_config(config)?;
-        Ok(Self::new(mysql_config))
+        Ok(Self::new(mysql_config, None))
     }
 
     /// Returns the number of cached table schemas.
@@ -548,10 +548,7 @@ impl SourceConnector for MySqlCdcSource {
         }
 
         // Check error count
-        let errors = self
-            .metrics
-            .errors
-            .load(std::sync::atomic::Ordering::Relaxed);
+        let errors = self.metrics.errors.get();
         if errors > 100 {
             return HealthStatus::Degraded(format!("{errors} errors encountered"));
         }
@@ -607,7 +604,7 @@ mod tests {
     #[test]
     fn test_new_source() {
         let config = test_config();
-        let source = MySqlCdcSource::new(config);
+        let source = MySqlCdcSource::new(config, None);
 
         assert!(!source.is_connected());
         assert_eq!(source.cached_table_count(), 0);
@@ -640,7 +637,7 @@ mod tests {
 
     #[test]
     fn test_restore_position_gtid() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
 
         let mut checkpoint = SourceCheckpoint::new(1);
         checkpoint.set_offset("gtid", "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5");
@@ -651,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_restore_position_file() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
 
         let mut checkpoint = SourceCheckpoint::new(1);
         checkpoint.set_offset("binlog_file", "mysql-bin.000003");
@@ -665,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_create_checkpoint_gtid() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.config.use_gtid = true;
         source.gtid_set = Some("3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5".parse().unwrap());
 
@@ -677,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_create_checkpoint_file() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.config.use_gtid = false;
         source.position = Some(BinlogPosition::new("mysql-bin.000003".to_string(), 9999));
 
@@ -691,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_schema() {
-        let source = MySqlCdcSource::new(test_config());
+        let source = MySqlCdcSource::new(test_config(), None);
         let schema = source.schema();
 
         // Should have CDC envelope fields
@@ -703,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_health_check_not_connected() {
-        let source = MySqlCdcSource::new(test_config());
+        let source = MySqlCdcSource::new(test_config(), None);
 
         match source.health_check() {
             HealthStatus::Unhealthy(message) => {
@@ -715,7 +712,7 @@ mod tests {
 
     #[test]
     fn test_health_check_healthy() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.connected = true;
         source.last_activity = Some(Instant::now());
 
@@ -724,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_health_check_degraded_no_activity() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.connected = true;
         source.config.heartbeat_interval = Duration::from_millis(1);
         source.last_activity = Instant::now().checked_sub(Duration::from_secs(10));
@@ -739,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_health_check_degraded_errors() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.connected = true;
         source.last_activity = Some(Instant::now());
 
@@ -758,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_metrics() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
         source.metrics.inc_inserts(100);
         source.metrics.inc_updates(50);
         source.metrics.inc_deletes(25);
@@ -776,7 +773,7 @@ mod tests {
         let mut config = test_config();
         config.table_include = vec!["users".to_string(), "orders".to_string()];
 
-        let source = MySqlCdcSource::new(config);
+        let source = MySqlCdcSource::new(config, None);
 
         assert!(source.should_include_table("testdb", "users"));
         assert!(source.should_include_table("testdb", "orders"));
@@ -787,7 +784,7 @@ mod tests {
     #[cfg(not(feature = "mysql-cdc"))]
     #[tokio::test]
     async fn test_open_fails_without_feature() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
 
         let result = source.open(&ConnectorConfig::default()).await;
         assert!(result.is_err());
@@ -800,7 +797,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_poll_not_connected() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
 
         let result = source.poll_batch(100).await;
         assert!(result.is_err());
@@ -811,7 +808,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_async() {
-        let mut source = MySqlCdcSource::new(test_config());
+        let mut source = MySqlCdcSource::new(test_config(), None);
 
         let mut checkpoint = SourceCheckpoint::new(1);
         checkpoint.set_offset("binlog_file", "mysql-bin.000005");

--- a/crates/laminar-connectors/src/cdc/postgres/metrics.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/metrics.rs
@@ -1,168 +1,225 @@
 //! `PostgreSQL` CDC source connector metrics.
 //!
-//! Lock-free atomic counters for tracking CDC replication performance.
+//! Prometheus-backed counters/gauges for tracking CDC replication performance.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
 /// Metrics for the `PostgreSQL` CDC source connector.
 ///
-/// All counters use relaxed atomic ordering for lock-free access
-/// from the Ring 1 async runtime.
-#[derive(Debug)]
+/// All counters are prometheus-backed and will appear in the scrape
+/// output when a shared registry is provided.
+#[derive(Debug, Clone)]
 pub struct PostgresCdcMetrics {
     /// Total change events received (insert + update + delete).
-    pub events_received: AtomicU64,
+    pub events_received: IntCounter,
 
     /// Total bytes received from the WAL stream.
-    pub bytes_received: AtomicU64,
+    pub bytes_received: IntCounter,
 
     /// Total errors encountered.
-    pub errors: AtomicU64,
+    pub errors: IntCounter,
 
     /// Total batches produced for downstream.
-    pub batches_produced: AtomicU64,
+    pub batches_produced: IntCounter,
 
     /// Total INSERT operations received.
-    pub inserts: AtomicU64,
+    pub inserts: IntCounter,
 
     /// Total UPDATE operations received.
-    pub updates: AtomicU64,
+    pub updates: IntCounter,
 
     /// Total DELETE operations received.
-    pub deletes: AtomicU64,
+    pub deletes: IntCounter,
 
     /// Total transactions (commit messages) received.
-    pub transactions: AtomicU64,
+    pub transactions: IntCounter,
 
     /// Current confirmed flush LSN (as raw u64).
-    pub confirmed_flush_lsn: AtomicU64,
+    pub confirmed_flush_lsn: IntGauge,
 
     /// Current replication lag in bytes (`write_lsn` - `confirmed_flush_lsn`).
-    pub replication_lag_bytes: AtomicU64,
+    pub replication_lag_bytes: IntGauge,
 
     /// Total keepalive/heartbeat messages sent.
-    pub keepalives_sent: AtomicU64,
+    pub keepalives_sent: IntCounter,
 
     /// Total events dropped due to buffer cap enforcement.
-    pub events_dropped: AtomicU64,
+    pub events_dropped: IntCounter,
 }
 
 impl PostgresCdcMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let events_received = IntCounter::new(
+            "postgres_cdc_events_received_total",
+            "Total CDC change events received",
+        )
+        .unwrap();
+        let bytes_received = IntCounter::new(
+            "postgres_cdc_bytes_received_total",
+            "Total bytes from WAL stream",
+        )
+        .unwrap();
+        let errors = IntCounter::new("postgres_cdc_errors_total", "Total CDC errors").unwrap();
+        let batches_produced = IntCounter::new(
+            "postgres_cdc_batches_produced_total",
+            "Total batches produced",
+        )
+        .unwrap();
+        let inserts = IntCounter::new("postgres_cdc_inserts_total", "Total INSERT events").unwrap();
+        let updates = IntCounter::new("postgres_cdc_updates_total", "Total UPDATE events").unwrap();
+        let deletes = IntCounter::new("postgres_cdc_deletes_total", "Total DELETE events").unwrap();
+        let transactions = IntCounter::new(
+            "postgres_cdc_transactions_total",
+            "Total transactions received",
+        )
+        .unwrap();
+        let confirmed_flush_lsn = IntGauge::new(
+            "postgres_cdc_confirmed_flush_lsn",
+            "Current confirmed flush LSN",
+        )
+        .unwrap();
+        let replication_lag_bytes = IntGauge::new(
+            "postgres_cdc_replication_lag_bytes",
+            "Replication lag in bytes",
+        )
+        .unwrap();
+        let keepalives_sent = IntCounter::new(
+            "postgres_cdc_keepalives_sent_total",
+            "Total keepalive messages sent",
+        )
+        .unwrap();
+        let events_dropped = IntCounter::new(
+            "postgres_cdc_events_dropped_total",
+            "Total events dropped (buffer cap)",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(events_received.clone()));
+        let _ = reg.register(Box::new(bytes_received.clone()));
+        let _ = reg.register(Box::new(errors.clone()));
+        let _ = reg.register(Box::new(batches_produced.clone()));
+        let _ = reg.register(Box::new(inserts.clone()));
+        let _ = reg.register(Box::new(updates.clone()));
+        let _ = reg.register(Box::new(deletes.clone()));
+        let _ = reg.register(Box::new(transactions.clone()));
+        let _ = reg.register(Box::new(confirmed_flush_lsn.clone()));
+        let _ = reg.register(Box::new(replication_lag_bytes.clone()));
+        let _ = reg.register(Box::new(keepalives_sent.clone()));
+        let _ = reg.register(Box::new(events_dropped.clone()));
+
         Self {
-            events_received: AtomicU64::new(0),
-            bytes_received: AtomicU64::new(0),
-            errors: AtomicU64::new(0),
-            batches_produced: AtomicU64::new(0),
-            inserts: AtomicU64::new(0),
-            updates: AtomicU64::new(0),
-            deletes: AtomicU64::new(0),
-            transactions: AtomicU64::new(0),
-            confirmed_flush_lsn: AtomicU64::new(0),
-            replication_lag_bytes: AtomicU64::new(0),
-            keepalives_sent: AtomicU64::new(0),
-            events_dropped: AtomicU64::new(0),
+            events_received,
+            bytes_received,
+            errors,
+            batches_produced,
+            inserts,
+            updates,
+            deletes,
+            transactions,
+            confirmed_flush_lsn,
+            replication_lag_bytes,
+            keepalives_sent,
+            events_dropped,
         }
     }
 
     /// Records a received INSERT event.
     pub fn record_insert(&self) {
-        self.inserts.fetch_add(1, Ordering::Relaxed);
-        self.events_received.fetch_add(1, Ordering::Relaxed);
+        self.inserts.inc();
+        self.events_received.inc();
     }
 
     /// Records a received UPDATE event.
     pub fn record_update(&self) {
-        self.updates.fetch_add(1, Ordering::Relaxed);
-        self.events_received.fetch_add(1, Ordering::Relaxed);
+        self.updates.inc();
+        self.events_received.inc();
     }
 
     /// Records a received DELETE event.
     pub fn record_delete(&self) {
-        self.deletes.fetch_add(1, Ordering::Relaxed);
-        self.events_received.fetch_add(1, Ordering::Relaxed);
+        self.deletes.inc();
+        self.events_received.inc();
     }
 
     /// Records a received transaction commit.
     pub fn record_transaction(&self) {
-        self.transactions.fetch_add(1, Ordering::Relaxed);
+        self.transactions.inc();
     }
 
     /// Records bytes received from the WAL stream.
     pub fn record_bytes(&self, bytes: u64) {
-        self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
+        self.bytes_received.inc_by(bytes);
     }
 
     /// Records an error.
     pub fn record_error(&self) {
-        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.errors.inc();
     }
 
     /// Records a batch produced for downstream.
     pub fn record_batch(&self) {
-        self.batches_produced.fetch_add(1, Ordering::Relaxed);
+        self.batches_produced.inc();
     }
 
     /// Updates the confirmed flush LSN.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn set_confirmed_flush_lsn(&self, lsn: u64) {
-        self.confirmed_flush_lsn.store(lsn, Ordering::Relaxed);
+        self.confirmed_flush_lsn.set(lsn as i64);
     }
 
     /// Updates the replication lag in bytes.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn set_replication_lag_bytes(&self, lag: u64) {
-        self.replication_lag_bytes.store(lag, Ordering::Relaxed);
+        self.replication_lag_bytes.set(lag as i64);
     }
 
     /// Records a keepalive sent to `PostgreSQL`.
     pub fn record_keepalive(&self) {
-        self.keepalives_sent.fetch_add(1, Ordering::Relaxed);
+        self.keepalives_sent.inc();
     }
 
     /// Records events dropped due to buffer cap.
     pub fn record_dropped(&self, count: u64) {
-        self.events_dropped.fetch_add(count, Ordering::Relaxed);
+        self.events_dropped.inc_by(count);
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics::new();
-        m.records_total = self.events_received.load(Ordering::Relaxed);
-        m.bytes_total = self.bytes_received.load(Ordering::Relaxed);
-        m.errors_total = self.errors.load(Ordering::Relaxed);
-        m.lag = self.replication_lag_bytes.load(Ordering::Relaxed);
+        m.records_total = self.events_received.get();
+        m.bytes_total = self.bytes_received.get();
+        m.errors_total = self.errors.get();
+        m.lag = self.replication_lag_bytes.get() as u64;
 
-        m.add_custom("inserts", self.inserts.load(Ordering::Relaxed) as f64);
-        m.add_custom("updates", self.updates.load(Ordering::Relaxed) as f64);
-        m.add_custom("deletes", self.deletes.load(Ordering::Relaxed) as f64);
-        m.add_custom(
-            "transactions",
-            self.transactions.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "confirmed_flush_lsn",
-            self.confirmed_flush_lsn.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "events_dropped",
-            self.events_dropped.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "keepalives_sent",
-            self.keepalives_sent.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("inserts", self.inserts.get() as f64);
+        m.add_custom("updates", self.updates.get() as f64);
+        m.add_custom("deletes", self.deletes.get() as f64);
+        m.add_custom("transactions", self.transactions.get() as f64);
+        m.add_custom("confirmed_flush_lsn", self.confirmed_flush_lsn.get() as f64);
+        m.add_custom("events_dropped", self.events_dropped.get() as f64);
+        m.add_custom("keepalives_sent", self.keepalives_sent.get() as f64);
         m
     }
 }
 
 impl Default for PostgresCdcMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -172,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_record_operations() {
-        let m = PostgresCdcMetrics::new();
+        let m = PostgresCdcMetrics::new(None);
         m.record_insert();
         m.record_insert();
         m.record_update();
@@ -183,30 +240,30 @@ mod tests {
         m.record_batch();
         m.record_keepalive();
 
-        assert_eq!(m.events_received.load(Ordering::Relaxed), 4);
-        assert_eq!(m.inserts.load(Ordering::Relaxed), 2);
-        assert_eq!(m.updates.load(Ordering::Relaxed), 1);
-        assert_eq!(m.deletes.load(Ordering::Relaxed), 1);
-        assert_eq!(m.transactions.load(Ordering::Relaxed), 1);
-        assert_eq!(m.bytes_received.load(Ordering::Relaxed), 1024);
-        assert_eq!(m.errors.load(Ordering::Relaxed), 1);
-        assert_eq!(m.batches_produced.load(Ordering::Relaxed), 1);
-        assert_eq!(m.keepalives_sent.load(Ordering::Relaxed), 1);
+        assert_eq!(m.events_received.get(), 4);
+        assert_eq!(m.inserts.get(), 2);
+        assert_eq!(m.updates.get(), 1);
+        assert_eq!(m.deletes.get(), 1);
+        assert_eq!(m.transactions.get(), 1);
+        assert_eq!(m.bytes_received.get(), 1024);
+        assert_eq!(m.errors.get(), 1);
+        assert_eq!(m.batches_produced.get(), 1);
+        assert_eq!(m.keepalives_sent.get(), 1);
     }
 
     #[test]
     fn test_lsn_and_lag_tracking() {
-        let m = PostgresCdcMetrics::new();
+        let m = PostgresCdcMetrics::new(None);
         m.set_confirmed_flush_lsn(0x1234_ABCD);
         m.set_replication_lag_bytes(4096);
 
-        assert_eq!(m.confirmed_flush_lsn.load(Ordering::Relaxed), 0x1234_ABCD);
-        assert_eq!(m.replication_lag_bytes.load(Ordering::Relaxed), 4096);
+        assert_eq!(m.confirmed_flush_lsn.get(), 0x1234_ABCD_i64);
+        assert_eq!(m.replication_lag_bytes.get(), 4096);
     }
 
     #[test]
     fn test_to_connector_metrics() {
-        let m = PostgresCdcMetrics::new();
+        let m = PostgresCdcMetrics::new(None);
         m.record_insert();
         m.record_bytes(512);
         m.record_error();

--- a/crates/laminar-connectors/src/cdc/postgres/mod.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/mod.rs
@@ -34,7 +34,12 @@ pub fn register_postgres_cdc_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "postgres-cdc",
         info.clone(),
-        Arc::new(|| Box::new(PostgresCdcSource::new(PostgresCdcConfig::default()))),
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(PostgresCdcSource::new(
+                PostgresCdcConfig::default(),
+                registry,
+            ))
+        }),
     );
 
     // Also register as a table source so CREATE LOOKUP TABLE ... WITH
@@ -43,7 +48,7 @@ pub fn register_postgres_cdc_source(registry: &ConnectorRegistry) {
         "postgres-cdc",
         info,
         Arc::new(|config| {
-            let connector = Box::new(PostgresCdcSource::new(PostgresCdcConfig::default()));
+            let connector = Box::new(PostgresCdcSource::new(PostgresCdcConfig::default(), None));
             Ok(Box::new(crate::lookup::cdc_adapter::CdcTableSource::new(
                 connector,
                 config.clone(),

--- a/crates/laminar-connectors/src/cdc/postgres/source.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/source.rs
@@ -149,12 +149,12 @@ enum WalPayload {
 impl PostgresCdcSource {
     /// Creates a new `PostgreSQL` CDC source with the given configuration.
     #[must_use]
-    pub fn new(config: PostgresCdcConfig) -> Self {
+    pub fn new(config: PostgresCdcConfig, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             state: ConnectorState::Created,
             schema: cdc_envelope_schema(),
-            metrics: Arc::new(PostgresCdcMetrics::new()),
+            metrics: Arc::new(PostgresCdcMetrics::new(registry)),
             relation_cache: RelationCache::new(),
             event_buffer: VecDeque::new(),
             current_txn: None,
@@ -183,7 +183,7 @@ impl PostgresCdcSource {
     /// Returns `ConnectorError` if the configuration is invalid.
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let pg_config = PostgresCdcConfig::from_config(config)?;
-        Ok(Self::new(pg_config))
+        Ok(Self::new(pg_config, None))
     }
 
     /// Returns a reference to the CDC configuration.
@@ -1051,7 +1051,7 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     fn default_source() -> PostgresCdcSource {
-        PostgresCdcSource::new(PostgresCdcConfig::default())
+        PostgresCdcSource::new(PostgresCdcConfig::default(), None)
     }
 
     fn running_source() -> PostgresCdcSource {
@@ -1349,7 +1349,7 @@ mod tests {
     async fn test_table_exclude_filter() {
         let mut config = PostgresCdcConfig::default();
         config.table_exclude = vec!["users".to_string()];
-        let mut src = PostgresCdcSource::new(config);
+        let mut src = PostgresCdcSource::new(config, None);
         src.state = ConnectorState::Running;
 
         let rel_msg = PostgresCdcSource::build_relation_message(
@@ -1715,6 +1715,6 @@ mod tests {
         assert_eq!(batch.records.num_rows(), 50);
         // 200 - 50 drained = 150 remaining. No events dropped.
         assert_eq!(src.event_buffer.len(), 150);
-        assert_eq!(src.metrics.events_dropped.load(Ordering::Relaxed), 0);
+        assert_eq!(src.metrics.events_dropped.get(), 0);
     }
 }

--- a/crates/laminar-connectors/src/cdc/postgres/source.rs
+++ b/crates/laminar-connectors/src/cdc/postgres/source.rs
@@ -1048,7 +1048,6 @@ mod tests {
     use super::*;
     use crate::cdc::postgres::types::{INT4_OID, INT8_OID, TEXT_OID};
     use arrow_array::cast::AsArray;
-    use std::sync::atomic::Ordering;
 
     fn default_source() -> PostgresCdcSource {
         PostgresCdcSource::new(PostgresCdcConfig::default(), None)

--- a/crates/laminar-connectors/src/files/mod.rs
+++ b/crates/laminar-connectors/src/files/mod.rs
@@ -33,7 +33,13 @@ pub fn register_file_source(registry: &ConnectorRegistry) {
         is_sink: false,
         config_keys: vec![],
     };
-    registry.register_source("files", info, Arc::new(|| Box::new(FileSource::new())));
+    registry.register_source(
+        "files",
+        info,
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(FileSource::with_registry(registry))
+        }),
+    );
 }
 
 /// Registers the file sink connector in the registry.
@@ -48,7 +54,13 @@ pub fn register_file_sink(registry: &ConnectorRegistry) {
         is_sink: true,
         config_keys: vec![],
     };
-    registry.register_sink("files", info, Arc::new(|| Box::new(FileSink::new())));
+    registry.register_sink(
+        "files",
+        info,
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(FileSink::with_registry(registry))
+        }),
+    );
 }
 
 #[cfg(test)]
@@ -89,7 +101,7 @@ mod tests {
         register_file_source(&registry);
 
         let config = crate::config::ConnectorConfig::new("files");
-        let source = registry.create_source(&config);
+        let source = registry.create_source(&config, None);
         assert!(source.is_ok());
     }
 
@@ -99,7 +111,7 @@ mod tests {
         register_file_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("files");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 }

--- a/crates/laminar-connectors/src/files/sink.rs
+++ b/crates/laminar-connectors/src/files/sink.rs
@@ -53,6 +53,12 @@ impl FileSink {
     /// Creates a new file sink with a placeholder schema.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_registry(None)
+    }
+
+    /// Creates a new file sink with an optional Prometheus registry.
+    #[must_use]
+    pub fn with_registry(_registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config: None,
             schema: Arc::new(arrow_schema::Schema::empty()),

--- a/crates/laminar-connectors/src/files/source.rs
+++ b/crates/laminar-connectors/src/files/source.rs
@@ -47,6 +47,12 @@ impl FileSource {
     /// Creates a new file source with a placeholder schema.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_registry(None)
+    }
+
+    /// Creates a new file source with an optional Prometheus registry.
+    #[must_use]
+    pub fn with_registry(_registry: Option<&prometheus::Registry>) -> Self {
         let empty_schema = Arc::new(Schema::empty());
         Self {
             config: None,

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -330,7 +330,10 @@ mod tests {
 
         // Verify the metrics are registered on the registry.
         let families = reg.gather();
-        let names: Vec<&str> = families.iter().map(prometheus::proto::MetricFamily::name).collect();
+        let names: Vec<&str> = families
+            .iter()
+            .map(prometheus::proto::MetricFamily::name)
+            .collect();
         assert!(names.contains(&"kafka_source_records_polled_total"));
         assert!(names.contains(&"kafka_source_errors_total"));
     }

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -1,129 +1,198 @@
 //! Kafka source connector metrics.
 //!
-//! [`KafkaSourceMetrics`] provides lock-free atomic counters for
-//! tracking consumption statistics, convertible to the SDK's
+//! [`KafkaSourceMetrics`] provides prometheus-backed counters and gauges
+//! for tracking consumption statistics, convertible to the SDK's
 //! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for Kafka source connector statistics.
-#[derive(Debug)]
+/// Prometheus-backed counters/gauges for Kafka source connector statistics.
+#[derive(Debug, Clone)]
 pub struct KafkaSourceMetrics {
     /// Total records polled from Kafka.
-    pub records_polled: AtomicU64,
+    pub records_polled: IntCounter,
     /// Total bytes polled from Kafka.
-    pub bytes_polled: AtomicU64,
+    pub bytes_polled: IntCounter,
     /// Total deserialization or consumer errors.
-    pub errors: AtomicU64,
+    pub errors: IntCounter,
     /// Total batches returned from `poll_batch()`.
-    pub batches_polled: AtomicU64,
+    pub batches_polled: IntCounter,
     /// Total offset commits to Kafka.
-    pub commits: AtomicU64,
+    pub commits: IntCounter,
     /// Total consumer group rebalances.
-    pub rebalances: AtomicU64,
+    pub rebalances: IntCounter,
     /// Consumer lag (sum across all partitions of `high_watermark - current_offset`).
-    pub lag: AtomicU64,
+    pub lag: IntGauge,
     /// Count of successful Schema Registry discoveries at DDL time.
-    pub sr_discovery_successes: AtomicU64,
+    pub sr_discovery_successes: IntCounter,
     /// Count of Schema Registry discovery failures (HTTP error, parse error).
-    pub sr_discovery_failures: AtomicU64,
+    pub sr_discovery_failures: IntCounter,
     /// Count of Schema Registry discovery timeouts.
-    pub sr_discovery_timeouts: AtomicU64,
+    pub sr_discovery_timeouts: IntCounter,
 }
 
 impl KafkaSourceMetrics {
     /// All counters start at zero.
+    ///
+    /// If `registry` is `Some`, the metrics are registered on it and
+    /// will appear in the Prometheus scrape output. Otherwise a local
+    /// throwaway registry is used.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let records_polled = IntCounter::new(
+            "kafka_source_records_polled_total",
+            "Total records polled from Kafka",
+        )
+        .unwrap();
+        let bytes_polled = IntCounter::new(
+            "kafka_source_bytes_polled_total",
+            "Total bytes polled from Kafka",
+        )
+        .unwrap();
+        let errors =
+            IntCounter::new("kafka_source_errors_total", "Total Kafka consumer errors").unwrap();
+        let batches_polled = IntCounter::new(
+            "kafka_source_batches_polled_total",
+            "Total batches polled from Kafka",
+        )
+        .unwrap();
+        let commits = IntCounter::new(
+            "kafka_source_commits_total",
+            "Total offset commits to Kafka",
+        )
+        .unwrap();
+        let rebalances = IntCounter::new(
+            "kafka_source_rebalances_total",
+            "Total consumer group rebalances",
+        )
+        .unwrap();
+        let lag = IntGauge::new(
+            "kafka_source_consumer_lag",
+            "Consumer lag (sum across partitions)",
+        )
+        .unwrap();
+        let sr_discovery_successes = IntCounter::new(
+            "kafka_source_sr_discovery_successes_total",
+            "Schema Registry discovery successes",
+        )
+        .unwrap();
+        let sr_discovery_failures = IntCounter::new(
+            "kafka_source_sr_discovery_failures_total",
+            "Schema Registry discovery failures",
+        )
+        .unwrap();
+        let sr_discovery_timeouts = IntCounter::new(
+            "kafka_source_sr_discovery_timeouts_total",
+            "Schema Registry discovery timeouts",
+        )
+        .unwrap();
+
+        // Best-effort registration — ignore `AlreadyReg` if another
+        // Kafka source is already on the same registry.
+        let _ = reg.register(Box::new(records_polled.clone()));
+        let _ = reg.register(Box::new(bytes_polled.clone()));
+        let _ = reg.register(Box::new(errors.clone()));
+        let _ = reg.register(Box::new(batches_polled.clone()));
+        let _ = reg.register(Box::new(commits.clone()));
+        let _ = reg.register(Box::new(rebalances.clone()));
+        let _ = reg.register(Box::new(lag.clone()));
+        let _ = reg.register(Box::new(sr_discovery_successes.clone()));
+        let _ = reg.register(Box::new(sr_discovery_failures.clone()));
+        let _ = reg.register(Box::new(sr_discovery_timeouts.clone()));
+
         Self {
-            records_polled: AtomicU64::new(0),
-            bytes_polled: AtomicU64::new(0),
-            errors: AtomicU64::new(0),
-            batches_polled: AtomicU64::new(0),
-            commits: AtomicU64::new(0),
-            rebalances: AtomicU64::new(0),
-            lag: AtomicU64::new(0),
-            sr_discovery_successes: AtomicU64::new(0),
-            sr_discovery_failures: AtomicU64::new(0),
-            sr_discovery_timeouts: AtomicU64::new(0),
+            records_polled,
+            bytes_polled,
+            errors,
+            batches_polled,
+            commits,
+            rebalances,
+            lag,
+            sr_discovery_successes,
+            sr_discovery_failures,
+            sr_discovery_timeouts,
         }
     }
 
     /// Records a successful poll of `records` records totaling `bytes`.
     pub fn record_poll(&self, records: u64, bytes: u64) {
-        self.records_polled.fetch_add(records, Ordering::Relaxed);
-        self.bytes_polled.fetch_add(bytes, Ordering::Relaxed);
-        self.batches_polled.fetch_add(1, Ordering::Relaxed);
+        self.records_polled.inc_by(records);
+        self.bytes_polled.inc_by(bytes);
+        self.batches_polled.inc();
     }
 
     /// Records a consumer or deserialization error.
     pub fn record_error(&self) {
-        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.errors.inc();
     }
 
     /// Records a successful offset commit.
     pub fn record_commit(&self) {
-        self.commits.fetch_add(1, Ordering::Relaxed);
+        self.commits.inc();
     }
 
     /// Records a consumer group rebalance event.
     pub fn record_rebalance(&self) {
-        self.rebalances.fetch_add(1, Ordering::Relaxed);
+        self.rebalances.inc();
     }
 
     /// Updates the consumer lag value.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn set_lag(&self, lag: u64) {
-        self.lag.store(lag, Ordering::Relaxed);
+        self.lag.set(lag as i64);
     }
 
     /// Records a successful Schema Registry discovery at DDL time.
     pub fn record_sr_discovery_success(&self) {
-        self.sr_discovery_successes.fetch_add(1, Ordering::Relaxed);
+        self.sr_discovery_successes.inc();
     }
 
     /// Records a Schema Registry discovery failure.
     pub fn record_sr_discovery_failure(&self) {
-        self.sr_discovery_failures.fetch_add(1, Ordering::Relaxed);
+        self.sr_discovery_failures.inc();
     }
 
     /// Records a Schema Registry discovery timeout.
     pub fn record_sr_discovery_timeout(&self) {
-        self.sr_discovery_timeouts.fetch_add(1, Ordering::Relaxed);
+        self.sr_discovery_timeouts.inc();
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
-            records_total: self.records_polled.load(Ordering::Relaxed),
-            bytes_total: self.bytes_polled.load(Ordering::Relaxed),
-            errors_total: self.errors.load(Ordering::Relaxed),
-            lag: self.lag.load(Ordering::Relaxed),
+            records_total: self.records_polled.get(),
+            bytes_total: self.bytes_polled.get(),
+            errors_total: self.errors.get(),
+            lag: self.lag.get() as u64,
             custom: Vec::new(),
         };
-        m.add_custom(
-            "kafka.batches_polled",
-            self.batches_polled.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom("kafka.commits", self.commits.load(Ordering::Relaxed) as f64);
-        m.add_custom(
-            "kafka.rebalances",
-            self.rebalances.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("kafka.batches_polled", self.batches_polled.get() as f64);
+        m.add_custom("kafka.commits", self.commits.get() as f64);
+        m.add_custom("kafka.rebalances", self.rebalances.get() as f64);
         m.add_custom(
             "kafka.sr_discovery_successes",
-            self.sr_discovery_successes.load(Ordering::Relaxed) as f64,
+            self.sr_discovery_successes.get() as f64,
         );
         m.add_custom(
             "kafka.sr_discovery_failures",
-            self.sr_discovery_failures.load(Ordering::Relaxed) as f64,
+            self.sr_discovery_failures.get() as f64,
         );
         m.add_custom(
             "kafka.sr_discovery_timeouts",
-            self.sr_discovery_timeouts.load(Ordering::Relaxed) as f64,
+            self.sr_discovery_timeouts.get() as f64,
         );
         m
     }
@@ -131,7 +200,7 @@ impl KafkaSourceMetrics {
 
 impl Default for KafkaSourceMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -141,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -150,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_record_poll() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         m.record_poll(100, 5000);
         m.record_poll(200, 10000);
 
@@ -161,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_record_error_and_commit() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         m.record_error();
         m.record_error();
         m.record_commit();
@@ -176,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_record_rebalance() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         m.record_rebalance();
         m.record_rebalance();
 
@@ -187,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_set_lag() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         assert_eq!(m.to_connector_metrics().lag, 0);
 
         m.set_lag(42);
@@ -199,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_sr_discovery_counters() {
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         m.record_sr_discovery_success();
         m.record_sr_discovery_success();
         m.record_sr_discovery_failure();
@@ -247,8 +316,22 @@ mod tests {
             .sum();
         assert_eq!(total_lag, 598);
 
-        let m = KafkaSourceMetrics::new();
+        let m = KafkaSourceMetrics::new(None);
         m.set_lag(total_lag);
         assert_eq!(m.to_connector_metrics().lag, 598);
+    }
+
+    #[test]
+    fn test_registered_on_prometheus_registry() {
+        let reg = Registry::new();
+        let m = KafkaSourceMetrics::new(Some(&reg));
+        m.record_poll(10, 500);
+        m.record_error();
+
+        // Verify the metrics are registered on the registry.
+        let families = reg.gather();
+        let names: Vec<&str> = families.iter().map(|f| f.get_name()).collect();
+        assert!(names.contains(&"kafka_source_records_polled_total"));
+        assert!(names.contains(&"kafka_source_errors_total"));
     }
 }

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -330,7 +330,7 @@ mod tests {
 
         // Verify the metrics are registered on the registry.
         let families = reg.gather();
-        let names: Vec<&str> = families.iter().map(|f| f.get_name()).collect();
+        let names: Vec<&str> = families.iter().map(|f| f.name()).collect();
         assert!(names.contains(&"kafka_source_records_polled_total"));
         assert!(names.contains(&"kafka_source_errors_total"));
     }

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -330,7 +330,7 @@ mod tests {
 
         // Verify the metrics are registered on the registry.
         let families = reg.gather();
-        let names: Vec<&str> = families.iter().map(|f| f.name()).collect();
+        let names: Vec<&str> = families.iter().map(prometheus::proto::MetricFamily::name).collect();
         assert!(names.contains(&"kafka_source_records_polled_total"));
         assert!(names.contains(&"kafka_source_errors_total"));
     }

--- a/crates/laminar-connectors/src/kafka/mod.rs
+++ b/crates/laminar-connectors/src/kafka/mod.rs
@@ -64,10 +64,14 @@ pub fn register_kafka_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "kafka",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             // Empty schema — filled in by discover_schema / open() / SQL DDL columns.
             let empty = Arc::new(arrow_schema::Schema::empty());
-            Box::new(KafkaSource::new(empty, KafkaSourceConfig::default()))
+            Box::new(KafkaSource::new(
+                empty,
+                KafkaSourceConfig::default(),
+                registry,
+            ))
         }),
     );
 }
@@ -86,10 +90,10 @@ pub fn register_kafka_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "kafka",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             // Empty schema — the sink's schema is bound from the upstream query at build time.
             let empty = Arc::new(arrow_schema::Schema::empty());
-            Box::new(KafkaSink::new(empty, KafkaSinkConfig::default()))
+            Box::new(KafkaSink::new(empty, KafkaSinkConfig::default(), registry))
         }),
     );
 }
@@ -629,7 +633,7 @@ mod tests {
         register_kafka_source(&registry);
 
         let config = crate::config::ConnectorConfig::new("kafka");
-        let source = registry.create_source(&config);
+        let source = registry.create_source(&config, None);
         assert!(source.is_ok());
     }
 
@@ -656,7 +660,7 @@ mod tests {
         register_kafka_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("kafka");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 }

--- a/crates/laminar-connectors/src/kafka/sink.rs
+++ b/crates/laminar-connectors/src/kafka/sink.rs
@@ -135,7 +135,11 @@ impl KafkaSink {
     /// Panics if `config.format` is not a supported serialization format.
     /// Call [`KafkaSinkConfig::validate`] first to catch this at config time.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: KafkaSinkConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: KafkaSinkConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let avro_schema_id = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let serializer =
             select_serializer(config.format, &schema, Arc::clone(&avro_schema_id), None)
@@ -152,7 +156,7 @@ impl KafkaSink {
             last_committed_epoch: 0,
             transaction_active: false,
             dlq_producer: None,
-            metrics: KafkaSinkMetrics::new(),
+            metrics: KafkaSinkMetrics::new(registry),
             schema,
             schema_registry: None,
             avro_schema_id,
@@ -193,7 +197,7 @@ impl KafkaSink {
             last_committed_epoch: 0,
             transaction_active: false,
             dlq_producer: None,
-            metrics: KafkaSinkMetrics::new(),
+            metrics: KafkaSinkMetrics::new(None),
             schema,
             schema_registry: Some(sr),
             avro_schema_id,
@@ -1009,7 +1013,7 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         assert_eq!(sink.state(), ConnectorState::Created);
         assert!(sink.producer.is_none());
         assert_eq!(sink.current_epoch(), 0);
@@ -1020,33 +1024,33 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let sink = KafkaSink::new(schema.clone(), test_config());
+        let sink = KafkaSink::new(schema.clone(), test_config(), None);
         assert_eq!(sink.schema(), schema);
     }
 
     #[test]
     fn test_health_check_created() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
     }
 
     #[test]
     fn test_health_check_running() {
-        let mut sink = KafkaSink::new(test_schema(), test_config());
+        let mut sink = KafkaSink::new(test_schema(), test_config(), None);
         sink.state = ConnectorState::Running;
         assert_eq!(sink.health_check(), HealthStatus::Healthy);
     }
 
     #[test]
     fn test_health_check_closed() {
-        let mut sink = KafkaSink::new(test_schema(), test_config());
+        let mut sink = KafkaSink::new(test_schema(), test_config(), None);
         sink.state = ConnectorState::Closed;
         assert!(matches!(sink.health_check(), HealthStatus::Unhealthy(_)));
     }
 
     #[test]
     fn test_metrics_initial() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         let m = sink.metrics();
         assert_eq!(m.records_total, 0);
         assert_eq!(m.bytes_total, 0);
@@ -1055,7 +1059,7 @@ mod tests {
 
     #[test]
     fn test_capabilities_at_least_once() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         let caps = sink.capabilities();
         assert!(!caps.exactly_once);
         assert!(caps.idempotent);
@@ -1067,7 +1071,7 @@ mod tests {
     fn test_capabilities_exactly_once() {
         let mut cfg = test_config();
         cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-        let sink = KafkaSink::new(test_schema(), cfg);
+        let sink = KafkaSink::new(test_schema(), cfg, None);
         let caps = sink.capabilities();
         assert!(caps.exactly_once);
         assert!(caps.idempotent);
@@ -1076,7 +1080,7 @@ mod tests {
 
     #[test]
     fn test_serializer_selection_json() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         assert_eq!(sink.serializer.format(), Format::Json);
     }
 
@@ -1084,7 +1088,7 @@ mod tests {
     fn test_serializer_selection_avro() {
         let mut cfg = test_config();
         cfg.format = Format::Avro;
-        let sink = KafkaSink::new(test_schema(), cfg);
+        let sink = KafkaSink::new(test_schema(), cfg, None);
         assert_eq!(sink.serializer.format(), Format::Avro);
     }
 
@@ -1104,7 +1108,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         let debug = format!("{sink:?}");
         assert!(debug.contains("KafkaSink"));
         assert!(debug.contains("output-events"));
@@ -1112,7 +1116,7 @@ mod tests {
 
     #[test]
     fn test_extract_keys_no_key_column() {
-        let sink = KafkaSink::new(test_schema(), test_config());
+        let sink = KafkaSink::new(test_schema(), test_config(), None);
         let batch = arrow_array::RecordBatch::try_new(
             test_schema(),
             vec![
@@ -1128,7 +1132,7 @@ mod tests {
     fn test_extract_keys_with_key_column() {
         let mut cfg = test_config();
         cfg.key_column = Some("value".into());
-        let sink = KafkaSink::new(test_schema(), cfg);
+        let sink = KafkaSink::new(test_schema(), cfg, None);
         let batch = arrow_array::RecordBatch::try_new(
             test_schema(),
             vec![

--- a/crates/laminar-connectors/src/kafka/sink_metrics.rs
+++ b/crates/laminar-connectors/src/kafka/sink_metrics.rs
@@ -1,151 +1,167 @@
 //! Kafka sink connector metrics.
-//!
-//! [`KafkaSinkMetrics`] provides lock-free atomic counters for
-//! tracking production statistics, convertible to the SDK's
-//! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for Kafka sink connector statistics.
-#[derive(Debug)]
+/// Prometheus-backed counters for Kafka sink connector statistics.
+#[derive(Debug, Clone)]
 pub struct KafkaSinkMetrics {
-    /// Total records written to Kafka.
-    pub records_written: AtomicU64,
-    /// Total bytes written to Kafka (payload only).
-    pub bytes_written: AtomicU64,
-    /// Total errors encountered.
-    pub errors_total: AtomicU64,
-    /// Total epochs committed.
-    pub epochs_committed: AtomicU64,
-    /// Total epochs rolled back.
-    pub epochs_rolled_back: AtomicU64,
-    /// Total records routed to dead letter queue.
-    pub dlq_records: AtomicU64,
-    /// Total serialization errors.
-    pub serialization_errors: AtomicU64,
+    /// Records written to Kafka.
+    pub records_written: IntCounter,
+    /// Bytes written to Kafka (payload only).
+    pub bytes_written: IntCounter,
+    /// Errors encountered.
+    pub errors_total: IntCounter,
+    /// Epochs committed.
+    pub epochs_committed: IntCounter,
+    /// Epochs rolled back.
+    pub epochs_rolled_back: IntCounter,
+    /// Records routed to dead letter queue.
+    pub dlq_records: IntCounter,
+    /// Serialization errors.
+    pub serialization_errors: IntCounter,
     /// Sum of produce delivery latencies in microseconds.
-    pub produce_latency_sum_us: AtomicU64,
+    pub produce_latency_sum_us: IntCounter,
     /// Maximum produce delivery latency in microseconds.
-    pub produce_latency_max_us: AtomicU64,
+    pub produce_latency_max_us: IntGauge,
     /// Number of produce delivery latency samples.
-    pub produce_latency_count: AtomicU64,
+    pub produce_latency_count: IntCounter,
 }
 
 impl KafkaSinkMetrics {
-    /// All counters start at zero.
+    /// All counters start at zero. Registers on `registry` if provided.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        macro_rules! reg_c {
+            ($name:expr, $help:expr) => {{
+                let c = IntCounter::new($name, $help).unwrap();
+                let _ = reg.register(Box::new(c.clone()));
+                c
+            }};
+        }
+
+        let produce_latency_max_us = IntGauge::new(
+            "kafka_sink_produce_latency_max_us",
+            "Max produce delivery latency (us)",
+        )
+        .unwrap();
+        let _ = reg.register(Box::new(produce_latency_max_us.clone()));
+
         Self {
-            records_written: AtomicU64::new(0),
-            bytes_written: AtomicU64::new(0),
-            errors_total: AtomicU64::new(0),
-            epochs_committed: AtomicU64::new(0),
-            epochs_rolled_back: AtomicU64::new(0),
-            dlq_records: AtomicU64::new(0),
-            serialization_errors: AtomicU64::new(0),
-            produce_latency_sum_us: AtomicU64::new(0),
-            produce_latency_max_us: AtomicU64::new(0),
-            produce_latency_count: AtomicU64::new(0),
+            records_written: reg_c!(
+                "kafka_sink_records_written_total",
+                "Records written to Kafka"
+            ),
+            bytes_written: reg_c!("kafka_sink_bytes_written_total", "Bytes written to Kafka"),
+            errors_total: reg_c!("kafka_sink_errors_total", "Kafka sink errors"),
+            epochs_committed: reg_c!("kafka_sink_epochs_committed_total", "Epochs committed"),
+            epochs_rolled_back: reg_c!("kafka_sink_epochs_rolled_back_total", "Epochs rolled back"),
+            dlq_records: reg_c!("kafka_sink_dlq_records_total", "Records routed to DLQ"),
+            serialization_errors: reg_c!(
+                "kafka_sink_serialization_errors_total",
+                "Serialization errors"
+            ),
+            produce_latency_sum_us: reg_c!(
+                "kafka_sink_produce_latency_sum_us",
+                "Sum of produce latencies (us)"
+            ),
+            produce_latency_count: reg_c!(
+                "kafka_sink_produce_latency_count",
+                "Produce latency samples"
+            ),
+            produce_latency_max_us,
         }
     }
 
     /// Records a successful write of `records` records totaling `bytes`.
     pub fn record_write(&self, records: u64, bytes: u64) {
-        self.records_written.fetch_add(records, Ordering::Relaxed);
-        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.records_written.inc_by(records);
+        self.bytes_written.inc_by(bytes);
     }
 
-    /// Records a production or serialization error.
+    /// Records a production error.
     pub fn record_error(&self) {
-        self.errors_total.fetch_add(1, Ordering::Relaxed);
+        self.errors_total.inc();
     }
 
     /// Records a successful epoch commit.
     pub fn record_commit(&self) {
-        self.epochs_committed.fetch_add(1, Ordering::Relaxed);
+        self.epochs_committed.inc();
     }
 
     /// Records an epoch rollback.
     pub fn record_rollback(&self) {
-        self.epochs_rolled_back.fetch_add(1, Ordering::Relaxed);
+        self.epochs_rolled_back.inc();
     }
 
     /// Records a DLQ routing event.
     pub fn record_dlq(&self) {
-        self.dlq_records.fetch_add(1, Ordering::Relaxed);
+        self.dlq_records.inc();
     }
 
     /// Records a serialization error.
     pub fn record_serialization_error(&self) {
-        self.serialization_errors.fetch_add(1, Ordering::Relaxed);
+        self.serialization_errors.inc();
     }
 
     /// Records a produce delivery latency sample in microseconds.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn record_produce_latency(&self, latency_us: u64) {
-        self.produce_latency_sum_us
-            .fetch_add(latency_us, Ordering::Relaxed);
-        self.produce_latency_count.fetch_add(1, Ordering::Relaxed);
-        // CAS loop for max.
-        let mut current = self.produce_latency_max_us.load(Ordering::Relaxed);
-        while latency_us > current {
-            match self.produce_latency_max_us.compare_exchange_weak(
-                current,
-                latency_us,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => break,
-                Err(actual) => current = actual,
-            }
+        self.produce_latency_sum_us.inc_by(latency_us);
+        self.produce_latency_count.inc();
+        if latency_us as i64 > self.produce_latency_max_us.get() {
+            self.produce_latency_max_us.set(latency_us as i64);
         }
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
-            records_total: self.records_written.load(Ordering::Relaxed),
-            bytes_total: self.bytes_written.load(Ordering::Relaxed),
-            errors_total: self.errors_total.load(Ordering::Relaxed),
+            records_total: self.records_written.get(),
+            bytes_total: self.bytes_written.get(),
+            errors_total: self.errors_total.get(),
             lag: 0,
             custom: Vec::new(),
         };
-        m.add_custom(
-            "kafka.epochs_committed",
-            self.epochs_committed.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("kafka.epochs_committed", self.epochs_committed.get() as f64);
         m.add_custom(
             "kafka.epochs_rolled_back",
-            self.epochs_rolled_back.load(Ordering::Relaxed) as f64,
+            self.epochs_rolled_back.get() as f64,
         );
-        m.add_custom(
-            "kafka.dlq_records",
-            self.dlq_records.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("kafka.dlq_records", self.dlq_records.get() as f64);
         m.add_custom(
             "kafka.serialization_errors",
-            self.serialization_errors.load(Ordering::Relaxed) as f64,
+            self.serialization_errors.get() as f64,
         );
-        let latency_count = self.produce_latency_count.load(Ordering::Relaxed);
-        let latency_sum = self.produce_latency_sum_us.load(Ordering::Relaxed);
-        let latency_max = self.produce_latency_max_us.load(Ordering::Relaxed);
-        let latency_avg = if latency_count > 0 {
-            latency_sum as f64 / latency_count as f64
+        let count = self.produce_latency_count.get();
+        let sum = self.produce_latency_sum_us.get();
+        let max = self.produce_latency_max_us.get() as u64;
+        let avg = if count > 0 {
+            sum as f64 / count as f64
         } else {
             0.0
         };
-        m.add_custom("kafka.produce_latency_avg_us", latency_avg);
-        m.add_custom("kafka.produce_latency_max_us", latency_max as f64);
+        m.add_custom("kafka.produce_latency_avg_us", avg);
+        m.add_custom("kafka.produce_latency_max_us", max as f64);
         m
     }
 }
 
 impl Default for KafkaSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -155,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = KafkaSinkMetrics::new();
+        let m = KafkaSinkMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -164,94 +180,23 @@ mod tests {
 
     #[test]
     fn test_record_write() {
-        let m = KafkaSinkMetrics::new();
+        let m = KafkaSinkMetrics::new(None);
         m.record_write(100, 5000);
         m.record_write(200, 10000);
-
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 300);
         assert_eq!(cm.bytes_total, 15000);
     }
 
     #[test]
-    fn test_epoch_metrics() {
-        let m = KafkaSinkMetrics::new();
-        m.record_commit();
-        m.record_commit();
-        m.record_rollback();
-
-        let cm = m.to_connector_metrics();
-        let committed = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.epochs_committed");
-        assert_eq!(committed.unwrap().1, 2.0);
-        let rolled_back = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.epochs_rolled_back");
-        assert_eq!(rolled_back.unwrap().1, 1.0);
-    }
-
-    #[test]
-    fn test_dlq_and_serde_errors() {
-        let m = KafkaSinkMetrics::new();
-        m.record_dlq();
-        m.record_dlq();
-        m.record_serialization_error();
-        m.record_error();
-
-        let cm = m.to_connector_metrics();
-        assert_eq!(cm.errors_total, 1);
-        let dlq = cm.custom.iter().find(|(k, _)| k == "kafka.dlq_records");
-        assert_eq!(dlq.unwrap().1, 2.0);
-        let serde = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.serialization_errors");
-        assert_eq!(serde.unwrap().1, 1.0);
-    }
-
-    #[test]
-    fn test_produce_latency_recording() {
-        let m = KafkaSinkMetrics::new();
-        m.record_produce_latency(100);
-        m.record_produce_latency(200);
-        m.record_produce_latency(50);
-
-        assert_eq!(m.produce_latency_count.load(Ordering::Relaxed), 3);
-        assert_eq!(m.produce_latency_sum_us.load(Ordering::Relaxed), 350);
-        assert_eq!(m.produce_latency_max_us.load(Ordering::Relaxed), 200);
-    }
-
-    #[test]
-    fn test_produce_latency_avg_and_max_in_custom_metrics() {
-        let m = KafkaSinkMetrics::new();
+    fn test_produce_latency() {
+        let m = KafkaSinkMetrics::new(None);
         m.record_produce_latency(100);
         m.record_produce_latency(300);
+        m.record_produce_latency(50);
 
-        let cm = m.to_connector_metrics();
-        let avg = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.produce_latency_avg_us");
-        assert!((avg.unwrap().1 - 200.0).abs() < f64::EPSILON);
-
-        let max = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.produce_latency_max_us");
-        assert!((max.unwrap().1 - 300.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_produce_latency_zero_when_no_samples() {
-        let m = KafkaSinkMetrics::new();
-        let cm = m.to_connector_metrics();
-        let avg = cm
-            .custom
-            .iter()
-            .find(|(k, _)| k == "kafka.produce_latency_avg_us");
-        assert!((avg.unwrap().1).abs() < f64::EPSILON);
+        assert_eq!(m.produce_latency_count.get(), 3);
+        assert_eq!(m.produce_latency_sum_us.get(), 450);
+        assert_eq!(m.produce_latency_max_us.get(), 300);
     }
 }

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -142,8 +142,12 @@ pub struct KafkaSource {
 impl KafkaSource {
     /// Creates a new Kafka source connector with explicit schema.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: KafkaSourceConfig) -> Self {
-        Self::build_base(schema, config, select_deserializer, None)
+    pub fn new(
+        schema: SchemaRef,
+        config: KafkaSourceConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
+        Self::build_base(schema, config, select_deserializer, None, registry)
     }
 
     /// Creates a new Kafka source connector with Schema Registry.
@@ -162,7 +166,7 @@ impl KafkaSource {
                 select_deserializer(format)
             }
         };
-        Self::build_base(schema, config, deser_factory, Some(sr))
+        Self::build_base(schema, config, deser_factory, Some(sr), None)
     }
 
     /// Build a Schema Registry client from the parsed config, or
@@ -192,6 +196,7 @@ impl KafkaSource {
         config: KafkaSourceConfig,
         deser_factory: impl FnOnce(Format) -> Box<dyn RecordDeserializer>,
         schema_registry: Option<Arc<SchemaRegistryClient>>,
+        registry: Option<&prometheus::Registry>,
     ) -> Self {
         let deserializer = deser_factory(config.format);
         let channel_len = Arc::new(AtomicUsize::new(0));
@@ -211,7 +216,7 @@ impl KafkaSource {
             deserializer,
             offsets: OffsetTracker::new(),
             state: ConnectorState::Created,
-            metrics: KafkaSourceMetrics::new(),
+            metrics: KafkaSourceMetrics::new(registry),
             schema,
             channel_len,
             rebalance_state: Arc::new(Mutex::new(RebalanceState::new())),
@@ -1492,7 +1497,7 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         assert_eq!(source.state(), ConnectorState::Created);
         assert!(source.consumer.is_none());
         assert_eq!(source.offsets().partition_count(), 0);
@@ -1501,20 +1506,20 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let source = KafkaSource::new(schema.clone(), test_config());
+        let source = KafkaSource::new(schema.clone(), test_config(), None);
         assert_eq!(source.schema(), schema);
     }
 
     #[test]
     fn test_checkpoint_empty() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         let cp = source.checkpoint();
         assert!(cp.is_empty());
     }
 
     #[test]
     fn test_checkpoint_with_offsets() {
-        let mut source = KafkaSource::new(test_schema(), test_config());
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
         source.offsets.update("events", 0, 100);
         source.offsets.update("events", 1, 200);
 
@@ -1531,27 +1536,27 @@ mod tests {
 
     #[test]
     fn test_health_check_created() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         assert_eq!(source.health_check(), HealthStatus::Unknown);
     }
 
     #[test]
     fn test_health_check_running() {
-        let mut source = KafkaSource::new(test_schema(), test_config());
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
         source.state = ConnectorState::Running;
         assert_eq!(source.health_check(), HealthStatus::Healthy);
     }
 
     #[test]
     fn test_health_check_closed() {
-        let mut source = KafkaSource::new(test_schema(), test_config());
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
         source.state = ConnectorState::Closed;
         assert!(matches!(source.health_check(), HealthStatus::Unhealthy(_)));
     }
 
     #[test]
     fn test_metrics_initial() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         let m = source.metrics();
         assert_eq!(m.records_total, 0);
         assert_eq!(m.bytes_total, 0);
@@ -1560,7 +1565,7 @@ mod tests {
 
     #[test]
     fn test_deserializer_selection_json() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         assert_eq!(source.deserializer.format(), Format::Json);
     }
 
@@ -1568,7 +1573,7 @@ mod tests {
     fn test_deserializer_selection_csv() {
         let mut cfg = test_config();
         cfg.format = Format::Csv;
-        let source = KafkaSource::new(test_schema(), cfg);
+        let source = KafkaSource::new(test_schema(), cfg, None);
         assert_eq!(source.deserializer.format(), Format::Csv);
     }
 
@@ -1603,7 +1608,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let source = KafkaSource::new(test_schema(), test_config());
+        let source = KafkaSource::new(test_schema(), test_config(), None);
         let debug = format!("{source:?}");
         assert!(debug.contains("KafkaSource"));
         assert!(debug.contains("events"));
@@ -1611,7 +1616,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_filters_revoked_partitions() {
-        let mut source = KafkaSource::new(test_schema(), test_config());
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
         source.offsets.update("events", 0, 100);
         source.offsets.update("events", 1, 200);
         source.offsets.update("events", 2, 300);
@@ -1630,7 +1635,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_empty_before_first_rebalance() {
-        let mut source = KafkaSource::new(test_schema(), test_config());
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
         source.offsets.update("events", 0, 100);
         source.offsets.update("events", 1, 200);
 
@@ -1657,7 +1662,7 @@ mod tests {
 
     #[tokio::test]
     async fn discover_schema_skips_non_avro_format() {
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
@@ -1673,7 +1678,7 @@ mod tests {
 
     #[tokio::test]
     async fn discover_schema_skips_without_sr_url() {
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
@@ -1689,7 +1694,7 @@ mod tests {
     async fn discover_schema_skips_topic_pattern() {
         // topic.pattern cannot map to a single SR subject. Must skip
         // cleanly, not panic or select an arbitrary topic.
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
@@ -1707,7 +1712,7 @@ mod tests {
         // Use a reserved-documentation IP on a closed port and bound the
         // whole test by a generous wall-clock budget so a bug where we
         // forgot the timeout would fail loudly.
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         let start = std::time::Instant::now();
         tokio::time::timeout(
             std::time::Duration::from_secs(20),
@@ -1760,7 +1765,7 @@ mod tests {
             .mount(&sr)
             .await;
 
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
@@ -1815,7 +1820,7 @@ mod tests {
             .mount(&sr)
             .await;
 
-        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default());
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),

--- a/crates/laminar-connectors/src/lakehouse/delta.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta.rs
@@ -131,7 +131,7 @@ pub struct DeltaLakeSink {
 impl DeltaLakeSink {
     /// Creates a new Delta Lake sink with the given configuration.
     #[must_use]
-    pub fn new(config: DeltaLakeSinkConfig) -> Self {
+    pub fn new(config: DeltaLakeSinkConfig, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             schema: None,
@@ -143,7 +143,7 @@ impl DeltaLakeSink {
             buffered_bytes: 0,
             delta_version: 0,
             buffer_start_time: None,
-            metrics: DeltaLakeSinkMetrics::new(),
+            metrics: DeltaLakeSinkMetrics::new(registry),
             epoch_skipped: false,
             staged_batches: Vec::new(),
             staged_rows: 0,
@@ -166,7 +166,7 @@ impl DeltaLakeSink {
     /// Creates a new Delta Lake sink with an explicit schema.
     #[must_use]
     pub fn with_schema(config: DeltaLakeSinkConfig, schema: SchemaRef) -> Self {
-        let mut sink = Self::new(config);
+        let mut sink = Self::new(config, None);
         sink.schema = Some(schema);
         sink
     }
@@ -1331,7 +1331,7 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         assert_eq!(sink.state(), ConnectorState::Created);
         assert_eq!(sink.current_epoch(), 0);
         assert_eq!(sink.last_committed_epoch(), 0);
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn test_schema_empty_when_none() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         let schema = sink.schema();
         assert_eq!(schema.fields().len(), 0);
     }
@@ -1358,7 +1358,7 @@ mod tests {
     #[cfg(feature = "delta-lake")]
     #[test]
     fn test_deferred_init_flag_default_false() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         assert!(!sink.needs_deferred_delta_init);
     }
 
@@ -1380,7 +1380,7 @@ mod tests {
         use crate::config::ConnectorConfig;
 
         let config = unity_config();
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
 
         // open() with empty ConnectorConfig (simulates factory path)
         let connector_config = ConnectorConfig::new("delta-lake");
@@ -1402,7 +1402,7 @@ mod tests {
     async fn test_deferred_init_transitions_to_failed_on_error() {
         // When deferred init fails, the sink must transition to Failed
         // to prevent an unbounded retry storm.
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Initializing;
         sink.needs_deferred_delta_init = true;
         sink.schema = Some(test_schema());
@@ -1421,7 +1421,7 @@ mod tests {
     async fn test_write_batch_accepts_initializing_state() {
         // During deferred init, write_batch must accept Initializing state
         // so the first batch can provide the schema.
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Initializing;
         sink.needs_deferred_delta_init = true;
 
@@ -1440,7 +1440,7 @@ mod tests {
         // Unity catalog without catalog.storage.location should NOT defer.
         let mut config = unity_config();
         config.catalog_storage_location = None;
-        let sink = DeltaLakeSink::new(config);
+        let sink = DeltaLakeSink::new(config, None);
 
         let should_defer = matches!(sink.config.catalog_type, DeltaCatalogType::Unity { .. })
             && sink.config.catalog_storage_location.is_some()
@@ -1462,7 +1462,7 @@ mod tests {
 
     #[test]
     fn test_health_check_initializing_during_deferred() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Initializing;
         // During deferred init, health should NOT report Healthy.
         assert!(matches!(sink.health_check(), HealthStatus::Unknown));
@@ -1492,7 +1492,7 @@ mod tests {
     fn test_should_flush_by_rows() {
         let mut config = test_config();
         config.max_buffer_records = 100;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.buffered_rows = 99;
         assert!(!sink.should_flush());
         sink.buffered_rows = 100;
@@ -1503,7 +1503,7 @@ mod tests {
     fn test_should_flush_by_bytes() {
         let mut config = test_config();
         config.target_file_size = 1000;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.buffered_bytes = 999;
         assert!(!sink.should_flush());
         sink.buffered_bytes = 1000;
@@ -1512,7 +1512,7 @@ mod tests {
 
     #[test]
     fn test_should_flush_empty() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         assert!(!sink.should_flush());
     }
 
@@ -1522,7 +1522,7 @@ mod tests {
     async fn test_write_batch_buffering() {
         let mut config = test_config();
         config.max_buffer_records = 100;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);
@@ -1536,7 +1536,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_batch_empty() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(0);
@@ -1547,7 +1547,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_batch_not_running() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         // state is Created, not Running
 
         let batch = test_batch(10);
@@ -1557,7 +1557,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_batch_sets_schema() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Running;
         assert!(sink.schema.is_none());
 
@@ -1571,7 +1571,7 @@ mod tests {
     async fn test_multiple_write_batches_accumulate() {
         let mut config = test_config();
         config.max_buffer_records = 100;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);
@@ -1589,7 +1589,7 @@ mod tests {
     async fn test_rollback_clears_buffer() {
         let mut config = test_config();
         config.max_buffer_records = 1000;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(50);
@@ -1607,7 +1607,7 @@ mod tests {
     async fn test_rollback_after_pre_commit_discards_staged() {
         let mut config = test_config();
         config.max_buffer_records = 1000;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         sink.begin_epoch(1).await.unwrap();
@@ -1637,7 +1637,7 @@ mod tests {
     async fn test_staged_data_preserved_until_commit_or_rollback() {
         let mut config = test_config();
         config.max_buffer_records = 1000;
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         sink.begin_epoch(1).await.unwrap();
@@ -1665,7 +1665,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_empty_epoch() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Running;
 
         sink.begin_epoch(1).await.unwrap();
@@ -1683,7 +1683,7 @@ mod tests {
         let mut config = test_config();
         config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
         config.writer_id = "test-writer".to_string();
-        let mut sink = DeltaLakeSink::new(config);
+        let mut sink = DeltaLakeSink::new(config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);
@@ -1704,7 +1704,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_close() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Running;
 
         sink.close().await.unwrap();
@@ -1715,34 +1715,34 @@ mod tests {
 
     #[test]
     fn test_health_check_created() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
     }
 
     #[test]
     fn test_health_check_running() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Running;
         assert_eq!(sink.health_check(), HealthStatus::Healthy);
     }
 
     #[test]
     fn test_health_check_closed() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Closed;
         assert!(matches!(sink.health_check(), HealthStatus::Unhealthy(_)));
     }
 
     #[test]
     fn test_health_check_failed() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Failed;
         assert!(matches!(sink.health_check(), HealthStatus::Unhealthy(_)));
     }
 
     #[test]
     fn test_health_check_paused() {
-        let mut sink = DeltaLakeSink::new(test_config());
+        let mut sink = DeltaLakeSink::new(test_config(), None);
         sink.state = ConnectorState::Paused;
         assert!(matches!(sink.health_check(), HealthStatus::Degraded(_)));
     }
@@ -1753,7 +1753,7 @@ mod tests {
     fn test_capabilities_append_exactly_once() {
         let mut config = test_config();
         config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-        let sink = DeltaLakeSink::new(config);
+        let sink = DeltaLakeSink::new(config, None);
         let caps = sink.capabilities();
         assert!(caps.exactly_once);
         assert!(caps.idempotent);
@@ -1765,7 +1765,7 @@ mod tests {
 
     #[test]
     fn test_capabilities_upsert() {
-        let sink = DeltaLakeSink::new(upsert_config());
+        let sink = DeltaLakeSink::new(upsert_config(), None);
         let caps = sink.capabilities();
         assert!(caps.upsert);
         assert!(caps.changelog);
@@ -1776,7 +1776,7 @@ mod tests {
     fn test_capabilities_schema_evolution() {
         let mut config = test_config();
         config.schema_evolution = true;
-        let sink = DeltaLakeSink::new(config);
+        let sink = DeltaLakeSink::new(config, None);
         let caps = sink.capabilities();
         assert!(caps.schema_evolution);
     }
@@ -1785,7 +1785,7 @@ mod tests {
     fn test_capabilities_partitioned() {
         let mut config = test_config();
         config.partition_columns = vec!["trade_date".to_string()];
-        let sink = DeltaLakeSink::new(config);
+        let sink = DeltaLakeSink::new(config, None);
         let caps = sink.capabilities();
         assert!(caps.partitioned);
     }
@@ -1794,7 +1794,7 @@ mod tests {
     fn test_capabilities_at_least_once() {
         let mut config = test_config();
         config.delivery_guarantee = DeliveryGuarantee::AtLeastOnce;
-        let sink = DeltaLakeSink::new(config);
+        let sink = DeltaLakeSink::new(config, None);
         let caps = sink.capabilities();
         assert!(!caps.exactly_once);
         assert!(caps.idempotent);
@@ -1804,7 +1804,7 @@ mod tests {
 
     #[test]
     fn test_metrics_initial() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         let m = sink.metrics();
         assert_eq!(m.records_total, 0);
         assert_eq!(m.bytes_total, 0);
@@ -1940,7 +1940,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let sink = DeltaLakeSink::new(test_config());
+        let sink = DeltaLakeSink::new(test_config(), None);
         let debug = format!("{sink:?}");
         assert!(debug.contains("DeltaLakeSink"));
         assert!(debug.contains("delta_test_nonexistent_8f3a"));

--- a/crates/laminar-connectors/src/lakehouse/delta_io.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_io.rs
@@ -1717,7 +1717,7 @@ mod tests {
         // Read data via source.
         let mut source_config = DeltaSourceConfig::new(table_path);
         source_config.starting_version = Some(0);
-        let mut source = DeltaSource::new(source_config);
+        let mut source = DeltaSource::new(source_config, None);
         let source_connector_config = ConnectorConfig::new("delta-lake");
         source.open(&source_connector_config).await.unwrap();
 
@@ -1786,7 +1786,7 @@ mod tests {
         // latest version (2) in a single poll, reading the full snapshot.
         let mut source_config = DeltaSourceConfig::new(table_path);
         source_config.starting_version = Some(0);
-        let mut source = DeltaSource::new(source_config.clone());
+        let mut source = DeltaSource::new(source_config.clone(), None);
         let connector_config = ConnectorConfig::new("delta-lake");
         source.open(&connector_config).await.unwrap();
 
@@ -1801,7 +1801,7 @@ mod tests {
         source.close().await.unwrap();
 
         // Restore from checkpoint — should resume at version 2.
-        let mut source2 = DeltaSource::new(source_config);
+        let mut source2 = DeltaSource::new(source_config, None);
         source2.open(&connector_config).await.unwrap();
         source2.restore(&cp).await.unwrap();
 

--- a/crates/laminar-connectors/src/lakehouse/delta_metrics.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_metrics.rs
@@ -1,51 +1,95 @@
 //! Delta Lake sink connector metrics.
 //!
-//! [`DeltaLakeSinkMetrics`] provides lock-free atomic counters for
-//! tracking write statistics, convertible to the SDK's
+//! [`DeltaLakeSinkMetrics`] provides prometheus-backed counters and gauges
+//! for tracking write statistics, convertible to the SDK's
 //! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use super::metrics::LakehouseSinkMetrics;
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for Delta Lake sink connector statistics.
-#[derive(Debug)]
+/// Prometheus-backed counters/gauges for Delta Lake sink connector statistics.
+#[derive(Debug, Clone)]
 pub struct DeltaLakeSinkMetrics {
     /// Common metrics (rows flushed, bytes written, commits, etc.).
     pub common: LakehouseSinkMetrics,
 
     /// Total MERGE operations (upsert mode).
-    pub merge_operations: AtomicU64,
+    pub merge_operations: IntCounter,
 
     /// Last Delta Lake table version committed.
-    pub last_delta_version: AtomicU64,
+    pub last_delta_version: IntGauge,
 
     /// Total compaction runs completed.
-    pub compaction_runs: AtomicU64,
+    pub compaction_runs: IntCounter,
 
     /// Total files added by compaction.
-    pub compaction_files_added: AtomicU64,
+    pub compaction_files_added: IntCounter,
 
     /// Total files removed by compaction.
-    pub compaction_files_removed: AtomicU64,
+    pub compaction_files_removed: IntCounter,
 
     /// Total files deleted by vacuum.
-    pub vacuum_files_deleted: AtomicU64,
+    pub vacuum_files_deleted: IntCounter,
 }
 
 impl DeltaLakeSinkMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let merge_operations = IntCounter::new(
+            "delta_sink_merge_operations_total",
+            "Total MERGE operations (upsert)",
+        )
+        .unwrap();
+        let last_delta_version = IntGauge::new(
+            "delta_sink_last_version",
+            "Last committed Delta table version",
+        )
+        .unwrap();
+        let compaction_runs =
+            IntCounter::new("delta_sink_compaction_runs_total", "Total compaction runs").unwrap();
+        let compaction_files_added = IntCounter::new(
+            "delta_sink_compaction_files_added_total",
+            "Total files added by compaction",
+        )
+        .unwrap();
+        let compaction_files_removed = IntCounter::new(
+            "delta_sink_compaction_files_removed_total",
+            "Total files removed by compaction",
+        )
+        .unwrap();
+        let vacuum_files_deleted = IntCounter::new(
+            "delta_sink_vacuum_files_deleted_total",
+            "Total files deleted by vacuum",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(merge_operations.clone()));
+        let _ = reg.register(Box::new(last_delta_version.clone()));
+        let _ = reg.register(Box::new(compaction_runs.clone()));
+        let _ = reg.register(Box::new(compaction_files_added.clone()));
+        let _ = reg.register(Box::new(compaction_files_removed.clone()));
+        let _ = reg.register(Box::new(vacuum_files_deleted.clone()));
+
         Self {
-            common: LakehouseSinkMetrics::new(),
-            merge_operations: AtomicU64::new(0),
-            last_delta_version: AtomicU64::new(0),
-            compaction_runs: AtomicU64::new(0),
-            compaction_files_added: AtomicU64::new(0),
-            compaction_files_removed: AtomicU64::new(0),
-            vacuum_files_deleted: AtomicU64::new(0),
+            common: LakehouseSinkMetrics::new(registry),
+            merge_operations,
+            last_delta_version,
+            compaction_runs,
+            compaction_files_added,
+            compaction_files_removed,
+            vacuum_files_deleted,
         }
     }
 
@@ -55,10 +99,10 @@ impl DeltaLakeSinkMetrics {
     }
 
     /// Records a successful epoch commit.
+    #[allow(clippy::cast_possible_wrap)]
     pub fn record_commit(&self, delta_version: u64) {
         self.common.record_commit();
-        self.last_delta_version
-            .store(delta_version, Ordering::Relaxed);
+        self.last_delta_version.set(delta_version as i64);
     }
 
     /// Records a write or I/O error.
@@ -73,7 +117,7 @@ impl DeltaLakeSinkMetrics {
 
     /// Records a MERGE operation (upsert mode).
     pub fn record_merge(&self) {
-        self.merge_operations.fetch_add(1, Ordering::Relaxed);
+        self.merge_operations.inc();
     }
 
     /// Records changelog DELETE operations.
@@ -83,17 +127,14 @@ impl DeltaLakeSinkMetrics {
 
     /// Records a completed compaction run.
     pub fn record_compaction(&self, files_added: u64, files_removed: u64) {
-        self.compaction_runs.fetch_add(1, Ordering::Relaxed);
-        self.compaction_files_added
-            .fetch_add(files_added, Ordering::Relaxed);
-        self.compaction_files_removed
-            .fetch_add(files_removed, Ordering::Relaxed);
+        self.compaction_runs.inc();
+        self.compaction_files_added.inc_by(files_added);
+        self.compaction_files_removed.inc_by(files_removed);
     }
 
     /// Records files deleted by vacuum.
     pub fn record_vacuum(&self, files_deleted: u64) {
-        self.vacuum_files_deleted
-            .fetch_add(files_deleted, Ordering::Relaxed);
+        self.vacuum_files_deleted.inc_by(files_deleted);
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
@@ -103,29 +144,20 @@ impl DeltaLakeSinkMetrics {
         let mut m = ConnectorMetrics::new();
         self.common.populate_metrics(&mut m, "delta");
 
-        m.add_custom(
-            "delta.merge_operations",
-            self.merge_operations.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "delta.last_version",
-            self.last_delta_version.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "delta.compaction_runs",
-            self.compaction_runs.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("delta.merge_operations", self.merge_operations.get() as f64);
+        m.add_custom("delta.last_version", self.last_delta_version.get() as f64);
+        m.add_custom("delta.compaction_runs", self.compaction_runs.get() as f64);
         m.add_custom(
             "delta.compaction_files_added",
-            self.compaction_files_added.load(Ordering::Relaxed) as f64,
+            self.compaction_files_added.get() as f64,
         );
         m.add_custom(
             "delta.compaction_files_removed",
-            self.compaction_files_removed.load(Ordering::Relaxed) as f64,
+            self.compaction_files_removed.get() as f64,
         );
         m.add_custom(
             "delta.vacuum_files_deleted",
-            self.vacuum_files_deleted.load(Ordering::Relaxed) as f64,
+            self.vacuum_files_deleted.get() as f64,
         );
         m
     }
@@ -133,7 +165,7 @@ impl DeltaLakeSinkMetrics {
 
 impl Default for DeltaLakeSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -144,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -153,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_record_flush() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_flush(100, 5000);
         m.record_flush(200, 10_000);
 
@@ -167,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_record_commit() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_commit(1);
         m.record_commit(5);
 
@@ -181,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_error_counting() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_error();
         m.record_error();
         m.record_error();
@@ -192,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_rollback_counting() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_rollback();
         m.record_rollback();
 
@@ -206,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_merge_operations() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_merge();
 
         let cm = m.to_connector_metrics();
@@ -219,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_changelog_deletes() {
-        let m = DeltaLakeSinkMetrics::new();
+        let m = DeltaLakeSinkMetrics::new(None);
         m.record_deletes(50);
         m.record_deletes(30);
 

--- a/crates/laminar-connectors/src/lakehouse/delta_source.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_source.rs
@@ -82,7 +82,7 @@ pub struct DeltaSource {
 impl DeltaSource {
     /// Creates a new Delta Lake source with the given configuration.
     #[must_use]
-    pub fn new(config: DeltaSourceConfig) -> Self {
+    pub fn new(config: DeltaSourceConfig, _registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             state: ConnectorState::Created,
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let source = DeltaSource::new(test_config());
+        let source = DeltaSource::new(test_config(), None);
         assert_eq!(source.state(), ConnectorState::Created);
         assert_eq!(source.current_version(), -1);
         assert!(source.schema.is_none());
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_roundtrip() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         source.current_version = 42;
 
         let cp = source.checkpoint();
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_from_checkpoint() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         assert_eq!(source.current_version(), -1);
 
         let mut cp = SourceCheckpoint::new(0);
@@ -644,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_health_check() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         assert_eq!(source.health_check(), HealthStatus::Unknown);
 
         source.state = ConnectorState::Running;
@@ -656,14 +656,14 @@ mod tests {
 
     #[test]
     fn test_schema_empty_when_none() {
-        let source = DeltaSource::new(test_config());
+        let source = DeltaSource::new(test_config(), None);
         let schema = source.schema();
         assert_eq!(schema.fields().len(), 0);
     }
 
     #[tokio::test]
     async fn test_poll_not_running() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         // state is Created, not Running
         let result = source.poll_batch(100).await;
         assert!(result.is_err());
@@ -671,7 +671,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_poll_returns_buffered_batches() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         source.state = ConnectorState::Running;
 
         // Manually buffer some batches.
@@ -694,7 +694,7 @@ mod tests {
     /// incrementally; with the feature, `read_batches_at_version` applies LIMIT.
     #[tokio::test]
     async fn test_poll_batch_returns_buffered_incrementally() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         source.state = ConnectorState::Running;
 
         // Simulate what read_batches_at_version produces: many small batches
@@ -715,7 +715,7 @@ mod tests {
     /// until the last batch is consumed, then jumps to the target version.
     #[tokio::test]
     async fn test_version_deferred_until_buffer_drained() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         source.state = ConnectorState::Running;
         source.current_version = 5;
 
@@ -750,7 +750,7 @@ mod tests {
     fn test_poll_interval_is_stored() {
         let mut config = test_config();
         config.poll_interval = std::time::Duration::from_millis(500);
-        let source = DeltaSource::new(config);
+        let source = DeltaSource::new(config, None);
         assert_eq!(
             source.config().poll_interval,
             std::time::Duration::from_millis(500)
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let source = DeltaSource::new(test_config());
+        let source = DeltaSource::new(test_config(), None);
         let debug = format!("{source:?}");
         assert!(debug.contains("DeltaSource"));
         assert!(debug.contains("/tmp/delta_source_test"));
@@ -767,7 +767,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_close() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         source.state = ConnectorState::Running;
         source.pending_batches.push_back(test_batch(5));
 
@@ -780,7 +780,7 @@ mod tests {
     #[cfg(not(feature = "delta-lake"))]
     #[tokio::test]
     async fn test_open_requires_feature() {
-        let mut source = DeltaSource::new(test_config());
+        let mut source = DeltaSource::new(test_config(), None);
         let connector_config = crate::config::ConnectorConfig::new("delta-lake");
         let result = source.open(&connector_config).await;
         assert!(result.is_err());

--- a/crates/laminar-connectors/src/lakehouse/iceberg.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg.rs
@@ -67,7 +67,7 @@ pub struct IcebergSink {
 impl IcebergSink {
     /// Creates a new Iceberg sink with the given configuration.
     #[must_use]
-    pub fn new(config: IcebergSinkConfig) -> Self {
+    pub fn new(config: IcebergSinkConfig, _registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             schema: None,
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_new_sink() {
-        let sink = IcebergSink::new(test_config());
+        let sink = IcebergSink::new(test_config(), None);
         assert!(sink.schema.is_none());
         assert_eq!(sink.current_epoch, 0);
         assert_eq!(sink.buffered_rows, 0);
@@ -558,7 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_buffers_batches() {
-        let mut sink = IcebergSink::new(test_config());
+        let mut sink = IcebergSink::new(test_config(), None);
         sink.begin_epoch(1).await.unwrap();
 
         let result = sink.write_batch(&test_batch(100)).await.unwrap();
@@ -574,7 +574,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pre_commit_stages_buffer() {
-        let mut sink = IcebergSink::new(test_config());
+        let mut sink = IcebergSink::new(test_config(), None);
         sink.begin_epoch(1).await.unwrap();
         sink.write_batch(&test_batch(100)).await.unwrap();
 
@@ -587,7 +587,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rollback_clears_staged() {
-        let mut sink = IcebergSink::new(test_config());
+        let mut sink = IcebergSink::new(test_config(), None);
         sink.begin_epoch(1).await.unwrap();
         sink.write_batch(&test_batch(100)).await.unwrap();
         sink.pre_commit(1).await.unwrap();
@@ -600,7 +600,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_epoch_skip_when_already_committed() {
-        let mut sink = IcebergSink::new(test_config());
+        let mut sink = IcebergSink::new(test_config(), None);
         sink.last_committed_epoch = 5;
 
         sink.begin_epoch(3).await.unwrap();
@@ -612,7 +612,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_epoch_commit() {
-        let mut sink = IcebergSink::new(test_config());
+        let mut sink = IcebergSink::new(test_config(), None);
         sink.begin_epoch(1).await.unwrap();
         sink.pre_commit(1).await.unwrap();
         sink.commit_epoch(1).await.unwrap();
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_capabilities() {
-        let sink = IcebergSink::new(test_config());
+        let sink = IcebergSink::new(test_config(), None);
         let caps = sink.capabilities();
         assert!(caps.exactly_once);
         assert!(caps.two_phase_commit);

--- a/crates/laminar-connectors/src/lakehouse/iceberg_source.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg_source.rs
@@ -59,7 +59,7 @@ pub struct IcebergSource {
 impl IcebergSource {
     /// Creates a new Iceberg source with the given configuration.
     #[must_use]
-    pub fn new(config: IcebergSourceConfig) -> Self {
+    pub fn new(config: IcebergSourceConfig, _registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             schema: None,
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_new_source() {
-        let source = IcebergSource::new(test_source_config());
+        let source = IcebergSource::new(test_source_config(), None);
         assert!(source.schema.is_none());
         assert!(source.last_snapshot_id.is_none());
         assert!(source.buffer.is_empty());
@@ -295,7 +295,7 @@ mod tests {
 
     #[test]
     fn test_checkpoint_round_trip() {
-        let mut source = IcebergSource::new(test_source_config());
+        let mut source = IcebergSource::new(test_source_config(), None);
         source.last_snapshot_id = Some(42);
         source.epoch = 5;
 
@@ -307,7 +307,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_from_checkpoint() {
-        let mut source = IcebergSource::new(test_source_config());
+        let mut source = IcebergSource::new(test_source_config(), None);
         let mut cp = SourceCheckpoint::new(10);
         cp.set_offset("snapshot_id", "123");
 
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_supports_replay_false() {
-        let source = IcebergSource::new(test_source_config());
+        let source = IcebergSource::new(test_source_config(), None);
         assert!(!source.supports_replay());
     }
 }

--- a/crates/laminar-connectors/src/lakehouse/metrics.rs
+++ b/crates/laminar-connectors/src/lakehouse/metrics.rs
@@ -1,77 +1,124 @@
 //! Common metrics for Lakehouse sink connectors.
 //!
-//! Provides shared atomic counters for tracking statistics across different
-//! table formats (Delta Lake, Iceberg, Hudi, Paimon).
+//! Provides shared prometheus-backed counters for tracking statistics across
+//! different table formats (Delta Lake, Iceberg, Hudi, Paimon).
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for Lakehouse sink connector statistics.
-#[derive(Debug)]
+/// Prometheus-backed counters for Lakehouse sink connector statistics.
+#[derive(Debug, Clone)]
 pub struct LakehouseSinkMetrics {
     /// Total rows flushed to storage (Parquet/ORC/etc.).
-    pub rows_flushed: AtomicU64,
+    pub rows_flushed: IntCounter,
 
     /// Total bytes written to storage.
-    pub bytes_written: AtomicU64,
+    pub bytes_written: IntCounter,
 
     /// Total number of flush operations.
-    pub flush_count: AtomicU64,
+    pub flush_count: IntCounter,
 
     /// Total number of commits (transactions/snapshots).
-    pub commits: AtomicU64,
+    pub commits: IntCounter,
 
     /// Total errors encountered.
-    pub errors_total: AtomicU64,
+    pub errors_total: IntCounter,
 
     /// Total epochs rolled back.
-    pub epochs_rolled_back: AtomicU64,
+    pub epochs_rolled_back: IntCounter,
 
     /// Total changelog DELETE operations processed.
-    pub changelog_deletes: AtomicU64,
+    pub changelog_deletes: IntCounter,
 }
 
 impl LakehouseSinkMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let rows_flushed = IntCounter::new(
+            "lakehouse_sink_rows_flushed_total",
+            "Total rows flushed to storage",
+        )
+        .unwrap();
+        let bytes_written = IntCounter::new(
+            "lakehouse_sink_bytes_written_total",
+            "Total bytes written to storage",
+        )
+        .unwrap();
+        let flush_count =
+            IntCounter::new("lakehouse_sink_flush_count_total", "Total flush operations").unwrap();
+        let commits = IntCounter::new(
+            "lakehouse_sink_commits_total",
+            "Total commits (transactions/snapshots)",
+        )
+        .unwrap();
+        let errors_total =
+            IntCounter::new("lakehouse_sink_errors_total", "Total lakehouse sink errors").unwrap();
+        let epochs_rolled_back = IntCounter::new(
+            "lakehouse_sink_epochs_rolled_back_total",
+            "Total epochs rolled back",
+        )
+        .unwrap();
+        let changelog_deletes = IntCounter::new(
+            "lakehouse_sink_changelog_deletes_total",
+            "Total changelog DELETE operations",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(rows_flushed.clone()));
+        let _ = reg.register(Box::new(bytes_written.clone()));
+        let _ = reg.register(Box::new(flush_count.clone()));
+        let _ = reg.register(Box::new(commits.clone()));
+        let _ = reg.register(Box::new(errors_total.clone()));
+        let _ = reg.register(Box::new(epochs_rolled_back.clone()));
+        let _ = reg.register(Box::new(changelog_deletes.clone()));
+
         Self {
-            rows_flushed: AtomicU64::new(0),
-            bytes_written: AtomicU64::new(0),
-            flush_count: AtomicU64::new(0),
-            commits: AtomicU64::new(0),
-            errors_total: AtomicU64::new(0),
-            epochs_rolled_back: AtomicU64::new(0),
-            changelog_deletes: AtomicU64::new(0),
+            rows_flushed,
+            bytes_written,
+            flush_count,
+            commits,
+            errors_total,
+            epochs_rolled_back,
+            changelog_deletes,
         }
     }
 
     /// Records a successful flush of `records` rows totaling `bytes`.
     pub fn record_flush(&self, records: u64, bytes: u64) {
-        self.rows_flushed.fetch_add(records, Ordering::Relaxed);
-        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
-        self.flush_count.fetch_add(1, Ordering::Relaxed);
+        self.rows_flushed.inc_by(records);
+        self.bytes_written.inc_by(bytes);
+        self.flush_count.inc();
     }
 
     /// Records a successful commit (transaction/snapshot).
     pub fn record_commit(&self) {
-        self.commits.fetch_add(1, Ordering::Relaxed);
+        self.commits.inc();
     }
 
     /// Records a write or I/O error.
     pub fn record_error(&self) {
-        self.errors_total.fetch_add(1, Ordering::Relaxed);
+        self.errors_total.inc();
     }
 
     /// Records an epoch rollback.
     pub fn record_rollback(&self) {
-        self.epochs_rolled_back.fetch_add(1, Ordering::Relaxed);
+        self.epochs_rolled_back.inc();
     }
 
     /// Records changelog DELETE operations processed.
     pub fn record_deletes(&self, count: u64) {
-        self.changelog_deletes.fetch_add(count, Ordering::Relaxed);
+        self.changelog_deletes.inc_by(count);
     }
 
     /// Populates standard `ConnectorMetrics` fields and adds common custom metrics with a prefix.
@@ -79,31 +126,28 @@ impl LakehouseSinkMetrics {
     /// The `prefix` is used for custom metrics keys, e.g., `"{prefix}.flush_count"`.
     #[allow(clippy::cast_precision_loss)]
     pub fn populate_metrics(&self, metrics: &mut ConnectorMetrics, prefix: &str) {
-        metrics.records_total = self.rows_flushed.load(Ordering::Relaxed);
-        metrics.bytes_total = self.bytes_written.load(Ordering::Relaxed);
-        metrics.errors_total = self.errors_total.load(Ordering::Relaxed);
+        metrics.records_total = self.rows_flushed.get();
+        metrics.bytes_total = self.bytes_written.get();
+        metrics.errors_total = self.errors_total.get();
 
         metrics.add_custom(
             format!("{prefix}.flush_count"),
-            self.flush_count.load(Ordering::Relaxed) as f64,
+            self.flush_count.get() as f64,
         );
-        metrics.add_custom(
-            format!("{prefix}.commits"),
-            self.commits.load(Ordering::Relaxed) as f64,
-        );
+        metrics.add_custom(format!("{prefix}.commits"), self.commits.get() as f64);
         metrics.add_custom(
             format!("{prefix}.epochs_rolled_back"),
-            self.epochs_rolled_back.load(Ordering::Relaxed) as f64,
+            self.epochs_rolled_back.get() as f64,
         );
         metrics.add_custom(
             format!("{prefix}.changelog_deletes"),
-            self.changelog_deletes.load(Ordering::Relaxed) as f64,
+            self.changelog_deletes.get() as f64,
         );
     }
 }
 
 impl Default for LakehouseSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }

--- a/crates/laminar-connectors/src/lakehouse/mod.rs
+++ b/crates/laminar-connectors/src/lakehouse/mod.rs
@@ -63,7 +63,9 @@ pub fn register_delta_lake_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "delta-lake",
         info,
-        Arc::new(|| Box::new(DeltaLakeSink::new(DeltaLakeSinkConfig::default()))),
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(DeltaLakeSink::new(DeltaLakeSinkConfig::default(), registry))
+        }),
     );
 }
 
@@ -81,7 +83,9 @@ pub fn register_delta_lake_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "delta-lake",
         info.clone(),
-        Arc::new(|| Box::new(DeltaSource::new(DeltaSourceConfig::default()))),
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(DeltaSource::new(DeltaSourceConfig::default(), registry))
+        }),
     );
 
     // Also register as a table source so CREATE LOOKUP TABLE ... WITH
@@ -167,7 +171,7 @@ pub fn register_iceberg_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "iceberg",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             // Default config with placeholder values — real config arrives via open().
             let mut cfg = crate::config::ConnectorConfig::new("iceberg");
             cfg.set("catalog.uri", "http://localhost:8181");
@@ -176,6 +180,7 @@ pub fn register_iceberg_sink(registry: &ConnectorRegistry) {
             cfg.set("table.name", "default");
             Box::new(IcebergSink::new(
                 IcebergSinkConfig::from_config(&cfg).expect("default iceberg sink config"),
+                registry,
             ))
         }),
     );
@@ -196,7 +201,7 @@ pub fn register_iceberg_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "iceberg",
         info.clone(),
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             let mut cfg = crate::config::ConnectorConfig::new("iceberg");
             cfg.set("catalog.uri", "http://localhost:8181");
             cfg.set("warehouse", "s3://default/wh");
@@ -204,6 +209,7 @@ pub fn register_iceberg_source(registry: &ConnectorRegistry) {
             cfg.set("table.name", "default");
             Box::new(IcebergSource::new(
                 IcebergSourceConfig::from_config(&cfg).expect("default iceberg source config"),
+                registry,
             ))
         }),
     );
@@ -650,7 +656,7 @@ mod tests {
         register_delta_lake_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("delta-lake");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 
@@ -699,7 +705,7 @@ mod tests {
         register_delta_lake_source(&registry);
 
         let config = crate::config::ConnectorConfig::new("delta-lake");
-        let source = registry.create_source(&config);
+        let source = registry.create_source(&config, None);
         assert!(source.is_ok());
     }
 
@@ -777,7 +783,7 @@ mod tests {
         register_iceberg_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("iceberg");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 
@@ -787,7 +793,7 @@ mod tests {
         register_iceberg_source(&registry);
 
         let config = crate::config::ConnectorConfig::new("iceberg");
-        let source = registry.create_source(&config);
+        let source = registry.create_source(&config, None);
         assert!(source.is_ok());
     }
 }

--- a/crates/laminar-connectors/src/metrics.rs
+++ b/crates/laminar-connectors/src/metrics.rs
@@ -2,9 +2,6 @@
 //!
 //! Provides metrics reporting for connectors:
 //! - `ConnectorMetrics`: Metrics reported by a connector implementation
-//! - `RuntimeMetrics`: Metrics tracked by the connector runtime
-
-use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Metrics reported by a connector implementation.
 ///
@@ -41,97 +38,6 @@ impl ConnectorMetrics {
     }
 }
 
-/// Metrics tracked by the connector runtime.
-///
-/// These are maintained by the runtime layer wrapping the connector,
-/// providing consistent metrics across all connector types.
-#[derive(Debug)]
-pub struct RuntimeMetrics {
-    /// Total records ingested (sources) or written (sinks).
-    pub records_total: AtomicU64,
-
-    /// Total bytes processed.
-    pub bytes_total: AtomicU64,
-
-    /// Total errors encountered.
-    pub errors_total: AtomicU64,
-
-    /// Total number of batches processed.
-    pub batches_total: AtomicU64,
-
-    /// Total number of checkpoint commits.
-    pub checkpoints_total: AtomicU64,
-}
-
-impl RuntimeMetrics {
-    /// Creates a new runtime metrics instance.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            records_total: AtomicU64::new(0),
-            bytes_total: AtomicU64::new(0),
-            errors_total: AtomicU64::new(0),
-            batches_total: AtomicU64::new(0),
-            checkpoints_total: AtomicU64::new(0),
-        }
-    }
-
-    /// Records that a batch of records was processed.
-    pub fn record_batch(&self, record_count: u64, byte_count: u64) {
-        self.records_total
-            .fetch_add(record_count, Ordering::Relaxed);
-        self.bytes_total.fetch_add(byte_count, Ordering::Relaxed);
-        self.batches_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Records an error.
-    pub fn record_error(&self) {
-        self.errors_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Records a checkpoint commit.
-    pub fn record_checkpoint(&self) {
-        self.checkpoints_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Returns a snapshot of the current metrics.
-    #[must_use]
-    pub fn snapshot(&self) -> RuntimeMetricsSnapshot {
-        RuntimeMetricsSnapshot {
-            records_total: self.records_total.load(Ordering::Relaxed),
-            bytes_total: self.bytes_total.load(Ordering::Relaxed),
-            errors_total: self.errors_total.load(Ordering::Relaxed),
-            batches_total: self.batches_total.load(Ordering::Relaxed),
-            checkpoints_total: self.checkpoints_total.load(Ordering::Relaxed),
-        }
-    }
-}
-
-impl Default for RuntimeMetrics {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Point-in-time snapshot of runtime metrics.
-#[derive(Debug, Clone, Default)]
-pub struct RuntimeMetricsSnapshot {
-    /// Total records processed.
-    pub records_total: u64,
-
-    /// Total bytes processed.
-    pub bytes_total: u64,
-
-    /// Total errors.
-    pub errors_total: u64,
-
-    /// Total batches.
-    pub batches_total: u64,
-
-    /// Total checkpoints.
-    pub checkpoints_total: u64,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,21 +52,5 @@ mod tests {
         assert_eq!(metrics.records_total, 1000);
         assert_eq!(metrics.custom.len(), 1);
         assert_eq!(metrics.custom[0].0, "kafka.lag");
-    }
-
-    #[test]
-    fn test_runtime_metrics() {
-        let metrics = RuntimeMetrics::new();
-        metrics.record_batch(100, 5000);
-        metrics.record_batch(200, 10000);
-        metrics.record_error();
-        metrics.record_checkpoint();
-
-        let snap = metrics.snapshot();
-        assert_eq!(snap.records_total, 300);
-        assert_eq!(snap.bytes_total, 15000);
-        assert_eq!(snap.errors_total, 1);
-        assert_eq!(snap.batches_total, 2);
-        assert_eq!(snap.checkpoints_total, 1);
     }
 }

--- a/crates/laminar-connectors/src/mongodb/metrics.rs
+++ b/crates/laminar-connectors/src/mongodb/metrics.rs
@@ -1,134 +1,179 @@
 //! `MongoDB` connector metrics.
 //!
-//! Lock-free atomic counters for tracking CDC source and sink performance.
+//! Prometheus-backed counters for tracking CDC source and sink performance.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
 /// Metrics for the `MongoDB` CDC source connector.
-///
-/// All counters use relaxed atomic ordering for lock-free access
-/// from the async runtime.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MongoDbCdcMetrics {
     /// Total change events received.
-    pub events_received: AtomicU64,
-
+    pub events_received: IntCounter,
     /// Total bytes received from the change stream.
-    pub bytes_received: AtomicU64,
-
+    pub bytes_received: IntCounter,
     /// Total errors encountered.
-    pub errors: AtomicU64,
-
+    pub errors: IntCounter,
     /// Total batches produced for downstream.
-    pub batches_produced: AtomicU64,
-
+    pub batches_produced: IntCounter,
     /// Total INSERT operations received.
-    pub inserts: AtomicU64,
-
+    pub inserts: IntCounter,
     /// Total UPDATE operations received.
-    pub updates: AtomicU64,
-
+    pub updates: IntCounter,
     /// Total REPLACE operations received.
-    pub replaces: AtomicU64,
-
+    pub replaces: IntCounter,
     /// Total DELETE operations received.
-    pub deletes: AtomicU64,
-
+    pub deletes: IntCounter,
     /// Total lifecycle events (drop/rename/invalidate).
-    pub lifecycle_events: AtomicU64,
-
+    pub lifecycle_events: IntCounter,
     /// Total resume token persist operations.
-    pub token_persists: AtomicU64,
-
+    pub token_persists: IntCounter,
     /// Total reconnection attempts.
-    pub reconnects: AtomicU64,
-
+    pub reconnects: IntCounter,
     /// Total large event fragments received.
-    pub large_event_fragments: AtomicU64,
-
+    pub large_event_fragments: IntCounter,
     /// Total large events reassembled.
-    pub large_events_reassembled: AtomicU64,
+    pub large_events_reassembled: IntCounter,
 }
 
 impl MongoDbCdcMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let events_received = IntCounter::new(
+            "mongodb_cdc_events_received_total",
+            "Total MongoDB CDC events received",
+        )
+        .unwrap();
+        let bytes_received = IntCounter::new(
+            "mongodb_cdc_bytes_received_total",
+            "Total bytes from change stream",
+        )
+        .unwrap();
+        let errors =
+            IntCounter::new("mongodb_cdc_errors_total", "Total MongoDB CDC errors").unwrap();
+        let batches_produced = IntCounter::new(
+            "mongodb_cdc_batches_produced_total",
+            "Total batches produced",
+        )
+        .unwrap();
+        let inserts = IntCounter::new("mongodb_cdc_inserts_total", "Total INSERT events").unwrap();
+        let updates = IntCounter::new("mongodb_cdc_updates_total", "Total UPDATE events").unwrap();
+        let replaces =
+            IntCounter::new("mongodb_cdc_replaces_total", "Total REPLACE events").unwrap();
+        let deletes = IntCounter::new("mongodb_cdc_deletes_total", "Total DELETE events").unwrap();
+        let lifecycle_events = IntCounter::new(
+            "mongodb_cdc_lifecycle_events_total",
+            "Total lifecycle events",
+        )
+        .unwrap();
+        let token_persists = IntCounter::new(
+            "mongodb_cdc_token_persists_total",
+            "Total resume token persist ops",
+        )
+        .unwrap();
+        let reconnects = IntCounter::new(
+            "mongodb_cdc_reconnects_total",
+            "Total reconnection attempts",
+        )
+        .unwrap();
+        let large_event_fragments = IntCounter::new(
+            "mongodb_cdc_large_event_fragments_total",
+            "Total large event fragments",
+        )
+        .unwrap();
+        let large_events_reassembled = IntCounter::new(
+            "mongodb_cdc_large_events_reassembled_total",
+            "Total large events reassembled",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(events_received.clone()));
+        let _ = reg.register(Box::new(bytes_received.clone()));
+        let _ = reg.register(Box::new(errors.clone()));
+        let _ = reg.register(Box::new(batches_produced.clone()));
+        let _ = reg.register(Box::new(inserts.clone()));
+        let _ = reg.register(Box::new(updates.clone()));
+        let _ = reg.register(Box::new(replaces.clone()));
+        let _ = reg.register(Box::new(deletes.clone()));
+        let _ = reg.register(Box::new(lifecycle_events.clone()));
+        let _ = reg.register(Box::new(token_persists.clone()));
+        let _ = reg.register(Box::new(reconnects.clone()));
+        let _ = reg.register(Box::new(large_event_fragments.clone()));
+        let _ = reg.register(Box::new(large_events_reassembled.clone()));
+
         Self {
-            events_received: AtomicU64::new(0),
-            bytes_received: AtomicU64::new(0),
-            errors: AtomicU64::new(0),
-            batches_produced: AtomicU64::new(0),
-            inserts: AtomicU64::new(0),
-            updates: AtomicU64::new(0),
-            replaces: AtomicU64::new(0),
-            deletes: AtomicU64::new(0),
-            lifecycle_events: AtomicU64::new(0),
-            token_persists: AtomicU64::new(0),
-            reconnects: AtomicU64::new(0),
-            large_event_fragments: AtomicU64::new(0),
-            large_events_reassembled: AtomicU64::new(0),
+            events_received,
+            bytes_received,
+            errors,
+            batches_produced,
+            inserts,
+            updates,
+            replaces,
+            deletes,
+            lifecycle_events,
+            token_persists,
+            reconnects,
+            large_event_fragments,
+            large_events_reassembled,
         }
     }
 
     /// Records a received change event by operation type.
     pub fn record_event(&self, op: &str) {
-        self.events_received.fetch_add(1, Ordering::Relaxed);
+        self.events_received.inc();
         match op {
-            "I" => {
-                self.inserts.fetch_add(1, Ordering::Relaxed);
-            }
-            "U" => {
-                self.updates.fetch_add(1, Ordering::Relaxed);
-            }
-            "R" => {
-                self.replaces.fetch_add(1, Ordering::Relaxed);
-            }
-            "D" => {
-                self.deletes.fetch_add(1, Ordering::Relaxed);
-            }
-            _ => {
-                self.lifecycle_events.fetch_add(1, Ordering::Relaxed);
-            }
+            "I" => self.inserts.inc(),
+            "U" => self.updates.inc(),
+            "R" => self.replaces.inc(),
+            "D" => self.deletes.inc(),
+            _ => self.lifecycle_events.inc(),
         }
     }
 
     /// Records bytes received from the change stream.
     pub fn record_bytes(&self, bytes: u64) {
-        self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
+        self.bytes_received.inc_by(bytes);
     }
 
     /// Records an error.
     pub fn record_error(&self) {
-        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.errors.inc();
     }
 
     /// Records a batch produced for downstream.
     pub fn record_batch(&self) {
-        self.batches_produced.fetch_add(1, Ordering::Relaxed);
+        self.batches_produced.inc();
     }
 
     /// Records a resume token persistence operation.
     pub fn record_token_persist(&self) {
-        self.token_persists.fetch_add(1, Ordering::Relaxed);
+        self.token_persists.inc();
     }
 
     /// Records a reconnection attempt.
     pub fn record_reconnect(&self) {
-        self.reconnects.fetch_add(1, Ordering::Relaxed);
+        self.reconnects.inc();
     }
 
     /// Records a large event fragment received.
     pub fn record_large_event_fragment(&self) {
-        self.large_event_fragments.fetch_add(1, Ordering::Relaxed);
+        self.large_event_fragments.inc();
     }
 
     /// Records a large event reassembled.
     pub fn record_large_event_reassembled(&self) {
-        self.large_events_reassembled
-            .fetch_add(1, Ordering::Relaxed);
+        self.large_events_reassembled.inc();
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
@@ -136,22 +181,19 @@ impl MongoDbCdcMetrics {
     #[allow(clippy::cast_precision_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics::new();
-        m.records_total = self.events_received.load(Ordering::Relaxed);
-        m.bytes_total = self.bytes_received.load(Ordering::Relaxed);
-        m.errors_total = self.errors.load(Ordering::Relaxed);
+        m.records_total = self.events_received.get();
+        m.bytes_total = self.bytes_received.get();
+        m.errors_total = self.errors.get();
 
-        m.add_custom("inserts", self.inserts.load(Ordering::Relaxed) as f64);
-        m.add_custom("updates", self.updates.load(Ordering::Relaxed) as f64);
-        m.add_custom("replaces", self.replaces.load(Ordering::Relaxed) as f64);
-        m.add_custom("deletes", self.deletes.load(Ordering::Relaxed) as f64);
-        m.add_custom(
-            "lifecycle_events",
-            self.lifecycle_events.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom("reconnects", self.reconnects.load(Ordering::Relaxed) as f64);
+        m.add_custom("inserts", self.inserts.get() as f64);
+        m.add_custom("updates", self.updates.get() as f64);
+        m.add_custom("replaces", self.replaces.get() as f64);
+        m.add_custom("deletes", self.deletes.get() as f64);
+        m.add_custom("lifecycle_events", self.lifecycle_events.get() as f64);
+        m.add_custom("reconnects", self.reconnects.get() as f64);
         m.add_custom(
             "large_events_reassembled",
-            self.large_events_reassembled.load(Ordering::Relaxed) as f64,
+            self.large_events_reassembled.get() as f64,
         );
         m
     }
@@ -159,84 +201,124 @@ impl MongoDbCdcMetrics {
 
 impl Default for MongoDbCdcMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
 /// Metrics for the `MongoDB` sink connector.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MongoDbSinkMetrics {
     /// Total records written.
-    pub records_written: AtomicU64,
-
+    pub records_written: IntCounter,
     /// Total bytes written.
-    pub bytes_written: AtomicU64,
-
+    pub bytes_written: IntCounter,
     /// Total errors encountered.
-    pub errors: AtomicU64,
-
+    pub errors: IntCounter,
     /// Total batches flushed.
-    pub batches_flushed: AtomicU64,
-
+    pub batches_flushed: IntCounter,
     /// Total bulk write operations issued.
-    pub bulk_writes: AtomicU64,
-
+    pub bulk_writes: IntCounter,
     /// Total individual insert operations.
-    pub inserts: AtomicU64,
-
+    pub inserts: IntCounter,
     /// Total upsert operations.
-    pub upserts: AtomicU64,
-
+    pub upserts: IntCounter,
     /// Total delete operations.
-    pub deletes: AtomicU64,
+    pub deletes: IntCounter,
 }
 
 impl MongoDbSinkMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let records_written = IntCounter::new(
+            "mongodb_sink_records_written_total",
+            "Total MongoDB sink records written",
+        )
+        .unwrap();
+        let bytes_written = IntCounter::new(
+            "mongodb_sink_bytes_written_total",
+            "Total MongoDB sink bytes written",
+        )
+        .unwrap();
+        let errors =
+            IntCounter::new("mongodb_sink_errors_total", "Total MongoDB sink errors").unwrap();
+        let batches_flushed = IntCounter::new(
+            "mongodb_sink_batches_flushed_total",
+            "Total batches flushed",
+        )
+        .unwrap();
+        let bulk_writes = IntCounter::new(
+            "mongodb_sink_bulk_writes_total",
+            "Total bulk write operations",
+        )
+        .unwrap();
+        let inserts =
+            IntCounter::new("mongodb_sink_inserts_total", "Total insert operations").unwrap();
+        let upserts =
+            IntCounter::new("mongodb_sink_upserts_total", "Total upsert operations").unwrap();
+        let deletes =
+            IntCounter::new("mongodb_sink_deletes_total", "Total delete operations").unwrap();
+
+        let _ = reg.register(Box::new(records_written.clone()));
+        let _ = reg.register(Box::new(bytes_written.clone()));
+        let _ = reg.register(Box::new(errors.clone()));
+        let _ = reg.register(Box::new(batches_flushed.clone()));
+        let _ = reg.register(Box::new(bulk_writes.clone()));
+        let _ = reg.register(Box::new(inserts.clone()));
+        let _ = reg.register(Box::new(upserts.clone()));
+        let _ = reg.register(Box::new(deletes.clone()));
+
         Self {
-            records_written: AtomicU64::new(0),
-            bytes_written: AtomicU64::new(0),
-            errors: AtomicU64::new(0),
-            batches_flushed: AtomicU64::new(0),
-            bulk_writes: AtomicU64::new(0),
-            inserts: AtomicU64::new(0),
-            upserts: AtomicU64::new(0),
-            deletes: AtomicU64::new(0),
+            records_written,
+            bytes_written,
+            errors,
+            batches_flushed,
+            bulk_writes,
+            inserts,
+            upserts,
+            deletes,
         }
     }
 
     /// Records a successful batch flush.
     pub fn record_flush(&self, records: u64, bytes: u64) {
-        self.records_written.fetch_add(records, Ordering::Relaxed);
-        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
-        self.batches_flushed.fetch_add(1, Ordering::Relaxed);
+        self.records_written.inc_by(records);
+        self.bytes_written.inc_by(bytes);
+        self.batches_flushed.inc();
     }
 
     /// Records a bulk write operation.
     pub fn record_bulk_write(&self) {
-        self.bulk_writes.fetch_add(1, Ordering::Relaxed);
+        self.bulk_writes.inc();
     }
 
     /// Records an error.
     pub fn record_error(&self) {
-        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.errors.inc();
     }
 
     /// Records insert operations.
     pub fn record_inserts(&self, count: u64) {
-        self.inserts.fetch_add(count, Ordering::Relaxed);
+        self.inserts.inc_by(count);
     }
 
     /// Records upsert operations.
     pub fn record_upserts(&self, count: u64) {
-        self.upserts.fetch_add(count, Ordering::Relaxed);
+        self.upserts.inc_by(count);
     }
 
     /// Records delete operations.
     pub fn record_deletes(&self, count: u64) {
-        self.deletes.fetch_add(count, Ordering::Relaxed);
+        self.deletes.inc_by(count);
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
@@ -244,28 +326,22 @@ impl MongoDbSinkMetrics {
     #[allow(clippy::cast_precision_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics::new();
-        m.records_total = self.records_written.load(Ordering::Relaxed);
-        m.bytes_total = self.bytes_written.load(Ordering::Relaxed);
-        m.errors_total = self.errors.load(Ordering::Relaxed);
+        m.records_total = self.records_written.get();
+        m.bytes_total = self.bytes_written.get();
+        m.errors_total = self.errors.get();
 
-        m.add_custom("inserts", self.inserts.load(Ordering::Relaxed) as f64);
-        m.add_custom("upserts", self.upserts.load(Ordering::Relaxed) as f64);
-        m.add_custom("deletes", self.deletes.load(Ordering::Relaxed) as f64);
-        m.add_custom(
-            "bulk_writes",
-            self.bulk_writes.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "batches_flushed",
-            self.batches_flushed.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("inserts", self.inserts.get() as f64);
+        m.add_custom("upserts", self.upserts.get() as f64);
+        m.add_custom("deletes", self.deletes.get() as f64);
+        m.add_custom("bulk_writes", self.bulk_writes.get() as f64);
+        m.add_custom("batches_flushed", self.batches_flushed.get() as f64);
         m
     }
 }
 
 impl Default for MongoDbSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -275,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_source_metrics_record_events() {
-        let m = MongoDbCdcMetrics::new();
+        let m = MongoDbCdcMetrics::new(None);
         m.record_event("I");
         m.record_event("I");
         m.record_event("U");
@@ -287,21 +363,21 @@ mod tests {
         m.record_token_persist();
         m.record_reconnect();
 
-        assert_eq!(m.events_received.load(Ordering::Relaxed), 5);
-        assert_eq!(m.inserts.load(Ordering::Relaxed), 2);
-        assert_eq!(m.updates.load(Ordering::Relaxed), 1);
-        assert_eq!(m.deletes.load(Ordering::Relaxed), 1);
-        assert_eq!(m.lifecycle_events.load(Ordering::Relaxed), 1);
-        assert_eq!(m.bytes_received.load(Ordering::Relaxed), 1024);
-        assert_eq!(m.errors.load(Ordering::Relaxed), 1);
-        assert_eq!(m.batches_produced.load(Ordering::Relaxed), 1);
-        assert_eq!(m.token_persists.load(Ordering::Relaxed), 1);
-        assert_eq!(m.reconnects.load(Ordering::Relaxed), 1);
+        assert_eq!(m.events_received.get(), 5);
+        assert_eq!(m.inserts.get(), 2);
+        assert_eq!(m.updates.get(), 1);
+        assert_eq!(m.deletes.get(), 1);
+        assert_eq!(m.lifecycle_events.get(), 1);
+        assert_eq!(m.bytes_received.get(), 1024);
+        assert_eq!(m.errors.get(), 1);
+        assert_eq!(m.batches_produced.get(), 1);
+        assert_eq!(m.token_persists.get(), 1);
+        assert_eq!(m.reconnects.get(), 1);
     }
 
     #[test]
     fn test_source_metrics_to_connector_metrics() {
-        let m = MongoDbCdcMetrics::new();
+        let m = MongoDbCdcMetrics::new(None);
         m.record_event("I");
         m.record_bytes(512);
         m.record_error();
@@ -315,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_sink_metrics_record_flush() {
-        let m = MongoDbSinkMetrics::new();
+        let m = MongoDbSinkMetrics::new(None);
         m.record_flush(100, 5000);
         m.record_bulk_write();
         m.record_inserts(80);
@@ -323,19 +399,19 @@ mod tests {
         m.record_deletes(5);
         m.record_error();
 
-        assert_eq!(m.records_written.load(Ordering::Relaxed), 100);
-        assert_eq!(m.bytes_written.load(Ordering::Relaxed), 5000);
-        assert_eq!(m.batches_flushed.load(Ordering::Relaxed), 1);
-        assert_eq!(m.bulk_writes.load(Ordering::Relaxed), 1);
-        assert_eq!(m.inserts.load(Ordering::Relaxed), 80);
-        assert_eq!(m.upserts.load(Ordering::Relaxed), 15);
-        assert_eq!(m.deletes.load(Ordering::Relaxed), 5);
-        assert_eq!(m.errors.load(Ordering::Relaxed), 1);
+        assert_eq!(m.records_written.get(), 100);
+        assert_eq!(m.bytes_written.get(), 5000);
+        assert_eq!(m.batches_flushed.get(), 1);
+        assert_eq!(m.bulk_writes.get(), 1);
+        assert_eq!(m.inserts.get(), 80);
+        assert_eq!(m.upserts.get(), 15);
+        assert_eq!(m.deletes.get(), 5);
+        assert_eq!(m.errors.get(), 1);
     }
 
     #[test]
     fn test_sink_metrics_to_connector_metrics() {
-        let m = MongoDbSinkMetrics::new();
+        let m = MongoDbSinkMetrics::new(None);
         m.record_flush(50, 2500);
         m.record_error();
 

--- a/crates/laminar-connectors/src/mongodb/mod.rs
+++ b/crates/laminar-connectors/src/mongodb/mod.rs
@@ -45,7 +45,12 @@ pub fn register_mongodb_cdc_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "mongodb-cdc",
         info,
-        Arc::new(|| Box::new(MongoDbCdcSource::new(MongoDbSourceConfig::default()))),
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(MongoDbCdcSource::new(
+                MongoDbSourceConfig::default(),
+                registry,
+            ))
+        }),
     );
 }
 
@@ -65,12 +70,16 @@ pub fn register_mongodb_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "mongodb-sink",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             let schema = Arc::new(Schema::new(vec![
                 Field::new("key", DataType::Utf8, true),
                 Field::new("value", DataType::Utf8, false),
             ]));
-            Box::new(MongoDbSink::new(schema, MongoDbSinkConfig::default()))
+            Box::new(MongoDbSink::new(
+                schema,
+                MongoDbSinkConfig::default(),
+                registry,
+            ))
         }),
     );
 }
@@ -180,7 +189,7 @@ mod tests {
         register_mongodb_cdc_source(&registry);
 
         let config = crate::config::ConnectorConfig::new("mongodb-cdc");
-        let source = registry.create_source(&config);
+        let source = registry.create_source(&config, None);
         assert!(source.is_ok());
     }
 
@@ -190,7 +199,7 @@ mod tests {
         register_mongodb_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("mongodb-sink");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 }

--- a/crates/laminar-connectors/src/mongodb/sink.rs
+++ b/crates/laminar-connectors/src/mongodb/sink.rs
@@ -77,7 +77,11 @@ pub struct MongoDbSink {
 impl MongoDbSink {
     /// Creates a new `MongoDB` sink connector.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: MongoDbSinkConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: MongoDbSinkConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let buf_capacity = (config.batch_size / 128).max(4);
         Self {
             config,
@@ -86,7 +90,7 @@ impl MongoDbSink {
             buffer: Vec::with_capacity(buf_capacity),
             buffered_rows: 0,
             last_flush: Instant::now(),
-            metrics: MongoDbSinkMetrics::new(),
+            metrics: MongoDbSinkMetrics::new(registry),
             #[cfg(feature = "mongodb-cdc")]
             client: None,
             #[cfg(feature = "mongodb-cdc")]
@@ -104,7 +108,7 @@ impl MongoDbSink {
         config: &ConnectorConfig,
     ) -> Result<Self, ConnectorError> {
         let mongo_config = MongoDbSinkConfig::from_config(config)?;
-        Ok(Self::new(schema, mongo_config))
+        Ok(Self::new(schema, mongo_config, None))
     }
 
     /// Returns a reference to the sink configuration.
@@ -745,14 +749,14 @@ mod tests {
     #[test]
     fn test_new_sink() {
         let config = MongoDbSinkConfig::new("mongodb://localhost:27017", "db", "coll");
-        let sink = MongoDbSink::new(test_schema(), config);
+        let sink = MongoDbSink::new(test_schema(), config, None);
         assert_eq!(sink.buffered_rows(), 0);
     }
 
     #[test]
     fn test_sink_capabilities_insert() {
         let config = MongoDbSinkConfig::default();
-        let sink = MongoDbSink::new(test_schema(), config);
+        let sink = MongoDbSink::new(test_schema(), config, None);
         let caps = sink.capabilities();
         assert!(caps.idempotent);
         assert!(!caps.upsert);
@@ -765,7 +769,7 @@ mod tests {
         config.write_mode = WriteMode::Upsert {
             key_fields: vec!["id".to_string()],
         };
-        let sink = MongoDbSink::new(test_schema(), config);
+        let sink = MongoDbSink::new(test_schema(), config, None);
         let caps = sink.capabilities();
         assert!(caps.upsert);
     }
@@ -774,7 +778,7 @@ mod tests {
     fn test_sink_capabilities_cdc_replay() {
         let mut config = MongoDbSinkConfig::default();
         config.write_mode = WriteMode::CdcReplay;
-        let sink = MongoDbSink::new(test_schema(), config);
+        let sink = MongoDbSink::new(test_schema(), config, None);
         let caps = sink.capabilities();
         assert!(caps.changelog);
     }
@@ -782,7 +786,7 @@ mod tests {
     #[test]
     fn test_batches_to_json() {
         let config = MongoDbSinkConfig::default();
-        let mut sink = MongoDbSink::new(test_schema(), config);
+        let mut sink = MongoDbSink::new(test_schema(), config, None);
         sink.buffer.push(test_batch(3));
         sink.buffered_rows = 3;
 
@@ -798,7 +802,7 @@ mod tests {
     fn test_should_flush_batch_size() {
         let mut config = MongoDbSinkConfig::default();
         config.batch_size = 100;
-        let mut sink = MongoDbSink::new(test_schema(), config);
+        let mut sink = MongoDbSink::new(test_schema(), config, None);
 
         assert!(!sink.should_flush());
         sink.buffered_rows = 100;
@@ -808,7 +812,7 @@ mod tests {
     #[test]
     fn test_clear_buffer() {
         let config = MongoDbSinkConfig::default();
-        let mut sink = MongoDbSink::new(test_schema(), config);
+        let mut sink = MongoDbSink::new(test_schema(), config, None);
 
         sink.buffer.push(test_batch(5));
         sink.buffered_rows = 5;
@@ -821,7 +825,7 @@ mod tests {
     #[test]
     fn test_health_check() {
         let config = MongoDbSinkConfig::default();
-        let mut sink = MongoDbSink::new(test_schema(), config);
+        let mut sink = MongoDbSink::new(test_schema(), config, None);
 
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
 

--- a/crates/laminar-connectors/src/mongodb/source.rs
+++ b/crates/laminar-connectors/src/mongodb/source.rs
@@ -145,12 +145,12 @@ type ChangeStreamRx = crossfire::AsyncRx<crossfire::mpsc::Array<ChangeStreamPayl
 impl MongoDbCdcSource {
     /// Creates a new `MongoDB` CDC source with the given configuration.
     #[must_use]
-    pub fn new(config: MongoDbSourceConfig) -> Self {
+    pub fn new(config: MongoDbSourceConfig, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config,
             state: ConnectorState::Created,
             schema: mongodb_cdc_envelope_schema(),
-            metrics: Arc::new(MongoDbCdcMetrics::new()),
+            metrics: Arc::new(MongoDbCdcMetrics::new(registry)),
             event_buffer: VecDeque::new(),
             last_resume_token: None,
             resume_token_store: Box::new(InMemoryResumeTokenStore::new()),
@@ -172,7 +172,7 @@ impl MongoDbCdcSource {
     /// Returns `ConnectorError` if the configuration is invalid.
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let mongo_config = MongoDbSourceConfig::from_config(config)?;
-        Ok(Self::new(mongo_config))
+        Ok(Self::new(mongo_config, None))
     }
 
     /// Sets a custom resume token store.
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn test_new_source() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let source = MongoDbCdcSource::new(config);
+        let source = MongoDbCdcSource::new(config, None);
         assert_eq!(source.buffered_events(), 0);
         assert!(!source.is_invalidated());
         assert!(source.last_resume_token().is_none());
@@ -915,7 +915,7 @@ mod tests {
     #[test]
     fn test_enqueue_event() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         source.enqueue_event(sample_event(OperationType::Insert));
         assert_eq!(source.buffered_events(), 1);
@@ -925,7 +925,7 @@ mod tests {
     #[test]
     fn test_enqueue_invalidate() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         let mut event = sample_event(OperationType::Invalidate);
         event.full_document = None;
@@ -957,7 +957,7 @@ mod tests {
     #[test]
     fn test_drain_to_batch() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         // Empty buffer returns None.
         assert!(source.drain_to_batch(10).unwrap().is_none());
@@ -979,7 +979,7 @@ mod tests {
     #[test]
     fn test_checkpoint() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "testdb", "users");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         // Without resume token.
         let cp = source.checkpoint();
@@ -995,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_restore_checkpoint() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         let mut cp = SourceCheckpoint::new(0);
         cp.set_offset("resume_token", "restored_token");
@@ -1010,7 +1010,7 @@ mod tests {
     #[test]
     fn test_health_check() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         assert_eq!(source.health_check(), HealthStatus::Unknown);
 
@@ -1027,7 +1027,7 @@ mod tests {
     #[test]
     fn test_drain_tracks_resume_token() {
         let config = MongoDbSourceConfig::new("mongodb://localhost:27017", "db", "coll");
-        let mut source = MongoDbCdcSource::new(config);
+        let mut source = MongoDbCdcSource::new(config, None);
 
         let mut event = sample_event(OperationType::Insert);
         event.resume_token = r#"{"_data": "final_token"}"#.to_string();

--- a/crates/laminar-connectors/src/otel/mod.rs
+++ b/crates/laminar-connectors/src/otel/mod.rs
@@ -46,6 +46,8 @@ pub fn register_otel_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "otel",
         info,
-        Arc::new(|| Box::new(OtelSource::new(traces_schema()))),
+        Arc::new(|registry: Option<&prometheus::Registry>| {
+            Box::new(OtelSource::new(traces_schema(), registry))
+        }),
     );
 }

--- a/crates/laminar-connectors/src/otel/source.rs
+++ b/crates/laminar-connectors/src/otel/source.rs
@@ -54,7 +54,7 @@ pub struct OtelSource {
 impl OtelSource {
     /// Create a new OTel source with the given default schema.
     #[must_use]
-    pub fn new(schema: SchemaRef) -> Self {
+    pub fn new(schema: SchemaRef, _registry: Option<&prometheus::Registry>) -> Self {
         Self {
             config: OtelSourceConfig::default(),
             schema,

--- a/crates/laminar-connectors/src/postgres/mod.rs
+++ b/crates/laminar-connectors/src/postgres/mod.rs
@@ -32,13 +32,17 @@ pub fn register_postgres_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "postgres-sink",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             // Default schema (overridden during open).
             let schema = Arc::new(Schema::new(vec![
                 Field::new("key", DataType::Utf8, true),
                 Field::new("value", DataType::Utf8, false),
             ]));
-            Box::new(PostgresSink::new(schema, PostgresSinkConfig::default()))
+            Box::new(PostgresSink::new(
+                schema,
+                PostgresSinkConfig::default(),
+                registry,
+            ))
         }),
     );
 }
@@ -149,7 +153,7 @@ mod tests {
         register_postgres_sink(&registry);
 
         let config = crate::config::ConnectorConfig::new("postgres-sink");
-        let sink = registry.create_sink(&config);
+        let sink = registry.create_sink(&config, None);
         assert!(sink.is_ok());
     }
 }

--- a/crates/laminar-connectors/src/postgres/sink.rs
+++ b/crates/laminar-connectors/src/postgres/sink.rs
@@ -86,7 +86,11 @@ pub struct PostgresSink {
 impl PostgresSink {
     /// Creates a new `PostgreSQL` sink connector.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: PostgresSinkConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: PostgresSinkConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let user_schema = build_user_schema(&schema);
         // Pre-allocate buffer to avoid reallocation during first epoch.
         let buf_capacity = (config.batch_size / 1024).max(4);
@@ -100,7 +104,7 @@ impl PostgresSink {
             buffer: Vec::with_capacity(buf_capacity),
             buffered_rows: 0,
             last_flush: Instant::now(),
-            metrics: PostgresSinkMetrics::new(),
+            metrics: PostgresSinkMetrics::new(registry),
             upsert_sql: None,
             copy_sql: None,
             create_table_sql: None,
@@ -995,12 +999,8 @@ impl SinkConnector for PostgresSink {
 
         info!(
             table = %self.config.qualified_table_name(),
-            records = self.metrics.records_written.load(
-                std::sync::atomic::Ordering::Relaxed
-            ),
-            epochs = self.metrics.epochs_committed.load(
-                std::sync::atomic::Ordering::Relaxed
-            ),
+            records = self.metrics.records_written.get(),
+            epochs = self.metrics.epochs_committed.get(),
             "PostgreSQL sink connector closed"
         );
 
@@ -1265,7 +1265,7 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let sink = PostgresSink::new(test_schema(), test_config());
+        let sink = PostgresSink::new(test_schema(), test_config(), None);
         assert_eq!(sink.state(), ConnectorState::Created);
         assert_eq!(sink.current_epoch(), 0);
         assert_eq!(sink.last_committed_epoch(), 0);
@@ -1281,7 +1281,7 @@ mod tests {
             Field::new("_op", DataType::Utf8, false),
             Field::new("value", DataType::Utf8, true),
         ]));
-        let sink = PostgresSink::new(schema, test_config());
+        let sink = PostgresSink::new(schema, test_config(), None);
         assert_eq!(sink.user_schema.fields().len(), 2);
         assert_eq!(sink.user_schema.field(0).name(), "id");
         assert_eq!(sink.user_schema.field(1).name(), "value");
@@ -1290,7 +1290,7 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let sink = PostgresSink::new(schema.clone(), test_config());
+        let sink = PostgresSink::new(schema.clone(), test_config(), None);
         assert_eq!(sink.schema(), schema);
     }
 
@@ -1561,7 +1561,7 @@ mod tests {
     async fn test_write_batch_buffering() {
         let mut config = test_config();
         config.batch_size = 100;
-        let mut sink = PostgresSink::new(test_schema(), config);
+        let mut sink = PostgresSink::new(test_schema(), config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);
@@ -1573,7 +1573,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_batch_empty() {
-        let mut sink = PostgresSink::new(test_schema(), test_config());
+        let mut sink = PostgresSink::new(test_schema(), test_config(), None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(0);
@@ -1584,7 +1584,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_batch_not_running() {
-        let mut sink = PostgresSink::new(test_schema(), test_config());
+        let mut sink = PostgresSink::new(test_schema(), test_config(), None);
 
         let batch = test_batch(10);
         let result = sink.write_batch(&batch).await;
@@ -1596,7 +1596,7 @@ mod tests {
         let mut config = test_config();
         config.batch_size = 5; // Would normally trigger flush at 10 rows
         config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-        let mut sink = PostgresSink::new(test_schema(), config);
+        let mut sink = PostgresSink::new(test_schema(), config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(10);
@@ -1611,7 +1611,7 @@ mod tests {
 
     #[test]
     fn test_health_check_created() {
-        let sink = PostgresSink::new(test_schema(), test_config());
+        let sink = PostgresSink::new(test_schema(), test_config(), None);
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
     }
 
@@ -1619,7 +1619,7 @@ mod tests {
 
     #[test]
     fn test_capabilities_append_at_least_once() {
-        let sink = PostgresSink::new(test_schema(), test_config());
+        let sink = PostgresSink::new(test_schema(), test_config(), None);
         let caps = sink.capabilities();
         assert!(caps.idempotent);
         assert!(!caps.upsert);
@@ -1629,7 +1629,7 @@ mod tests {
 
     #[test]
     fn test_capabilities_upsert() {
-        let sink = PostgresSink::new(test_schema(), upsert_config());
+        let sink = PostgresSink::new(test_schema(), upsert_config(), None);
         let caps = sink.capabilities();
         assert!(caps.upsert);
         assert!(caps.idempotent);
@@ -1639,7 +1639,7 @@ mod tests {
     fn test_capabilities_changelog() {
         let mut config = test_config();
         config.changelog_mode = true;
-        let sink = PostgresSink::new(test_schema(), config);
+        let sink = PostgresSink::new(test_schema(), config, None);
         let caps = sink.capabilities();
         assert!(caps.changelog);
     }
@@ -1648,7 +1648,7 @@ mod tests {
     fn test_capabilities_exactly_once() {
         let mut config = upsert_config();
         config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-        let sink = PostgresSink::new(test_schema(), config);
+        let sink = PostgresSink::new(test_schema(), config, None);
         let caps = sink.capabilities();
         assert!(caps.exactly_once);
     }
@@ -1657,7 +1657,7 @@ mod tests {
 
     #[test]
     fn test_metrics_initial() {
-        let sink = PostgresSink::new(test_schema(), test_config());
+        let sink = PostgresSink::new(test_schema(), test_config(), None);
         let m = sink.metrics();
         assert_eq!(m.records_total, 0);
         assert_eq!(m.bytes_total, 0);
@@ -1668,7 +1668,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_epoch_lifecycle_state() {
-        let mut sink = PostgresSink::new(test_schema(), test_config());
+        let mut sink = PostgresSink::new(test_schema(), test_config(), None);
         sink.state = ConnectorState::Running;
 
         sink.begin_epoch(1).await.expect("begin");
@@ -1685,7 +1685,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_epoch_mismatch_rejected() {
-        let mut sink = PostgresSink::new(test_schema(), test_config());
+        let mut sink = PostgresSink::new(test_schema(), test_config(), None);
         sink.state = ConnectorState::Running;
 
         sink.begin_epoch(1).await.expect("begin");
@@ -1697,7 +1697,7 @@ mod tests {
     async fn test_rollback_clears_buffer() {
         let mut config = test_config();
         config.batch_size = 1000;
-        let mut sink = PostgresSink::new(test_schema(), config);
+        let mut sink = PostgresSink::new(test_schema(), config, None);
         sink.state = ConnectorState::Running;
 
         let batch = test_batch(50);
@@ -1712,7 +1712,7 @@ mod tests {
 
     #[test]
     fn test_debug_output() {
-        let sink = PostgresSink::new(test_schema(), test_config());
+        let sink = PostgresSink::new(test_schema(), test_config(), None);
         let debug = format!("{sink:?}");
         assert!(debug.contains("PostgresSink"));
         assert!(debug.contains("public.events"));

--- a/crates/laminar-connectors/src/postgres/sink_metrics.rs
+++ b/crates/laminar-connectors/src/postgres/sink_metrics.rs
@@ -1,100 +1,162 @@
 //! `PostgreSQL` sink connector metrics.
 //!
-//! [`PostgresSinkMetrics`] provides lock-free atomic counters for
+//! [`PostgresSinkMetrics`] provides prometheus-backed counters for
 //! tracking write statistics, convertible to the SDK's
 //! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for `PostgreSQL` sink connector statistics.
-#[derive(Debug)]
+/// Prometheus-backed counters for `PostgreSQL` sink connector statistics.
+#[derive(Debug, Clone)]
 pub struct PostgresSinkMetrics {
     /// Total records written to `PostgreSQL`.
-    pub records_written: AtomicU64,
+    pub records_written: IntCounter,
 
     /// Total bytes written (estimated from `RecordBatch` sizes).
-    pub bytes_written: AtomicU64,
+    pub bytes_written: IntCounter,
 
     /// Total errors encountered.
-    pub errors_total: AtomicU64,
+    pub errors_total: IntCounter,
 
     /// Total batches flushed.
-    pub batches_flushed: AtomicU64,
+    pub batches_flushed: IntCounter,
 
     /// Total COPY BINARY operations (append mode).
-    pub copy_operations: AtomicU64,
+    pub copy_operations: IntCounter,
 
     /// Total upsert operations (upsert mode).
-    pub upsert_operations: AtomicU64,
+    pub upsert_operations: IntCounter,
 
     /// Total epochs committed (exactly-once).
-    pub epochs_committed: AtomicU64,
+    pub epochs_committed: IntCounter,
 
     /// Total epochs rolled back.
-    pub epochs_rolled_back: AtomicU64,
+    pub epochs_rolled_back: IntCounter,
 
     /// Total changelog deletes applied (Z-set weight -1).
-    pub changelog_deletes: AtomicU64,
+    pub changelog_deletes: IntCounter,
 }
 
 impl PostgresSinkMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let records_written = IntCounter::new(
+            "postgres_sink_records_written_total",
+            "Total records written to PostgreSQL",
+        )
+        .unwrap();
+        let bytes_written = IntCounter::new(
+            "postgres_sink_bytes_written_total",
+            "Total bytes written to PostgreSQL",
+        )
+        .unwrap();
+        let errors_total =
+            IntCounter::new("postgres_sink_errors_total", "Total PostgreSQL sink errors").unwrap();
+        let batches_flushed = IntCounter::new(
+            "postgres_sink_batches_flushed_total",
+            "Total batches flushed",
+        )
+        .unwrap();
+        let copy_operations = IntCounter::new(
+            "postgres_sink_copy_operations_total",
+            "Total COPY BINARY operations",
+        )
+        .unwrap();
+        let upsert_operations = IntCounter::new(
+            "postgres_sink_upsert_operations_total",
+            "Total upsert operations",
+        )
+        .unwrap();
+        let epochs_committed = IntCounter::new(
+            "postgres_sink_epochs_committed_total",
+            "Total epochs committed",
+        )
+        .unwrap();
+        let epochs_rolled_back = IntCounter::new(
+            "postgres_sink_epochs_rolled_back_total",
+            "Total epochs rolled back",
+        )
+        .unwrap();
+        let changelog_deletes = IntCounter::new(
+            "postgres_sink_changelog_deletes_total",
+            "Total changelog deletes applied",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(records_written.clone()));
+        let _ = reg.register(Box::new(bytes_written.clone()));
+        let _ = reg.register(Box::new(errors_total.clone()));
+        let _ = reg.register(Box::new(batches_flushed.clone()));
+        let _ = reg.register(Box::new(copy_operations.clone()));
+        let _ = reg.register(Box::new(upsert_operations.clone()));
+        let _ = reg.register(Box::new(epochs_committed.clone()));
+        let _ = reg.register(Box::new(epochs_rolled_back.clone()));
+        let _ = reg.register(Box::new(changelog_deletes.clone()));
+
         Self {
-            records_written: AtomicU64::new(0),
-            bytes_written: AtomicU64::new(0),
-            errors_total: AtomicU64::new(0),
-            batches_flushed: AtomicU64::new(0),
-            copy_operations: AtomicU64::new(0),
-            upsert_operations: AtomicU64::new(0),
-            epochs_committed: AtomicU64::new(0),
-            epochs_rolled_back: AtomicU64::new(0),
-            changelog_deletes: AtomicU64::new(0),
+            records_written,
+            bytes_written,
+            errors_total,
+            batches_flushed,
+            copy_operations,
+            upsert_operations,
+            epochs_committed,
+            epochs_rolled_back,
+            changelog_deletes,
         }
     }
 
     /// Records a successful write of `records` records totaling `bytes`.
     pub fn record_write(&self, records: u64, bytes: u64) {
-        self.records_written.fetch_add(records, Ordering::Relaxed);
-        self.bytes_written.fetch_add(bytes, Ordering::Relaxed);
+        self.records_written.inc_by(records);
+        self.bytes_written.inc_by(bytes);
     }
 
     /// Records a successful batch flush.
     pub fn record_flush(&self) {
-        self.batches_flushed.fetch_add(1, Ordering::Relaxed);
+        self.batches_flushed.inc();
     }
 
     /// Records a COPY BINARY operation.
     pub fn record_copy(&self) {
-        self.copy_operations.fetch_add(1, Ordering::Relaxed);
+        self.copy_operations.inc();
     }
 
     /// Records an upsert operation.
     pub fn record_upsert(&self) {
-        self.upsert_operations.fetch_add(1, Ordering::Relaxed);
+        self.upsert_operations.inc();
     }
 
     /// Records a write or connection error.
     pub fn record_error(&self) {
-        self.errors_total.fetch_add(1, Ordering::Relaxed);
+        self.errors_total.inc();
     }
 
     /// Records a successful epoch commit.
     pub fn record_commit(&self) {
-        self.epochs_committed.fetch_add(1, Ordering::Relaxed);
+        self.epochs_committed.inc();
     }
 
     /// Records an epoch rollback.
     pub fn record_rollback(&self) {
-        self.epochs_rolled_back.fetch_add(1, Ordering::Relaxed);
+        self.epochs_rolled_back.inc();
     }
 
     /// Records changelog DELETE operations.
     pub fn record_deletes(&self, count: u64) {
-        self.changelog_deletes.fetch_add(count, Ordering::Relaxed);
+        self.changelog_deletes.inc_by(count);
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
@@ -102,43 +164,28 @@ impl PostgresSinkMetrics {
     #[allow(clippy::cast_precision_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
-            records_total: self.records_written.load(Ordering::Relaxed),
-            bytes_total: self.bytes_written.load(Ordering::Relaxed),
-            errors_total: self.errors_total.load(Ordering::Relaxed),
+            records_total: self.records_written.get(),
+            bytes_total: self.bytes_written.get(),
+            errors_total: self.errors_total.get(),
             lag: 0,
             custom: Vec::new(),
         };
-        m.add_custom(
-            "pg.batches_flushed",
-            self.batches_flushed.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "pg.copy_operations",
-            self.copy_operations.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "pg.upsert_operations",
-            self.upsert_operations.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "pg.epochs_committed",
-            self.epochs_committed.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("pg.batches_flushed", self.batches_flushed.get() as f64);
+        m.add_custom("pg.copy_operations", self.copy_operations.get() as f64);
+        m.add_custom("pg.upsert_operations", self.upsert_operations.get() as f64);
+        m.add_custom("pg.epochs_committed", self.epochs_committed.get() as f64);
         m.add_custom(
             "pg.epochs_rolled_back",
-            self.epochs_rolled_back.load(Ordering::Relaxed) as f64,
+            self.epochs_rolled_back.get() as f64,
         );
-        m.add_custom(
-            "pg.changelog_deletes",
-            self.changelog_deletes.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("pg.changelog_deletes", self.changelog_deletes.get() as f64);
         m
     }
 }
 
 impl Default for PostgresSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -148,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -157,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_record_write() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_write(100, 5000);
         m.record_write(200, 10_000);
 
@@ -168,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_flush_and_copy_metrics() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_flush();
         m.record_flush();
         m.record_copy();
@@ -182,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_epoch_metrics() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_commit();
         m.record_commit();
         m.record_rollback();
@@ -196,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_changelog_deletes() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_deletes(50);
         m.record_deletes(30);
 
@@ -207,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_error_counting() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_error();
         m.record_error();
         m.record_error();
@@ -218,7 +265,7 @@ mod tests {
 
     #[test]
     fn test_upsert_metric() {
-        let m = PostgresSinkMetrics::new();
+        let m = PostgresSinkMetrics::new(None);
         m.record_upsert();
 
         let cm = m.to_connector_metrics();

--- a/crates/laminar-connectors/src/registry.rs
+++ b/crates/laminar-connectors/src/registry.rs
@@ -17,10 +17,18 @@ use crate::reference::ReferenceTableSource;
 use crate::serde::{self, Format, RecordDeserializer, RecordSerializer};
 
 /// Factory function type for creating source connectors.
-pub type SourceFactory = Arc<dyn Fn() -> Box<dyn SourceConnector> + Send + Sync>;
+///
+/// The optional `&prometheus::Registry` allows connectors to register
+/// their metrics on the shared Prometheus registry when one is available.
+pub type SourceFactory =
+    Arc<dyn Fn(Option<&prometheus::Registry>) -> Box<dyn SourceConnector> + Send + Sync>;
 
 /// Factory function type for creating sink connectors.
-pub type SinkFactory = Arc<dyn Fn() -> Box<dyn SinkConnector> + Send + Sync>;
+///
+/// The optional `&prometheus::Registry` allows connectors to register
+/// their metrics on the shared Prometheus registry when one is available.
+pub type SinkFactory =
+    Arc<dyn Fn(Option<&prometheus::Registry>) -> Box<dyn SinkConnector> + Send + Sync>;
 
 /// Factory function type for creating reference table sources.
 pub type TableSourceFactory = Arc<
@@ -116,7 +124,7 @@ impl ConnectorRegistry {
             factory.clone()
         };
 
-        let mut instance = factory();
+        let mut instance = factory(None);
         instance.discover_schema(properties).await;
         let schema = instance.schema();
         if schema.fields().is_empty() {
@@ -131,12 +139,16 @@ impl ConnectorRegistry {
     /// The factory creates a default-configured connector. The caller must
     /// subsequently call `open(config)` to forward WITH clause properties.
     ///
+    /// If a `prometheus::Registry` is provided, the connector will register
+    /// its metrics on it so they appear in the scrape output.
+    ///
     /// # Errors
     ///
     /// Returns `ConnectorError::ConfigurationError` if not registered.
     pub fn create_source(
         &self,
         config: &ConnectorConfig,
+        registry: Option<&prometheus::Registry>,
     ) -> Result<Box<dyn SourceConnector>, ConnectorError> {
         let sources = self.sources.read();
         let (_, factory) = sources.get(config.connector_type()).ok_or_else(|| {
@@ -145,12 +157,15 @@ impl ConnectorRegistry {
                 config.connector_type()
             ))
         })?;
-        Ok(factory())
+        Ok(factory(registry))
     }
 
     /// Creates a new sink connector instance.
     ///
     /// The connector type is determined by `config.connector_type()`.
+    ///
+    /// If a `prometheus::Registry` is provided, the connector will register
+    /// its metrics on it so they appear in the scrape output.
     ///
     /// # Errors
     ///
@@ -159,6 +174,7 @@ impl ConnectorRegistry {
     pub fn create_sink(
         &self,
         config: &ConnectorConfig,
+        registry: Option<&prometheus::Registry>,
     ) -> Result<Box<dyn SinkConnector>, ConnectorError> {
         let sinks = self.sinks.read();
         let (_, factory) = sinks.get(config.connector_type()).ok_or_else(|| {
@@ -167,7 +183,7 @@ impl ConnectorRegistry {
                 config.connector_type()
             ))
         })?;
-        Ok(factory())
+        Ok(factory(registry))
     }
 
     /// Registers a reference table source factory.
@@ -320,11 +336,11 @@ mod tests {
         registry.register_source(
             "mock",
             mock_info("mock", true, false),
-            Arc::new(|| Box::new(MockSourceConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSourceConnector::new())),
         );
 
         let config = ConnectorConfig::new("mock");
-        let connector = registry.create_source(&config);
+        let connector = registry.create_source(&config, None);
         assert!(connector.is_ok());
     }
 
@@ -334,11 +350,11 @@ mod tests {
         registry.register_sink(
             "mock",
             mock_info("mock", false, true),
-            Arc::new(|| Box::new(MockSinkConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSinkConnector::new())),
         );
 
         let config = ConnectorConfig::new("mock");
-        let connector = registry.create_sink(&config);
+        let connector = registry.create_sink(&config, None);
         assert!(connector.is_ok());
     }
 
@@ -347,8 +363,8 @@ mod tests {
         let registry = ConnectorRegistry::new();
         let config = ConnectorConfig::new("nonexistent");
 
-        assert!(registry.create_source(&config).is_err());
-        assert!(registry.create_sink(&config).is_err());
+        assert!(registry.create_source(&config, None).is_err());
+        assert!(registry.create_sink(&config, None).is_err());
     }
 
     #[test]
@@ -357,12 +373,12 @@ mod tests {
         registry.register_source(
             "kafka",
             mock_info("kafka", true, false),
-            Arc::new(|| Box::new(MockSourceConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSourceConnector::new())),
         );
         registry.register_sink(
             "delta",
             mock_info("delta", false, true),
-            Arc::new(|| Box::new(MockSinkConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSinkConnector::new())),
         );
 
         let sources = registry.list_sources();
@@ -380,7 +396,7 @@ mod tests {
         registry.register_source(
             "kafka",
             mock_info("kafka", true, false),
-            Arc::new(|| Box::new(MockSourceConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSourceConnector::new())),
         );
 
         let info = registry.source_info("kafka");
@@ -405,7 +421,7 @@ mod tests {
         registry.register_source(
             "mock",
             mock_info("mock", true, false),
-            Arc::new(|| Box::new(MockSourceConnector::new())),
+            Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSourceConnector::new())),
         );
         let schema = registry
             .default_source_schema("mock", &std::collections::HashMap::new())

--- a/crates/laminar-connectors/src/testing.rs
+++ b/crates/laminar-connectors/src/testing.rs
@@ -292,7 +292,7 @@ pub fn register_mock_source(registry: &ConnectorRegistry) {
             is_sink: false,
             config_keys: vec![],
         },
-        Arc::new(|| Box::new(MockSourceConnector::new())),
+        Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSourceConnector::new())),
     );
 }
 
@@ -308,7 +308,7 @@ pub fn register_mock_sink(registry: &ConnectorRegistry) {
             is_sink: true,
             config_keys: vec![],
         },
-        Arc::new(|| Box::new(MockSinkConnector::new())),
+        Arc::new(|_: Option<&prometheus::Registry>| Box::new(MockSinkConnector::new())),
     );
 }
 

--- a/crates/laminar-connectors/src/websocket/metrics.rs
+++ b/crates/laminar-connectors/src/websocket/metrics.rs
@@ -1,81 +1,127 @@
 //! `WebSocket` source connector metrics.
 //!
-//! [`WebSocketSourceMetrics`] provides lock-free atomic counters for
-//! tracking WebSocket source statistics, convertible to the SDK's
+//! [`WebSocketSourceMetrics`] provides prometheus-backed counters and gauges
+//! for tracking WebSocket source statistics, convertible to the SDK's
 //! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for WebSocket source connector statistics.
-///
-/// All counters use `Relaxed` ordering for maximum throughput on the
-/// hot path. Snapshot reads via [`to_connector_metrics`](Self::to_connector_metrics)
-/// provide a consistent-enough view for monitoring purposes.
-#[derive(Debug)]
+/// Prometheus-backed counters/gauges for WebSocket source connector statistics.
+#[derive(Debug, Clone)]
 pub struct WebSocketSourceMetrics {
     /// Total messages received from the WebSocket connection.
-    pub messages_received: AtomicU64,
+    pub messages_received: IntCounter,
     /// Total messages dropped due to backpressure.
-    pub messages_dropped_backpressure: AtomicU64,
+    pub messages_dropped_backpressure: IntCounter,
     /// Total bytes received (raw payload, before parsing).
-    pub bytes_received: AtomicU64,
+    pub bytes_received: IntCounter,
     /// Total number of reconnection attempts.
-    pub reconnect_count: AtomicU64,
+    pub reconnect_count: IntCounter,
     /// Total parse/deserialization errors.
-    pub parse_errors: AtomicU64,
+    pub parse_errors: IntCounter,
     /// Total detected sequence gaps (application-level).
-    pub sequence_gaps: AtomicU64,
+    pub sequence_gaps: IntCounter,
     /// Current number of connected clients (for server-mode source).
-    pub connected_clients: AtomicU64,
+    pub connected_clients: IntGauge,
 }
 
 impl WebSocketSourceMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let messages_received = IntCounter::new(
+            "ws_source_messages_received_total",
+            "Total WS messages received",
+        )
+        .unwrap();
+        let messages_dropped_backpressure = IntCounter::new(
+            "ws_source_messages_dropped_backpressure_total",
+            "Total WS messages dropped (backpressure)",
+        )
+        .unwrap();
+        let bytes_received =
+            IntCounter::new("ws_source_bytes_received_total", "Total WS bytes received").unwrap();
+        let reconnect_count = IntCounter::new(
+            "ws_source_reconnect_total",
+            "Total WS reconnection attempts",
+        )
+        .unwrap();
+        let parse_errors = IntCounter::new(
+            "ws_source_parse_errors_total",
+            "Total WS parse/deserialization errors",
+        )
+        .unwrap();
+        let sequence_gaps = IntCounter::new(
+            "ws_source_sequence_gaps_total",
+            "Total WS sequence gaps detected",
+        )
+        .unwrap();
+        let connected_clients = IntGauge::new(
+            "ws_source_connected_clients",
+            "Current connected WS clients (server mode)",
+        )
+        .unwrap();
+
+        let _ = reg.register(Box::new(messages_received.clone()));
+        let _ = reg.register(Box::new(messages_dropped_backpressure.clone()));
+        let _ = reg.register(Box::new(bytes_received.clone()));
+        let _ = reg.register(Box::new(reconnect_count.clone()));
+        let _ = reg.register(Box::new(parse_errors.clone()));
+        let _ = reg.register(Box::new(sequence_gaps.clone()));
+        let _ = reg.register(Box::new(connected_clients.clone()));
+
         Self {
-            messages_received: AtomicU64::new(0),
-            messages_dropped_backpressure: AtomicU64::new(0),
-            bytes_received: AtomicU64::new(0),
-            reconnect_count: AtomicU64::new(0),
-            parse_errors: AtomicU64::new(0),
-            sequence_gaps: AtomicU64::new(0),
-            connected_clients: AtomicU64::new(0),
+            messages_received,
+            messages_dropped_backpressure,
+            bytes_received,
+            reconnect_count,
+            parse_errors,
+            sequence_gaps,
+            connected_clients,
         }
     }
 
     /// Records a successfully received message with the given payload size.
     pub fn record_message(&self, bytes: u64) {
-        self.messages_received.fetch_add(1, Ordering::Relaxed);
-        self.bytes_received.fetch_add(bytes, Ordering::Relaxed);
+        self.messages_received.inc();
+        self.bytes_received.inc_by(bytes);
     }
 
     /// Records a message dropped due to backpressure.
     pub fn record_drop(&self) {
-        self.messages_dropped_backpressure
-            .fetch_add(1, Ordering::Relaxed);
+        self.messages_dropped_backpressure.inc();
     }
 
     /// Records a reconnection attempt.
     pub fn record_reconnect(&self) {
-        self.reconnect_count.fetch_add(1, Ordering::Relaxed);
+        self.reconnect_count.inc();
     }
 
     /// Records a parse/deserialization error.
     pub fn record_parse_error(&self) {
-        self.parse_errors.fetch_add(1, Ordering::Relaxed);
+        self.parse_errors.inc();
     }
 
     /// Records a detected sequence gap.
     pub fn record_sequence_gap(&self) {
-        self.sequence_gaps.fetch_add(1, Ordering::Relaxed);
+        self.sequence_gaps.inc();
     }
 
     /// Sets the current number of connected clients (server-mode source).
+    #[allow(clippy::cast_possible_wrap)]
     pub fn set_connected_clients(&self, n: u64) {
-        self.connected_clients.store(n, Ordering::Relaxed);
+        self.connected_clients.set(n as i64);
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
@@ -83,35 +129,26 @@ impl WebSocketSourceMetrics {
     #[allow(clippy::cast_precision_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
-            records_total: self.messages_received.load(Ordering::Relaxed),
-            bytes_total: self.bytes_received.load(Ordering::Relaxed),
-            errors_total: self.parse_errors.load(Ordering::Relaxed),
+            records_total: self.messages_received.get(),
+            bytes_total: self.bytes_received.get(),
+            errors_total: self.parse_errors.get(),
             lag: 0,
             custom: Vec::new(),
         };
         m.add_custom(
             "ws.messages_dropped_backpressure",
-            self.messages_dropped_backpressure.load(Ordering::Relaxed) as f64,
+            self.messages_dropped_backpressure.get() as f64,
         );
-        m.add_custom(
-            "ws.reconnect_count",
-            self.reconnect_count.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "ws.sequence_gaps",
-            self.sequence_gaps.load(Ordering::Relaxed) as f64,
-        );
-        m.add_custom(
-            "ws.connected_clients",
-            self.connected_clients.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("ws.reconnect_count", self.reconnect_count.get() as f64);
+        m.add_custom("ws.sequence_gaps", self.sequence_gaps.get() as f64);
+        m.add_custom("ws.connected_clients", self.connected_clients.get() as f64);
         m
     }
 }
 
 impl Default for WebSocketSourceMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -121,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -130,7 +167,7 @@ mod tests {
 
     #[test]
     fn test_record_message() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_message(1024);
         m.record_message(2048);
 
@@ -141,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_record_drop() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_drop();
         m.record_drop();
         m.record_drop();
@@ -156,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_record_reconnect() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_reconnect();
         m.record_reconnect();
 
@@ -167,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_record_parse_error() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_parse_error();
 
         let cm = m.to_connector_metrics();
@@ -176,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_record_sequence_gap() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_sequence_gap();
         m.record_sequence_gap();
 
@@ -187,7 +224,7 @@ mod tests {
 
     #[test]
     fn test_set_connected_clients() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.set_connected_clients(5);
 
         let cm = m.to_connector_metrics();
@@ -213,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_custom_metrics_count() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         let cm = m.to_connector_metrics();
         // Should have exactly 4 custom metrics
         assert_eq!(cm.custom.len(), 4);
@@ -221,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_combined_operations() {
-        let m = WebSocketSourceMetrics::new();
+        let m = WebSocketSourceMetrics::new(None);
         m.record_message(100);
         m.record_message(200);
         m.record_drop();

--- a/crates/laminar-connectors/src/websocket/mod.rs
+++ b/crates/laminar-connectors/src/websocket/mod.rs
@@ -71,7 +71,7 @@ pub fn register_websocket_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "websocket",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             use arrow_schema::{DataType, Field, Schema};
 
             let default_schema = Arc::new(Schema::new(vec![
@@ -81,6 +81,7 @@ pub fn register_websocket_source(registry: &ConnectorRegistry) {
             Box::new(WebSocketSource::new(
                 default_schema,
                 WebSocketSourceConfig::default(),
+                registry,
             ))
         }),
     );
@@ -103,7 +104,7 @@ pub fn register_websocket_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "websocket",
         info,
-        Arc::new(|| {
+        Arc::new(|registry: Option<&prometheus::Registry>| {
             use arrow_schema::{DataType, Field, Schema};
 
             let default_schema = Arc::new(Schema::new(vec![
@@ -113,6 +114,7 @@ pub fn register_websocket_sink(registry: &ConnectorRegistry) {
             Box::new(WebSocketSinkServer::new(
                 default_schema,
                 WebSocketSinkConfig::default(),
+                registry,
             ))
         }),
     );

--- a/crates/laminar-connectors/src/websocket/sink.rs
+++ b/crates/laminar-connectors/src/websocket/sink.rs
@@ -58,7 +58,11 @@ pub struct WebSocketSinkServer {
 impl WebSocketSinkServer {
     /// Creates a new WebSocket sink server connector.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: WebSocketSinkConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: WebSocketSinkConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let serializer = BatchSerializer::new(config.format.clone());
 
         let (buffer_capacity, policy, replay_size) = match &config.mode {
@@ -87,7 +91,7 @@ impl WebSocketSinkServer {
             serializer,
             fanout,
             state: ConnectorState::Created,
-            metrics: Arc::new(WebSocketSinkMetrics::new()),
+            metrics: Arc::new(WebSocketSinkMetrics::new(registry)),
             current_epoch: 0,
             shutdown_tx: None,
             acceptor_handle: None,
@@ -485,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let sink = WebSocketSinkServer::new(test_schema(), test_config());
+        let sink = WebSocketSinkServer::new(test_schema(), test_config(), None);
         assert_eq!(sink.state(), ConnectorState::Created);
         assert_eq!(sink.connected_clients(), 0);
     }
@@ -493,13 +497,13 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let sink = WebSocketSinkServer::new(schema.clone(), test_config());
+        let sink = WebSocketSinkServer::new(schema.clone(), test_config(), None);
         assert_eq!(sink.schema(), schema);
     }
 
     #[test]
     fn test_capabilities() {
-        let sink = WebSocketSinkServer::new(test_schema(), test_config());
+        let sink = WebSocketSinkServer::new(test_schema(), test_config(), None);
         let caps = sink.capabilities();
         assert!(!caps.exactly_once);
         assert!(!caps.upsert);
@@ -507,13 +511,13 @@ mod tests {
 
     #[test]
     fn test_health_created() {
-        let sink = WebSocketSinkServer::new(test_schema(), test_config());
+        let sink = WebSocketSinkServer::new(test_schema(), test_config(), None);
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
     }
 
     #[test]
     fn test_metrics_initial() {
-        let sink = WebSocketSinkServer::new(test_schema(), test_config());
+        let sink = WebSocketSinkServer::new(test_schema(), test_config(), None);
         let m = sink.metrics();
         assert_eq!(m.records_total, 0);
     }

--- a/crates/laminar-connectors/src/websocket/sink_client.rs
+++ b/crates/laminar-connectors/src/websocket/sink_client.rs
@@ -61,7 +61,11 @@ pub struct WebSocketSinkClient {
 impl WebSocketSinkClient {
     /// Creates a new WebSocket sink client connector.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: WebSocketSinkConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: WebSocketSinkConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let serializer = BatchSerializer::new(config.format.clone());
 
         let max_buffer_bytes = match &config.mode {
@@ -79,7 +83,7 @@ impl WebSocketSinkClient {
             conn_mgr: None,
             ws_sink: None,
             state: ConnectorState::Created,
-            metrics: WebSocketSinkMetrics::new(),
+            metrics: WebSocketSinkMetrics::new(registry),
             current_epoch: 0,
             disconnect_buffer: VecDeque::new(),
             max_buffer_bytes,
@@ -368,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let sink = WebSocketSinkClient::new(test_schema(), test_config());
+        let sink = WebSocketSinkClient::new(test_schema(), test_config(), None);
         assert_eq!(sink.state(), ConnectorState::Created);
         assert!(sink.ws_sink.is_none());
     }
@@ -376,13 +380,13 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let sink = WebSocketSinkClient::new(schema.clone(), test_config());
+        let sink = WebSocketSinkClient::new(schema.clone(), test_config(), None);
         assert_eq!(sink.schema(), schema);
     }
 
     #[test]
     fn test_buffer_message() {
-        let mut sink = WebSocketSinkClient::new(test_schema(), test_config());
+        let mut sink = WebSocketSinkClient::new(test_schema(), test_config(), None);
         sink.buffer_message("hello".into());
         sink.buffer_message("world".into());
         assert_eq!(sink.disconnect_buffer.len(), 2);
@@ -402,7 +406,7 @@ mod tests {
             format: super::super::sink_config::SinkFormat::Json,
             auth: None,
         };
-        let mut sink = WebSocketSinkClient::new(test_schema(), config);
+        let mut sink = WebSocketSinkClient::new(test_schema(), config, None);
 
         sink.buffer_message("12345".into()); // 5 bytes
         sink.buffer_message("67890".into()); // 5 bytes, total 10
@@ -426,21 +430,21 @@ mod tests {
             format: super::super::sink_config::SinkFormat::Json,
             auth: None,
         };
-        let mut sink = WebSocketSinkClient::new(test_schema(), config);
+        let mut sink = WebSocketSinkClient::new(test_schema(), config, None);
         sink.buffer_message("hello".into());
         assert!(sink.disconnect_buffer.is_empty());
     }
 
     #[test]
     fn test_capabilities() {
-        let sink = WebSocketSinkClient::new(test_schema(), test_config());
+        let sink = WebSocketSinkClient::new(test_schema(), test_config(), None);
         let caps = sink.capabilities();
         assert!(!caps.exactly_once);
     }
 
     #[test]
     fn test_health_created() {
-        let sink = WebSocketSinkClient::new(test_schema(), test_config());
+        let sink = WebSocketSinkClient::new(test_schema(), test_config(), None);
         assert_eq!(sink.health_check(), HealthStatus::Unknown);
     }
 }

--- a/crates/laminar-connectors/src/websocket/sink_metrics.rs
+++ b/crates/laminar-connectors/src/websocket/sink_metrics.rs
@@ -1,127 +1,151 @@
 //! WebSocket sink connector metrics.
 //!
-//! [`WebSocketSinkMetrics`] provides lock-free atomic counters for
-//! tracking WebSocket sink statistics, convertible to the SDK's
+//! [`WebSocketSinkMetrics`] provides prometheus-backed counters and gauges
+//! for tracking WebSocket sink statistics, convertible to the SDK's
 //! [`ConnectorMetrics`] type.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use prometheus::{IntCounter, IntGauge, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
-/// Atomic counters for WebSocket sink connector statistics.
-///
-/// All counters use `Relaxed` ordering for maximum throughput on the
-/// hot path. Snapshot reads via [`to_connector_metrics`](Self::to_connector_metrics)
-/// provide a consistent-enough view for monitoring purposes.
-#[derive(Debug)]
+/// Prometheus-backed counters/gauges for WebSocket sink connector statistics.
+#[derive(Debug, Clone)]
 pub struct WebSocketSinkMetrics {
     /// Total messages sent to connected clients.
-    pub messages_sent: AtomicU64,
+    pub messages_sent: IntCounter,
     /// Total messages dropped because a client was too slow.
-    pub messages_dropped_slow_client: AtomicU64,
+    pub messages_dropped_slow_client: IntCounter,
     /// Total bytes sent (serialized payload).
-    pub bytes_sent: AtomicU64,
+    pub bytes_sent: IntCounter,
     /// Current number of connected clients.
-    pub connected_clients: AtomicU64,
+    pub connected_clients: IntGauge,
     /// Total client disconnection events.
-    pub client_disconnects: AtomicU64,
+    pub client_disconnects: IntCounter,
     /// Total replay requests received from clients.
-    pub replay_requests: AtomicU64,
+    pub replay_requests: IntCounter,
     /// Total clients disconnected due to ping timeout.
-    pub ping_timeouts: AtomicU64,
+    pub ping_timeouts: IntCounter,
 }
 
 impl WebSocketSinkMetrics {
     /// Creates a new metrics instance with all counters at zero.
     #[must_use]
-    pub fn new() -> Self {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        let messages_sent =
+            IntCounter::new("ws_sink_messages_sent_total", "Total WS messages sent").unwrap();
+        let messages_dropped_slow_client = IntCounter::new(
+            "ws_sink_messages_dropped_slow_client_total",
+            "Total WS messages dropped (slow client)",
+        )
+        .unwrap();
+        let bytes_sent =
+            IntCounter::new("ws_sink_bytes_sent_total", "Total WS bytes sent").unwrap();
+        let connected_clients =
+            IntGauge::new("ws_sink_connected_clients", "Current connected WS clients").unwrap();
+        let client_disconnects = IntCounter::new(
+            "ws_sink_client_disconnects_total",
+            "Total WS client disconnections",
+        )
+        .unwrap();
+        let replay_requests =
+            IntCounter::new("ws_sink_replay_requests_total", "Total WS replay requests").unwrap();
+        let ping_timeouts =
+            IntCounter::new("ws_sink_ping_timeouts_total", "Total WS ping timeouts").unwrap();
+
+        let _ = reg.register(Box::new(messages_sent.clone()));
+        let _ = reg.register(Box::new(messages_dropped_slow_client.clone()));
+        let _ = reg.register(Box::new(bytes_sent.clone()));
+        let _ = reg.register(Box::new(connected_clients.clone()));
+        let _ = reg.register(Box::new(client_disconnects.clone()));
+        let _ = reg.register(Box::new(replay_requests.clone()));
+        let _ = reg.register(Box::new(ping_timeouts.clone()));
+
         Self {
-            messages_sent: AtomicU64::new(0),
-            messages_dropped_slow_client: AtomicU64::new(0),
-            bytes_sent: AtomicU64::new(0),
-            connected_clients: AtomicU64::new(0),
-            client_disconnects: AtomicU64::new(0),
-            replay_requests: AtomicU64::new(0),
-            ping_timeouts: AtomicU64::new(0),
+            messages_sent,
+            messages_dropped_slow_client,
+            bytes_sent,
+            connected_clients,
+            client_disconnects,
+            replay_requests,
+            ping_timeouts,
         }
     }
 
     /// Records a successfully sent message with the given payload size.
     pub fn record_send(&self, bytes: u64) {
-        self.messages_sent.fetch_add(1, Ordering::Relaxed);
-        self.bytes_sent.fetch_add(bytes, Ordering::Relaxed);
+        self.messages_sent.inc();
+        self.bytes_sent.inc_by(bytes);
     }
 
     /// Records a message dropped due to a slow client.
     pub fn record_drop(&self) {
-        self.messages_dropped_slow_client
-            .fetch_add(1, Ordering::Relaxed);
+        self.messages_dropped_slow_client.inc();
     }
 
     /// Records a new client connection.
     pub fn record_connect(&self) {
-        self.connected_clients.fetch_add(1, Ordering::Relaxed);
+        self.connected_clients.inc();
     }
 
     /// Records a client disconnection.
     pub fn record_disconnect(&self) {
-        self.client_disconnects.fetch_add(1, Ordering::Relaxed);
+        self.client_disconnects.inc();
         // Saturating subtract to avoid underflow on spurious disconnect events.
-        self.connected_clients
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                Some(v.saturating_sub(1))
-            })
-            .ok();
+        // IntGauge can go negative so we clamp manually.
+        let current = self.connected_clients.get();
+        if current > 0 {
+            self.connected_clients.dec();
+        }
     }
 
     /// Records a replay request from a client.
     pub fn record_replay(&self) {
-        self.replay_requests.fetch_add(1, Ordering::Relaxed);
+        self.replay_requests.inc();
     }
 
     /// Records a client disconnected due to ping timeout.
     pub fn record_ping_timeout(&self) {
-        self.ping_timeouts.fetch_add(1, Ordering::Relaxed);
+        self.ping_timeouts.inc();
     }
 
     /// Converts to the SDK's [`ConnectorMetrics`].
     #[must_use]
-    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
-            records_total: self.messages_sent.load(Ordering::Relaxed),
-            bytes_total: self.bytes_sent.load(Ordering::Relaxed),
-            errors_total: self.messages_dropped_slow_client.load(Ordering::Relaxed),
+            records_total: self.messages_sent.get(),
+            bytes_total: self.bytes_sent.get(),
+            errors_total: self.messages_dropped_slow_client.get(),
             lag: 0,
             custom: Vec::new(),
         };
-        m.add_custom(
-            "ws.connected_clients",
-            self.connected_clients.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("ws.connected_clients", self.connected_clients.get() as f64);
         m.add_custom(
             "ws.client_disconnects",
-            self.client_disconnects.load(Ordering::Relaxed) as f64,
+            self.client_disconnects.get() as f64,
         );
-        m.add_custom(
-            "ws.replay_requests",
-            self.replay_requests.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("ws.replay_requests", self.replay_requests.get() as f64);
         m.add_custom(
             "ws.messages_dropped_slow_client",
-            self.messages_dropped_slow_client.load(Ordering::Relaxed) as f64,
+            self.messages_dropped_slow_client.get() as f64,
         );
-        m.add_custom(
-            "ws.ping_timeouts",
-            self.ping_timeouts.load(Ordering::Relaxed) as f64,
-        );
+        m.add_custom("ws.ping_timeouts", self.ping_timeouts.get() as f64);
         m
     }
 }
 
 impl Default for WebSocketSinkMetrics {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -131,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_initial_zeros() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 0);
         assert_eq!(cm.bytes_total, 0);
@@ -140,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_record_send() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         m.record_send(512);
         m.record_send(1024);
 
@@ -151,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_record_drop() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         m.record_drop();
         m.record_drop();
 
@@ -167,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_record_connect_disconnect() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         m.record_connect();
         m.record_connect();
         m.record_connect();
@@ -183,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_disconnect_saturates_at_zero() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         // Disconnect without any connect should not underflow
         m.record_disconnect();
 
@@ -197,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_record_replay() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         m.record_replay();
         m.record_replay();
         m.record_replay();
@@ -219,15 +243,15 @@ mod tests {
 
     #[test]
     fn test_custom_metrics_count() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         let cm = m.to_connector_metrics();
-        // Should have exactly 4 custom metrics
+        // Should have exactly 5 custom metrics
         assert_eq!(cm.custom.len(), 5);
     }
 
     #[test]
     fn test_combined_operations() {
-        let m = WebSocketSinkMetrics::new();
+        let m = WebSocketSinkMetrics::new(None);
         m.record_send(100);
         m.record_send(200);
         m.record_send(300);

--- a/crates/laminar-connectors/src/websocket/source.rs
+++ b/crates/laminar-connectors/src/websocket/source.rs
@@ -79,7 +79,11 @@ pub struct WebSocketSource {
 impl WebSocketSource {
     /// Creates a new WebSocket source connector in client mode.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: WebSocketSourceConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: WebSocketSourceConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let parser = MessageParser::new(
             schema.clone(),
             config.format.clone(),
@@ -91,7 +95,7 @@ impl WebSocketSource {
             schema,
             parser,
             state: ConnectorState::Created,
-            metrics: WebSocketSourceMetrics::new(),
+            metrics: WebSocketSourceMetrics::new(registry),
             checkpoint_state: WebSocketSourceCheckpoint::default(),
             rx: None,
             shutdown_tx: None,
@@ -590,33 +594,33 @@ mod tests {
 
     #[test]
     fn test_new_defaults() {
-        let source = WebSocketSource::new(test_schema(), test_config());
+        let source = WebSocketSource::new(test_schema(), test_config(), None);
         assert_eq!(source.state(), ConnectorState::Created);
     }
 
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let source = WebSocketSource::new(schema.clone(), test_config());
+        let source = WebSocketSource::new(schema.clone(), test_config(), None);
         assert_eq!(source.schema(), schema);
     }
 
     #[test]
     fn test_checkpoint_empty() {
-        let source = WebSocketSource::new(test_schema(), test_config());
+        let source = WebSocketSource::new(test_schema(), test_config(), None);
         let cp = source.checkpoint();
         assert!(!cp.is_empty()); // has websocket_state key
     }
 
     #[test]
     fn test_health_check_created() {
-        let source = WebSocketSource::new(test_schema(), test_config());
+        let source = WebSocketSource::new(test_schema(), test_config(), None);
         assert_eq!(source.health_check(), HealthStatus::Unknown);
     }
 
     #[test]
     fn test_metrics_initial() {
-        let source = WebSocketSource::new(test_schema(), test_config());
+        let source = WebSocketSource::new(test_schema(), test_config(), None);
         let m = source.metrics();
         assert_eq!(m.records_total, 0);
         assert_eq!(m.bytes_total, 0);

--- a/crates/laminar-connectors/src/websocket/source_server.rs
+++ b/crates/laminar-connectors/src/websocket/source_server.rs
@@ -66,7 +66,11 @@ pub struct WebSocketSourceServer {
 impl WebSocketSourceServer {
     /// Creates a new WebSocket source connector in server mode.
     #[must_use]
-    pub fn new(schema: SchemaRef, config: WebSocketSourceConfig) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        config: WebSocketSourceConfig,
+        registry: Option<&prometheus::Registry>,
+    ) -> Self {
         let parser = MessageParser::new(
             schema.clone(),
             config.format.clone(),
@@ -78,7 +82,7 @@ impl WebSocketSourceServer {
             schema,
             parser,
             state: ConnectorState::Created,
-            metrics: WebSocketSourceMetrics::new(),
+            metrics: WebSocketSourceMetrics::new(registry),
             checkpoint_state: WebSocketSourceCheckpoint::default(),
             rx: None,
             shutdown_tx: None,
@@ -446,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let server = WebSocketSourceServer::new(test_schema(), test_config());
+        let server = WebSocketSourceServer::new(test_schema(), test_config(), None);
         assert_eq!(server.state(), ConnectorState::Created);
         assert_eq!(server.connected_clients(), 0);
     }
@@ -454,13 +458,13 @@ mod tests {
     #[test]
     fn test_schema_returned() {
         let schema = test_schema();
-        let server = WebSocketSourceServer::new(schema.clone(), test_config());
+        let server = WebSocketSourceServer::new(schema.clone(), test_config(), None);
         assert_eq!(server.schema(), schema);
     }
 
     #[test]
     fn test_health_created() {
-        let server = WebSocketSourceServer::new(test_schema(), test_config());
+        let server = WebSocketSourceServer::new(test_schema(), test_config(), None);
         assert_eq!(server.health_check(), HealthStatus::Unknown);
     }
 }

--- a/crates/laminar-connectors/tests/kafka_integration.rs
+++ b/crates/laminar-connectors/tests/kafka_integration.rs
@@ -132,7 +132,7 @@ async fn roundtrip(brokers: &str) {
     produce_messages(brokers, topic, n).await;
 
     let cfg = make_config(brokers, "test-roundtrip-group", topic);
-    let mut source = KafkaSource::new(test_schema(), cfg);
+    let mut source = KafkaSource::new(test_schema(), cfg, None);
     let connector_cfg = ConnectorConfig::new("kafka");
     source.open(&connector_cfg).await.unwrap();
 
@@ -172,7 +172,7 @@ async fn checkpoint_restore(brokers: &str) {
     let cfg = make_config(brokers, "test-checkpoint-group", topic);
     let connector_cfg = ConnectorConfig::new("kafka");
 
-    let mut source = KafkaSource::new(test_schema(), cfg.clone());
+    let mut source = KafkaSource::new(test_schema(), cfg.clone(), None);
     source.open(&connector_cfg).await.unwrap();
 
     poll_all(&mut source, n, Duration::from_secs(30)).await;
@@ -182,7 +182,7 @@ async fn checkpoint_restore(brokers: &str) {
     let extra = 10;
     produce_messages(brokers, topic, extra).await;
 
-    let mut source2 = KafkaSource::new(test_schema(), cfg);
+    let mut source2 = KafkaSource::new(test_schema(), cfg, None);
     source2.open(&connector_cfg).await.unwrap();
     source2.restore(&checkpoint).await.unwrap();
 
@@ -224,7 +224,7 @@ async fn poison_pill(brokers: &str) {
         ..make_config(brokers, "test-poison-group", topic)
     };
 
-    let mut source = KafkaSource::new(test_schema(), cfg);
+    let mut source = KafkaSource::new(test_schema(), cfg, None);
     let connector_cfg = ConnectorConfig::new("kafka");
     source.open(&connector_cfg).await.unwrap();
 

--- a/crates/laminar-connectors/tests/mongodb_integration.rs
+++ b/crates/laminar-connectors/tests/mongodb_integration.rs
@@ -105,7 +105,7 @@ async fn insert_cdc() {
 
     // Open the change stream before inserting.
     let config = MongoDbSourceConfig::new(&uri, "test_insert_cdc", "events");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
 
@@ -149,7 +149,7 @@ async fn resume_after_disconnect() {
 
     // Phase 1: Insert 5 docs and capture resume token.
     let config = MongoDbSourceConfig::new(&uri, "test_resume", "docs");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -178,7 +178,7 @@ async fn resume_after_disconnect() {
     }
 
     let config2 = MongoDbSourceConfig::new(&uri, "test_resume", "docs");
-    let mut source2 = MongoDbCdcSource::new(config2);
+    let mut source2 = MongoDbCdcSource::new(config2, None);
     source2.restore(&checkpoint).await.unwrap();
     source2.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -209,7 +209,7 @@ async fn sink_insert() {
     let (_container, uri) = start_mongo().await;
 
     let config = MongoDbSinkConfig::new(&uri, "test_sink_insert", "out");
-    let mut sink = MongoDbSink::new(sink_test_schema(), config);
+    let mut sink = MongoDbSink::new(sink_test_schema(), config, None);
     let connector_config = ConnectorConfig::new("mongodb-sink");
     sink.open(&connector_config).await.unwrap();
 
@@ -241,7 +241,7 @@ async fn sink_upsert() {
     config.write_mode = WriteMode::Upsert {
         key_fields: vec!["_id".to_string()],
     };
-    let mut sink = MongoDbSink::new(sink_test_schema(), config);
+    let mut sink = MongoDbSink::new(sink_test_schema(), config, None);
     let connector_config = ConnectorConfig::new("mongodb-sink");
     sink.open(&connector_config).await.unwrap();
 
@@ -286,7 +286,7 @@ async fn timeseries_source_guard() {
 
     // Attempt to open a CDC source on the time series collection.
     let config = MongoDbSourceConfig::new(&uri, "test_ts_guard", "metrics");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     let result = source.open(&connector_config).await;
 
@@ -322,7 +322,7 @@ async fn timeseries_insert() {
         Field::new("value", DataType::Int64, false),
     ]));
 
-    let mut sink = MongoDbSink::new(schema, config);
+    let mut sink = MongoDbSink::new(schema, config, None);
     let connector_config = ConnectorConfig::new("mongodb-sink");
     sink.open(&connector_config).await.unwrap();
 
@@ -362,7 +362,7 @@ async fn update_delta_mode() {
 
     // Open change stream in Delta mode (default).
     let config = MongoDbSourceConfig::new(&uri, "test_update_delta", "docs");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -433,7 +433,7 @@ async fn update_lookup_mode() {
 
     let mut config = MongoDbSourceConfig::new(&uri, "test_update_lookup", "docs");
     config.full_document_mode = FullDocumentMode::UpdateLookup;
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -492,7 +492,7 @@ async fn replace_cdc() {
         .unwrap();
 
     let config = MongoDbSourceConfig::new(&uri, "test_replace_cdc", "docs");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -544,7 +544,7 @@ async fn delete_cdc() {
         .unwrap();
 
     let config = MongoDbSourceConfig::new(&uri, "test_delete_cdc", "docs");
-    let mut source = MongoDbCdcSource::new(config);
+    let mut source = MongoDbCdcSource::new(config, None);
     let connector_config = ConnectorConfig::new("mongodb-cdc");
     source.open(&connector_config).await.unwrap();
     sleep(Duration::from_secs(1)).await;
@@ -588,7 +588,7 @@ async fn sink_cdc_replay() {
 
     let mut config = MongoDbSinkConfig::new(&uri, "test_cdc_replay", "replay_out");
     config.write_mode = WriteMode::CdcReplay;
-    let mut sink = MongoDbSink::new(schema.clone(), config);
+    let mut sink = MongoDbSink::new(schema.clone(), config, None);
     let connector_config = ConnectorConfig::new("mongodb-sink");
     sink.open(&connector_config).await.unwrap();
 

--- a/crates/laminar-connectors/tests/postgres_sink_integration.rs
+++ b/crates/laminar-connectors/tests/postgres_sink_integration.rs
@@ -91,7 +91,7 @@ async fn test_append_flush_writes_data() {
     let (_container, host, port) = start_pg().await;
 
     let config = sink_config(&host, port, WriteMode::Append);
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -125,7 +125,7 @@ async fn test_append_multiple_flushes() {
     let (_container, host, port) = start_pg().await;
 
     let config = sink_config(&host, port, WriteMode::Append);
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -159,7 +159,7 @@ async fn test_upsert_insert_and_update() {
     let (_container, host, port) = start_pg().await;
 
     let config = sink_config(&host, port, WriteMode::Upsert);
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -207,7 +207,7 @@ async fn test_auto_flush_on_batch_size() {
 
     let mut config = sink_config(&host, port, WriteMode::Append);
     config.batch_size = 5; // Flush after 5 rows.
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -242,7 +242,7 @@ async fn test_exactly_once_commit() {
 
     let mut config = sink_config(&host, port, WriteMode::Upsert);
     config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -279,7 +279,7 @@ async fn test_exactly_once_rollback_discards() {
 
     let mut config = sink_config(&host, port, WriteMode::Upsert);
     config.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -322,7 +322,7 @@ async fn test_auto_create_table() {
     assert!(!exists, "table should not exist yet");
 
     let config = sink_config(&host, port, WriteMode::Upsert);
-    let mut sink = PostgresSink::new(test_schema(), config);
+    let mut sink = PostgresSink::new(test_schema(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -356,7 +356,7 @@ async fn test_changelog_upsert_and_delete() {
 
     let mut config = sink_config(&host, port, WriteMode::Upsert);
     config.changelog_mode = true;
-    let mut sink = PostgresSink::new(changelog_schema.clone(), config);
+    let mut sink = PostgresSink::new(changelog_schema.clone(), config, None);
     sink.open(&ConnectorConfig::new("postgres-sink"))
         .await
         .expect("open");
@@ -403,7 +403,7 @@ async fn test_epoch_recovery_skips_replay() {
 
     // First sink: commit epoch 5.
     {
-        let mut sink = PostgresSink::new(test_schema(), config.clone());
+        let mut sink = PostgresSink::new(test_schema(), config.clone(), None);
         sink.open(&ConnectorConfig::new("postgres-sink"))
             .await
             .expect("open1");
@@ -418,7 +418,7 @@ async fn test_epoch_recovery_skips_replay() {
 
     // Second sink: simulate recovery replay of epoch 5.
     {
-        let mut sink = PostgresSink::new(test_schema(), config.clone());
+        let mut sink = PostgresSink::new(test_schema(), config.clone(), None);
         sink.open(&ConnectorConfig::new("postgres-sink"))
             .await
             .expect("open2");

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -36,10 +36,10 @@ gcs = ["laminar-storage/gcs"]
 azure = ["laminar-storage/azure"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.20.1" }
-laminar-sql = { path = "../laminar-sql", version = "0.20.1" }
-laminar-storage = { path = "../laminar-storage", version = "0.20.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.20.1" }
+laminar-core = { path = "../laminar-core", version = "0.20.2" }
+laminar-sql = { path = "../laminar-sql", version = "0.20.2" }
+laminar-storage = { path = "../laminar-storage", version = "0.20.2" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.20.2" }
 
 # Arrow
 arrow = { workspace = true }
@@ -84,11 +84,14 @@ ahash = { workspace = true }
 # Observability
 tracing = { workspace = true }
 
+# Metrics
+prometheus = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = { workspace = true }
-laminar-derive = { path = "../laminar-derive", version = "0.20.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.20.1", features = ["testing"] }
+laminar-derive = { path = "../laminar-derive", version = "0.20.2" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.20.2", features = ["testing"] }
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -21,8 +21,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use std::sync::atomic::Ordering;
-
 use laminar_connectors::checkpoint::SourceCheckpoint;
 use laminar_connectors::connector::SourceConnector;
 use laminar_storage::checkpoint_manifest::{
@@ -32,7 +30,6 @@ use laminar_storage::checkpoint_store::CheckpointStore;
 use tracing::{debug, error, info, warn};
 
 use crate::error::DbError;
-use crate::metrics::PipelineCounters;
 
 /// Unified checkpoint configuration.
 #[derive(Debug, Clone)]
@@ -240,8 +237,8 @@ pub struct CheckpointCoordinator {
     last_checkpoint_duration: Option<Duration>,
     /// Rolling histogram of checkpoint durations for percentile tracking.
     duration_histogram: DurationHistogram,
-    /// Shared counters for observability.
-    counters: Option<Arc<PipelineCounters>>,
+    /// Prometheus engine metrics.
+    prom: Option<Arc<crate::engine_metrics::EngineMetrics>>,
     /// Exponential moving average of checkpoint durations (milliseconds).
     smoothed_duration_ms: f64,
     /// Cumulative bytes written across all checkpoints (manifest + sidecar).
@@ -270,7 +267,7 @@ impl CheckpointCoordinator {
             checkpoints_failed: 0,
             last_checkpoint_duration: None,
             duration_histogram: DurationHistogram::new(),
-            counters: None,
+            prom: None,
             smoothed_duration_ms: 0.0,
             total_bytes_written: 0,
         }
@@ -334,29 +331,22 @@ impl CheckpointCoordinator {
         Ok(())
     }
 
-    /// Sets the shared pipeline counters for checkpoint metrics emission.
-    ///
-    /// When set, checkpoint completion and failure will update the counters
-    /// automatically.
-    pub fn set_counters(&mut self, counters: Arc<PipelineCounters>) {
-        self.counters = Some(counters);
+    /// Inject prometheus engine metrics.
+    pub fn set_metrics(&mut self, prom: Arc<crate::engine_metrics::EngineMetrics>) {
+        self.prom = Some(prom);
     }
 
-    /// Emits checkpoint metrics to the shared counters.
+    /// Emits checkpoint metrics to prometheus.
     fn emit_checkpoint_metrics(&self, success: bool, epoch: u64, duration: Duration) {
-        if let Some(ref counters) = self.counters {
+        if let Some(ref m) = self.prom {
             if success {
-                counters
-                    .checkpoints_completed
-                    .fetch_add(1, Ordering::Relaxed);
+                m.checkpoints_completed.inc();
             } else {
-                counters.checkpoints_failed.fetch_add(1, Ordering::Relaxed);
+                m.checkpoints_failed.inc();
             }
-            #[allow(clippy::cast_possible_truncation)]
-            counters
-                .last_checkpoint_duration_ms
-                .store(duration.as_millis() as u64, Ordering::Relaxed);
-            counters.checkpoint_epoch.store(epoch, Ordering::Relaxed);
+            #[allow(clippy::cast_possible_wrap)]
+            m.checkpoint_epoch.set(epoch as i64);
+            m.checkpoint_duration.observe(duration.as_secs_f64());
         }
     }
 
@@ -393,11 +383,9 @@ impl CheckpointCoordinator {
             };
 
         // Record pre-commit duration regardless of success/failure.
-        if let Some(ref counters) = self.counters {
-            #[allow(clippy::cast_possible_truncation)]
-            counters
-                .sink_precommit_duration_us
-                .store(start.elapsed().as_micros() as u64, Ordering::Relaxed);
+        if let Some(ref m) = self.prom {
+            m.sink_precommit_duration
+                .observe(start.elapsed().as_secs_f64());
         }
 
         result
@@ -459,11 +447,9 @@ impl CheckpointCoordinator {
         };
 
         // Record commit duration regardless of success/failure.
-        if let Some(ref counters) = self.counters {
-            #[allow(clippy::cast_possible_truncation)]
-            counters
-                .sink_commit_duration_us
-                .store(start.elapsed().as_micros() as u64, Ordering::Relaxed);
+        if let Some(ref m) = self.prom {
+            m.sink_commit_duration
+                .observe(start.elapsed().as_secs_f64());
         }
 
         statuses
@@ -974,19 +960,10 @@ impl CheckpointCoordinator {
         self.duration_histogram.record(duration);
         self.emit_checkpoint_metrics(true, epoch, duration);
 
-        // Emit checkpoint size and lag metrics.
-        if let Some(ref counters) = self.counters {
-            counters
-                .last_checkpoint_size_bytes
-                .store(checkpoint_bytes, Ordering::Relaxed);
-            #[allow(clippy::cast_possible_truncation)]
-            counters.last_checkpoint_timestamp_ms.store(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64,
-                Ordering::Relaxed,
-            );
+        // Emit checkpoint size metrics.
+        if let Some(ref m) = self.prom {
+            #[allow(clippy::cast_possible_wrap)]
+            m.checkpoint_size_bytes.set(checkpoint_bytes as i64);
         }
 
         self.adjust_interval();
@@ -1436,14 +1413,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_checkpoint_emits_metrics_on_success() {
-        use crate::metrics::PipelineCounters;
-        use std::sync::atomic::Ordering;
-
         let dir = tempfile::tempdir().unwrap();
         let mut coord = make_coordinator(dir.path());
 
-        let counters = Arc::new(PipelineCounters::new());
-        coord.set_counters(Arc::clone(&counters));
+        let registry = prometheus::Registry::new();
+        let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+        coord.set_metrics(Arc::clone(&prom));
 
         let result = coord
             .checkpoint(CheckpointRequest {
@@ -1454,10 +1429,9 @@ mod tests {
             .unwrap();
 
         assert!(result.success);
-        assert_eq!(counters.checkpoints_completed.load(Ordering::Relaxed), 1);
-        assert_eq!(counters.checkpoints_failed.load(Ordering::Relaxed), 0);
-        assert!(counters.last_checkpoint_duration_ms.load(Ordering::Relaxed) < 5000);
-        assert_eq!(counters.checkpoint_epoch.load(Ordering::Relaxed), 1);
+        assert_eq!(prom.checkpoints_completed.get(), 1);
+        assert_eq!(prom.checkpoints_failed.get(), 0);
+        assert_eq!(prom.checkpoint_epoch.get(), 1);
 
         // Second checkpoint
         let result2 = coord
@@ -1469,13 +1443,13 @@ mod tests {
             .unwrap();
 
         assert!(result2.success);
-        assert_eq!(counters.checkpoints_completed.load(Ordering::Relaxed), 2);
-        assert_eq!(counters.checkpoint_epoch.load(Ordering::Relaxed), 2);
+        assert_eq!(prom.checkpoints_completed.get(), 2);
+        assert_eq!(prom.checkpoint_epoch.get(), 2);
     }
 
     #[tokio::test]
-    async fn test_checkpoint_without_counters() {
-        // Verify checkpoint works fine without counters set
+    async fn test_checkpoint_without_metrics() {
+        // Verify checkpoint works fine without metrics set
         let dir = tempfile::tempdir().unwrap();
         let mut coord = make_coordinator(dir.path());
 

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -72,8 +72,11 @@ pub struct LaminarDB {
     pub(crate) runtime_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Signal to stop the processing loop.
     pub(crate) shutdown_signal: Arc<tokio::sync::Notify>,
-    /// Shared pipeline counters for observability.
-    pub(crate) counters: Arc<crate::metrics::PipelineCounters>,
+    /// Prometheus engine metrics. `None` until `set_engine_metrics()` is called.
+    pub(crate) engine_metrics:
+        parking_lot::Mutex<Option<Arc<crate::engine_metrics::EngineMetrics>>>,
+    /// Shared Prometheus registry. `None` until `set_prometheus_registry()` is called.
+    pub(crate) prometheus_registry: parking_lot::Mutex<Option<Arc<prometheus::Registry>>>,
     /// Instant when the database was created, for uptime calculation.
     pub(crate) start_time: std::time::Instant,
     /// Session properties set via `SET key = value`.
@@ -216,7 +219,8 @@ impl LaminarDB {
             state: Arc::new(std::sync::atomic::AtomicU8::new(STATE_CREATED)),
             runtime_handle: parking_lot::Mutex::new(None),
             shutdown_signal: Arc::new(tokio::sync::Notify::new()),
-            counters: Arc::new(crate::metrics::PipelineCounters::new()),
+            engine_metrics: parking_lot::Mutex::new(None),
+            prometheus_registry: parking_lot::Mutex::new(None),
             start_time: std::time::Instant::now(),
             session_properties: parking_lot::Mutex::new(HashMap::new()),
             pipeline_watermark: Arc::new(std::sync::atomic::AtomicI64::new(i64::MIN)),
@@ -2276,7 +2280,9 @@ mod tests {
                         is_sink: false,
                         config_keys: vec![],
                     },
-                    Arc::new(|| Box::new(laminar_connectors::testing::MockSourceConnector::new())),
+                    Arc::new(|_: Option<&prometheus::Registry>| {
+                        Box::new(laminar_connectors::testing::MockSourceConnector::new())
+                    }),
                 );
             })
             .build()
@@ -2440,7 +2446,7 @@ mod tests {
                         is_sink: false,
                         config_keys: vec![],
                     },
-                    Arc::new(move || {
+                    Arc::new(move |_: Option<&prometheus::Registry>| {
                         Box::new(FakeSource {
                             schema: Arc::new(ArrowSchema::empty()),
                             on_discover: discovered.clone(),
@@ -3747,11 +3753,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_counters_accessible() {
+    async fn test_engine_metrics_accessible() {
         let db = LaminarDB::open().unwrap();
-        let c = db.counters();
-        c.events_ingested
-            .fetch_add(42, std::sync::atomic::Ordering::Relaxed);
+        let registry = prometheus::Registry::new();
+        let prom = std::sync::Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+        db.set_engine_metrics(prom.clone());
+        prom.events_ingested.inc_by(42);
         let m = db.metrics();
         assert_eq!(m.total_events_ingested, 42);
     }

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -148,19 +148,23 @@ impl EngineMetrics {
                     .buckets(vec![1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3]),
             )
             .unwrap()),
+            // Checkpoint: serialization_timeout=120s, so max bucket must cover that.
+            // 0.01 * 2^14 = 163.84s.
             checkpoint_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("checkpoint_duration_seconds", "Checkpoint cycle duration")
-                    .buckets(prometheus::exponential_buckets(0.01, 2.0, 10).unwrap()),
+                    .buckets(prometheus::exponential_buckets(0.01, 2.0, 15).unwrap()),
             )
             .unwrap()),
+            // pre_commit_timeout=30s. 0.005 * 2^13 = 40.96s.
             sink_precommit_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("sink_precommit_duration_seconds", "Sink pre-commit latency")
-                    .buckets(prometheus::exponential_buckets(0.001, 2.0, 10).unwrap()),
+                    .buckets(prometheus::exponential_buckets(0.005, 2.0, 14).unwrap()),
             )
             .unwrap()),
+            // commit_timeout=60s. 0.005 * 2^14 = 81.92s.
             sink_commit_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("sink_commit_duration_seconds", "Sink commit latency")
-                    .buckets(prometheus::exponential_buckets(0.001, 2.0, 10).unwrap()),
+                    .buckets(prometheus::exponential_buckets(0.005, 2.0, 15).unwrap()),
             )
             .unwrap()),
         }

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -1,0 +1,168 @@
+//! Prometheus metrics for the streaming engine.
+
+use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge, Registry};
+
+/// Pipeline metrics registered on an explicit prometheus `Registry`.
+///
+/// Constructed once at startup, `Arc`-shared into `PipelineCallback`,
+/// `CheckpointCoordinator`, and `OperatorGraph`.
+pub struct EngineMetrics {
+    /// Events ingested from sources.
+    pub events_ingested: IntCounter,
+    /// Events emitted to streams.
+    pub events_emitted: IntCounter,
+    /// Events dropped.
+    pub events_dropped: IntCounter,
+    /// Processing cycles completed.
+    pub cycles: IntCounter,
+    /// Batches processed.
+    pub batches: IntCounter,
+    /// Queries using compiled `PhysicalExpr`.
+    pub queries_compiled: IntCounter,
+    /// Queries using cached logical plan.
+    pub queries_cached_plan: IntCounter,
+    /// Cycles skipped by backpressure.
+    pub cycles_backpressured: IntCounter,
+    /// Materialized view updates.
+    pub mv_updates: IntCounter,
+    /// Approximate MV bytes stored.
+    pub mv_bytes_stored: IntGauge,
+    /// Global pipeline watermark.
+    pub pipeline_watermark: IntGauge,
+    /// Completed checkpoints.
+    pub checkpoints_completed: IntCounter,
+    /// Failed checkpoints.
+    pub checkpoints_failed: IntCounter,
+    /// Current checkpoint epoch.
+    pub checkpoint_epoch: IntGauge,
+    /// Last checkpoint size in bytes.
+    pub checkpoint_size_bytes: IntGauge,
+    /// Sink write errors.
+    pub sink_write_failures: IntCounter,
+    /// Sink write timeouts.
+    pub sink_write_timeouts: IntCounter,
+    /// Sink task channel closed.
+    pub sink_task_channel_closed: IntCounter,
+    /// Per-cycle processing duration.
+    pub cycle_duration: Histogram,
+    /// Checkpoint cycle duration.
+    pub checkpoint_duration: Histogram,
+    /// Sink pre-commit round-trip (2PC phase 1).
+    pub sink_precommit_duration: Histogram,
+    /// Sink commit round-trip (2PC phase 2).
+    pub sink_commit_duration: Histogram,
+}
+
+impl EngineMetrics {
+    /// Register all engine metrics on the given registry. Startup only.
+    ///
+    /// # Panics
+    ///
+    /// Panics if metric registration fails (duplicate names).
+    #[must_use]
+    #[allow(clippy::too_many_lines)]
+    pub fn new(registry: &Registry) -> Self {
+        macro_rules! reg {
+            ($m:expr) => {{
+                let m = $m;
+                registry.register(Box::new(m.clone())).unwrap();
+                m
+            }};
+        }
+
+        Self {
+            events_ingested: reg!(IntCounter::new(
+                "events_ingested_total",
+                "Events ingested from sources"
+            )
+            .unwrap()),
+            events_emitted: reg!(IntCounter::new(
+                "events_emitted_total",
+                "Events emitted to streams"
+            )
+            .unwrap()),
+            events_dropped: reg!(IntCounter::new("events_dropped_total", "Events dropped").unwrap()),
+            cycles: reg!(IntCounter::new("cycles_total", "Processing cycles completed").unwrap()),
+            batches: reg!(IntCounter::new("batches_total", "Batches processed").unwrap()),
+            queries_compiled: reg!(IntCounter::new(
+                "queries_compiled_total",
+                "Queries using compiled PhysicalExpr"
+            )
+            .unwrap()),
+            queries_cached_plan: reg!(IntCounter::new(
+                "queries_cached_plan_total",
+                "Queries using cached logical plan"
+            )
+            .unwrap()),
+            cycles_backpressured: reg!(IntCounter::new(
+                "cycles_backpressured_total",
+                "Cycles skipped by backpressure"
+            )
+            .unwrap()),
+            mv_updates: reg!(
+                IntCounter::new("mv_updates_total", "Materialized view updates").unwrap()
+            ),
+            mv_bytes_stored: reg!(
+                IntGauge::new("mv_bytes_stored", "Approximate MV bytes stored").unwrap()
+            ),
+            pipeline_watermark: reg!(IntGauge::new(
+                "pipeline_watermark",
+                "Global pipeline watermark"
+            )
+            .unwrap()),
+            checkpoints_completed: reg!(IntCounter::new(
+                "checkpoints_completed_total",
+                "Completed checkpoints"
+            )
+            .unwrap()),
+            checkpoints_failed: reg!(IntCounter::new(
+                "checkpoints_failed_total",
+                "Failed checkpoints"
+            )
+            .unwrap()),
+            checkpoint_epoch: reg!(
+                IntGauge::new("checkpoint_epoch", "Current checkpoint epoch").unwrap()
+            ),
+            checkpoint_size_bytes: reg!(IntGauge::new(
+                "checkpoint_size_bytes",
+                "Last checkpoint size"
+            )
+            .unwrap()),
+            sink_write_failures: reg!(IntCounter::new(
+                "sink_write_failures_total",
+                "Sink write errors"
+            )
+            .unwrap()),
+            sink_write_timeouts: reg!(IntCounter::new(
+                "sink_write_timeouts_total",
+                "Sink write timeouts"
+            )
+            .unwrap()),
+            sink_task_channel_closed: reg!(IntCounter::new(
+                "sink_task_channel_closed_total",
+                "Sink task channel closed"
+            )
+            .unwrap()),
+            cycle_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new("cycle_duration_seconds", "Per-cycle processing duration")
+                    .buckets(vec![1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3]),
+            )
+            .unwrap()),
+            checkpoint_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new("checkpoint_duration_seconds", "Checkpoint cycle duration")
+                    .buckets(prometheus::exponential_buckets(0.01, 2.0, 10).unwrap()),
+            )
+            .unwrap()),
+            sink_precommit_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new("sink_precommit_duration_seconds", "Sink pre-commit latency")
+                    .buckets(prometheus::exponential_buckets(0.001, 2.0, 10).unwrap()),
+            )
+            .unwrap()),
+            sink_commit_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new("sink_commit_duration_seconds", "Sink commit latency")
+                    .buckets(prometheus::exponential_buckets(0.001, 2.0, 10).unwrap()),
+            )
+            .unwrap()),
+        }
+    }
+}

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -36,6 +36,8 @@ mod config;
 mod connector_manager;
 mod core_window_state;
 mod db;
+/// Prometheus metrics for the streaming engine.
+pub mod engine_metrics;
 mod eowc_state;
 // Reopened `impl LaminarDB` modules — split from db.rs
 /// FFI-friendly API for language bindings.
@@ -98,13 +100,14 @@ pub use checkpoint_coordinator::{
 };
 pub use config::{IdentifierCaseSensitivity, LaminarConfig, TieringConfig};
 pub use db::LaminarDB;
+pub use engine_metrics::EngineMetrics;
 pub use error::DbError;
 pub use handle::{
     DdlInfo, ExecuteResult, FromBatch, PipelineEdge, PipelineNode, PipelineNodeType,
     PipelineTopology, QueryHandle, QueryInfo, SinkInfo, SourceHandle, SourceInfo, StreamInfo,
     TypedSubscription, UntypedSourceHandle,
 };
-pub use metrics::{PipelineCounters, PipelineMetrics, PipelineState, SourceMetrics, StreamMetrics};
+pub use metrics::{PipelineMetrics, PipelineState, SourceMetrics, StreamMetrics};
 pub use profile::{Profile, ProfileError};
 pub use recovery_manager::{RecoveredState, RecoveryManager};
 

--- a/crates/laminar-db/src/metrics.rs
+++ b/crates/laminar-db/src/metrics.rs
@@ -1,6 +1,5 @@
 //! Pipeline observability metrics.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 /// The state of a streaming pipeline.
@@ -30,210 +29,6 @@ impl std::fmt::Display for PipelineState {
     }
 }
 
-const CACHE_LINE_SIZE: usize = 64;
-
-/// Shared atomic counters for the pipeline processing loop.
-///
-/// Ring 0 fields (hot path) and Ring 2 fields (checkpoint) are on separate
-/// cache lines to prevent false sharing. All use `Ordering::Relaxed`.
-#[repr(C)]
-pub struct PipelineCounters {
-    // Ring 0 (reactor thread, every cycle)
-    /// Events ingested.
-    pub events_ingested: AtomicU64,
-    /// Events emitted.
-    pub events_emitted: AtomicU64,
-    /// Events dropped.
-    pub events_dropped: AtomicU64,
-    /// Processing cycles.
-    pub cycles: AtomicU64,
-    /// Last cycle duration (ns).
-    pub last_cycle_duration_ns: AtomicU64,
-    /// Batches processed.
-    pub total_batches: AtomicU64,
-    /// Queries using compiled `PhysicalExpr`.
-    pub queries_compiled: AtomicU64,
-    /// Queries using cached logical plan.
-    pub queries_cached_plan: AtomicU64,
-
-    // Pad to cache line boundary so Ring 2 starts on a new line.
-    _pad: [u8; CACHE_LINE_SIZE - (8 * std::mem::size_of::<AtomicU64>()) % CACHE_LINE_SIZE],
-
-    // Ring 2 (checkpoint coordinator, async)
-    /// Checkpoints completed.
-    pub checkpoints_completed: AtomicU64,
-    /// Checkpoints failed.
-    pub checkpoints_failed: AtomicU64,
-    /// Last checkpoint duration (ms).
-    pub last_checkpoint_duration_ms: AtomicU64,
-    /// Checkpoint epoch.
-    pub checkpoint_epoch: AtomicU64,
-    /// Max state bytes per operator (0 = unlimited).
-    pub max_state_bytes: AtomicU64,
-    /// Cycle p50 (ns).
-    pub cycle_p50_ns: AtomicU64,
-    /// Cycle p95 (ns).
-    pub cycle_p95_ns: AtomicU64,
-    /// Cycle p99 (ns).
-    pub cycle_p99_ns: AtomicU64,
-
-    // Sink 2PC timing
-    /// Last sink pre-commit (us).
-    pub sink_precommit_duration_us: AtomicU64,
-    /// Last sink commit (us).
-    pub sink_commit_duration_us: AtomicU64,
-    /// `write_batch` returned `Err` (broker, serialization, etc.).
-    pub sink_write_failures: AtomicU64,
-    /// `write_batch` exceeded its per-call I/O timeout.
-    pub sink_write_timeouts: AtomicU64,
-    /// Sink command channel was closed (sink task died).
-    pub sink_task_channel_closed: AtomicU64,
-    /// Cycles skipped due to backpressure.
-    pub cycles_backpressured: AtomicU64,
-
-    /// Last checkpoint size (bytes).
-    pub last_checkpoint_size_bytes: AtomicU64,
-    /// Last checkpoint wall-clock timestamp (ms since epoch).
-    pub last_checkpoint_timestamp_ms: AtomicU64,
-
-    /// MV update operations.
-    pub mv_updates: AtomicU64,
-    /// Approximate MV bytes stored.
-    pub mv_bytes_stored: AtomicU64,
-}
-
-impl PipelineCounters {
-    /// Zeroed counters.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            events_ingested: AtomicU64::new(0),
-            events_emitted: AtomicU64::new(0),
-            events_dropped: AtomicU64::new(0),
-            cycles: AtomicU64::new(0),
-            last_cycle_duration_ns: AtomicU64::new(0),
-            total_batches: AtomicU64::new(0),
-            queries_compiled: AtomicU64::new(0),
-            queries_cached_plan: AtomicU64::new(0),
-            _pad: [0; CACHE_LINE_SIZE - (8 * std::mem::size_of::<AtomicU64>()) % CACHE_LINE_SIZE],
-            checkpoints_completed: AtomicU64::new(0),
-            checkpoints_failed: AtomicU64::new(0),
-            last_checkpoint_duration_ms: AtomicU64::new(0),
-            checkpoint_epoch: AtomicU64::new(0),
-            max_state_bytes: AtomicU64::new(0),
-            cycle_p50_ns: AtomicU64::new(0),
-            cycle_p95_ns: AtomicU64::new(0),
-            cycle_p99_ns: AtomicU64::new(0),
-            sink_precommit_duration_us: AtomicU64::new(0),
-            sink_commit_duration_us: AtomicU64::new(0),
-            sink_write_failures: AtomicU64::new(0),
-            sink_write_timeouts: AtomicU64::new(0),
-            sink_task_channel_closed: AtomicU64::new(0),
-            cycles_backpressured: AtomicU64::new(0),
-            last_checkpoint_size_bytes: AtomicU64::new(0),
-            last_checkpoint_timestamp_ms: AtomicU64::new(0),
-            mv_updates: AtomicU64::new(0),
-            mv_bytes_stored: AtomicU64::new(0),
-        }
-    }
-
-    /// Relaxed-load snapshot of all counters.
-    #[must_use]
-    pub fn snapshot(&self) -> CounterSnapshot {
-        CounterSnapshot {
-            events_ingested: self.events_ingested.load(Ordering::Relaxed),
-            events_emitted: self.events_emitted.load(Ordering::Relaxed),
-            events_dropped: self.events_dropped.load(Ordering::Relaxed),
-            cycles: self.cycles.load(Ordering::Relaxed),
-            last_cycle_duration_ns: self.last_cycle_duration_ns.load(Ordering::Relaxed),
-            total_batches: self.total_batches.load(Ordering::Relaxed),
-            queries_compiled: self.queries_compiled.load(Ordering::Relaxed),
-            queries_cached_plan: self.queries_cached_plan.load(Ordering::Relaxed),
-            checkpoints_completed: self.checkpoints_completed.load(Ordering::Relaxed),
-            checkpoints_failed: self.checkpoints_failed.load(Ordering::Relaxed),
-            last_checkpoint_duration_ms: self.last_checkpoint_duration_ms.load(Ordering::Relaxed),
-            checkpoint_epoch: self.checkpoint_epoch.load(Ordering::Relaxed),
-            max_state_bytes: self.max_state_bytes.load(Ordering::Relaxed),
-            cycle_p50_ns: self.cycle_p50_ns.load(Ordering::Relaxed),
-            cycle_p95_ns: self.cycle_p95_ns.load(Ordering::Relaxed),
-            cycle_p99_ns: self.cycle_p99_ns.load(Ordering::Relaxed),
-            sink_precommit_duration_us: self.sink_precommit_duration_us.load(Ordering::Relaxed),
-            sink_commit_duration_us: self.sink_commit_duration_us.load(Ordering::Relaxed),
-            sink_write_failures: self.sink_write_failures.load(Ordering::Relaxed),
-            sink_write_timeouts: self.sink_write_timeouts.load(Ordering::Relaxed),
-            sink_task_channel_closed: self.sink_task_channel_closed.load(Ordering::Relaxed),
-            cycles_backpressured: self.cycles_backpressured.load(Ordering::Relaxed),
-            last_checkpoint_size_bytes: self.last_checkpoint_size_bytes.load(Ordering::Relaxed),
-            last_checkpoint_timestamp_ms: self.last_checkpoint_timestamp_ms.load(Ordering::Relaxed),
-            mv_updates: self.mv_updates.load(Ordering::Relaxed),
-            mv_bytes_stored: self.mv_bytes_stored.load(Ordering::Relaxed),
-        }
-    }
-}
-
-impl Default for PipelineCounters {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Point-in-time snapshot of [`PipelineCounters`]. Fields mirror the atomic originals.
-#[derive(Debug, Clone, Copy)]
-pub struct CounterSnapshot {
-    /// Events ingested.
-    pub events_ingested: u64,
-    /// Events emitted.
-    pub events_emitted: u64,
-    /// Events dropped.
-    pub events_dropped: u64,
-    /// Processing cycles.
-    pub cycles: u64,
-    /// Last cycle (ns).
-    pub last_cycle_duration_ns: u64,
-    /// Batches processed.
-    pub total_batches: u64,
-    /// Compiled-expr queries.
-    pub queries_compiled: u64,
-    /// Cached-plan queries.
-    pub queries_cached_plan: u64,
-    /// Checkpoints completed.
-    pub checkpoints_completed: u64,
-    /// Checkpoints failed.
-    pub checkpoints_failed: u64,
-    /// Last checkpoint (ms).
-    pub last_checkpoint_duration_ms: u64,
-    /// Checkpoint epoch.
-    pub checkpoint_epoch: u64,
-    /// Max state bytes (0 = unlimited).
-    pub max_state_bytes: u64,
-    /// Cycle p50 (ns).
-    pub cycle_p50_ns: u64,
-    /// Cycle p95 (ns).
-    pub cycle_p95_ns: u64,
-    /// Cycle p99 (ns).
-    pub cycle_p99_ns: u64,
-    /// Last pre-commit (us).
-    pub sink_precommit_duration_us: u64,
-    /// Last commit (us).
-    pub sink_commit_duration_us: u64,
-    /// `write_batch` returned `Err`.
-    pub sink_write_failures: u64,
-    /// `write_batch` exceeded its per-call I/O timeout.
-    pub sink_write_timeouts: u64,
-    /// Sink command channel closed (task died).
-    pub sink_task_channel_closed: u64,
-    /// Backpressure-skipped cycles.
-    pub cycles_backpressured: u64,
-    /// Last checkpoint size (bytes).
-    pub last_checkpoint_size_bytes: u64,
-    /// Last checkpoint timestamp (ms since epoch).
-    pub last_checkpoint_timestamp_ms: u64,
-    /// MV updates.
-    pub mv_updates: u64,
-    /// Approximate MV bytes.
-    pub mv_bytes_stored: u64,
-}
-
 /// Pipeline-wide metrics snapshot.
 #[derive(Debug, Clone)]
 pub struct PipelineMetrics {
@@ -251,8 +46,6 @@ pub struct PipelineMetrics {
     pub uptime: Duration,
     /// State.
     pub state: PipelineState,
-    /// Last cycle (ns).
-    pub last_cycle_duration_ns: u64,
     /// Sources.
     pub source_count: usize,
     /// Streams.
@@ -328,57 +121,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pipeline_counters_default() {
-        let c = PipelineCounters::new();
-        let s = c.snapshot();
-        assert_eq!(s.events_ingested, 0);
-        assert_eq!(s.events_emitted, 0);
-        assert_eq!(s.events_dropped, 0);
-        assert_eq!(s.cycles, 0);
-        assert_eq!(s.total_batches, 0);
-        assert_eq!(s.last_cycle_duration_ns, 0);
-    }
-
-    #[test]
-    fn test_pipeline_counters_increment() {
-        let c = PipelineCounters::new();
-        c.events_ingested.fetch_add(100, Ordering::Relaxed);
-        c.events_emitted.fetch_add(50, Ordering::Relaxed);
-        c.events_dropped.fetch_add(3, Ordering::Relaxed);
-        c.cycles.fetch_add(10, Ordering::Relaxed);
-        c.total_batches.fetch_add(5, Ordering::Relaxed);
-        c.last_cycle_duration_ns.store(1234, Ordering::Relaxed);
-
-        let s = c.snapshot();
-        assert_eq!(s.events_ingested, 100);
-        assert_eq!(s.events_emitted, 50);
-        assert_eq!(s.events_dropped, 3);
-        assert_eq!(s.cycles, 10);
-        assert_eq!(s.total_batches, 5);
-        assert_eq!(s.last_cycle_duration_ns, 1234);
-    }
-
-    #[test]
-    fn test_pipeline_counters_concurrent_access() {
-        use std::sync::Arc;
-        let c = Arc::new(PipelineCounters::new());
-        let c2 = Arc::clone(&c);
-
-        let t = std::thread::spawn(move || {
-            for _ in 0..1000 {
-                c2.events_ingested.fetch_add(1, Ordering::Relaxed);
-            }
-        });
-
-        for _ in 0..1000 {
-            c.events_ingested.fetch_add(1, Ordering::Relaxed);
-        }
-
-        t.join().unwrap();
-        assert_eq!(c.events_ingested.load(Ordering::Relaxed), 2000);
-    }
-
-    #[test]
     fn test_pipeline_state_display() {
         assert_eq!(PipelineState::Created.to_string(), "Created");
         assert_eq!(PipelineState::Starting.to_string(), "Starting");
@@ -427,7 +169,6 @@ mod tests {
             total_batches: 5,
             uptime: Duration::from_secs(60),
             state: PipelineState::Running,
-            last_cycle_duration_ns: 500,
             source_count: 2,
             stream_count: 1,
             sink_count: 1,
@@ -454,38 +195,6 @@ mod tests {
         let dbg = format!("{m:?}");
         assert!(dbg.contains("trades"));
         assert!(dbg.contains("1000"));
-    }
-
-    #[test]
-    fn test_cache_line_separation() {
-        let c = PipelineCounters::new();
-        let base = &raw const c as usize;
-        let ring0_start = &raw const c.events_ingested as usize;
-        let ring2_start = &raw const c.checkpoints_completed as usize;
-
-        // Ring 0 starts at offset 0
-        assert_eq!(ring0_start - base, 0);
-        // Ring 2 starts at least 64 bytes from Ring 0
-        assert!(
-            ring2_start - ring0_start >= 64,
-            "Ring 2 counters must be on a separate cache line (offset: {})",
-            ring2_start - ring0_start
-        );
-    }
-
-    #[test]
-    fn test_checkpoint_counters() {
-        let c = PipelineCounters::new();
-        c.checkpoints_completed.fetch_add(5, Ordering::Relaxed);
-        c.checkpoints_failed.fetch_add(1, Ordering::Relaxed);
-        c.last_checkpoint_duration_ms.store(250, Ordering::Relaxed);
-        c.checkpoint_epoch.store(10, Ordering::Relaxed);
-
-        let s = c.snapshot();
-        assert_eq!(s.checkpoints_completed, 5);
-        assert_eq!(s.checkpoints_failed, 1);
-        assert_eq!(s.last_checkpoint_duration_ms, 250);
-        assert_eq!(s.checkpoint_epoch, 10);
     }
 
     #[test]

--- a/crates/laminar-db/src/metrics_api.rs
+++ b/crates/laminar-db/src/metrics_api.rs
@@ -10,6 +10,32 @@ use crate::db::{
 use crate::error::DbError;
 
 impl LaminarDB {
+    /// Time elapsed since the database was created.
+    #[must_use]
+    pub fn uptime(&self) -> std::time::Duration {
+        self.start_time.elapsed()
+    }
+
+    /// Inject prometheus engine metrics. Called once at startup before `start()`.
+    pub fn set_engine_metrics(&self, metrics: Arc<crate::engine_metrics::EngineMetrics>) {
+        *self.engine_metrics.lock() = Some(metrics);
+    }
+
+    /// Inject a shared Prometheus registry for connector-level metrics.
+    ///
+    /// Called once at startup, after the registry is constructed but before
+    /// `start()`. Connectors created after this call will register their
+    /// metrics on this registry so they appear in the scrape output.
+    pub fn set_prometheus_registry(&self, registry: Arc<prometheus::Registry>) {
+        *self.prometheus_registry.lock() = Some(registry);
+    }
+
+    /// Get the engine metrics if set.
+    #[must_use]
+    pub fn engine_metrics(&self) -> Option<Arc<crate::engine_metrics::EngineMetrics>> {
+        self.engine_metrics.lock().clone()
+    }
+
     /// Get the current pipeline state as a string.
     pub fn pipeline_state(&self) -> &'static str {
         match self.state.load(std::sync::atomic::Ordering::Acquire) {
@@ -24,26 +50,40 @@ impl LaminarDB {
 
     /// Get a pipeline-wide metrics snapshot.
     ///
-    /// Reads shared atomic counters and catalog sizes to produce a
+    /// Reads prometheus engine metrics and catalog sizes to produce a
     /// point-in-time view of pipeline health.
     #[must_use]
+    #[allow(clippy::cast_sign_loss)]
     pub fn metrics(&self) -> crate::metrics::PipelineMetrics {
-        let snap = self.counters.snapshot();
+        let guard = self.engine_metrics.lock();
+        let (ingested, emitted, dropped, cycles, batches, mv_updates, mv_bytes) =
+            if let Some(ref m) = *guard {
+                (
+                    m.events_ingested.get(),
+                    m.events_emitted.get(),
+                    m.events_dropped.get(),
+                    m.cycles.get(),
+                    m.batches.get(),
+                    m.mv_updates.get(),
+                    m.mv_bytes_stored.get() as u64,
+                )
+            } else {
+                (0, 0, 0, 0, 0, 0, 0)
+            };
         crate::metrics::PipelineMetrics {
-            total_events_ingested: snap.events_ingested,
-            total_events_emitted: snap.events_emitted,
-            total_events_dropped: snap.events_dropped,
-            total_cycles: snap.cycles,
-            total_batches: snap.total_batches,
+            total_events_ingested: ingested,
+            total_events_emitted: emitted,
+            total_events_dropped: dropped,
+            total_cycles: cycles,
+            total_batches: batches,
             uptime: self.start_time.elapsed(),
             state: self.pipeline_state_enum(),
-            last_cycle_duration_ns: snap.last_cycle_duration_ns,
             source_count: self.catalog.list_sources().len(),
             stream_count: self.catalog.list_streams().len(),
             sink_count: self.catalog.list_sinks().len(),
             pipeline_watermark: self.pipeline_watermark(),
-            mv_updates: snap.mv_updates,
-            mv_bytes_stored: snap.mv_bytes_stored,
+            mv_updates,
+            mv_bytes_stored: mv_bytes,
         }
     }
 
@@ -110,17 +150,12 @@ impl LaminarDB {
     /// Get the total number of events processed (ingested + emitted).
     #[must_use]
     pub fn total_events_processed(&self) -> u64 {
-        let snap = self.counters.snapshot();
-        snap.events_ingested + snap.events_emitted
-    }
-
-    /// Get a reference to the shared pipeline counters.
-    ///
-    /// Useful for external code that needs to read counters directly
-    /// (e.g. a TUI dashboard polling at high frequency).
-    #[must_use]
-    pub fn counters(&self) -> &Arc<crate::metrics::PipelineCounters> {
-        &self.counters
+        let guard = self.engine_metrics.lock();
+        if let Some(ref m) = *guard {
+            m.events_ingested.get() + m.events_emitted.get()
+        } else {
+            0
+        }
     }
 
     /// Returns the global pipeline watermark (minimum across all source watermarks).
@@ -168,15 +203,6 @@ impl LaminarDB {
     /// Get the number of registered sinks.
     pub fn sink_count(&self) -> usize {
         self.catalog.list_sinks().len()
-    }
-
-    /// Returns cycle duration percentiles from atomic counters (non-blocking).
-    ///
-    /// Returns (`p50_ns`, `p95_ns`, `p99_ns`).
-    #[must_use]
-    pub fn cycle_duration_percentiles(&self) -> (u64, u64, u64) {
-        let snap = self.counters.snapshot();
-        (snap.cycle_p50_ns, snap.cycle_p95_ns, snap.cycle_p99_ns)
     }
 
     /// Returns checkpoint statistics if available (non-blocking).

--- a/crates/laminar-db/src/operator/eowc_query.rs
+++ b/crates/laminar-db/src/operator/eowc_query.rs
@@ -20,9 +20,9 @@ use datafusion::prelude::SessionContext;
 
 use crate::aggregate_state::{apply_compiled_having, EowcStateCheckpoint};
 use crate::core_window_state::{CoreWindowCheckpoint, CoreWindowState};
+use crate::engine_metrics::EngineMetrics;
 use crate::eowc_state::IncrementalEowcState;
 use crate::error::DbError;
-use crate::metrics::PipelineCounters;
 use crate::operator_graph::{try_evaluate_compiled, GraphOperator, OperatorCheckpoint};
 use crate::sql_analysis::compute_closed_boundary;
 use laminar_sql::parser::EmitClause;
@@ -79,7 +79,7 @@ impl EowcQueryOperator {
         emit_clause: Option<EmitClause>,
         window_config: Option<WindowOperatorConfig>,
         ctx: SessionContext,
-        _counters: Option<Arc<PipelineCounters>>,
+        _prom: Option<Arc<EngineMetrics>>,
     ) -> Self {
         Self {
             op_name: Arc::from(name),

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -16,8 +16,8 @@ use datafusion_expr::LogicalPlan;
 use crate::aggregate_state::{
     apply_compiled_having, AggStateCheckpoint, CompiledProjection, IncrementalAggState,
 };
+use crate::engine_metrics::EngineMetrics;
 use crate::error::DbError;
-use crate::metrics::PipelineCounters;
 use crate::operator_graph::{try_evaluate_compiled, GraphOperator, OperatorCheckpoint};
 use crate::sql_analysis::{extract_projection_filter, single_source_table};
 
@@ -45,7 +45,7 @@ pub(crate) struct SqlQueryOperator {
     sql: String,
     ctx: SessionContext,
     state: QueryState,
-    counters: Option<Arc<PipelineCounters>>,
+    prom: Option<Arc<EngineMetrics>>,
     pending_restore: Option<AggStateCheckpoint>,
     tier_logged: bool,
     cached_having_plan: Option<LogicalPlan>,
@@ -58,7 +58,7 @@ impl SqlQueryOperator {
         name: &str,
         sql: &str,
         ctx: SessionContext,
-        counters: Option<Arc<PipelineCounters>>,
+        prom: Option<Arc<EngineMetrics>>,
         emit_changelog: bool,
         idle_ttl_ms: Option<u64>,
     ) -> Self {
@@ -67,7 +67,7 @@ impl SqlQueryOperator {
             sql: sql.to_string(),
             ctx,
             state: QueryState::Uninit,
-            counters,
+            prom,
             pending_restore: None,
             tier_logged: false,
             cached_having_plan: None,
@@ -148,13 +148,11 @@ impl SqlQueryOperator {
             return;
         }
         self.tier_logged = true;
-        if let Some(ref c) = self.counters {
+        if let Some(ref m) = self.prom {
             if compiled {
-                c.queries_compiled
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.queries_compiled.inc();
             } else {
-                c.queries_cached_plan
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                m.queries_cached_plan.inc();
             }
         }
     }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -11,8 +11,8 @@ use laminar_sql::datafusion::live_source::{LiveSourceHandle, LiveSourceProvider}
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
+use crate::engine_metrics::EngineMetrics;
 use crate::error::DbError;
-use crate::metrics::PipelineCounters;
 use crate::sql_analysis::{
     apply_topk_filter, detect_asof_query, detect_stream_join_query, detect_temporal_probe_query,
     detect_temporal_query, extract_table_references, StreamJoinDetection,
@@ -195,7 +195,7 @@ pub(crate) struct OperatorGraph {
     deferred_scan_offset: usize,
     max_state_bytes: Option<usize>,
     ctx: SessionContext,
-    counters: Option<Arc<PipelineCounters>>,
+    prom: Option<Arc<EngineMetrics>>,
     lookup_registry: Option<Arc<laminar_sql::datafusion::LookupTableRegistry>>,
     source_schemas: FxHashMap<String, SchemaRef>,
     temporal_configs: Vec<TemporalJoinTranslatorConfig>,
@@ -225,7 +225,7 @@ impl OperatorGraph {
             deferred_scan_offset: 0,
             max_state_bytes: None,
             ctx,
-            counters: None,
+            prom: None,
             lookup_registry: None,
             source_schemas: FxHashMap::default(),
             temporal_configs: Vec::new(),
@@ -247,8 +247,8 @@ impl OperatorGraph {
         self.query_budget_ns = ns;
     }
 
-    pub fn set_counters(&mut self, c: Arc<PipelineCounters>) {
-        self.counters = Some(c);
+    pub fn set_metrics(&mut self, m: Arc<EngineMetrics>) {
+        self.prom = Some(m);
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -753,7 +753,7 @@ impl OperatorGraph {
                 emit_clause.cloned(),
                 window_config.cloned(),
                 self.ctx.clone(),
-                self.counters.clone(),
+                self.prom.clone(),
             ));
         }
 
@@ -763,7 +763,7 @@ impl OperatorGraph {
             name,
             sql,
             self.ctx.clone(),
-            self.counters.clone(),
+            self.prom.clone(),
             emit_changelog,
             idle_ttl_ms,
         ))

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -50,7 +50,7 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) source_entries_for_wm: FxHashMap<String, Arc<crate::catalog::SourceEntry>>,
     pub(crate) source_ids: FxHashMap<String, usize>,
     pub(crate) tracker: Option<laminar_core::time::WatermarkTracker>,
-    pub(crate) counters: Arc<crate::metrics::PipelineCounters>,
+    pub(crate) prom: Arc<crate::engine_metrics::EngineMetrics>,
     pub(crate) pipeline_watermark: Arc<std::sync::atomic::AtomicI64>,
     pub(crate) coordinator:
         Arc<tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>>,
@@ -79,9 +79,6 @@ pub(crate) struct ConnectorPipelineCallback {
     /// Set when a sink write times out in this cycle. Suppresses the next
     /// checkpoint to preserve the replay window.
     pub(crate) sink_timed_out: bool,
-    /// Cycle duration histogram for percentile tracking (single-threaded access).
-    pub(crate) cycle_histogram:
-        std::cell::RefCell<crate::checkpoint_coordinator::DurationHistogram>,
 }
 
 impl ConnectorPipelineCallback {
@@ -192,15 +189,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                     if batch.num_rows() > 0 {
                         #[allow(clippy::cast_possible_truncation)]
                         let row_count = batch.num_rows() as u64;
-                        self.counters
-                            .events_emitted
-                            .fetch_add(row_count, std::sync::atomic::Ordering::Relaxed);
+                        self.prom.events_emitted.inc_by(row_count);
                         if src.push_arrow(batch.clone()).is_err() {
                             #[allow(clippy::cast_possible_truncation)]
                             let dropped = batch.num_rows() as u64;
-                            self.counters
-                                .events_dropped
-                                .fetch_add(dropped, std::sync::atomic::Ordering::Relaxed);
+                            self.prom.events_dropped.inc_by(dropped);
                         }
                     }
                 }
@@ -225,14 +218,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
         if updates > 0 {
-            self.counters
-                .mv_updates
-                .fetch_add(updates, std::sync::atomic::Ordering::Relaxed);
+            self.prom.mv_updates.inc_by(updates);
             #[allow(clippy::cast_possible_truncation)]
-            self.counters.mv_bytes_stored.store(
-                store.total_bytes() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
+            let bytes = store.total_bytes() as u64;
+            #[allow(clippy::cast_possible_wrap)]
+            self.prom.mv_bytes_stored.set(bytes as i64);
         }
     }
 
@@ -343,19 +333,18 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         // Drain SinkEvents emitted by sink tasks during this cycle.
         while let Ok(event) = self.sink_event_rx.try_recv() {
             tracing::debug!(?event, "sink event");
-            let counter = match &event {
+            match &event {
                 crate::sink_task::SinkEvent::WriteError { .. } => {
-                    &self.counters.sink_write_failures
+                    self.prom.sink_write_failures.inc();
                 }
                 crate::sink_task::SinkEvent::WriteTimeout { .. } => {
                     self.sink_timed_out = true;
-                    &self.counters.sink_write_timeouts
+                    self.prom.sink_write_timeouts.inc();
                 }
                 crate::sink_task::SinkEvent::ChannelClosed { .. } => {
-                    &self.counters.sink_task_channel_closed
+                    self.prom.sink_task_channel_closed.inc();
                 }
-            };
-            counter.fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 
@@ -401,12 +390,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         // Update ingestion counters.
         #[allow(clippy::cast_possible_truncation)]
         let row_count = batch.num_rows() as u64;
-        self.counters
-            .events_ingested
-            .fetch_add(row_count, std::sync::atomic::Ordering::Relaxed);
-        self.counters
-            .total_batches
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.prom.events_ingested.inc_by(row_count);
+        self.prom.batches.inc();
     }
 
     fn filter_late_rows(&self, source_name: &str, batch: &RecordBatch) -> Option<RecordBatch> {
@@ -449,12 +434,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             return false;
         }
 
-        if self
-            .counters
-            .cycles
-            .load(std::sync::atomic::Ordering::Relaxed)
-            == 0
-        {
+        if self.prom.cycles.get() == 0 {
             return false;
         }
 
@@ -581,12 +561,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
-        if self
-            .counters
-            .cycles
-            .load(std::sync::atomic::Ordering::Relaxed)
-            == 0
-        {
+        if self.prom.cycles.get() == 0 {
             return false;
         }
 
@@ -679,36 +654,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
     fn record_cycle(&self, events_ingested: u64, _batches: u64, elapsed_ns: u64) {
         let _ = events_ingested; // already recorded in extract_watermark
-        self.counters
-            .cycles
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.counters
-            .last_cycle_duration_ns
-            .store(elapsed_ns, std::sync::atomic::Ordering::Relaxed);
-
-        // Record to histogram for percentile tracking.
-        self.cycle_histogram
-            .borrow_mut()
-            .record(std::time::Duration::from_nanos(elapsed_ns));
-
-        // Update percentile atomics every 100 cycles to amortize sort cost.
-        let cycle_count = self
-            .counters
-            .cycles
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if cycle_count.is_multiple_of(100) {
-            let (p50, p95, p99) = self.cycle_histogram.borrow().percentiles();
-            // DurationHistogram records in microseconds; convert to nanoseconds.
-            self.counters
-                .cycle_p50_ns
-                .store(p50 * 1_000, std::sync::atomic::Ordering::Relaxed);
-            self.counters
-                .cycle_p95_ns
-                .store(p95 * 1_000, std::sync::atomic::Ordering::Relaxed);
-            self.counters
-                .cycle_p99_ns
-                .store(p99 * 1_000, std::sync::atomic::Ordering::Relaxed);
-        }
+        self.prom.cycles.inc();
+        #[allow(clippy::cast_precision_loss)]
+        self.prom
+            .cycle_duration
+            .observe(elapsed_ns as f64 / 1_000_000_000.0);
     }
 
     fn apply_control(&mut self, msg: crate::pipeline::ControlMsg) {
@@ -743,9 +693,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     fn is_backpressured(&self) -> bool {
         let bp = self.graph.input_buf_pressure() > 0.8;
         if bp {
-            self.counters
-                .cycles_backpressured
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.prom.cycles_backpressured.inc();
         }
         bp
     }
@@ -777,9 +725,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         if let Err(e) = ts.upsert_and_rebuild(name, &batch) {
                             #[allow(clippy::cast_possible_truncation)]
                             let dropped = batch.num_rows() as u64;
-                            self.counters
-                                .events_dropped
-                                .fetch_add(dropped, std::sync::atomic::Ordering::Relaxed);
+                            self.prom.events_dropped.inc_by(dropped);
                             tracing::error!(
                                 table=%name, error=%e, rows_dropped=dropped,
                                 "[LDB-5030] Table upsert failed (partial); \
@@ -863,9 +809,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         if let Err(e) = ts.upsert_and_rebuild(name, &batch) {
                             #[allow(clippy::cast_possible_truncation)]
                             let dropped = batch.num_rows() as u64;
-                            self.counters
-                                .events_dropped
-                                .fetch_add(dropped, std::sync::atomic::Ordering::Relaxed);
+                            self.prom.events_dropped.inc_by(dropped);
                             tracing::error!(
                                 table=%name, error=%e, rows_dropped=dropped,
                                 "[LDB-5030] Table upsert failed (versioned); \
@@ -878,9 +822,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             if let Err(e) = ts.upsert_and_rebuild(name, &batch) {
                                 #[allow(clippy::cast_possible_truncation)]
                                 let dropped = batch.num_rows() as u64;
-                                self.counters
-                                    .events_dropped
-                                    .fetch_add(dropped, std::sync::atomic::Ordering::Relaxed);
+                                self.prom.events_dropped.inc_by(dropped);
                                 tracing::error!(
                                     table=%name, error=%e, rows_dropped=dropped,
                                     "[LDB-5030] Table upsert failed; \

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -86,6 +86,16 @@ impl LaminarDB {
         self.state
             .store(STATE_STARTING, std::sync::atomic::Ordering::Release);
 
+        // Fallback for embedded use without a server.
+        {
+            let mut guard = self.engine_metrics.lock();
+            if guard.is_none() {
+                *guard = Some(Arc::new(crate::engine_metrics::EngineMetrics::new(
+                    &prometheus::Registry::new(),
+                )));
+            }
+        }
+
         match self.start_inner().await {
             Ok(()) => {
                 self.state
@@ -1100,21 +1110,11 @@ impl LaminarDB {
         graph.set_query_budget_ns(pipeline_config.query_budget_ns);
         graph.set_max_input_buf_batches(pipeline_config.max_input_buf_batches);
 
-        let prom = {
-            let mut guard = self.engine_metrics.lock();
-            if let Some(ref m) = *guard {
-                Arc::clone(m)
-            } else {
-                // No external EngineMetrics was injected — create a private one
-                // so the pipeline always has a metrics instance. Store it back
-                // so `metrics()` / `total_events_processed()` can read it too.
-                let m = Arc::new(crate::engine_metrics::EngineMetrics::new(
-                    &prometheus::Registry::new(),
-                ));
-                *guard = Some(Arc::clone(&m));
-                m
-            }
-        };
+        let prom = self
+            .engine_metrics
+            .lock()
+            .clone()
+            .expect("EngineMetrics must be set before start()");
         let callback = crate::pipeline_callback::ConnectorPipelineCallback {
             graph,
             stream_sources,

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -172,7 +172,9 @@ impl LaminarDB {
                 ..CkpConfig::default()
             };
             let mut coord = CheckpointCoordinator::new(config, store);
-            coord.set_counters(Arc::clone(&self.counters));
+            if let Some(ref prom) = *self.engine_metrics.lock() {
+                coord.set_metrics(Arc::clone(prom));
+            }
 
             *self.coordinator.lock().await = Some(coord);
         }
@@ -265,7 +267,9 @@ impl LaminarDB {
         let mut graph = OperatorGraph::new(ctx);
         graph.set_max_state_bytes(self.config.max_state_bytes_per_operator);
         graph.set_lookup_registry(Arc::clone(&self.lookup_registry));
-        graph.set_counters(Arc::clone(&self.counters));
+        if let Some(ref prom) = *self.engine_metrics.lock() {
+            graph.set_metrics(Arc::clone(prom));
+        }
 
         // Register source schemas for ALL sources (both external connectors
         // and catalog-bridge sources) so the graph can create empty
@@ -383,6 +387,10 @@ impl LaminarDB {
             }
         }
 
+        // Grab the shared Prometheus registry (if set) so connectors can
+        // register their metrics on it.
+        let prom_registry = self.prometheus_registry.lock().clone();
+
         // Build sources as owned SourceRegistrations (no Arc<Mutex>).
         let mut sources: Vec<SourceRegistration> = Vec::new();
         for (name, reg) in &source_regs {
@@ -400,7 +408,7 @@ impl LaminarDB {
 
             let source = self
                 .connector_registry
-                .create_source(&config)
+                .create_source(&config, prom_registry.as_deref())
                 .map_err(|e| {
                     DbError::Connector(format!(
                         "Cannot create source '{}' (type '{}'): {e}",
@@ -537,13 +545,16 @@ impl LaminarDB {
                 continue;
             }
             let config = build_sink_config(reg)?;
-            let mut sink = self.connector_registry.create_sink(&config).map_err(|e| {
-                DbError::Connector(format!(
-                    "Cannot create sink '{}' (type '{}'): {e}",
-                    name,
-                    config.connector_type()
-                ))
-            })?;
+            let mut sink = self
+                .connector_registry
+                .create_sink(&config, prom_registry.as_deref())
+                .map_err(|e| {
+                    DbError::Connector(format!(
+                        "Cannot create sink '{}' (type '{}'): {e}",
+                        name,
+                        config.connector_type()
+                    ))
+                })?;
             // Open the connector before handing it to the task.
             sink.open(&config)
                 .await
@@ -1065,15 +1076,6 @@ impl LaminarDB {
         let shutdown = self.shutdown_signal.clone();
 
         // Build the PipelineCallback implementation that bridges to db.rs internals.
-        let counters = Arc::clone(&self.counters);
-        // Mirror the configured per-operator state cap into the counters
-        // so the /metrics endpoint can report the enforced limit.
-        if let Some(cap) = self.config.max_state_bytes_per_operator {
-            #[allow(clippy::cast_possible_truncation)]
-            counters
-                .max_state_bytes
-                .store(cap as u64, std::sync::atomic::Ordering::Relaxed);
-        }
         let pipeline_watermark = Arc::clone(&self.pipeline_watermark);
         let coordinator = Arc::clone(&self.coordinator);
         let table_store_for_loop = self.table_store.clone();
@@ -1098,6 +1100,21 @@ impl LaminarDB {
         graph.set_query_budget_ns(pipeline_config.query_budget_ns);
         graph.set_max_input_buf_batches(pipeline_config.max_input_buf_batches);
 
+        let prom = {
+            let mut guard = self.engine_metrics.lock();
+            if let Some(ref m) = *guard {
+                Arc::clone(m)
+            } else {
+                // No external EngineMetrics was injected — create a private one
+                // so the pipeline always has a metrics instance. Store it back
+                // so `metrics()` / `total_events_processed()` can read it too.
+                let m = Arc::new(crate::engine_metrics::EngineMetrics::new(
+                    &prometheus::Registry::new(),
+                ));
+                *guard = Some(Arc::clone(&m));
+                m
+            }
+        };
         let callback = crate::pipeline_callback::ConnectorPipelineCallback {
             graph,
             stream_sources,
@@ -1106,7 +1123,7 @@ impl LaminarDB {
             source_entries_for_wm,
             source_ids,
             tracker,
-            counters,
+            prom,
             pipeline_watermark,
             coordinator,
             table_sources,
@@ -1127,9 +1144,6 @@ impl LaminarDB {
             serialization_timeout: std::time::Duration::from_secs(120),
             sink_event_rx,
             sink_timed_out: false,
-            cycle_histogram: std::cell::RefCell::new(
-                crate::checkpoint_coordinator::DurationHistogram::new(),
-            ),
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -21,5 +21,5 @@ proc-macro2 = "1.0"
 arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.20.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.20.1" }
+laminar-core = { path = "../laminar-core", version = "0.20.2" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.20.2" }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/main.rs"
 
 [dependencies]
 # All LaminarDB crates
-laminar-core = { path = "../laminar-core", version = "0.20.1" }
-laminar-sql = { path = "../laminar-sql", version = "0.20.1" }
-laminar-storage = { path = "../laminar-storage", version = "0.20.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.20.1" }
-laminar-db = { path = "../laminar-db", version = "0.20.1", features = ["api"] }
+laminar-core = { path = "../laminar-core", version = "0.20.2" }
+laminar-sql = { path = "../laminar-sql", version = "0.20.2" }
+laminar-storage = { path = "../laminar-storage", version = "0.20.2" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.20.2" }
+laminar-db = { path = "../laminar-db", version = "0.20.2", features = ["api"] }
 
 # Arrow (for WS JSON serialization)
 arrow-array = { workspace = true }
@@ -57,11 +57,14 @@ regex = { workspace = true }
 humantime-serde = { workspace = true }
 chrono = { workspace = true }
 
+# Metrics
+prometheus = { workspace = true }
+
 # File watching for hot reload
 notify = { workspace = true }
 
-# Delta mode: hostname discovery and unique node IDs (only needed with delta-experimental)
-gethostname = { workspace = true, optional = true }
+# Hostname for metrics instance label + delta mode
+gethostname = { workspace = true }
 uuid = { workspace = true, optional = true }
 xxhash-rust = { workspace = true, optional = true }
 
@@ -130,7 +133,6 @@ azure = ["laminar-db/azure"]
 # so the binary does not present it as a first-class option.
 delta-experimental = [
     "laminar-core/delta",
-    "dep:gethostname",
     "dep:uuid",
     "dep:xxhash-rust",
 ]

--- a/crates/laminar-server/src/delta.rs
+++ b/crates/laminar-server/src/delta.rs
@@ -371,6 +371,21 @@ pub async fn start_delta(
         .map_err(|e| DeltaStartupError::EngineConstruction(e.to_string()))?;
     let db = Arc::new(db);
 
+    // Build prometheus registry before start() so connectors register on it.
+    let hostname = gethostname::gethostname().to_string_lossy().into_owned();
+    let pipeline_name = config
+        .pipelines
+        .first()
+        .map_or("default", |p| p.name.as_str())
+        .to_string();
+    let registry = Arc::new(crate::metrics::build_registry([
+        ("instance".into(), hostname),
+        ("pipeline".into(), pipeline_name),
+    ]));
+    let engine_metrics = Arc::new(laminar_db::EngineMetrics::new(&registry));
+    db.set_engine_metrics(engine_metrics);
+    db.set_prometheus_registry(Arc::clone(&registry));
+
     server::execute_config_ddl(&db, &config)
         .await
         .map_err(|e| DeltaStartupError::EngineConstruction(e.to_string()))?;
@@ -381,7 +396,7 @@ pub async fn start_delta(
     info!("Pipeline started");
 
     let (app_state, api_handle) =
-        server::start_http_api(Arc::clone(&db), config_path.clone(), config)
+        server::start_http_api(Arc::clone(&db), registry, config_path.clone(), config)
             .await
             .map_err(|e| DeltaStartupError::HttpStartup(e.to_string()))?;
     let watcher_handle = server::spawn_config_watcher(&app_state, config_path);

--- a/crates/laminar-server/src/http.rs
+++ b/crates/laminar-server/src/http.rs
@@ -1,9 +1,10 @@
 //! HTTP API for LaminarDB server.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+
+use prometheus::Registry;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, State};
@@ -18,18 +19,17 @@ use tracing::{info, warn};
 use laminar_db::LaminarDB;
 
 use crate::config::ServerConfig;
+use crate::metrics::ServerMetrics;
 use crate::reload::{self, ReloadGuard};
 use crate::server::ServerError;
 
 pub struct AppState {
     pub db: Arc<LaminarDB>,
     pub config_path: PathBuf,
-    pub started_at: chrono::DateTime<chrono::Utc>,
     pub current_config: tokio::sync::RwLock<ServerConfig>,
     pub reload_guard: ReloadGuard,
-    pub reload_total: AtomicU64,
-    pub reload_last_ts: AtomicU64,
-    pub ws_connections: AtomicU64,
+    pub registry: Arc<Registry>,
+    pub server_metrics: ServerMetrics,
 }
 
 pub fn build_router(state: Arc<AppState>) -> Router {
@@ -186,101 +186,20 @@ async fn readiness_check(State(state): State<Arc<AppState>>) -> impl IntoRespons
 }
 
 async fn prometheus_metrics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let metrics = state.db.metrics();
-    let source_metrics = state.db.all_source_metrics();
-    let pipeline_state = state.db.pipeline_state();
-    let uptime_secs = state.started_at.signed_duration_since(chrono::Utc::now());
-    #[allow(clippy::cast_sign_loss)]
-    let uptime = uptime_secs.num_seconds().unsigned_abs();
-
-    let mut lines = Vec::new();
-
-    lines.push(format!(
-        "laminardb_events_ingested_total {}",
-        metrics.total_events_ingested
-    ));
-    lines.push(format!(
-        "laminardb_events_emitted_total {}",
-        metrics.total_events_emitted
-    ));
-    lines.push(format!(
-        "laminardb_events_dropped_total {}",
-        metrics.total_events_dropped
-    ));
-
-    for sm in &source_metrics {
-        lines.push(format!(
-            "laminardb_source_events_total{{source=\"{}\"}} {}",
-            sm.name, sm.total_events
-        ));
-    }
-
-    lines.push(format!(
-        "laminardb_pipeline_state_info{{state=\"{pipeline_state}\"}} 1"
-    ));
-    lines.push(format!("laminardb_uptime_seconds {uptime}"));
-    lines.push(format!("laminardb_source_count {}", metrics.source_count));
-    lines.push(format!("laminardb_stream_count {}", metrics.stream_count));
-    lines.push(format!("laminardb_sink_count {}", metrics.sink_count));
-
-    // Checkpoint metrics
-    let snap = state.db.counters().snapshot();
-    lines.push(format!(
-        "laminardb_checkpoints_completed_total {}",
-        snap.checkpoints_completed
-    ));
-    lines.push(format!(
-        "laminardb_checkpoints_failed_total {}",
-        snap.checkpoints_failed
-    ));
-    lines.push(format!(
-        "laminardb_checkpoint_epoch {}",
-        snap.checkpoint_epoch
-    ));
-    lines.push(format!(
-        "laminardb_sink_write_failures_total {}",
-        snap.sink_write_failures
-    ));
-    lines.push(format!(
-        "laminardb_sink_write_timeouts_total {}",
-        snap.sink_write_timeouts
-    ));
-    lines.push(format!(
-        "laminardb_sink_task_channel_closed_total {}",
-        snap.sink_task_channel_closed
-    ));
-    if snap.last_checkpoint_duration_ms > 0 {
-        lines.push(format!(
-            "laminardb_checkpoint_last_duration_ms {}",
-            snap.last_checkpoint_duration_ms
-        ));
-    }
-
-    // Cycle duration percentiles
-    lines.push(format!(
-        "laminardb_cycle_duration_p50_ns {}",
-        snap.cycle_p50_ns
-    ));
-    lines.push(format!(
-        "laminardb_cycle_duration_p95_ns {}",
-        snap.cycle_p95_ns
-    ));
-    lines.push(format!(
-        "laminardb_cycle_duration_p99_ns {}",
-        snap.cycle_p99_ns
-    ));
-
-    let reload_total = state.reload_total.load(Ordering::Relaxed);
-    let reload_last_ts = state.reload_last_ts.load(Ordering::Relaxed);
-    lines.push(format!("laminardb_reload_total {reload_total}"));
-    if reload_last_ts > 0 {
-        lines.push(format!("laminardb_reload_last_timestamp {reload_last_ts}"));
-    }
+    // Update uptime gauge on each scrape — cheap, and always fresh.
+    #[allow(clippy::cast_possible_wrap)]
+    state
+        .server_metrics
+        .uptime_seconds
+        .set(state.db.uptime().as_secs() as i64);
 
     (
         StatusCode::OK,
-        [("content-type", "text/plain; charset=utf-8")],
-        lines.join("\n"),
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        crate::metrics::render(&state.registry),
     )
 }
 
@@ -435,10 +354,7 @@ async fn handle_reload(State(state): State<Arc<AppState>>) -> impl IntoResponse 
     let result = reload::apply_reload(&state.db, &diff).await;
 
     // Update metrics
-    state.reload_total.fetch_add(1, Ordering::Relaxed);
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    let now = chrono::Utc::now().timestamp() as u64;
-    state.reload_last_ts.store(now, Ordering::Relaxed);
+    state.server_metrics.reload_total.inc();
 
     // Update current config on success
     if result.success {
@@ -498,7 +414,7 @@ async fn cluster_status(State(state): State<Arc<AppState>>) -> impl IntoResponse
 // WebSocket stream subscriptions
 // ---------------------------------------------------------------------------
 
-const MAX_WS_CONNECTIONS: u64 = 10_000;
+const MAX_WS_CONNECTIONS: i64 = 10_000;
 const WS_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
 
 async fn ws_upgrade(
@@ -506,7 +422,7 @@ async fn ws_upgrade(
     Path(name): Path<String>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
-    if state.ws_connections.load(Ordering::Relaxed) >= MAX_WS_CONNECTIONS {
+    if state.server_metrics.ws_connections.get() >= MAX_WS_CONNECTIONS {
         return error_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "too many WebSocket connections".to_string(),
@@ -533,9 +449,9 @@ async fn ws_upgrade(
 
     let st = Arc::clone(&state);
     ws.on_upgrade(move |socket| async move {
-        st.ws_connections.fetch_add(1, Ordering::Relaxed);
+        st.server_metrics.ws_connections.inc();
         ws_client(socket, sub, name).await;
-        st.ws_connections.fetch_sub(1, Ordering::Relaxed);
+        st.server_metrics.ws_connections.dec();
     })
     .into_response()
 }
@@ -614,10 +530,17 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_state() -> Arc<AppState> {
+        let registry = Arc::new(crate::metrics::build_registry([
+            ("instance".into(), "test".into()),
+            ("pipeline".into(), "test".into()),
+        ]));
+        let engine_metrics = Arc::new(laminar_db::EngineMetrics::new(&registry));
+        let db = Arc::new(LaminarDB::open().unwrap());
+        db.set_engine_metrics(engine_metrics);
+        let server_metrics = crate::metrics::ServerMetrics::new(&registry);
         Arc::new(AppState {
-            db: Arc::new(LaminarDB::open().unwrap()),
+            db,
             config_path: PathBuf::from("test.toml"),
-            started_at: chrono::Utc::now(),
             current_config: tokio::sync::RwLock::new(crate::config::ServerConfig {
                 server: crate::config::ServerSection::default(),
                 state: crate::config::StateSection::default(),
@@ -632,9 +555,9 @@ mod tests {
                 sql: None,
             }),
             reload_guard: ReloadGuard::new(),
-            reload_total: AtomicU64::new(0),
-            reload_last_ts: AtomicU64::new(0),
-            ws_connections: AtomicU64::new(0),
+
+            registry,
+            server_metrics,
         })
     }
 
@@ -684,13 +607,33 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            ct.contains("text/plain"),
+            "expected text/plain content-type, got: {ct}"
+        );
+
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
         let text = String::from_utf8(body.to_vec()).unwrap();
-        assert!(text.contains("laminardb_events_ingested_total"));
-        assert!(text.contains("laminardb_pipeline_state_info"));
-        assert!(text.contains("laminardb_uptime_seconds"));
+        assert!(
+            text.contains("laminardb_events_ingested_total"),
+            "missing events_ingested_total"
+        );
+        assert!(
+            text.contains("laminardb_cycles_total"),
+            "missing cycles_total"
+        );
+        assert!(
+            text.contains("laminardb_checkpoints_completed_total"),
+            "missing checkpoints_completed_total"
+        );
     }
 
     #[tokio::test]
@@ -837,10 +780,17 @@ mod tests {
         writeln!(tmpfile, "[server]").unwrap();
         let path = tmpfile.path().to_path_buf();
 
+        let registry = Arc::new(crate::metrics::build_registry([
+            ("instance".into(), "test".into()),
+            ("pipeline".into(), "test".into()),
+        ]));
+        let db = Arc::new(LaminarDB::open().unwrap());
+        let engine_metrics = Arc::new(laminar_db::EngineMetrics::new(&registry));
+        db.set_engine_metrics(engine_metrics);
+        let server_metrics = crate::metrics::ServerMetrics::new(&registry);
         let state = Arc::new(AppState {
-            db: Arc::new(LaminarDB::open().unwrap()),
+            db,
             config_path: path,
-            started_at: chrono::Utc::now(),
             current_config: tokio::sync::RwLock::new(crate::config::ServerConfig {
                 server: crate::config::ServerSection::default(),
                 state: crate::config::StateSection::default(),
@@ -855,9 +805,9 @@ mod tests {
                 sql: None,
             }),
             reload_guard: ReloadGuard::new(),
-            reload_total: AtomicU64::new(0),
-            reload_last_ts: AtomicU64::new(0),
-            ws_connections: AtomicU64::new(0),
+
+            registry,
+            server_metrics,
         });
 
         let app = build_router(state.clone());
@@ -877,10 +827,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_metrics_includes_reload() {
+    async fn test_metrics_contains_help_and_type() {
         let state = test_state();
-        state.reload_total.store(5, Ordering::Relaxed);
-        state.reload_last_ts.store(1_700_000_000, Ordering::Relaxed);
         let app = build_router(state);
 
         let req = Request::builder()
@@ -892,7 +840,8 @@ mod tests {
             .await
             .unwrap();
         let text = String::from_utf8(body.to_vec()).unwrap();
-        assert!(text.contains("laminardb_reload_total 5"));
-        assert!(text.contains("laminardb_reload_last_timestamp 1700000000"));
+        // Prometheus text format includes HELP and TYPE annotations
+        assert!(text.contains("# HELP"), "missing # HELP annotation");
+        assert!(text.contains("# TYPE"), "missing # TYPE annotation");
     }
 }

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -8,6 +8,7 @@ mod delta;
 #[cfg(feature = "delta-experimental")]
 mod delta_config;
 mod http;
+mod metrics;
 mod reload;
 mod server;
 mod watcher;

--- a/crates/laminar-server/src/metrics.rs
+++ b/crates/laminar-server/src/metrics.rs
@@ -1,0 +1,101 @@
+//! Prometheus metrics setup for LaminarDB server.
+
+use prometheus::{Encoder, IntCounter, IntGauge, Registry, TextEncoder};
+
+/// Create the prometheus registry with const labels and process collector.
+pub fn build_registry(const_labels: impl IntoIterator<Item = (String, String)>) -> Registry {
+    let labels: std::collections::HashMap<_, _> = const_labels.into_iter().collect();
+    let registry = Registry::new_custom(Some("laminardb".into()), Some(labels))
+        .expect("registry construction is infallible with valid label names");
+
+    #[cfg(target_os = "linux")]
+    {
+        let pc = prometheus::process_collector::ProcessCollector::for_self();
+        registry
+            .register(Box::new(pc))
+            .expect("process collector registration");
+    }
+
+    registry
+}
+
+/// Render the registry as Prometheus text format 0.0.4.
+pub fn render(registry: &Registry) -> Vec<u8> {
+    let mf = registry.gather();
+    let mut buf = Vec::with_capacity(4096);
+    TextEncoder::new()
+        .encode(&mf, &mut buf)
+        .expect("encoding is infallible");
+    buf
+}
+
+/// Server-level metrics (reload, uptime, connections).
+pub struct ServerMetrics {
+    pub reload_total: IntCounter,
+    pub uptime_seconds: IntGauge,
+    pub ws_connections: IntGauge,
+}
+
+impl ServerMetrics {
+    /// Register server metrics. Startup only.
+    #[must_use]
+    pub fn new(registry: &Registry) -> Self {
+        macro_rules! reg {
+            ($m:expr) => {{
+                let m = $m;
+                registry.register(Box::new(m.clone())).unwrap();
+                m
+            }};
+        }
+        Self {
+            reload_total: reg!(IntCounter::new("reload_total", "Config reload count").unwrap()),
+            uptime_seconds: reg!(
+                IntGauge::new("uptime_seconds", "Server uptime in seconds").unwrap()
+            ),
+            ws_connections: reg!(
+                IntGauge::new("ws_connections", "Active WebSocket connections").unwrap()
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use laminar_db::EngineMetrics;
+
+    #[test]
+    fn registry_renders_engine_metrics() {
+        let registry = build_registry([
+            ("instance".into(), "test".into()),
+            ("pipeline".into(), "smoke".into()),
+        ]);
+        let engine = EngineMetrics::new(&registry);
+
+        engine.events_ingested.inc_by(100);
+        engine.events_emitted.inc_by(42);
+        engine.cycles.inc();
+
+        let text = String::from_utf8(render(&registry)).unwrap();
+        assert!(text.contains("laminardb_events_ingested_total"));
+        assert!(text.contains("laminardb_events_emitted_total"));
+        assert!(text.contains("laminardb_cycles_total"));
+    }
+
+    #[test]
+    fn server_metrics_appear_in_output() {
+        let registry = build_registry([
+            ("instance".into(), "test".into()),
+            ("pipeline".into(), "t".into()),
+        ]);
+        let srv = ServerMetrics::new(&registry);
+        srv.reload_total.inc();
+        srv.uptime_seconds.set(60);
+        srv.ws_connections.set(3);
+
+        let text = String::from_utf8(render(&registry)).unwrap();
+        assert!(text.contains("laminardb_reload_total"));
+        assert!(text.contains("laminardb_uptime_seconds"));
+        assert!(text.contains("laminardb_ws_connections"));
+    }
+}

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -1,14 +1,13 @@
 //! Engine construction and lifecycle for LaminarDB server.
 
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use tokio::signal;
 use tracing::info;
 
 use laminar_core::streaming::checkpoint::StreamCheckpointConfig;
-use laminar_db::{DbError, LaminarDB, Profile};
+use laminar_db::{DbError, EngineMetrics, LaminarDB, Profile};
 
 use crate::config::{
     ConfigError, LookupConfig, PipelineConfig, ServerConfig, SinkConfig, SourceConfig,
@@ -16,6 +15,7 @@ use crate::config::{
 #[cfg(feature = "delta-experimental")]
 use crate::delta_config::{DeltaConfig, DeltaConfigError};
 use crate::http;
+use crate::metrics::ServerMetrics;
 use crate::reload::ReloadGuard;
 
 /// Handle to a running LaminarDB server. Call `wait_for_shutdown` to block until Ctrl-C.
@@ -134,6 +134,23 @@ pub async fn run_server(
         .map_err(|e| ServerError::Build(e.to_string()))?;
     let db = Arc::new(db);
 
+    // Build the prometheus registry and inject it BEFORE start() so
+    // connectors created during pipeline startup register their metrics
+    // on the shared registry.
+    let hostname = gethostname::gethostname().to_string_lossy().into_owned();
+    let pipeline_name = config
+        .pipelines
+        .first()
+        .map_or("default", |p| p.name.as_str())
+        .to_string();
+    let registry = Arc::new(crate::metrics::build_registry([
+        ("instance".into(), hostname),
+        ("pipeline".into(), pipeline_name),
+    ]));
+    let engine_metrics = Arc::new(EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&engine_metrics));
+    db.set_prometheus_registry(Arc::clone(&registry));
+
     execute_config_ddl(&db, &config).await?;
 
     db.start()
@@ -142,7 +159,7 @@ pub async fn run_server(
     info!("Pipeline started");
 
     let (app_state, api_handle) =
-        start_http_api(Arc::clone(&db), config_path.clone(), config).await?;
+        start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     Ok(ServerHandle::Embedded {
@@ -261,19 +278,21 @@ pub(crate) async fn execute_config_ddl(
 /// Start HTTP API server and return (shared state, join handle).
 pub(crate) async fn start_http_api(
     db: Arc<LaminarDB>,
+    registry: Arc<prometheus::Registry>,
     config_path: PathBuf,
     config: ServerConfig,
 ) -> Result<(Arc<http::AppState>, tokio::task::JoinHandle<()>), ServerError> {
     let bind = config.server.bind.clone();
+
+    let server_metrics = ServerMetrics::new(&registry);
+
     let app_state = Arc::new(http::AppState {
         db,
         config_path,
-        started_at: chrono::Utc::now(),
         current_config: tokio::sync::RwLock::new(config),
         reload_guard: ReloadGuard::new(),
-        reload_total: AtomicU64::new(0),
-        reload_last_ts: AtomicU64::new(0),
-        ws_connections: AtomicU64::new(0),
+        registry,
+        server_metrics,
     });
     let router = http::build_router(Arc::clone(&app_state));
     let api_handle = http::serve(router, &bind).await?;

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -134,9 +134,7 @@ pub async fn run_server(
         .map_err(|e| ServerError::Build(e.to_string()))?;
     let db = Arc::new(db);
 
-    // Build the prometheus registry and inject it BEFORE start() so
-    // connectors created during pipeline startup register their metrics
-    // on the shared registry.
+    // Prometheus registry — must be set before start().
     let hostname = gethostname::gethostname().to_string_lossy().into_owned();
     let pipeline_name = config
         .pipelines

--- a/crates/laminar-server/src/watcher.rs
+++ b/crates/laminar-server/src/watcher.rs
@@ -1,7 +1,6 @@
 //! File system watcher for automatic config hot-reload.
 
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -144,10 +143,7 @@ pub async fn watch_config(config_path: PathBuf, state: Arc<AppState>, debounce: 
         let result = reload::apply_reload(&state.db, &diff).await;
 
         // Update metrics
-        state.reload_total.fetch_add(1, Ordering::Relaxed);
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let now = chrono::Utc::now().timestamp() as u64;
-        state.reload_last_ts.store(now, Ordering::Relaxed);
+        state.server_metrics.reload_total.inc();
 
         if result.success {
             let mut current = state.current_config.write().await;

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -11,7 +11,7 @@ description = "SQL layer for LaminarDB with streaming extensions"
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.20.1" }
+laminar-core = { path = "../laminar-core", version = "0.20.2" }
 
 # DataFusion for SQL processing
 datafusion = { workspace = true }

--- a/examples/binance-ws/Cargo.toml
+++ b/examples/binance-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-ws"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 publish = false
 description = "Binance VWAP signals: minimal LaminarDB streaming example"
@@ -10,8 +10,8 @@ name = "binance-ws"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.20.1", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.1" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.20.2", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.2" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"

--- a/examples/binance-ws/src/main.rs
+++ b/examples/binance-ws/src/main.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let m = db.metrics();
         state.total_events = m.total_events_ingested;
-        state.cycle_ns = m.last_cycle_duration_ns;
+        state.cycle_ns = 0; // cycle latency now in prometheus histogram
         state.source_count = m.source_count;
         state.stream_count = m.stream_count;
         let elapsed = last_tp_time.elapsed().as_secs_f64();

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb-demo"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 publish = false
 description = "Market Data Demo: Real-time analytics with Ratatui TUI for LaminarDB"
@@ -23,9 +23,9 @@ default = []
 kafka = ["laminar-db/kafka", "dep:rdkafka", "dep:serde", "dep:serde_json"]
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.20.1" }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.1" }
-laminar-core = { path = "../../crates/laminar-core", version = "0.20.1" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.20.2" }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.2" }
+laminar-core = { path = "../../crates/laminar-core", version = "0.20.2" }
 
 # Arrow
 arrow = "57.2"

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "microstructure"
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 publish = false
 description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
@@ -12,8 +12,8 @@ name = "microstructure"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.20.1", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.1" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.20.2", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.20.2" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"

--- a/examples/microstructure/src/main.rs
+++ b/examples/microstructure/src/main.rs
@@ -92,8 +92,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         state.source_count = m.source_count;
         state.stream_count = m.stream_count;
         state.pipeline_watermark = m.pipeline_watermark;
-        state.latency.record(m.last_cycle_duration_ns);
-        state.latency_history.push(m.last_cycle_duration_ns);
 
         let elapsed = last_tp_time.elapsed().as_secs_f64();
         if elapsed >= 1.0 {

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,34 @@
+# LaminarDB Grafana Dashboard
+
+Import `laminardb.json` into Grafana (Dashboards > Import > Upload JSON file).
+
+## Setup
+
+1. Add a Prometheus datasource pointing at your Prometheus server
+2. Configure Prometheus to scrape `http://<laminardb-host>:8080/metrics`
+3. Import the dashboard and select the Prometheus datasource
+
+Example `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: laminardb
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['localhost:8080']
+```
+
+## Layout
+
+- **Pipeline Overview** — ingested/emitted/dropped totals, uptime, backpressure, WS connections
+- **Throughput** — events/sec rates, cycle duration percentiles (p50/p99)
+- **Checkpoints** — epoch, completed/failed counts, size, duration percentiles
+- **Sink Errors** — write failures, timeouts, channel closed rates, 2PC latency
+- **Kafka Source** (collapsed) — consumer lag, poll rate, commits, rebalances
+- **Kafka Sink** (collapsed) — write rate, produce latency
+- **PostgreSQL CDC** (collapsed) — replication lag, insert/update/delete rates
+- **Delta Lake Sink** (collapsed) — commits, table version, rows flushed, compaction
+- **MySQL CDC** (collapsed) — binlog position, event rates
+- **MongoDB** (collapsed) — CDC event rates, sink write rates
+
+Connector sections are collapsed by default — expand the ones relevant to your pipeline.

--- a/grafana/laminardb.json
+++ b/grafana/laminardb.json
@@ -1,0 +1,407 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" }
+  ],
+  "id": null,
+  "uid": "laminardb-overview",
+  "title": "LaminarDB",
+  "description": "Pipeline, checkpoint, source, and sink metrics for LaminarDB",
+  "tags": ["laminardb", "streaming"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(laminardb_cycles_total, instance)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "pipeline",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(laminardb_cycles_total, pipeline)",
+        "refresh": 2,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Pipeline Overview",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false
+    },
+    {
+      "title": "Events Ingested",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [{ "expr": "laminardb_events_ingested_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "title": "Events Emitted",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "targets": [{ "expr": "laminardb_events_emitted_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "title": "Events Dropped",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "targets": [{ "expr": "laminardb_events_dropped_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short", "thresholds": { "steps": [{"color":"green","value":null},{"color":"red","value":1}] } } }
+    },
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "targets": [{ "expr": "laminardb_uptime_seconds{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "title": "Backpressured Cycles",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "targets": [{ "expr": "laminardb_cycles_backpressured_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short", "thresholds": { "steps": [{"color":"green","value":null},{"color":"yellow","value":100},{"color":"red","value":1000}] } } }
+    },
+    {
+      "title": "WS Connections",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "targets": [{ "expr": "laminardb_ws_connections{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+
+    {
+      "title": "Throughput",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "collapsed": false
+    },
+    {
+      "title": "Events/sec (ingested vs emitted)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "expr": "rate(laminardb_events_ingested_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "ingested/s" },
+        { "expr": "rate(laminardb_events_emitted_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "emitted/s" },
+        { "expr": "rate(laminardb_events_dropped_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "dropped/s" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Cycle Duration (p50 / p99)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, rate(laminardb_cycle_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m]))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.99, rate(laminardb_cycle_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m]))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "Checkpoints",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "collapsed": false
+    },
+    {
+      "title": "Checkpoint Epoch",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 15 },
+      "targets": [{ "expr": "laminardb_checkpoint_epoch{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "title": "Completed / Failed",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 15 },
+      "targets": [
+        { "expr": "laminardb_checkpoints_completed_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "completed" },
+        { "expr": "laminardb_checkpoints_failed_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "failed" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "title": "Checkpoint Size",
+      "type": "stat",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 15 },
+      "targets": [{ "expr": "laminardb_checkpoint_size_bytes{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "title": "Checkpoint Duration (p50 / p99)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, rate(laminardb_checkpoint_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[5m]))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.99, rate(laminardb_checkpoint_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[5m]))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "Sink Errors",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "collapsed": false
+    },
+    {
+      "title": "Sink Errors",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "rate(laminardb_sink_write_failures_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "write failures/s" },
+        { "expr": "rate(laminardb_sink_write_timeouts_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "write timeouts/s" },
+        { "expr": "rate(laminardb_sink_task_channel_closed_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "channel closed/s" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+    {
+      "title": "Sink 2PC Latency (p99)",
+      "type": "timeseries",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        { "expr": "histogram_quantile(0.99, rate(laminardb_sink_precommit_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[5m]))", "legendFormat": "pre-commit p99" },
+        { "expr": "histogram_quantile(0.99, rate(laminardb_sink_commit_duration_seconds_bucket{instance=~\"$instance\",pipeline=~\"$pipeline\"}[5m]))", "legendFormat": "commit p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+    },
+
+    {
+      "title": "Kafka Source",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Consumer Lag",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+          "targets": [{ "expr": "laminardb_kafka_source_consumer_lag{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "lag" }],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "Records Polled/sec",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+          "targets": [
+            { "expr": "rate(laminardb_kafka_source_records_polled_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "records/s" },
+            { "expr": "rate(laminardb_kafka_source_errors_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "errors/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "Commits & Rebalances",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 41 },
+          "targets": [
+            { "expr": "rate(laminardb_kafka_source_commits_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "commits/s" },
+            { "expr": "laminardb_kafka_source_rebalances_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "rebalances total" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        }
+      ]
+    },
+    {
+      "title": "Kafka Sink",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Records Written/sec",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+          "targets": [
+            { "expr": "rate(laminardb_kafka_sink_records_written_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "records/s" },
+            { "expr": "rate(laminardb_kafka_sink_errors_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "errors/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "Produce Latency Max",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+          "targets": [{ "expr": "laminardb_kafka_sink_produce_latency_max_us{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "max latency (us)" }],
+          "fieldConfig": { "defaults": { "unit": "\u00b5s", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        }
+      ]
+    },
+    {
+      "title": "PostgreSQL CDC",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Replication Lag",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+          "targets": [{ "expr": "laminardb_postgres_cdc_replication_lag_bytes{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "lag bytes" }],
+          "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "CDC Events/sec by Type",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+          "targets": [
+            { "expr": "rate(laminardb_postgres_cdc_inserts_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "inserts/s" },
+            { "expr": "rate(laminardb_postgres_cdc_updates_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "updates/s" },
+            { "expr": "rate(laminardb_postgres_cdc_deletes_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "deletes/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        }
+      ]
+    },
+    {
+      "title": "Delta Lake Sink",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Delta Commits & Version",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+          "targets": [
+            { "expr": "rate(laminardb_lakehouse_sink_commits_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "commits/s" },
+            { "expr": "laminardb_delta_sink_last_version{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "table version" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "title": "Rows Flushed & Errors",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+          "targets": [
+            { "expr": "rate(laminardb_lakehouse_sink_rows_flushed_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "rows flushed/s" },
+            { "expr": "rate(laminardb_lakehouse_sink_errors_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "errors/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "Compaction",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+          "targets": [
+            { "expr": "laminardb_delta_sink_compaction_runs_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "runs" },
+            { "expr": "laminardb_delta_sink_compaction_files_added_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "files added" },
+            { "expr": "laminardb_delta_sink_compaction_files_removed_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}", "legendFormat": "files removed" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        }
+      ]
+    },
+    {
+      "title": "MySQL CDC",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Binlog Position",
+          "type": "stat",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 37 },
+          "targets": [{ "expr": "laminardb_mysql_cdc_binlog_position{instance=~\"$instance\",pipeline=~\"$pipeline\"}" }],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "title": "CDC Events/sec by Type",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 18, "x": 6, "y": 37 },
+          "targets": [
+            { "expr": "rate(laminardb_mysql_cdc_inserts_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "inserts/s" },
+            { "expr": "rate(laminardb_mysql_cdc_updates_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "updates/s" },
+            { "expr": "rate(laminardb_mysql_cdc_deletes_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "deletes/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        }
+      ]
+    },
+    {
+      "title": "MongoDB",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 37 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "CDC Events/sec",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 38 },
+          "targets": [
+            { "expr": "rate(laminardb_mongodb_cdc_inserts_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "inserts/s" },
+            { "expr": "rate(laminardb_mongodb_cdc_updates_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "updates/s" },
+            { "expr": "rate(laminardb_mongodb_cdc_deletes_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "deletes/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        },
+        {
+          "title": "Sink Writes/sec",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 38 },
+          "targets": [
+            { "expr": "rate(laminardb_mongodb_sink_records_written_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "records/s" },
+            { "expr": "rate(laminardb_mongodb_sink_errors_total{instance=~\"$instance\",pipeline=~\"$pipeline\"}[1m])", "legendFormat": "errors/s" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace hand-rolled AtomicU64 pipeline counters with `prometheus` 0.14 metrics on an explicit `Registry`
- Wire engine metrics into `PipelineCallback`, `CheckpointCoordinator`, and `SqlQueryOperator`
- Convert all connector metrics (Kafka, Postgres CDC/sink, MySQL CDC, WebSocket, MongoDB, Delta Lake, Lakehouse) from AtomicU64 to prometheus IntCounter/IntGauge
- Thread `Option<&Registry>` through factory signatures so connectors register on the shared registry at pipeline startup
- Add `ServerMetrics` for uptime, reload count, and WebSocket connections
- Delete `PipelineCounters`, `CounterSnapshot`, `RuntimeMetrics`, `RuntimeMetricsSnapshot`
- Include Grafana dashboard (`grafana/laminardb.json`) with pipeline overview, throughput, checkpoints, sink errors, and per-connector panels
- Bump version to 0.20.2

## Test plan

- [x] `cargo clippy --all --no-default-features -- -D warnings` clean
- [x] `cargo clippy -p laminar-server -- -D warnings` clean (all features)
- [x] 2,233 lib tests pass across all crates
- [x] 68 server tests pass with default features
- [x] Verified metric names in Grafana dashboard match registered names in code
- [x] Verified registry is injected before `db.start()` so connectors register on shared registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Central Prometheus metrics + /metrics endpoint for server and engine monitoring
  * Grafana dashboard added for pipeline, throughput, checkpoints, and connector visibility

* **Bug Fixes**
  * Unified metrics handling so connectors and server report consistently to a shared registry

* **Chores**
  * Workspace bumped to v0.20.2
  * Internal metrics migrated to Prometheus and connector factories now accept an optional metrics registry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->