### PR TITLE
feat(connectors): notify_epoch_committed hook on SourceConnector

### DIFF
--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -441,6 +441,36 @@ pub trait SourceConnector: Send {
     fn checkpoint_requested(&self) -> Option<Arc<std::sync::atomic::AtomicBool>> {
         None
     }
+
+    /// Notifies the source that epoch `epoch` has been durably committed.
+    ///
+    /// Called by the pipeline after the checkpoint manifest has been
+    /// persisted and every exactly-once sink's `commit_epoch` has returned
+    /// successfully. Sources that tie external acknowledgements to
+    /// checkpoint-commit boundaries (e.g., `JetStream` ack-on-commit)
+    /// release their pending-ack set for `epoch` here.
+    ///
+    /// Epoch numbers are monotonic. A successful notification for epoch
+    /// `N` implies epochs `< N` are also committed; implementations
+    /// may opportunistically release any state bound to `≤ N`.
+    ///
+    /// This call is cancellable — on pipeline shutdown the runtime may
+    /// drop it mid-flight. Implementations must tolerate that (external
+    /// systems will redeliver unacknowledged messages on reconnect) and
+    /// must be idempotent across retries on the same epoch.
+    ///
+    /// The default implementation is a no-op. Sources that commit offsets
+    /// independently (Kafka with timer-based commit, CDC sources writing
+    /// to replication slots, file sources) need no override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConnectorError`] if the acknowledgement round-trip fails.
+    /// Errors are logged by the runtime; they do not roll back the
+    /// committed epoch.
+    async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+        Ok(())
+    }
 }
 
 /// Trait for sink connectors that write data to external systems.

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -442,32 +442,15 @@ pub trait SourceConnector: Send {
         None
     }
 
-    /// Notifies the source that epoch `epoch` has been durably committed.
+    /// Acknowledge that `epoch` has been durably committed.
     ///
-    /// Called by the pipeline after the checkpoint manifest has been
-    /// persisted and every exactly-once sink's `commit_epoch` has returned
-    /// successfully. Sources that tie external acknowledgements to
-    /// checkpoint-commit boundaries (e.g., `JetStream` ack-on-commit)
-    /// release their pending-ack set for `epoch` here.
-    ///
-    /// Epoch numbers are monotonic. A successful notification for epoch
-    /// `N` implies epochs `< N` are also committed; implementations
-    /// may opportunistically release any state bound to `≤ N`.
-    ///
-    /// This call is cancellable — on pipeline shutdown the runtime may
-    /// drop it mid-flight. Implementations must tolerate that (external
-    /// systems will redeliver unacknowledged messages on reconnect) and
-    /// must be idempotent across retries on the same epoch.
-    ///
-    /// The default implementation is a no-op. Sources that commit offsets
-    /// independently (Kafka with timer-based commit, CDC sources writing
-    /// to replication slots, file sources) need no override.
+    /// Called after the manifest is persisted and every exactly-once sink
+    /// committed the epoch. Idempotent — a retry after cancellation is
+    /// legal.
     ///
     /// # Errors
     ///
-    /// Returns [`ConnectorError`] if the acknowledgement round-trip fails.
-    /// Errors are logged by the runtime; they do not roll back the
-    /// committed epoch.
+    /// Errors are logged; they do not roll back the committed epoch.
     async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
         Ok(())
     }

