### PR TITLE
chore(alloc): route C deps through jemalloc via unprefixed interposition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = "0.4"
 
 # Allocators
-tikv-jemallocator = "0.6"  # jemalloc for reduced fragmentation in Ring 1/2 (Unix)
+tikv-jemallocator = { version = "0.6", features = [
+    "unprefixed_malloc_on_supported_platforms",
+    "background_threads",
+    "profiling",
+] }  # jemalloc: unprefixed interposes libc malloc for C deps (librdkafka, OpenSSL, glibc)
 mimalloc = { version = "0.1", default-features = false }  # mimalloc for Windows MSVC
 
 # Performance-critical


### PR DESCRIPTION
## Summary

Enable `tikv-jemallocator` features so jemalloc's `malloc`/`free`/`realloc` symbols override libc's at link time. This removes the dual-heap fragmentation (Rust on jemalloc, librdkafka/OpenSSL/glibc on ptmalloc) that forced `MALLOC_ARENA_MAX=2` as a workaround in production.

Features added:

- **`unprefixed_malloc_on_supported_platforms`** — whole-process interposition. C FFI (librdkafka, OpenSSL) and glibc internals now allocate through jemalloc. No-op on MSVC; Windows continues using mimalloc via the existing `cfg(target_env = \"msvc\")` gate.
- **`background_threads`** — dedicated jemalloc purge threads instead of piggybacking on the thread that performs a free. Smoother tail latencies.
- **`profiling`** — enables `MALLOC_CONF=prof:true,...` heap dumps. Useful to disambiguate fragmentation vs. genuine leaks.

No source change in `laminar-server` is needed — the `#[global_allocator]` wiring at `crates/laminar-server/src/main.rs:19-21` was already in place; this PR only ensures C deps share the same allocator.

## Operational notes

- After deploying, drop any `MALLOC_ARENA_MAX` env var from runbooks — ptmalloc is no longer in the allocation path.
- Recommended runtime tuning: `MALLOC_CONF=\"background_thread:true,narenas:4,dirty_decay_ms:10000,muzzy_decay_ms:10000\"`.
- Heap profiling: `MALLOC_CONF=\"prof:true,prof_active:true,lg_prof_sample:19,prof_prefix:/tmp/jeprof.out\"` then `jeprof --show_bytes --pdf ./target/release/laminardb /tmp/jeprof.out.*.heap`.

## Test plan

- [ ] `cargo build --release -p laminar-server` on Linux (glibc) succeeds.
- [ ] `cargo build --release -p laminar-server` on Linux (musl) succeeds — verifies `vendored-openssl` path still links cleanly against the interposed allocator.
- [ ] `nm target/release/laminardb | grep -E ' T (malloc|free|calloc)$'` resolves to jemalloc source, not libc `malloc.c`.
- [ ] Windows MSVC build unaffected (feature gated out; mimalloc still used).
- [ ] Smoke test: run server against a Kafka source/sink pipeline for 30+ minutes; RSS should plateau instead of the prior slow creep, and p99 produce latency should be equal or better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated memory allocator dependency with enhanced feature configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->