--- a/crates/laminar-connectors/src/testing.rs
+++ b/crates/laminar-connectors/src/testing.rs
@@ -63,6 +63,7 @@ pub struct MockSourceConnector {
     batch_size: usize,
     records_produced: AtomicU64,
     is_open: std::sync::atomic::AtomicBool,
+    committed_epochs: Arc<Mutex<Vec<u64>>>,
 }
 
 impl MockSourceConnector {
@@ -75,6 +76,7 @@ impl MockSourceConnector {
             batch_size: 5,
             records_produced: AtomicU64::new(0),
             is_open: std::sync::atomic::AtomicBool::new(false),
+            committed_epochs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -87,6 +89,7 @@ impl MockSourceConnector {
             batch_size,
             records_produced: AtomicU64::new(0),
             is_open: std::sync::atomic::AtomicBool::new(false),
+            committed_epochs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -94,6 +97,15 @@ impl MockSourceConnector {
     #[must_use]
     pub fn records_produced(&self) -> u64 {
         self.records_produced.load(Ordering::Relaxed)
+    }
+
+    /// Returns a handle for inspecting epochs reported to
+    /// `notify_epoch_committed` from outside the connector (the
+    /// connector itself is moved into a background task when run via
+    /// the pipeline).
+    #[must_use]
+    pub fn committed_epochs_handle(&self) -> Arc<Mutex<Vec<u64>>> {
+        Arc::clone(&self.committed_epochs)
     }
 }
 
@@ -162,6 +174,11 @@ impl SourceConnector for MockSourceConnector {
     async fn close(&mut self) -> Result<(), ConnectorError> {
         self.is_open
             .store(false, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn notify_epoch_committed(&mut self, epoch: u64) -> Result<(), ConnectorError> {
+        self.committed_epochs.lock().push(epoch);
         Ok(())
     }
 }

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -64,7 +64,8 @@ pub trait PipelineCallback: Send + 'static {
     /// Get the current pipeline watermark.
     fn current_watermark(&self) -> i64;
 
-    /// Perform a periodic (timer-based) checkpoint. Returns true if checkpoint was triggered.
+    /// Perform a periodic (timer-based) checkpoint. Returns `Some(epoch)`
+    /// on successful commit, `None` if skipped or failed.
     ///
     /// **Semantics: at-least-once.** Timer-based checkpoints capture source
     /// offsets *before* operator state. On recovery the consumer replays
@@ -75,22 +76,30 @@ pub trait PipelineCallback: Send + 'static {
     /// which captures offsets and operator state at a consistent cut across
     /// all sources.
     ///
+    /// The returned epoch is the monotonic checkpoint epoch number that
+    /// was just committed. The coordinator propagates it to each source's
+    /// [`SourceConnector::notify_epoch_committed`] so sources can release
+    /// external state bound to the epoch (e.g., ack messages).
+    ///
     /// [`checkpoint_with_barrier`]: PipelineCallback::checkpoint_with_barrier
+    /// [`SourceConnector::notify_epoch_committed`]: laminar_connectors::connector::SourceConnector::notify_epoch_committed
     async fn maybe_checkpoint(
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool;
+    ) -> Option<u64>;
 
     /// Called when all sources have aligned on a barrier.
     ///
-    /// Receives source checkpoints captured at the barrier point (consistent).
-    /// The callback should snapshot operator state and persist the checkpoint.
-    /// Returns true if the checkpoint succeeded.
+    /// Receives source checkpoints captured at the barrier point
+    /// (consistent). The callback snapshots operator state and persists
+    /// the checkpoint. Returns `Some(epoch)` on successful commit, `None`
+    /// on failure — the caller re-drives via the periodic path on
+    /// failure.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool;
+    ) -> Option<u64>;
 
     /// Record cycle metrics.
     fn record_cycle(&self, events_ingested: u64, batches: u64, elapsed_ns: u64);

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -65,7 +65,7 @@ pub trait PipelineCallback: Send + 'static {
     fn current_watermark(&self) -> i64;
 
     /// Perform a periodic (timer-based) checkpoint. Returns `Some(epoch)`
-    /// on successful commit, `None` if skipped or failed.
+    /// on successful commit, `None` otherwise.
     ///
     /// **Semantics: at-least-once.** Timer-based checkpoints capture source
     /// offsets *before* operator state. On recovery the consumer replays
@@ -76,26 +76,16 @@ pub trait PipelineCallback: Send + 'static {
     /// which captures offsets and operator state at a consistent cut across
     /// all sources.
     ///
-    /// The returned epoch is the monotonic checkpoint epoch number that
-    /// was just committed. The coordinator propagates it to each source's
-    /// [`SourceConnector::notify_epoch_committed`] so sources can release
-    /// external state bound to the epoch (e.g., ack messages).
-    ///
     /// [`checkpoint_with_barrier`]: PipelineCallback::checkpoint_with_barrier
-    /// [`SourceConnector::notify_epoch_committed`]: laminar_connectors::connector::SourceConnector::notify_epoch_committed
     async fn maybe_checkpoint(
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64>;
 
-    /// Called when all sources have aligned on a barrier.
-    ///
-    /// Receives source checkpoints captured at the barrier point
-    /// (consistent). The callback snapshots operator state and persists
-    /// the checkpoint. Returns `Some(epoch)` on successful commit, `None`
-    /// on failure — the caller re-drives via the periodic path on
-    /// failure.
+    /// Called when all sources have aligned on a barrier. Returns
+    /// `Some(epoch)` on successful commit, `None` on failure — the
+    /// caller retries on the next interval.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -26,7 +26,8 @@ use std::time::{Duration, Instant};
 use arrow_array::RecordBatch;
 use crossfire::{mpsc, AsyncRx};
 use laminar_connectors::checkpoint::SourceCheckpoint;
-use laminar_connectors::connector::DeliveryGuarantee;
+use laminar_connectors::connector::{DeliveryGuarantee, SourceBatch};
+use laminar_connectors::error::ConnectorError;
 use laminar_core::alloc::{PriorityClass, PriorityGuard};
 use laminar_core::checkpoint::{CheckpointBarrier, CheckpointBarrierInjector};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -72,14 +73,9 @@ struct SourceHandle {
     join: tokio::task::JoinHandle<()>,
     /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
-    /// Pushes the most-recently-committed epoch to the source task so the
-    /// connector can release external state tied to that epoch (e.g.,
-    /// `JetStream` acks, Kafka committed offsets). `watch` gives
-    /// latest-wins semantics: because epochs are monotonic and a commit
-    /// at `N` subsumes all `< N`, a source that misses intermediate
-    /// values is still correct. Value `0` is the sentinel for "no epoch
-    /// committed yet".
-    epoch_committed_tx: tokio::sync::watch::Sender<u64>,
+    /// Latest committed epoch; source acks on pickup. Monotonic, so
+    /// watch's skip-latest semantics are safe.
+    epoch_committed_tx: tokio::sync::watch::Sender<Option<u64>>,
 }
 
 /// Simplified pipeline coordinator — single tokio task, no core threads.
@@ -161,15 +157,18 @@ impl PendingBarrier {
 /// Fallback timeout for idle wake.
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// What woke a source task's select loop.
+enum SourceWake {
+    Shutdown,
+    EpochCommitted(u64),
+    Polled(Result<Option<SourceBatch>, ConnectorError>),
+}
+
 impl StreamingCoordinator {
-    /// Publish a committed-epoch number to every source task. Called
-    /// after a successful checkpoint so connectors that tie external
-    /// state to epoch commits (e.g., `JetStream` ack-on-commit) can
-    /// release that state. Send errors — a task whose receiver has been
-    /// dropped — are ignored; the task is shutting down anyway.
+    /// Fan out a committed epoch to every source so they can ack.
     fn broadcast_epoch_committed(&self, epoch: u64) {
         for handle in &self.source_handles {
-            let _ = handle.epoch_committed_tx.send(epoch);
+            let _ = handle.epoch_committed_tx.send(Some(epoch));
         }
     }
 
@@ -259,49 +258,42 @@ impl StreamingCoordinator {
             let barrier_injector = CheckpointBarrierInjector::new();
             let barrier_handle = barrier_injector.handle();
 
-            // Epoch-committed channel: coordinator publishes the most
-            // recently committed epoch; task dispatches to
-            // `connector.notify_epoch_committed`. Initial value `0` is
-            // the "no commit yet" sentinel and is skipped.
             let (epoch_committed_tx, mut epoch_committed_rx) =
-                tokio::sync::watch::channel::<u64>(0);
+                tokio::sync::watch::channel::<Option<u64>>(None);
 
             let join = tokio::spawn(async move {
                 let mut epoch: u64 = 0;
 
-                // Poll loop — tokio::select! ensures shutdown cancels a
-                // long-running poll_batch or notify_epoch_committed without
-                // waiting for it to return.
+                // Ack a fresh commit before polling more — keeps
+                // max_ack_pending headroom for the broker.
                 loop {
-                    let poll_result = tokio::select! {
+                    let wake = tokio::select! {
                         biased;
-                        () = task_shutdown_clone.notified() => break,
-                        // A new committed epoch takes priority over more
-                        // polling — releasing external state (e.g.,
-                        // JetStream acks) frees up pending-ack budget so
-                        // the broker can keep delivering.
-                        changed = epoch_committed_rx.changed() => {
-                            if changed.is_err() {
-                                // Sender dropped; coordinator is shutting
-                                // down. Shutdown notify will fire next.
-                                continue;
-                            }
-                            let committed = *epoch_committed_rx.borrow_and_update();
-                            if committed > 0 {
-                                if let Err(err) =
-                                    connector.notify_epoch_committed(committed).await
-                                {
-                                    tracing::warn!(
-                                        source = %src_name,
-                                        error = %err,
-                                        epoch = committed,
-                                        "notify_epoch_committed failed",
-                                    );
-                                }
+                        () = task_shutdown_clone.notified() => SourceWake::Shutdown,
+                        r = epoch_committed_rx.changed() => match r {
+                            Ok(()) => match *epoch_committed_rx.borrow_and_update() {
+                                Some(e) => SourceWake::EpochCommitted(e),
+                                None => continue,
+                            },
+                            Err(_) => SourceWake::Shutdown,
+                        },
+                        r = connector.poll_batch(max_poll) => SourceWake::Polled(r),
+                    };
+
+                    let poll_result = match wake {
+                        SourceWake::Shutdown => break,
+                        SourceWake::EpochCommitted(e) => {
+                            if let Err(err) = connector.notify_epoch_committed(e).await {
+                                tracing::warn!(
+                                    source = %src_name,
+                                    error = %err,
+                                    epoch = e,
+                                    "notify_epoch_committed failed",
+                                );
                             }
                             continue;
                         }
-                        result = connector.poll_batch(max_poll) => result,
+                        SourceWake::Polled(r) => r,
                     };
 
                     match poll_result {

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -72,6 +72,14 @@ struct SourceHandle {
     join: tokio::task::JoinHandle<()>,
     /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
+    /// Pushes the most-recently-committed epoch to the source task so the
+    /// connector can release external state tied to that epoch (e.g.,
+    /// `JetStream` acks, Kafka committed offsets). `watch` gives
+    /// latest-wins semantics: because epochs are monotonic and a commit
+    /// at `N` subsumes all `< N`, a source that misses intermediate
+    /// values is still correct. Value `0` is the sentinel for "no epoch
+    /// committed yet".
+    epoch_committed_tx: tokio::sync::watch::Sender<u64>,
 }
 
 /// Simplified pipeline coordinator — single tokio task, no core threads.
@@ -154,6 +162,17 @@ impl PendingBarrier {
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
 impl StreamingCoordinator {
+    /// Publish a committed-epoch number to every source task. Called
+    /// after a successful checkpoint so connectors that tie external
+    /// state to epoch commits (e.g., `JetStream` ack-on-commit) can
+    /// release that state. Send errors — a task whose receiver has been
+    /// dropped — are ignored; the task is shutting down anyway.
+    fn broadcast_epoch_committed(&self, epoch: u64) {
+        for handle in &self.source_handles {
+            let _ = handle.epoch_committed_tx.send(epoch);
+        }
+    }
+
     /// Create a new streaming coordinator.
     ///
     /// Spawns a tokio task for each source that polls the connector and
@@ -240,15 +259,48 @@ impl StreamingCoordinator {
             let barrier_injector = CheckpointBarrierInjector::new();
             let barrier_handle = barrier_injector.handle();
 
+            // Epoch-committed channel: coordinator publishes the most
+            // recently committed epoch; task dispatches to
+            // `connector.notify_epoch_committed`. Initial value `0` is
+            // the "no commit yet" sentinel and is skipped.
+            let (epoch_committed_tx, mut epoch_committed_rx) =
+                tokio::sync::watch::channel::<u64>(0);
+
             let join = tokio::spawn(async move {
                 let mut epoch: u64 = 0;
 
                 // Poll loop — tokio::select! ensures shutdown cancels a
-                // long-running poll_batch without waiting for it to return.
+                // long-running poll_batch or notify_epoch_committed without
+                // waiting for it to return.
                 loop {
                     let poll_result = tokio::select! {
                         biased;
                         () = task_shutdown_clone.notified() => break,
+                        // A new committed epoch takes priority over more
+                        // polling — releasing external state (e.g.,
+                        // JetStream acks) frees up pending-ack budget so
+                        // the broker can keep delivering.
+                        changed = epoch_committed_rx.changed() => {
+                            if changed.is_err() {
+                                // Sender dropped; coordinator is shutting
+                                // down. Shutdown notify will fire next.
+                                continue;
+                            }
+                            let committed = *epoch_committed_rx.borrow_and_update();
+                            if committed > 0 {
+                                if let Err(err) =
+                                    connector.notify_epoch_committed(committed).await
+                                {
+                                    tracing::warn!(
+                                        source = %src_name,
+                                        error = %err,
+                                        epoch = committed,
+                                        "notify_epoch_committed failed",
+                                    );
+                                }
+                            }
+                            continue;
+                        }
                         result = connector.poll_batch(max_poll) => result,
                     };
 
@@ -330,6 +382,7 @@ impl StreamingCoordinator {
                 shutdown: task_shutdown,
                 join,
                 barrier_injector,
+                epoch_committed_tx,
             });
             source_names.push(arc_name);
         }
@@ -640,8 +693,9 @@ impl StreamingCoordinator {
                     })
                 })
                 .collect();
-            if callback.maybe_checkpoint(true, source_offsets).await {
-                tracing::info!("final checkpoint completed before shutdown");
+            if let Some(epoch) = callback.maybe_checkpoint(true, source_offsets).await {
+                tracing::info!(epoch, "final checkpoint completed before shutdown");
+                self.broadcast_epoch_committed(epoch);
             }
         }
     }
@@ -754,8 +808,9 @@ impl StreamingCoordinator {
         // Check if all sources aligned.
         if self.pending_barrier.sources_aligned.len() >= self.pending_barrier.sources_total {
             let checkpoints = std::mem::take(&mut self.pending_barrier.source_checkpoints);
-            let ok = callback.checkpoint_with_barrier(checkpoints).await;
-            if !ok {
+            if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
+                self.broadcast_epoch_committed(epoch);
+            } else {
                 tracing::warn!(
                     checkpoint_id = self.pending_barrier.checkpoint_id,
                     "barrier checkpoint failed, will retry on next interval"
@@ -784,7 +839,9 @@ impl StreamingCoordinator {
         // Leader-side nodes short-circuit here (no checkpoint_interval
         // configured in the tests that drive `db.checkpoint()` manually).
         let offsets = FxHashMap::default();
-        callback.maybe_checkpoint(false, offsets).await;
+        if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
+            self.broadcast_epoch_committed(epoch);
+        }
 
         let should_checkpoint = self
             .config
@@ -802,8 +859,9 @@ impl StreamingCoordinator {
         if self.source_handles.is_empty() {
             // No sources — timer-based checkpoint only.
             let offsets = FxHashMap::default();
-            if callback.maybe_checkpoint(false, offsets).await {
+            if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
                 self.last_checkpoint = Instant::now();
+                self.broadcast_epoch_committed(epoch);
             }
             return;
         }
@@ -887,20 +945,22 @@ mod tests {
             &mut self,
             force: bool,
             _source_offsets: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             if force {
                 if let Some(ref flag) = self.force_checkpoint_flag {
                     flag.store(true, std::sync::atomic::Ordering::SeqCst);
                 }
+                Some(1)
+            } else {
+                None
             }
-            force
         }
 
         async fn checkpoint_with_barrier(
             &mut self,
             _source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
-            true
+        ) -> Option<u64> {
+            Some(1)
         }
 
         fn record_cycle(&self, _events: u64, _batches: u64, _elapsed_ns: u64) {}
@@ -1288,13 +1348,13 @@ mod tests {
             &mut self,
             force: bool,
             offsets: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             self.inner.maybe_checkpoint(force, offsets).await
         }
         async fn checkpoint_with_barrier(
             &mut self,
             cp: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             self.inner.checkpoint_with_barrier(cp).await
         }
         fn record_cycle(&self, e: u64, b: u64, ns: u64) {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -753,24 +753,41 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        let committed_epoch: Option<u64> = {
+        let mut committed = None;
+        if force {
+            // Blocking checkpoint at shutdown.
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
                 match coord.checkpoint_with_offsets(request).await {
                     Ok(result) if result.success => {
-                        if force {
-                            tracing::info!(
-                                epoch = result.epoch,
-                                "Final pipeline checkpoint saved"
-                            );
-                        } else {
-                            tracing::info!(
-                                epoch = result.epoch,
-                                duration_ms = result.duration.as_millis(),
-                                "Pipeline checkpoint completed"
-                            );
-                        }
-                        Some(result.epoch)
+                        tracing::info!(epoch = result.epoch, "Final pipeline checkpoint saved");
+                        committed = Some(result.epoch);
+                    }
+                    Ok(result) => {
+                        tracing::warn!(
+                            epoch = result.epoch,
+                            error = ?result.error,
+                            "Final checkpoint failed"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Final checkpoint error");
+                    }
+                }
+            }
+        } else {
+            // Periodic checkpoint — run inline (single-threaded runtime, no
+            // parallelism to exploit with tokio::spawn).
+            let mut guard = self.coordinator.lock().await;
+            if let Some(ref mut coord) = *guard {
+                match coord.checkpoint_with_offsets(request).await {
+                    Ok(result) if result.success => {
+                        tracing::info!(
+                            epoch = result.epoch,
+                            duration_ms = result.duration.as_millis(),
+                            "Pipeline checkpoint completed"
+                        );
+                        committed = Some(result.epoch);
                     }
                     Ok(result) => {
                         tracing::warn!(
@@ -778,20 +795,16 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             error = ?result.error,
                             "Pipeline checkpoint failed"
                         );
-                        None
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Checkpoint error");
-                        None
                     }
                 }
-            } else {
-                None
             }
-        };
+        }
 
         self.last_checkpoint = std::time::Instant::now();
-        committed_epoch
+        committed
     }
 
     async fn checkpoint_with_barrier(

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -198,16 +198,16 @@ impl ConnectorPipelineCallback {
         &mut self,
         controller: Arc<laminar_core::cluster::control::ClusterController>,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use laminar_core::cluster::control::Phase;
 
         let ann = match controller.observe_barrier().await {
             Ok(Some(a)) if a.phase == Phase::Prepare => a,
-            _ => return false,
+            _ => return None,
         };
         if self.last_follower_epoch.is_some_and(|e| e >= ann.epoch) {
-            return false;
+            return None;
         }
         self.last_follower_epoch = Some(ann.epoch);
 
@@ -215,7 +215,7 @@ impl ConnectorPipelineCallback {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(error = %e, "follower state capture failed — skipping");
-                return false;
+                return None;
             }
         };
         let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
@@ -248,7 +248,7 @@ impl ConnectorPipelineCallback {
 
         let mut guard = self.coordinator.lock().await;
         let Some(ref mut coord) = *guard else {
-            return false;
+            return None;
         };
         // Phase 1.3: stamp this instance's current pipeline watermark
         // into the coordinator so the next `BarrierAck` carries it.
@@ -258,22 +258,23 @@ impl ConnectorPipelineCallback {
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
         coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
+        let follower_epoch = ann.epoch;
         match coord
             .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
             .await
         {
             Ok(true) => {
-                tracing::info!("follower checkpoint committed");
+                tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
                 self.last_checkpoint = std::time::Instant::now();
-                true
+                Some(follower_epoch)
             }
             Ok(false) => {
                 tracing::warn!("follower checkpoint aborted (leader signalled Abort)");
-                false
+                None
             }
             Err(e) => {
                 tracing::warn!(error = %e, "follower checkpoint errored");
-                false
+                None
             }
         }
     }
@@ -632,7 +633,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
@@ -680,11 +681,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
         {
             tracing::debug!("skipping timer checkpoint under exactly-once (use barriers)");
-            return false;
+            return None;
         }
 
         if self.prom.cycles.get() == 0 {
-            return false;
+            return None;
         }
 
         // After a sink timeout, skip one checkpoint cycle so that source
@@ -694,15 +695,15 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if !force && self.sink_timed_out {
             self.sink_timed_out = false;
             tracing::info!("skipping checkpoint after sink timeout to preserve replay window");
-            return false;
+            return None;
         }
 
         if !force {
             let Some(interval) = self.checkpoint_interval else {
-                return false; // no auto-checkpointing configured
+                return None; // no auto-checkpointing configured
             };
             if self.last_checkpoint.elapsed() < interval {
-                return false;
+                return None;
             }
         }
 
@@ -729,7 +730,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             Ok(states) => states,
             Err(e) => {
                 tracing::warn!(error = %e, "Stream executor checkpoint failed — skipping checkpoint");
-                return false;
+                return None;
             }
         };
 
@@ -752,38 +753,24 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        if force {
-            // Blocking checkpoint at shutdown.
+        let committed_epoch: Option<u64> = {
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
                 match coord.checkpoint_with_offsets(request).await {
                     Ok(result) if result.success => {
-                        tracing::info!(epoch = result.epoch, "Final pipeline checkpoint saved");
-                    }
-                    Ok(result) => {
-                        tracing::warn!(
-                            epoch = result.epoch,
-                            error = ?result.error,
-                            "Final checkpoint failed"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Final checkpoint error");
-                    }
-                }
-            }
-        } else {
-            // Periodic checkpoint — run inline (single-threaded runtime, no
-            // parallelism to exploit with tokio::spawn).
-            let mut guard = self.coordinator.lock().await;
-            if let Some(ref mut coord) = *guard {
-                match coord.checkpoint_with_offsets(request).await {
-                    Ok(result) if result.success => {
-                        tracing::info!(
-                            epoch = result.epoch,
-                            duration_ms = result.duration.as_millis(),
-                            "Pipeline checkpoint completed"
-                        );
+                        if force {
+                            tracing::info!(
+                                epoch = result.epoch,
+                                "Final pipeline checkpoint saved"
+                            );
+                        } else {
+                            tracing::info!(
+                                epoch = result.epoch,
+                                duration_ms = result.duration.as_millis(),
+                                "Pipeline checkpoint completed"
+                            );
+                        }
+                        Some(result.epoch)
                     }
                     Ok(result) => {
                         tracing::warn!(
@@ -791,27 +778,31 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             error = ?result.error,
                             "Pipeline checkpoint failed"
                         );
+                        None
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Checkpoint error");
+                        None
                     }
                 }
+            } else {
+                None
             }
-        }
+        };
 
         self.last_checkpoint = std::time::Instant::now();
-        true
+        committed_epoch
     }
 
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
         if self.prom.cycles.get() == 0 {
-            return false;
+            return None;
         }
 
         // Clear after one suppression — the timer-based path that also
@@ -821,7 +812,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             tracing::warn!(
                 "skipping barrier checkpoint after sink timeout to preserve replay window"
             );
-            return false;
+            return None;
         }
 
         // Capture table source offsets.
@@ -841,7 +832,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             Ok(states) => states,
             Err(e) => {
                 tracing::warn!(error = %e, "Stream executor barrier checkpoint failed — skipping");
-                return false;
+                return None;
             }
         };
 
@@ -883,7 +874,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         "Barrier-aligned checkpoint completed"
                     );
                     self.last_checkpoint = std::time::Instant::now();
-                    return true;
+                    return Some(result.epoch);
                 }
                 Ok(result) => {
                     tracing::warn!(
@@ -898,7 +889,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        false
+        None
     }
 
     fn record_cycle(&self, events_ingested: u64, _batches: u64, elapsed_ns: u64) {

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -183,17 +183,10 @@ async fn test_barrier_aligned_checkpoint_fires() {
     );
 }
 
-/// Verifies that after a barrier-aligned checkpoint commits, every
-/// registered source's `SourceConnector::notify_epoch_committed` is
-/// called with the committed epoch number.
-///
-/// Regression guard for PR: `notify_epoch_committed` SDK hook. Without
-/// the wiring, JetStream-style sources would never release pending acks
-/// and `max_ack_pending` would saturate.
+/// After a barrier checkpoint commits, each source's
+/// `notify_epoch_committed` should fire with a monotonic epoch.
 #[tokio::test]
 async fn test_notify_epoch_committed_propagates_to_sources() {
-    use parking_lot::Mutex;
-
     let src_a = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
     let src_b = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
     let epochs_a = src_a.committed_epochs_handle();
@@ -246,35 +239,15 @@ async fn test_notify_epoch_committed_propagates_to_sources() {
     shutdown_clone.notify_one();
     handle.await.unwrap();
 
-    fn observed(handle: &Arc<Mutex<Vec<u64>>>) -> Vec<u64> {
-        handle.lock().clone()
-    }
-
-    let a = observed(&epochs_a);
-    let b = observed(&epochs_b);
-
-    assert!(
-        !a.is_empty(),
-        "src_a should have received at least one notify_epoch_committed call, got {a:?}"
-    );
-    assert!(
-        !b.is_empty(),
-        "src_b should have received at least one notify_epoch_committed call, got {b:?}"
-    );
-
-    // Epochs must be monotonically non-decreasing. `watch` has
-    // latest-wins semantics so intermediate values may be skipped —
-    // that is correct behavior and the assertion tolerates it.
-    for window in a.windows(2) {
+    for (label, epochs) in [("src_a", &epochs_a), ("src_b", &epochs_b)] {
+        let observed = epochs.lock().clone();
         assert!(
-            window[0] <= window[1],
-            "src_a epochs must be non-decreasing, got {a:?}"
+            !observed.is_empty(),
+            "{label}: expected at least one notify_epoch_committed call, got {observed:?}"
         );
-    }
-    for window in b.windows(2) {
         assert!(
-            window[0] <= window[1],
-            "src_b epochs must be non-decreasing, got {b:?}"
+            observed.windows(2).all(|w| w[0] <= w[1]),
+            "{label}: epochs must be non-decreasing, got {observed:?}"
         );
     }
 }

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -88,20 +88,25 @@ impl PipelineCallback for BarrierTrackingCallback {
             String,
             laminar_connectors::checkpoint::SourceCheckpoint,
         >,
-    ) -> bool {
+    ) -> Option<u64> {
         if force {
             self.force_checkpoints += 1;
-            return true;
+            return Some(self.force_checkpoints);
         }
-        self.should_trigger.load(Ordering::Relaxed)
+        if self.should_trigger.load(Ordering::Relaxed) {
+            Some(1)
+        } else {
+            None
+        }
     }
 
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
+        let epoch = self.barrier_checkpoints.len() as u64 + 1;
         self.barrier_checkpoints.push(source_checkpoints);
-        true
+        Some(epoch)
     }
 
     fn record_cycle(&self, _events_ingested: u64, _batches: u64, _elapsed_ns: u64) {}
@@ -176,6 +181,102 @@ async fn test_barrier_aligned_checkpoint_fires() {
         total > 0,
         "pipeline should have processed records, got {total}"
     );
+}
+
+/// Verifies that after a barrier-aligned checkpoint commits, every
+/// registered source's `SourceConnector::notify_epoch_committed` is
+/// called with the committed epoch number.
+///
+/// Regression guard for PR: `notify_epoch_committed` SDK hook. Without
+/// the wiring, JetStream-style sources would never release pending acks
+/// and `max_ack_pending` would saturate.
+#[tokio::test]
+async fn test_notify_epoch_committed_propagates_to_sources() {
+    use parking_lot::Mutex;
+
+    let src_a = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
+    let src_b = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
+    let epochs_a = src_a.committed_epochs_handle();
+    let epochs_b = src_b.committed_epochs_handle();
+
+    let sources = vec![
+        SourceRegistration {
+            name: "src_a".to_string(),
+            connector: Box::new(src_a),
+            config: laminar_connectors::config::ConnectorConfig::new("mock"),
+            supports_replay: true,
+            restore_checkpoint: None,
+        },
+        SourceRegistration {
+            name: "src_b".to_string(),
+            connector: Box::new(src_b),
+            config: laminar_connectors::config::ConnectorConfig::new("mock"),
+            supports_replay: true,
+            restore_checkpoint: None,
+        },
+    ];
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_clone = Arc::clone(&shutdown);
+
+    let config = PipelineConfig {
+        fallback_poll_interval: Duration::from_millis(1),
+        batch_window: Duration::ZERO,
+        checkpoint_interval: Some(Duration::from_millis(10)),
+        barrier_alignment_timeout: Duration::from_secs(5),
+        ..PipelineConfig::default()
+    };
+
+    let (_control_tx, control_rx) =
+        crossfire::mpsc::bounded_async::<laminar_db::pipeline::ControlMsg>(64);
+    let coordinator = StreamingCoordinator::new(sources, config, shutdown, control_rx)
+        .await
+        .unwrap();
+
+    let should_trigger = Arc::new(AtomicBool::new(true));
+    let record_counter = Arc::new(AtomicU64::new(0));
+    let callback =
+        BarrierTrackingCallback::new(Arc::clone(&should_trigger), Arc::clone(&record_counter));
+
+    let handle = tokio::spawn(async move {
+        coordinator.run(callback).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    shutdown_clone.notify_one();
+    handle.await.unwrap();
+
+    fn observed(handle: &Arc<Mutex<Vec<u64>>>) -> Vec<u64> {
+        handle.lock().clone()
+    }
+
+    let a = observed(&epochs_a);
+    let b = observed(&epochs_b);
+
+    assert!(
+        !a.is_empty(),
+        "src_a should have received at least one notify_epoch_committed call, got {a:?}"
+    );
+    assert!(
+        !b.is_empty(),
+        "src_b should have received at least one notify_epoch_committed call, got {b:?}"
+    );
+
+    // Epochs must be monotonically non-decreasing. `watch` has
+    // latest-wins semantics so intermediate values may be skipped —
+    // that is correct behavior and the assertion tolerates it.
+    for window in a.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "src_a epochs must be non-decreasing, got {a:?}"
+        );
+    }
+    for window in b.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "src_b epochs must be non-decreasing, got {b:?}"
+        );
+    }
 }
 
 /// Test that checkpoint persisted via barrier path can be recovered.

--- a/docs/plans/nats-connector.md
+++ b/docs/plans/nats-connector.md
@@ -1,0 +1,363 @@
+# NATS connector
+
+Source + sink connector for NATS, covering Core NATS and JetStream, plus a
+cluster-discovery backend on JetStream KV.
+
+## Goals
+
+- One `nats` connector type, two modes: `core` (non-durable pub/sub) and
+  `jetstream` (durable streams, default).
+- At-least-once by default; exactly-once on JetStream with user-supplied
+  message id.
+- Per-subject lanes for watermarks and offset tracking — matches how the
+  Kafka source treats partitions.
+- Cluster coordination backend using JetStream KV as a peer to
+  `kafka-discovery`, not a replacement.
+
+## Non-goals (v1)
+
+- Push consumers. Pull only.
+- Ephemeral consumers. Durable name required.
+- Subject templates with placeholders (`orders.{region}.created`).
+  Literal subject or single `subject.column` only.
+- Protobuf format. Deferred to a cross-cutting "protobuf format"
+  effort covering Kafka/NATS/files.
+- Avro without the `kafka` feature. Reuses the existing
+  `SchemaRegistryClient`; fails at open() otherwise.
+
+## Crate layout
+
+```
+crates/laminar-connectors/src/nats/
+├── mod.rs          // registration
+├── config.rs       // source + sink config + enums
+├── source.rs       // NatsSource — mode dispatch inside
+├── sink.rs         // NatsSink  — mode dispatch inside
+├── subject.rs      // literal | column → subject
+├── dedup.rs        // Nats-Msg-Id accessor from configured column
+├── discovery.rs    // JetStream KV cluster-discovery backend
+└── metrics.rs
+```
+
+Features:
+
+```toml
+nats           = ["dep:async-nats"]
+nats-discovery = ["nats", "laminar-core/cluster-unstable"]
+```
+
+Pinned: `async-nats = "0.47"`.
+
+Registration sits beside Kafka in
+`crates/laminar-db/src/db.rs::register_builtin_connectors`, gated by
+`#[cfg(feature = "nats")]`.
+
+## SDK prerequisite — PR #1
+
+Add one method to `SourceConnector` with a default no-op. The coordinator
+calls it after the manifest is persisted and after the sink's
+`commit_epoch` returns. NATS uses it to ack the full set of messages for
+the committed epoch.
+
+```rust
+async fn notify_epoch_committed(&mut self, _epoch: u64)
+    -> Result<(), ConnectorError> { Ok(()) }
+```
+
+Kafka is **not** migrated in this PR. Today's timer-based commit stays.
+The migration to epoch-gated commits is a separate hardening PR
+sequenced after #1 stabilizes — it is not behavior-neutral and deserves
+its own release note.
+
+## Source
+
+### Config (WITH-clause keys)
+
+```
+-- connection
+servers                nats://a:4222,nats://b:4222            (required)
+mode                   core | jetstream                       (default jetstream)
+auth.mode              none | user_pass | token | nkey | jwt | creds_file
+<auth fields>          routed through storage credential resolver
+tls.*                  ca / cert / key / key.password
+
+-- jetstream
+stream                 ORDERS                                  (required jetstream)
+subject                orders.>                                (core required; JS optional filter)
+subject.filters        orders.us.*,orders.eu.*                 (JS multi-filter, 2.10+)
+consumer               laminar-orders                          (required durable name)
+deliver.policy         all | new | by_start_sequence | by_start_time
+start.sequence | start.time                                    (only when matching policy)
+ack.policy             explicit | none                         (default explicit)
+ack.wait.ms            60000                                   (see validation)
+max.deliver            5
+max.ack.pending        10000
+fetch.batch            500
+fetch.max.wait.ms      500
+fetch.max.bytes        1048576
+
+-- core
+queue.group            laminar-workers                         (core only, load balance)
+
+-- format & metadata
+format                 json | csv | raw | avro                 (avro needs kafka feature)
+include.metadata       false                                   (_subject, _stream_seq, _consumer_seq,
+                                                                _timestamp, _num_delivered)
+include.headers        false                                   (_headers as JSON)
+event.time.column      ""
+schema.registry.*      (same keys as Kafka; only live with kafka feature)
+
+-- error handling
+poison.dlq.subject     orders.dead                             (Term on max_deliver + republish)
+```
+
+### Per-subject lanes
+
+`PartitionInfo.id = <subject>`. The source opens a lane on first
+observation of a subject (or eagerly for each declared `subject.filters`
+entry). `OffsetTracker` keys by subject → last `stream_seq`. The
+watermark tracker treats each subject as an independent lane for
+idle-partition detection, matching `KafkaWatermarkTracker`.
+
+### Lifecycle (jetstream)
+
+1. `open()`:
+   - Build `async_nats::ConnectOptions` from auth/tls, `connect()`.
+   - `jetstream::new(client)`, `get_stream(stream).await` for validation.
+   - `create_or_update_consumer` with `consumer::pull::Config`.
+   - Run validation rules below; fail fast with `LDB-5xxx` on any
+     violation.
+   - Spawn reader task: loops on `consumer.fetch().batch(N).expires(T).messages()`,
+     pushes `(payload, AckHandle, subject, stream_seq, timestamp, headers)`
+     into a bounded `crossfire::mpsc::Array`. **Reader never acks.**
+2. `poll_batch(max)`:
+   - Drain the queue into per-subject deserializer inputs + metadata
+     columns.
+   - Deserialize via the shared `RecordDeserializer`.
+   - Record every `AckHandle` in the current epoch's pending set (keyed
+     by epoch number).
+   - Update `OffsetTracker` per subject.
+3. `checkpoint()`:
+   - Emit `SourceCheckpoint { consumer, per_subject_seq }`.
+4. `restore(cp)`:
+   - Trust the server-side ack floor. The durable consumer resumes
+     delivery from its floor on reconnect. If the manifest's seq is
+     strictly greater than the server floor (possible only after
+     out-of-band consumer surgery), log loudly at warn and proceed from
+     the server floor — don't try to "rewrite" the consumer.
+5. `notify_epoch_committed(e)`:
+   - Ack **every** `AckHandle` in epoch `e`'s pending set. Not the
+     high watermark — the full set. JetStream's ack floor only advances
+     over contiguous prefixes; gaps cause permanent redelivery of
+     already-processed messages.
+6. `close()`: drain reader, drop client.
+
+### Core mode
+
+`client.subscribe(subject)` or `queue_subscribe(subject, queue_group)`.
+Override `supports_replay() → false`. Checkpoint is a no-op. Reject at
+plan time if `DELIVERY = EXACTLY_ONCE` is combined with `mode=core`.
+
+### Startup validation (hard-fail with `LDB-5xxx`)
+
+- `mode=core` with `delivery.guarantee=exactly_once`.
+- `mode=jetstream`, exactly-once requested, no `dedup.id.column` on the
+  paired sink.
+- `checkpoint_interval + 5s ≥ ack.wait.ms`.
+- `ack.wait.ms * max.deliver ≥ stream.duplicate_window` on the paired
+  sink side — rollback redelivery must stay inside the dedup window.
+- Consumer exists with conflicting immutable fields
+  (`filter_subjects`, `ack_policy`, `deliver_policy`). Error text tells
+  the operator to rotate the durable name or delete the consumer
+  out-of-band.
+- `format=avro` without the `kafka` feature.
+
+### Back-pressure surfaces
+
+`max_ack_pending` saturation pauses delivery server-side silently.
+Surface as:
+
+- `laminar_nats_source_pending_acks` gauge.
+- `HealthStatus::Degraded { reason: "max_ack_pending saturated" }`
+  when the pending count is within 5% of the cap for >30s.
+
+### Consumer config drift
+
+`create_or_update_consumer` returns `ErrConsumerCreate` on
+immutable-field conflict. Surface as
+`ConnectorError::Configuration("consumer '{name}' exists with
+incompatible config; rotate the durable name or delete out-of-band")`.
+
+## Sink
+
+### Config
+
+```
+servers, mode, auth.*, tls.*
+stream                 ORDERS_OUT                              (for validation)
+subject                orders.processed                        (literal) OR
+subject.column         out_subject                             (per-row)
+expected.stream        ORDERS_OUT                              (Nats-Expected-Stream header)
+
+delivery.guarantee     at_least_once | exactly_once
+dedup.id.column        event_id                                (required for exactly_once)
+
+max.pending            4096                                    (PubAck outstanding)
+ack.timeout.ms         30000
+flush.batch.size       1000
+
+format                 json | csv | raw | avro
+header.columns         trace_id,tenant
+poison.dlq.subject     orders.failed
+```
+
+### Lifecycle
+
+- `open()`: connect → `jetstream::new()`. Query stream config; validate
+  `duplicate_window` against source-side `ack.wait * max.deliver`.
+- `write_batch`: for each row compute subject, headers (header.columns +
+  `Nats-Msg-Id = <row[dedup.id.column]>` when exactly-once),
+  serialized payload; call `jetstream.publish_with_headers`; push the
+  returned `PublishAckFuture` into a `VecDeque` capped at `max.pending`.
+- `pre_commit`: `try_join_all` on the deque with `ack.timeout.ms` each;
+  any non-duplicate error fails the epoch. Duplicate acks are counted
+  (metric) and accepted.
+- `commit_epoch`: no-op on the NATS side; bump `last_committed_epoch`.
+- `rollback_epoch`: drop in-flight buffer. Already-landed publishes are
+  covered by server dedup on retry (validated at open()).
+- `close()`: flush the deque with a bounded deadline.
+
+### Capabilities
+
+```rust
+SinkConnectorCapabilities::new(Duration::from_secs(5))
+    .with_idempotent()        // always in JS mode
+    .with_exactly_once()      // when dedup.id.column set
+    .with_two_phase_commit()  // pre_commit awaits all PubAckFutures
+    .with_partitioned()       // subject-per-row
+```
+
+No `changelog` / `upsert` — NATS is append-only.
+
+### Core sink
+
+`client.publish`. Capabilities declare at-least-once best-effort only.
+`pre_commit` is a no-op. Reject plan-time if paired with
+`exactly_once`.
+
+## Cluster discovery (`nats-discovery` feature)
+
+Alternative to `kafka-discovery`. A cluster picks **one** coordinator
+backend at boot; mixing Kafka and NATS coordination inside a single
+cluster is not supported and is rejected at startup.
+
+### Backend selection
+
+```
+cluster.coordinator    kafka | nats        (required when cluster mode is enabled)
+```
+
+Resolution order:
+
+- Both features compiled in → config key selects the backend.
+- Only one feature compiled in → config key must match the compiled
+  backend or `open()` fails.
+- Both config keys set, or `cluster.coordinator` points at a backend
+  whose feature is not compiled in → hard-fail at startup with
+  `LDB-5xxx`.
+- Leader detects a peer announcing a different coordinator backend
+  (visible in the heartbeat payload) → fence the cluster: refuse to
+  publish an assignment and raise `HealthStatus::Unhealthy`. Prevents
+  a mid-flight misconfiguration from silently splitting the cluster
+  across two coordination planes.
+
+### KV buckets
+
+- `_laminar_nodes` — TTL 30s, key = `node_id`, value = heartbeat payload
+  (addr, epoch, assignment_version). Each node refreshes every 10s;
+  dead nodes auto-expire.
+- `_laminar_leader` — single key `leader`, value = `node_id`. Election
+  via `create` on the key (CAS fail = someone else won). Leader
+  refreshes TTL; on expiry, watchers race to claim.
+- `_laminar_assignments` — key = version number, value =
+  `AssignmentSnapshot`. Written with `PutMode::Create` so concurrent
+  leader writes cannot clobber. Same struct and versioned layout as the
+  existing cluster primitives.
+
+### Node watch loop
+
+Subscribe to `_laminar_assignments` updates. On new version, call
+`LaminarDB::adopt_assignment_snapshot` (already present). Leader
+election and assignment publication reuse the existing debounced
+rebalance controller from #342.
+
+### Bucket lifecycle
+
+Auto-create on first use with `replicas=3, history=5, ttl=30s`.
+Overridable via:
+
+```
+nats.discovery.bucket.replicas       3
+nats.discovery.bucket.history        5
+nats.discovery.nodes.ttl.ms          30000
+nats.discovery.leader.ttl.ms         15000
+```
+
+Operators who prefer preprovisioning use
+`laminar-cli cluster init --coordinator=nats --servers=...`; the
+runtime then refuses to create buckets and errors on missing ones.
+
+### Why JetStream KV over Kafka for this
+
+- Native CAS on `create` — leader election without compacted-topic
+  hacks.
+- Native TTL on heartbeats — no consumer-group liveness dance.
+- Sub-ms watch notifications vs Kafka poll.
+
+### Scope
+
+Opt-in, `cluster-unstable` feature flag for honesty. Peer to
+`kafka-discovery` at compile time, mutually exclusive at run time.
+Shops with Kafka stay on `kafka-discovery`; NATS-only shops pick
+`nats-discovery`. No hybrid.
+
+## Test matrix
+
+Five scenarios. All gated behind `--features nats` and `--ignored`
+(testcontainers, `nats:2.10-alpine`). Same stance as the Mongo tests.
+
+1. **Round-trip**: publish via sink → consume via source → identity.
+2. **Broker kill mid-epoch**: kill `nats-server` during a write batch,
+   restart, verify no loss and no duplicates downstream.
+3. **LaminarDB kill after pre_commit, before manifest**: restart,
+   rollback path fires, verify no duplicate rows.
+4. **Forced redelivery**: sleep the sink past `ack.wait`, verify source
+   redelivers, sink dedup drops, `duplicate` metric non-zero.
+5. **Startup validation**: each of the six hard-fail rules raises the
+   correct `LDB-5xxx` code with the documented message.
+
+Discovery (nats-discovery feature):
+
+6. **Three-node convergence**: kill leader, verify a new leader claims
+   the TTL'd key and publishes a new assignment version that the
+   remaining nodes adopt.
+
+## Staging
+
+| PR | Scope | Merge criterion |
+|---|---|---|
+| 1 | `SourceConnector::notify_epoch_committed` hook + coordinator wiring. Kafka untouched. | All existing connector tests green. |
+| 2 | `nats` feature. Core + JetStream pull source, at-least-once sink. Per-subject lanes. Startup validation. Back-pressure + drift surfaces. | Scenarios 1, 2, 4, 5. |
+| 3 | JetStream sink exactly-once via `Nats-Msg-Id`. `duplicate_window` validation. | Scenario 3 + full exactly-once matrix. |
+| 4 | `nats-discovery` feature. KV-based nodes / leader / assignments. | Scenario 6. |
+
+Kafka commit-timer → epoch-based migration: separate PR, sequenced
+after PR 1 has been live at least one release cycle.
+
+## Open items
+
+- Default KV bucket replicas (`3`) assumes a 3-node JetStream cluster.
+  Single-node dev deployments need `1`. Propose: auto-detect via
+  `jetstream.account_info()` topology and pick accordingly; fall back
+  to `replicas=1` with a startup warning if the account reports fewer
+  than 3 servers.


### PR DESCRIPTION
## Summary

Adds a default-no-op `SourceConnector::notify_epoch_committed(epoch)` that the pipeline coordinator calls after the checkpoint manifest is persisted and every exactly-once sink's `commit_epoch` returns. Sources that tie external state to epoch-commit boundaries release that state here.

This is **prerequisite PR #1** of the NATS connector effort ([plan](docs/plans/nats-connector.md)). JetStream acks must fire on checkpoint commit, not inside the reader; without this hook there is no place in the SDK to wire that.

## Design notes

- **Trait addition is additive.** Default impl is a no-op. Every existing source — Kafka, CDC, files, WebSocket — keeps its current behavior.
- **Kafka is deliberately untouched.** Moving Kafka from its timer-based commit to epoch-gated commits changes *when* offsets land (strictly better: aligned to checkpoint) but is not behavior-neutral and deserves its own PR with a release note.
- **Latest-wins watch semantics.** The per-source `tokio::sync::watch<u64>` channel can drop intermediate epoch values under load. That is correct: epochs are monotonic and \`notify_epoch_committed(N)\` subsumes every \`< N\`.
- **Cancellation.** Shutdown cancels an in-flight \`notify_epoch_committed\` call via \`tokio::select!\`. External systems will redeliver unacked messages on reconnect; the trait contract requires idempotent re-calls.

## Interface changes

\`PipelineCallback::maybe_checkpoint\` and \`checkpoint_with_barrier\` return \`Option<u64>\` (Some(epoch) on success) instead of \`bool\`. Five impls updated (production, cluster-follower, three test mocks). All call sites are inside the \`laminar-db\` crate — zero external API surface.

## Test plan

- [x] \`cargo check --all --no-default-features\` clean
- [x] \`cargo clippy -p laminar-connectors -p laminar-db --tests -- -D warnings\` clean
- [x] \`cargo test -p laminar-connectors --lib\` — 505 passed
- [x] \`cargo test -p laminar-db --lib\` — 614 passed
- [x] \`cargo test -p laminar-db --test checkpoint_exactly_once\` — 5/5 passed
- [x] New \`test_notify_epoch_committed_propagates_to_sources\` asserts both sources observe monotonic committed epochs after barrier alignment

## Out of scope

- Kafka migration to epoch-gated commit (separate PR, follow-up).
- NATS connector itself (PRs #2–#4 of the NATS effort).