### PR TITLE
feat(nats): NATS source + sink connector with exactly-once semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1396,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1902,6 +1947,32 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "darling"
@@ -2943,6 +3014,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3217,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,6 +3380,12 @@ dependencies = [
  "rand 0.9.2",
  "web-time",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -4522,6 +4632,7 @@ dependencies = [
  "arrow-row",
  "arrow-schema",
  "arrow-select",
+ "async-nats",
  "async-trait",
  "base64 0.22.1",
  "bson",
@@ -5333,6 +5444,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5366,6 +5492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5906,6 +6041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6033,6 +6177,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -7066,9 +7220,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7253,6 +7407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7374,6 +7537,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7433,6 +7618,16 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -7916,6 +8111,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8146,6 +8362,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-postgres",
  "tokio-stream",

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -89,6 +89,10 @@ futures-util = { version = "0.3", features = ["sink"], optional = true }
 
 # NATS (core + JetStream)
 async-nats = { version = "0.47", optional = true }
+# Used by the NATS connector for RFC3339 → OffsetDateTime parsing when
+# deliver.policy=by_start_time. Already pulled in transitively by
+# async-nats — making the dep direct so we can name the type.
+time = { version = "0.3", optional = true, features = ["parsing"] }
 
 # OpenTelemetry OTLP/gRPC receiver
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic", "trace", "metrics", "logs"], optional = true }
@@ -132,7 +136,7 @@ files = ["dep:notify", "dep:globset", "dep:object_store", "dep:parquet", "dep:li
 # OpenTelemetry OTLP/gRPC source
 otel = ["dep:opentelemetry-proto", "dep:tonic", "dep:prost", "dep:base64"]
 # NATS core + JetStream source and sink
-nats = ["dep:async-nats", "dep:tokio-stream", "dep:futures-util"]
+nats = ["dep:async-nats", "dep:tokio-stream", "dep:futures-util", "dep:time"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -87,6 +87,9 @@ tokio-tungstenite = { version = "0.28", features = ["native-tls"], optional = tr
 tungstenite = { version = "0.28", optional = true }
 futures-util = { version = "0.3", features = ["sink"], optional = true }
 
+# NATS (core + JetStream)
+async-nats = { version = "0.47", optional = true }
+
 # OpenTelemetry OTLP/gRPC receiver
 opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic", "trace", "metrics", "logs"], optional = true }
 tonic = { version = "0.14", optional = true }
@@ -128,6 +131,8 @@ websocket = ["dep:tokio-tungstenite", "dep:tungstenite", "dep:futures-util", "de
 files = ["dep:notify", "dep:globset", "dep:object_store", "dep:parquet", "dep:libc", "dep:tokio-stream", "dep:xorf"]
 # OpenTelemetry OTLP/gRPC source
 otel = ["dep:opentelemetry-proto", "dep:tonic", "dep:prost", "dep:base64"]
+# NATS core + JetStream source and sink
+nats = ["dep:async-nats", "dep:tokio-stream", "dep:futures-util"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -441,6 +441,36 @@ pub trait SourceConnector: Send {
     fn checkpoint_requested(&self) -> Option<Arc<std::sync::atomic::AtomicBool>> {
         None
     }
+
+    /// Notifies the source that epoch `epoch` has been durably committed.
+    ///
+    /// Called by the pipeline after the checkpoint manifest has been
+    /// persisted and every exactly-once sink's `commit_epoch` has returned
+    /// successfully. Sources that tie external acknowledgements to
+    /// checkpoint-commit boundaries (e.g., `JetStream` ack-on-commit)
+    /// release their pending-ack set for `epoch` here.
+    ///
+    /// Epoch numbers are monotonic. A successful notification for epoch
+    /// `N` implies epochs `< N` are also committed; implementations
+    /// may opportunistically release any state bound to `≤ N`.
+    ///
+    /// This call is cancellable — on pipeline shutdown the runtime may
+    /// drop it mid-flight. Implementations must tolerate that (external
+    /// systems will redeliver unacknowledged messages on reconnect) and
+    /// must be idempotent across retries on the same epoch.
+    ///
+    /// The default implementation is a no-op. Sources that commit offsets
+    /// independently (Kafka with timer-based commit, CDC sources writing
+    /// to replication slots, file sources) need no override.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConnectorError`] if the acknowledgement round-trip fails.
+    /// Errors are logged by the runtime; they do not roll back the
+    /// committed epoch.
+    async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+        Ok(())
+    }
 }
 
 /// Trait for sink connectors that write data to external systems.

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -442,32 +442,15 @@ pub trait SourceConnector: Send {
         None
     }
 
-    /// Notifies the source that epoch `epoch` has been durably committed.
+    /// Acknowledge that `epoch` has been durably committed.
     ///
-    /// Called by the pipeline after the checkpoint manifest has been
-    /// persisted and every exactly-once sink's `commit_epoch` has returned
-    /// successfully. Sources that tie external acknowledgements to
-    /// checkpoint-commit boundaries (e.g., `JetStream` ack-on-commit)
-    /// release their pending-ack set for `epoch` here.
-    ///
-    /// Epoch numbers are monotonic. A successful notification for epoch
-    /// `N` implies epochs `< N` are also committed; implementations
-    /// may opportunistically release any state bound to `≤ N`.
-    ///
-    /// This call is cancellable — on pipeline shutdown the runtime may
-    /// drop it mid-flight. Implementations must tolerate that (external
-    /// systems will redeliver unacknowledged messages on reconnect) and
-    /// must be idempotent across retries on the same epoch.
-    ///
-    /// The default implementation is a no-op. Sources that commit offsets
-    /// independently (Kafka with timer-based commit, CDC sources writing
-    /// to replication slots, file sources) need no override.
+    /// Called after the manifest is persisted and every exactly-once sink
+    /// committed the epoch. Idempotent — a retry after cancellation is
+    /// legal.
     ///
     /// # Errors
     ///
-    /// Returns [`ConnectorError`] if the acknowledgement round-trip fails.
-    /// Errors are logged by the runtime; they do not roll back the
-    /// committed epoch.
+    /// Errors are logged; they do not roll back the committed epoch.
     async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
         Ok(())
     }

--- a/crates/laminar-connectors/src/lib.rs
+++ b/crates/laminar-connectors/src/lib.rs
@@ -99,6 +99,10 @@ pub mod mongodb;
 #[cfg(feature = "otel")]
 pub mod otel;
 
+/// NATS core and JetStream source and sink connectors.
+#[cfg(feature = "nats")]
+pub mod nats;
+
 /// AutoLoader-style file source and sink connectors.
 #[cfg(feature = "files")]
 #[allow(

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -232,6 +232,13 @@ pub struct NatsSinkConfig {
     pub expected_stream: Option<String>,
     pub delivery_guarantee: DeliveryGuarantee,
     pub dedup_id_column: Option<String>,
+    /// Minimum `duplicate_window` the target stream must be configured
+    /// with when `delivery.guarantee=exactly_once`. Parsed from
+    /// `min.duplicate.window.ms`; defaults to 2 minutes. The sink
+    /// refuses to start if the stream's actual window is shorter, since
+    /// a short window means rollback redelivery can land outside the
+    /// dedup horizon and produce duplicates silently.
+    pub min_duplicate_window: Duration,
     pub max_pending: usize,
     pub ack_timeout: Duration,
     pub flush_batch_size: usize,
@@ -279,6 +286,11 @@ impl NatsSinkConfig {
             expected_stream: config.get("expected.stream").map(str::to_string),
             delivery_guarantee,
             dedup_id_column,
+            min_duplicate_window: parse_duration_ms(
+                config,
+                "min.duplicate.window.ms",
+                Duration::from_secs(120),
+            )?,
             max_pending: parse_usize(config, "max.pending", 4096)?,
             ack_timeout: parse_duration_ms(config, "ack.timeout.ms", Duration::from_secs(30))?,
             flush_batch_size: parse_usize(config, "flush.batch.size", 1000)?,
@@ -307,6 +319,12 @@ impl NatsSinkConfig {
                 "[LDB-5054] delivery.guarantee=exactly_once requires 'dedup.id.column' — \
                  msg-id dedup with epoch-row hashing is not supported (deterministic replay \
                  is too fragile; name a unique-per-row column)",
+            ));
+        }
+        if self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce && self.stream.is_none() {
+            return Err(cfg_err(
+                "[LDB-5055] delivery.guarantee=exactly_once requires 'stream' so the sink \
+                 can validate its duplicate_window at startup",
             ));
         }
         Ok(())
@@ -540,6 +558,19 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(err.contains("LDB-5053"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_rejects_exactly_once_without_stream() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("subject", "x"),
+            ("delivery.guarantee", "exactly_once"),
+            ("dedup.id.column", "event_id"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5055"), "got: {err}");
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -129,6 +129,10 @@ pub struct NatsSourceConfig {
     pub fetch_batch: usize,
     pub fetch_max_wait: Duration,
     pub fetch_max_bytes: usize,
+    /// Consecutive fetch errors before the source is reported
+    /// `Unhealthy`. Zero means "never flip to unhealthy from error
+    /// counts alone" — useful in tests.
+    pub fetch_error_threshold: u32,
 
     // Core
     pub queue_group: Option<String>,
@@ -175,6 +179,7 @@ impl NatsSourceConfig {
         let fetch_max_wait =
             parse_duration_ms(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
         let fetch_max_bytes = parse_usize(config, "fetch.max.bytes", 1 << 20)?;
+        let fetch_error_threshold = parse_u32(config, "fetch.error.threshold", 10)?;
         let queue_group = config.get("queue.group").map(str::to_string);
         let format = parse_format(config)?;
         let include_metadata = parse_bool(config, "include.metadata", false)?;
@@ -201,6 +206,7 @@ impl NatsSourceConfig {
             fetch_batch,
             fetch_max_wait,
             fetch_max_bytes,
+            fetch_error_threshold,
             queue_group,
             format,
             include_metadata,
@@ -443,6 +449,10 @@ fn parse_usize(
     key: &str,
     default: usize,
 ) -> Result<usize, ConnectorError> {
+    config.get(key).map_or(Ok(default), |s| parse_int(key, s))
+}
+
+fn parse_u32(config: &ConnectorConfig, key: &str, default: u32) -> Result<u32, ConnectorError> {
     config.get(key).map_or(Ok(default), |s| parse_int(key, s))
 }
 

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -130,7 +130,6 @@ pub struct NatsSourceConfig {
     pub max_ack_pending: i64,
     pub fetch_batch: usize,
     pub fetch_max_wait: Duration,
-    pub fetch_max_bytes: usize,
     /// Consecutive fetch errors before `health_check` reports
     /// `Unhealthy`. Zero disables the flip.
     pub fetch_error_threshold: u32,
@@ -141,14 +140,7 @@ pub struct NatsSourceConfig {
     // Core
     pub queue_group: Option<String>,
 
-    // Format / metadata
     pub format: Format,
-    pub include_metadata: bool,
-    pub include_headers: bool,
-    pub event_time_column: Option<String>,
-
-    // Error handling
-    pub poison_dlq_subject: Option<String>,
 }
 
 impl NatsSourceConfig {
@@ -178,16 +170,11 @@ impl NatsSourceConfig {
         let fetch_batch = require_positive_usize(config, "fetch.batch", 500)?;
         let fetch_max_wait =
             require_positive_duration(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
-        let fetch_max_bytes = require_positive_usize(config, "fetch.max.bytes", 1 << 20)?;
         let fetch_error_threshold = parse_u32(config, "fetch.error.threshold", 10)?;
         let lag_poll_interval =
             parse_duration_ms(config, "lag.poll.interval.ms", Duration::from_secs(10))?;
         let queue_group = config.get("queue.group").map(str::to_string);
         let format = parse_format(config)?;
-        let include_metadata = parse_bool(config, "include.metadata", false)?;
-        let include_headers = parse_bool(config, "include.headers", false)?;
-        let event_time_column = config.get("event.time.column").map(str::to_string);
-        let poison_dlq_subject = config.get("poison.dlq.subject").map(str::to_string);
 
         let cfg = Self {
             servers,
@@ -207,15 +194,10 @@ impl NatsSourceConfig {
             max_ack_pending,
             fetch_batch,
             fetch_max_wait,
-            fetch_max_bytes,
             fetch_error_threshold,
             lag_poll_interval,
             queue_group,
             format,
-            include_metadata,
-            include_headers,
-            event_time_column,
-            poison_dlq_subject,
         };
         cfg.validate()?;
         Ok(cfg)
@@ -288,10 +270,8 @@ pub struct NatsSinkConfig {
     pub min_duplicate_window: Duration,
     pub max_pending: usize,
     pub ack_timeout: Duration,
-    pub flush_batch_size: usize,
     pub format: Format,
     pub header_columns: Vec<String>,
-    pub poison_dlq_subject: Option<String>,
 }
 
 impl NatsSinkConfig {
@@ -345,13 +325,11 @@ impl NatsSinkConfig {
                 "ack.timeout.ms",
                 Duration::from_secs(30),
             )?,
-            flush_batch_size: require_positive_usize(config, "flush.batch.size", 1000)?,
             format: parse_format(config)?,
             header_columns: config
                 .get("header.columns")
                 .map(split_csv)
                 .unwrap_or_default(),
-            poison_dlq_subject: config.get("poison.dlq.subject").map(str::to_string),
         };
         cfg.validate()?;
         Ok(cfg)
@@ -379,8 +357,23 @@ impl NatsSinkConfig {
                  can validate its duplicate_window at startup",
             ));
         }
+        for h in &self.header_columns {
+            if is_reserved_header(h) {
+                return Err(cfg_err(&format!(
+                    "[LDB-5065] header.columns entry '{h}' collides with a reserved NATS \
+                     header (Nats-Msg-Id / Nats-Expected-Stream); rename the column",
+                )));
+            }
+        }
         Ok(())
     }
+}
+
+/// Header names the sink manages itself; a user header with the same
+/// name would otherwise silently clobber exactly-once semantics.
+fn is_reserved_header(name: &str) -> bool {
+    const RESERVED: &[&str] = &["Nats-Msg-Id", "Nats-Expected-Stream"];
+    RESERVED.iter().any(|r| r.eq_ignore_ascii_case(name))
 }
 
 // ── helpers ──
@@ -697,7 +690,6 @@ mod tests {
             ("subject.filters", "orders.us.*,orders.eu.*"),
             ("ack.wait.ms", "45000"),
             ("max.deliver", "3"),
-            ("include.metadata", "true"),
         ]))
         .unwrap();
         assert_eq!(parsed.servers.len(), 2);
@@ -705,7 +697,6 @@ mod tests {
         assert_eq!(parsed.subject_filters, vec!["orders.us.*", "orders.eu.*"]);
         assert_eq!(parsed.ack_wait, Duration::from_secs(45));
         assert_eq!(parsed.max_deliver, 3);
-        assert!(parsed.include_metadata);
     }
 
     #[test]
@@ -742,6 +733,18 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("LDB-5051"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_rejects_header_column_colliding_with_reserved() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("subject", "x"),
+            ("header.columns", "trace_id,nats-msg-id"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5065"), "got: {err}");
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -68,7 +68,12 @@ pub enum SubjectSpec {
 }
 
 /// NATS user-authentication mode.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+///
+/// `Debug` is implemented manually to redact passwords and tokens —
+/// `NatsSourceConfig` / `NatsSinkConfig` both derive `Debug` and carry
+/// an `AuthMode`, so any `debug!("{cfg:?}")` or panic backtrace would
+/// otherwise log secrets.
+#[derive(Clone, Default, PartialEq, Eq)]
 pub enum AuthMode {
     /// No authentication.
     #[default]
@@ -85,6 +90,23 @@ pub enum AuthMode {
     /// Path to a NATS credentials file (typically `.creds` from
     /// NATS Cloud / NSC).
     CredsFile(String),
+}
+
+impl std::fmt::Debug for AuthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("None"),
+            Self::UserPass { user, .. } => f
+                .debug_struct("UserPass")
+                .field("user", user)
+                .field("password", &"<redacted>")
+                .finish(),
+            Self::Token(_) => f.debug_tuple("Token").field(&"<redacted>").finish(),
+            // File paths aren't secrets themselves — the file contents are,
+            // and we don't store them in this enum.
+            Self::CredsFile(path) => f.debug_tuple("CredsFile").field(path).finish(),
+        }
+    }
 }
 
 /// TLS transport configuration. Independent of [`AuthMode`].
@@ -166,13 +188,13 @@ impl NatsSourceConfig {
         let start_sequence = parse_opt_u64(config, "start.sequence")?;
         let start_time = config.get("start.time").map(str::to_string);
         let ack_policy = parse_or_default::<AckPolicy>(config, "ack.policy")?;
-        let ack_wait = parse_duration_ms(config, "ack.wait.ms", Duration::from_secs(60))?;
-        let max_deliver = parse_i64(config, "max.deliver", 5)?;
-        let max_ack_pending = parse_i64(config, "max.ack.pending", 10_000)?;
-        let fetch_batch = parse_usize(config, "fetch.batch", 500)?;
+        let ack_wait = require_positive_duration(config, "ack.wait.ms", Duration::from_secs(60))?;
+        let max_deliver = require_positive_or_unlimited_i64(config, "max.deliver", 5)?;
+        let max_ack_pending = require_positive_or_unlimited_i64(config, "max.ack.pending", 10_000)?;
+        let fetch_batch = require_positive_usize(config, "fetch.batch", 500)?;
         let fetch_max_wait =
-            parse_duration_ms(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
-        let fetch_max_bytes = parse_usize(config, "fetch.max.bytes", 1 << 20)?;
+            require_positive_duration(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
+        let fetch_max_bytes = require_positive_usize(config, "fetch.max.bytes", 1 << 20)?;
         let fetch_error_threshold = parse_u32(config, "fetch.error.threshold", 10)?;
         let lag_poll_interval =
             parse_duration_ms(config, "lag.poll.interval.ms", Duration::from_secs(10))?;
@@ -336,9 +358,13 @@ impl NatsSinkConfig {
                 "min.duplicate.window.ms",
                 Duration::from_secs(120),
             )?,
-            max_pending: parse_usize(config, "max.pending", 4096)?,
-            ack_timeout: parse_duration_ms(config, "ack.timeout.ms", Duration::from_secs(30))?,
-            flush_batch_size: parse_usize(config, "flush.batch.size", 1000)?,
+            max_pending: require_positive_usize(config, "max.pending", 4096)?,
+            ack_timeout: require_positive_duration(
+                config,
+                "ack.timeout.ms",
+                Duration::from_secs(30),
+            )?,
+            flush_batch_size: require_positive_usize(config, "flush.batch.size", 1000)?,
             format: parse_format(config)?,
             header_columns: config
                 .get("header.columns")
@@ -448,6 +474,44 @@ fn parse_usize(
 
 fn parse_u32(config: &ConnectorConfig, key: &str, default: u32) -> Result<u32, ConnectorError> {
     config.get(key).map_or(Ok(default), |s| parse_int(key, s))
+}
+
+fn require_positive_duration(
+    config: &ConnectorConfig,
+    key: &str,
+    default: Duration,
+) -> Result<Duration, ConnectorError> {
+    let v = parse_duration_ms(config, key, default)?;
+    if v.is_zero() {
+        return Err(cfg_err(&format!("{key} must be > 0")));
+    }
+    Ok(v)
+}
+
+fn require_positive_usize(
+    config: &ConnectorConfig,
+    key: &str,
+    default: usize,
+) -> Result<usize, ConnectorError> {
+    let v = parse_usize(config, key, default)?;
+    if v == 0 {
+        return Err(cfg_err(&format!("{key} must be > 0")));
+    }
+    Ok(v)
+}
+
+/// NATS allows `-1` for "unlimited" in `max_deliver` / `max_ack_pending`.
+/// Reject 0 (undefined) and negative values other than -1.
+fn require_positive_or_unlimited_i64(
+    config: &ConnectorConfig,
+    key: &str,
+    default: i64,
+) -> Result<i64, ConnectorError> {
+    let v = parse_i64(config, key, default)?;
+    if v == 0 || v < -1 {
+        return Err(cfg_err(&format!("{key} must be > 0, or -1 for unlimited")));
+    }
+    Ok(v)
 }
 
 fn parse_duration_ms(
@@ -768,6 +832,49 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("servers"), "got: {err}");
+    }
+
+    #[test]
+    fn zero_fetch_batch_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("fetch.batch", "0")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("fetch.batch must be > 0"), "got: {err}");
+    }
+
+    #[test]
+    fn zero_ack_wait_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("ack.wait.ms", "0")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ack.wait.ms must be > 0"), "got: {err}");
+    }
+
+    #[test]
+    fn max_deliver_unlimited_accepted() {
+        let parsed =
+            NatsSourceConfig::from_config(&jetstream_happy(&[("max.deliver", "-1")])).unwrap();
+        assert_eq!(parsed.max_deliver, -1);
+    }
+
+    #[test]
+    fn max_deliver_negative_other_than_minus_one_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("max.deliver", "-5")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("max.deliver"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_zero_max_pending_rejected() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("subject", "x"),
+            ("max.pending", "0"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("max.pending must be > 0"), "got: {err}");
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -130,8 +130,8 @@ pub struct NatsSourceConfig {
     pub fetch_max_wait: Duration,
     pub fetch_max_bytes: usize,
     /// Consecutive fetch errors before the source is reported
-    /// `Unhealthy`. Zero means "never flip to unhealthy from error
-    /// counts alone" — useful in tests.
+    /// `Unhealthy`. Zero disables the health flip (an escape hatch for
+    /// tests that need to decouple health from error counts).
     pub fetch_error_threshold: u32,
 
     // Core

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -12,7 +12,7 @@ use crate::serde::Format;
 pub enum Mode {
     /// Plain NATS pub/sub. No durability, no replay, at-most-once.
     Core,
-    /// `JetStream` with durable pull consumers. Default.
+    /// `JetStream` with durable pull consumers.
     #[default]
     JetStream,
 }
@@ -25,10 +25,10 @@ str_enum!(fromstr Mode, lowercase, ConnectorError, "invalid nats mode",
 /// `JetStream` consumer ack policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AckPolicy {
-    /// Each message acked individually. Default.
+    /// Each message acked individually.
     #[default]
     Explicit,
-    /// No ack required (fire-and-forget within JS).
+    /// No ack required.
     None,
 }
 
@@ -40,7 +40,7 @@ str_enum!(fromstr AckPolicy, lowercase, ConnectorError, "invalid ack.policy",
 /// `JetStream` consumer delivery policy — where to start.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DeliverPolicy {
-    /// Replay every message retained by the stream. Default.
+    /// Every message retained by the stream.
     #[default]
     All,
     /// Only messages published after consumer creation.
@@ -67,28 +67,18 @@ pub enum SubjectSpec {
     Column(String),
 }
 
-/// NATS user-authentication mode.
-///
-/// `Debug` is implemented manually to redact passwords and tokens —
-/// `NatsSourceConfig` / `NatsSinkConfig` both derive `Debug` and carry
-/// an `AuthMode`, so any `debug!("{cfg:?}")` or panic backtrace would
-/// otherwise log secrets.
+/// NATS user-authentication mode. Custom `Debug` redacts secrets
+/// because the parent config structs derive `Debug`.
 #[derive(Clone, Default, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum AuthMode {
-    /// No authentication.
     #[default]
     None,
-    /// Username + password (one of the most common NATS auth shapes).
     UserPass {
-        /// Username.
         user: String,
-        /// Password.
         password: String,
     },
-    /// Plain-text bearer token.
     Token(String),
-    /// Path to a NATS credentials file (typically `.creds` from
-    /// NATS Cloud / NSC).
     CredsFile(String),
 }
 
@@ -102,14 +92,12 @@ impl std::fmt::Debug for AuthMode {
                 .field("password", &"<redacted>")
                 .finish(),
             Self::Token(_) => f.debug_tuple("Token").field(&"<redacted>").finish(),
-            // File paths aren't secrets themselves — the file contents are,
-            // and we don't store them in this enum.
             Self::CredsFile(path) => f.debug_tuple("CredsFile").field(path).finish(),
         }
     }
 }
 
-/// TLS transport configuration. Independent of [`AuthMode`].
+/// TLS transport configuration.
 #[derive(Debug, Clone, Default)]
 #[allow(missing_docs)]
 pub struct TlsConfig {
@@ -164,13 +152,9 @@ pub struct NatsSourceConfig {
 }
 
 impl NatsSourceConfig {
-    /// Parse the source config from a `ConnectorConfig`.
-    ///
     /// # Errors
     ///
-    /// Returns `ConnectorError::ConfigurationError` on missing required keys,
-    /// unparseable values, or violations of the startup-validation rules
-    /// that don't need server metadata.
+    /// `ConfigurationError` on any parse or validation failure.
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let servers = parse_servers(config)?;
         let mode = parse_or_default::<Mode>(config, "mode")?;
@@ -311,12 +295,9 @@ pub struct NatsSinkConfig {
 }
 
 impl NatsSinkConfig {
-    /// Parse the sink config from a `ConnectorConfig`.
-    ///
     /// # Errors
     ///
-    /// Returns `ConnectorError::ConfigurationError` on missing required keys,
-    /// unparseable values, or violations of startup-validation rules.
+    /// `ConfigurationError` on any parse or validation failure.
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let servers = parse_servers(config)?;
         let mode = parse_or_default::<Mode>(config, "mode")?;
@@ -533,8 +514,6 @@ fn parse_auth(config: &ConnectorConfig) -> Result<AuthMode, ConnectorError> {
     let mode = config.get("auth.mode").unwrap_or("none");
     match mode {
         "none" | "" => {
-            // Leftover credentials with auth.mode=none is a muddle. Fail
-            // loudly so the operator chooses one.
             if config.get("user").is_some()
                 || config.get("password").is_some()
                 || config.get("token").is_some()
@@ -595,13 +574,12 @@ fn parse_tls(config: &ConnectorConfig) -> Result<TlsConfig, ConnectorError> {
     })
 }
 
-/// Build `ConnectOptions` from parsed auth + TLS config. Shared by the
-/// source and the sink so they don't drift in how they apply these.
+/// Build `ConnectOptions` from parsed auth + TLS. Shared between
+/// source and sink.
 ///
 /// # Errors
 ///
-/// Returns `ConnectorError` if `auth.mode=creds_file` points at a file
-/// we can't read or that doesn't parse as a NATS credentials bundle.
+/// Returns `ConnectorError` if the creds file can't be read or parsed.
 pub(super) fn build_connect_options(
     auth: &AuthMode,
     tls: &TlsConfig,
@@ -622,8 +600,6 @@ pub(super) fn build_connect_options(
                 .map_err(|e| cfg_err(&format!("creds.file '{path}' invalid: {e}")))?;
         }
     }
-    // Any TLS-related key turns on the requirement. Operators who want
-    // plain TCP just leave the TLS keys unset.
     let tls_touched = tls.enabled || tls.ca_location.is_some() || tls.cert_location.is_some();
     if tls_touched {
         opts = opts.require_tls(true);

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -82,6 +82,9 @@ pub enum AuthMode {
     },
     /// Plain-text bearer token.
     Token(String),
+    /// Path to a NATS credentials file (typically `.creds` from
+    /// NATS Cloud / NSC).
+    CredsFile(String),
 }
 
 /// TLS transport configuration. Independent of [`AuthMode`].
@@ -121,6 +124,9 @@ pub struct NatsSourceConfig {
     /// Consecutive fetch errors before `health_check` reports
     /// `Unhealthy`. Zero disables the flip.
     pub fetch_error_threshold: u32,
+    /// Interval between `consumer.info()` polls that feed the
+    /// `nats_source_consumer_lag` gauge. Zero disables the poll.
+    pub lag_poll_interval: Duration,
 
     // Core
     pub queue_group: Option<String>,
@@ -168,6 +174,8 @@ impl NatsSourceConfig {
             parse_duration_ms(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
         let fetch_max_bytes = parse_usize(config, "fetch.max.bytes", 1 << 20)?;
         let fetch_error_threshold = parse_u32(config, "fetch.error.threshold", 10)?;
+        let lag_poll_interval =
+            parse_duration_ms(config, "lag.poll.interval.ms", Duration::from_secs(10))?;
         let queue_group = config.get("queue.group").map(str::to_string);
         let format = parse_format(config)?;
         let include_metadata = parse_bool(config, "include.metadata", false)?;
@@ -195,6 +203,7 @@ impl NatsSourceConfig {
             fetch_max_wait,
             fetch_max_bytes,
             fetch_error_threshold,
+            lag_poll_interval,
             queue_group,
             format,
             include_metadata,
@@ -465,6 +474,7 @@ fn parse_auth(config: &ConnectorConfig) -> Result<AuthMode, ConnectorError> {
             if config.get("user").is_some()
                 || config.get("password").is_some()
                 || config.get("token").is_some()
+                || config.get("creds.file").is_some()
             {
                 return Err(cfg_err(
                     "[LDB-5063] credentials set but auth.mode=none; \
@@ -491,8 +501,15 @@ fn parse_auth(config: &ConnectorConfig) -> Result<AuthMode, ConnectorError> {
                 .to_string();
             Ok(AuthMode::Token(token))
         }
+        "creds_file" => {
+            let path = config
+                .get("creds.file")
+                .ok_or_else(|| cfg_err("[LDB-5064] auth.mode=creds_file requires 'creds.file'"))?
+                .to_string();
+            Ok(AuthMode::CredsFile(path))
+        }
         other => Err(cfg_err(&format!(
-            "invalid auth.mode '{other}'; expected none | user_pass | token"
+            "invalid auth.mode '{other}'; expected none | user_pass | token | creds_file"
         ))),
     }
 }
@@ -516,10 +533,15 @@ fn parse_tls(config: &ConnectorConfig) -> Result<TlsConfig, ConnectorError> {
 
 /// Build `ConnectOptions` from parsed auth + TLS config. Shared by the
 /// source and the sink so they don't drift in how they apply these.
+///
+/// # Errors
+///
+/// Returns `ConnectorError` if `auth.mode=creds_file` points at a file
+/// we can't read or that doesn't parse as a NATS credentials bundle.
 pub(super) fn build_connect_options(
     auth: &AuthMode,
     tls: &TlsConfig,
-) -> async_nats::ConnectOptions {
+) -> Result<async_nats::ConnectOptions, ConnectorError> {
     let mut opts = async_nats::ConnectOptions::new();
     match auth {
         AuthMode::None => {}
@@ -528,6 +550,12 @@ pub(super) fn build_connect_options(
         }
         AuthMode::Token(token) => {
             opts = opts.token(token.clone());
+        }
+        AuthMode::CredsFile(path) => {
+            let contents = std::fs::read_to_string(path)
+                .map_err(|e| cfg_err(&format!("creds.file '{path}': {e}")))?;
+            opts = async_nats::ConnectOptions::with_credentials(&contents)
+                .map_err(|e| cfg_err(&format!("creds.file '{path}' invalid: {e}")))?;
         }
     }
     // Any TLS-related key turns on the requirement. Operators who want
@@ -542,7 +570,7 @@ pub(super) fn build_connect_options(
     if let (Some(cert), Some(key)) = (&tls.cert_location, &tls.key_location) {
         opts = opts.add_client_certificate(cert.into(), key.into());
     }
-    opts
+    Ok(opts)
 }
 
 #[cfg(test)]
@@ -826,6 +854,27 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("LDB-5063"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_creds_file_requires_path() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("auth.mode", "creds_file")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("LDB-5064"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_creds_file_happy_path() {
+        let parsed = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("auth.mode", "creds_file"),
+            ("creds.file", "/secrets/user.creds"),
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.auth,
+            AuthMode::CredsFile("/secrets/user.creds".into())
+        );
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -1,9 +1,4 @@
 //! NATS source and sink configuration.
-//!
-//! Parsing + startup validation for the six hard-fail rules from the plan
-//! that can be checked without a live NATS connection. The remaining two
-//! rules (ack-wait vs checkpoint interval, duplicate-window vs max-deliver)
-//! need server-side metadata and run in `open()` — not here.
 
 use std::time::Duration;
 
@@ -89,19 +84,13 @@ pub enum AuthMode {
     Token(String),
 }
 
-/// TLS transport configuration.
-///
-/// Independent of [`AuthMode`] — real deployments usually pair TLS with
-/// user/password or token auth on top.
+/// TLS transport configuration. Independent of [`AuthMode`].
 #[derive(Debug, Clone, Default)]
+#[allow(missing_docs)]
 pub struct TlsConfig {
-    /// Require the connection to upgrade to TLS.
     pub enabled: bool,
-    /// PEM-encoded CA certificate used to verify the server.
     pub ca_location: Option<String>,
-    /// Client certificate for mutual TLS (paired with `key_location`).
     pub cert_location: Option<String>,
-    /// Client private key for mutual TLS (paired with `cert_location`).
     pub key_location: Option<String>,
 }
 
@@ -129,9 +118,8 @@ pub struct NatsSourceConfig {
     pub fetch_batch: usize,
     pub fetch_max_wait: Duration,
     pub fetch_max_bytes: usize,
-    /// Consecutive fetch errors before the source is reported
-    /// `Unhealthy`. Zero disables the health flip (an escape hatch for
-    /// tests that need to decouple health from error counts).
+    /// Consecutive fetch errors before `health_check` reports
+    /// `Unhealthy`. Zero disables the flip.
     pub fetch_error_threshold: u32,
 
     // Core
@@ -279,12 +267,9 @@ pub struct NatsSinkConfig {
     pub expected_stream: Option<String>,
     pub delivery_guarantee: DeliveryGuarantee,
     pub dedup_id_column: Option<String>,
-    /// Minimum `duplicate_window` the target stream must be configured
-    /// with when `delivery.guarantee=exactly_once`. Parsed from
-    /// `min.duplicate.window.ms`; defaults to 2 minutes. The sink
-    /// refuses to start if the stream's actual window is shorter, since
-    /// a short window means rollback redelivery can land outside the
-    /// dedup horizon and produce duplicates silently.
+    /// Stream's `duplicate_window` must be at least this long under
+    /// exactly-once — else rollback redelivery can land outside the
+    /// dedup horizon.
     pub min_duplicate_window: Duration,
     pub max_pending: usize,
     pub ack_timeout: Duration,

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -1,0 +1,592 @@
+//! NATS source and sink configuration.
+//!
+//! Parsing + startup validation for the six hard-fail rules from the plan
+//! that can be checked without a live NATS connection. The remaining two
+//! rules (ack-wait vs checkpoint interval, duplicate-window vs max-deliver)
+//! need server-side metadata and run in `open()` — not here.
+
+use std::time::Duration;
+
+use crate::config::ConnectorConfig;
+use crate::connector::DeliveryGuarantee;
+use crate::error::ConnectorError;
+use crate::serde::Format;
+
+/// NATS connector mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Mode {
+    /// Plain NATS pub/sub. No durability, no replay, at-most-once.
+    Core,
+    /// `JetStream` with durable pull consumers. Default.
+    #[default]
+    JetStream,
+}
+
+str_enum!(fromstr Mode, lowercase, ConnectorError, "invalid nats mode",
+    Core => "core";
+    JetStream => "jetstream"
+);
+
+/// `JetStream` consumer ack policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AckPolicy {
+    /// Each message acked individually. Default.
+    #[default]
+    Explicit,
+    /// No ack required (fire-and-forget within JS).
+    None,
+}
+
+str_enum!(fromstr AckPolicy, lowercase, ConnectorError, "invalid ack.policy",
+    Explicit => "explicit";
+    None => "none"
+);
+
+/// `JetStream` consumer delivery policy — where to start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DeliverPolicy {
+    /// Replay every message retained by the stream. Default.
+    #[default]
+    All,
+    /// Only messages published after consumer creation.
+    New,
+    /// Start from a user-supplied stream sequence.
+    ByStartSequence,
+    /// Start from a user-supplied timestamp.
+    ByStartTime,
+}
+
+str_enum!(fromstr DeliverPolicy, lowercase, ConnectorError, "invalid deliver.policy",
+    All => "all";
+    New => "new";
+    ByStartSequence => "by_start_sequence";
+    ByStartTime => "by_start_time"
+);
+
+/// Where the sink gets the subject to publish to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubjectSpec {
+    /// A single literal subject used for every row.
+    Literal(String),
+    /// Per-row: read the named column and use its string value.
+    Column(String),
+}
+
+/// NATS source configuration.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)] // one-line `///` per field noises up the config struct
+pub struct NatsSourceConfig {
+    pub servers: Vec<String>,
+    pub mode: Mode,
+
+    // JetStream
+    pub stream: Option<String>,
+    pub subject: Option<String>,
+    pub subject_filters: Vec<String>,
+    pub consumer: Option<String>,
+    pub deliver_policy: DeliverPolicy,
+    pub start_sequence: Option<u64>,
+    pub start_time: Option<String>, // RFC3339; parsed against the NATS client's time type in open()
+    pub ack_policy: AckPolicy,
+    pub ack_wait: Duration,
+    pub max_deliver: i64,
+    pub max_ack_pending: i64,
+    pub fetch_batch: usize,
+    pub fetch_max_wait: Duration,
+    pub fetch_max_bytes: usize,
+
+    // Core
+    pub queue_group: Option<String>,
+
+    // Format / metadata
+    pub format: Format,
+    pub include_metadata: bool,
+    pub include_headers: bool,
+    pub event_time_column: Option<String>,
+
+    // Error handling
+    pub poison_dlq_subject: Option<String>,
+}
+
+impl NatsSourceConfig {
+    /// Parse the source config from a `ConnectorConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConnectorError::ConfigurationError` on missing required keys,
+    /// unparseable values, or violations of the startup-validation rules
+    /// that don't need server metadata.
+    pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
+        let servers = parse_servers(config)?;
+        let mode = parse_or_default::<Mode>(config, "mode")?;
+
+        let stream = config.get("stream").map(str::to_string);
+        let subject = config.get("subject").map(str::to_string);
+        let subject_filters = config
+            .get("subject.filters")
+            .map(split_csv)
+            .unwrap_or_default();
+        let consumer = config.get("consumer").map(str::to_string);
+        let deliver_policy = parse_or_default::<DeliverPolicy>(config, "deliver.policy")?;
+        let start_sequence = parse_opt_u64(config, "start.sequence")?;
+        let start_time = config.get("start.time").map(str::to_string);
+        let ack_policy = parse_or_default::<AckPolicy>(config, "ack.policy")?;
+        let ack_wait = parse_duration_ms(config, "ack.wait.ms", Duration::from_secs(60))?;
+        let max_deliver = parse_i64(config, "max.deliver", 5)?;
+        let max_ack_pending = parse_i64(config, "max.ack.pending", 10_000)?;
+        let fetch_batch = parse_usize(config, "fetch.batch", 500)?;
+        let fetch_max_wait =
+            parse_duration_ms(config, "fetch.max.wait.ms", Duration::from_millis(500))?;
+        let fetch_max_bytes = parse_usize(config, "fetch.max.bytes", 1 << 20)?;
+        let queue_group = config.get("queue.group").map(str::to_string);
+        let format = parse_format(config)?;
+        let include_metadata = parse_bool(config, "include.metadata", false)?;
+        let include_headers = parse_bool(config, "include.headers", false)?;
+        let event_time_column = config.get("event.time.column").map(str::to_string);
+        let poison_dlq_subject = config.get("poison.dlq.subject").map(str::to_string);
+
+        let cfg = Self {
+            servers,
+            mode,
+            stream,
+            subject,
+            subject_filters,
+            consumer,
+            deliver_policy,
+            start_sequence,
+            start_time,
+            ack_policy,
+            ack_wait,
+            max_deliver,
+            max_ack_pending,
+            fetch_batch,
+            fetch_max_wait,
+            fetch_max_bytes,
+            queue_group,
+            format,
+            include_metadata,
+            include_headers,
+            event_time_column,
+            poison_dlq_subject,
+        };
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    fn validate(&self) -> Result<(), ConnectorError> {
+        match self.mode {
+            Mode::JetStream => {
+                if self.stream.is_none() {
+                    return Err(cfg_err(
+                        "[LDB-5040] jetstream mode requires 'stream' to be set",
+                    ));
+                }
+                if self.consumer.is_none() {
+                    return Err(cfg_err(
+                        "[LDB-5041] jetstream mode requires 'consumer' (durable name) — \
+                         ephemeral consumers are not supported",
+                    ));
+                }
+                if self.subject.is_none() && self.subject_filters.is_empty() {
+                    return Err(cfg_err(
+                        "[LDB-5042] jetstream mode requires 'subject' or 'subject.filters' \
+                         — the consumer must have at least one filter",
+                    ));
+                }
+                if matches!(self.deliver_policy, DeliverPolicy::ByStartSequence)
+                    && self.start_sequence.is_none()
+                {
+                    return Err(cfg_err(
+                        "[LDB-5043] deliver.policy=by_start_sequence requires 'start.sequence'",
+                    ));
+                }
+                if matches!(self.deliver_policy, DeliverPolicy::ByStartTime)
+                    && self.start_time.is_none()
+                {
+                    return Err(cfg_err(
+                        "[LDB-5044] deliver.policy=by_start_time requires 'start.time'",
+                    ));
+                }
+            }
+            Mode::Core => {
+                if self.subject.is_none() {
+                    return Err(cfg_err(
+                        "[LDB-5045] core mode requires 'subject' (JetStream stream config \
+                         does not apply)",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// NATS sink configuration.
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
+pub struct NatsSinkConfig {
+    pub servers: Vec<String>,
+    pub mode: Mode,
+    pub stream: Option<String>,
+    pub subject: SubjectSpec,
+    pub expected_stream: Option<String>,
+    pub delivery_guarantee: DeliveryGuarantee,
+    pub dedup_id_column: Option<String>,
+    pub max_pending: usize,
+    pub ack_timeout: Duration,
+    pub flush_batch_size: usize,
+    pub format: Format,
+    pub header_columns: Vec<String>,
+    pub poison_dlq_subject: Option<String>,
+}
+
+impl NatsSinkConfig {
+    /// Parse the sink config from a `ConnectorConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConnectorError::ConfigurationError` on missing required keys,
+    /// unparseable values, or violations of startup-validation rules.
+    pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
+        let servers = parse_servers(config)?;
+        let mode = parse_or_default::<Mode>(config, "mode")?;
+
+        let subject = match (config.get("subject"), config.get("subject.column")) {
+            (Some(s), None) => SubjectSpec::Literal(s.to_string()),
+            (None, Some(col)) => SubjectSpec::Column(col.to_string()),
+            (Some(_), Some(_)) => {
+                return Err(cfg_err(
+                    "[LDB-5050] set 'subject' OR 'subject.column', not both",
+                ));
+            }
+            (None, None) => {
+                return Err(cfg_err(
+                    "[LDB-5051] 'subject' or 'subject.column' is required",
+                ));
+            }
+        };
+
+        let delivery_guarantee =
+            parse_or_default::<DeliveryGuarantee>(config, "delivery.guarantee")
+                .map_err(|_| cfg_err("[LDB-5052] invalid delivery.guarantee"))?;
+        let dedup_id_column = config.get("dedup.id.column").map(str::to_string);
+
+        let cfg = Self {
+            servers,
+            mode,
+            stream: config.get("stream").map(str::to_string),
+            subject,
+            expected_stream: config.get("expected.stream").map(str::to_string),
+            delivery_guarantee,
+            dedup_id_column,
+            max_pending: parse_usize(config, "max.pending", 4096)?,
+            ack_timeout: parse_duration_ms(config, "ack.timeout.ms", Duration::from_secs(30))?,
+            flush_batch_size: parse_usize(config, "flush.batch.size", 1000)?,
+            format: parse_format(config)?,
+            header_columns: config
+                .get("header.columns")
+                .map(split_csv)
+                .unwrap_or_default(),
+            poison_dlq_subject: config.get("poison.dlq.subject").map(str::to_string),
+        };
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    fn validate(&self) -> Result<(), ConnectorError> {
+        if self.mode == Mode::Core && self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+            return Err(cfg_err(
+                "[LDB-5053] delivery.guarantee=exactly_once is not supported in mode=core \
+                 (no server-side dedup); use mode=jetstream",
+            ));
+        }
+        if self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce
+            && self.dedup_id_column.is_none()
+        {
+            return Err(cfg_err(
+                "[LDB-5054] delivery.guarantee=exactly_once requires 'dedup.id.column' — \
+                 msg-id dedup with epoch-row hashing is not supported (deterministic replay \
+                 is too fragile; name a unique-per-row column)",
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ── helpers ──
+
+fn cfg_err(msg: &str) -> ConnectorError {
+    ConnectorError::ConfigurationError(msg.to_string())
+}
+
+fn parse_servers(config: &ConnectorConfig) -> Result<Vec<String>, ConnectorError> {
+    let raw = config.require("servers")?;
+    let servers: Vec<String> = split_csv(raw);
+    if servers.is_empty() {
+        return Err(cfg_err("[LDB-5030] 'servers' must not be empty"));
+    }
+    Ok(servers)
+}
+
+fn split_csv(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn parse_or_default<T: std::str::FromStr + Default>(
+    config: &ConnectorConfig,
+    key: &str,
+) -> Result<T, ConnectorError>
+where
+    T::Err: std::fmt::Display,
+{
+    match config.get(key) {
+        Some(s) => s
+            .parse()
+            .map_err(|e: T::Err| cfg_err(&format!("invalid {key}: {e}"))),
+        None => Ok(T::default()),
+    }
+}
+
+fn parse_format(config: &ConnectorConfig) -> Result<Format, ConnectorError> {
+    match config.get("format") {
+        Some(s) => Format::parse(s).map_err(|e| cfg_err(&e.to_string())),
+        None => Ok(Format::Json),
+    }
+}
+
+fn parse_bool(config: &ConnectorConfig, key: &str, default: bool) -> Result<bool, ConnectorError> {
+    match config.get(key) {
+        Some(s) => s
+            .parse::<bool>()
+            .map_err(|_| cfg_err(&format!("{key} must be 'true' or 'false', got '{s}'"))),
+        None => Ok(default),
+    }
+}
+
+fn parse_opt_u64(config: &ConnectorConfig, key: &str) -> Result<Option<u64>, ConnectorError> {
+    config.get(key).map(|s| parse_int(key, s)).transpose()
+}
+
+fn parse_i64(config: &ConnectorConfig, key: &str, default: i64) -> Result<i64, ConnectorError> {
+    config.get(key).map_or(Ok(default), |s| parse_int(key, s))
+}
+
+fn parse_usize(
+    config: &ConnectorConfig,
+    key: &str,
+    default: usize,
+) -> Result<usize, ConnectorError> {
+    config.get(key).map_or(Ok(default), |s| parse_int(key, s))
+}
+
+fn parse_duration_ms(
+    config: &ConnectorConfig,
+    key: &str,
+    default: Duration,
+) -> Result<Duration, ConnectorError> {
+    config.get(key).map_or(Ok(default), |s| {
+        parse_int::<u64>(key, s).map(Duration::from_millis)
+    })
+}
+
+fn parse_int<T: std::str::FromStr>(key: &str, raw: &str) -> Result<T, ConnectorError> {
+    raw.parse::<T>()
+        .map_err(|_| cfg_err(&format!("{key} must be an integer, got '{raw}'")))
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_types)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn cfg(pairs: &[(&str, &str)]) -> ConnectorConfig {
+        let mut props = HashMap::new();
+        for (k, v) in pairs {
+            props.insert((*k).to_string(), (*v).to_string());
+        }
+        ConnectorConfig::with_properties("nats", props)
+    }
+
+    // ── source ──
+
+    #[test]
+    fn source_jetstream_requires_stream() {
+        let err = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("consumer", "c"),
+            ("subject", "x.>"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5040"), "got: {err}");
+    }
+
+    #[test]
+    fn source_jetstream_requires_consumer() {
+        let err = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("stream", "S"),
+            ("subject", "x.>"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5041"), "got: {err}");
+    }
+
+    #[test]
+    fn source_jetstream_requires_subject_or_filters() {
+        let err = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("stream", "S"),
+            ("consumer", "c"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5042"), "got: {err}");
+    }
+
+    #[test]
+    fn source_core_requires_subject() {
+        let err =
+            NatsSourceConfig::from_config(&cfg(&[("servers", "nats://a:4222"), ("mode", "core")]))
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("LDB-5045"), "got: {err}");
+    }
+
+    #[test]
+    fn source_by_start_sequence_requires_start_sequence() {
+        let err = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("stream", "S"),
+            ("consumer", "c"),
+            ("subject", "x.>"),
+            ("deliver.policy", "by_start_sequence"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5043"), "got: {err}");
+    }
+
+    #[test]
+    fn source_happy_path_jetstream() {
+        let parsed = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222,nats://b:4222"),
+            ("stream", "ORDERS"),
+            ("consumer", "laminar-orders"),
+            ("subject.filters", "orders.us.*,orders.eu.*"),
+            ("ack.wait.ms", "45000"),
+            ("max.deliver", "3"),
+            ("include.metadata", "true"),
+        ]))
+        .unwrap();
+        assert_eq!(parsed.servers.len(), 2);
+        assert_eq!(parsed.mode, Mode::JetStream);
+        assert_eq!(parsed.subject_filters, vec!["orders.us.*", "orders.eu.*"]);
+        assert_eq!(parsed.ack_wait, Duration::from_secs(45));
+        assert_eq!(parsed.max_deliver, 3);
+        assert!(parsed.include_metadata);
+    }
+
+    #[test]
+    fn source_happy_path_core() {
+        let parsed = NatsSourceConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("mode", "core"),
+            ("subject", "events"),
+            ("queue.group", "workers"),
+        ]))
+        .unwrap();
+        assert_eq!(parsed.mode, Mode::Core);
+        assert_eq!(parsed.subject.as_deref(), Some("events"));
+        assert_eq!(parsed.queue_group.as_deref(), Some("workers"));
+    }
+
+    // ── sink ──
+
+    #[test]
+    fn sink_rejects_subject_and_subject_column() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("subject", "x"),
+            ("subject.column", "c"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5050"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_rejects_neither_subject_nor_column() {
+        let err = NatsSinkConfig::from_config(&cfg(&[("servers", "nats://a:4222")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("LDB-5051"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_rejects_core_with_exactly_once() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("mode", "core"),
+            ("subject", "x"),
+            ("delivery.guarantee", "exactly_once"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5053"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_rejects_exactly_once_without_dedup_column() {
+        let err = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("stream", "OUT"),
+            ("subject", "x.processed"),
+            ("delivery.guarantee", "exactly_once"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5054"), "got: {err}");
+    }
+
+    #[test]
+    fn sink_happy_path_exactly_once() {
+        let parsed = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("stream", "OUT"),
+            ("subject.column", "out_subject"),
+            ("delivery.guarantee", "exactly_once"),
+            ("dedup.id.column", "event_id"),
+            ("header.columns", "trace_id,tenant"),
+        ]))
+        .unwrap();
+        assert_eq!(parsed.subject, SubjectSpec::Column("out_subject".into()));
+        assert_eq!(parsed.delivery_guarantee, DeliveryGuarantee::ExactlyOnce);
+        assert_eq!(parsed.dedup_id_column.as_deref(), Some("event_id"));
+        assert_eq!(parsed.header_columns, vec!["trace_id", "tenant"]);
+    }
+
+    // ── servers ──
+
+    #[test]
+    fn servers_required() {
+        let err = NatsSourceConfig::from_config(&cfg(&[]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("servers"), "got: {err}");
+    }
+
+    #[test]
+    fn servers_empty_csv_rejected() {
+        let err = NatsSourceConfig::from_config(&cfg(&[("servers", ",,")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("LDB-5030"), "got: {err}");
+    }
+}

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -72,12 +72,47 @@ pub enum SubjectSpec {
     Column(String),
 }
 
+/// NATS user-authentication mode.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum AuthMode {
+    /// No authentication.
+    #[default]
+    None,
+    /// Username + password (one of the most common NATS auth shapes).
+    UserPass {
+        /// Username.
+        user: String,
+        /// Password.
+        password: String,
+    },
+    /// Plain-text bearer token.
+    Token(String),
+}
+
+/// TLS transport configuration.
+///
+/// Independent of [`AuthMode`] — real deployments usually pair TLS with
+/// user/password or token auth on top.
+#[derive(Debug, Clone, Default)]
+pub struct TlsConfig {
+    /// Require the connection to upgrade to TLS.
+    pub enabled: bool,
+    /// PEM-encoded CA certificate used to verify the server.
+    pub ca_location: Option<String>,
+    /// Client certificate for mutual TLS (paired with `key_location`).
+    pub cert_location: Option<String>,
+    /// Client private key for mutual TLS (paired with `cert_location`).
+    pub key_location: Option<String>,
+}
+
 /// NATS source configuration.
 #[derive(Debug, Clone)]
 #[allow(missing_docs)] // one-line `///` per field noises up the config struct
 pub struct NatsSourceConfig {
     pub servers: Vec<String>,
     pub mode: Mode,
+    pub auth: AuthMode,
+    pub tls: TlsConfig,
 
     // JetStream
     pub stream: Option<String>,
@@ -119,6 +154,8 @@ impl NatsSourceConfig {
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let servers = parse_servers(config)?;
         let mode = parse_or_default::<Mode>(config, "mode")?;
+        let auth = parse_auth(config)?;
+        let tls = parse_tls(config)?;
 
         let stream = config.get("stream").map(str::to_string);
         let subject = config.get("subject").map(str::to_string);
@@ -148,6 +185,8 @@ impl NatsSourceConfig {
         let cfg = Self {
             servers,
             mode,
+            auth,
+            tls,
             stream,
             subject,
             subject_filters,
@@ -227,6 +266,8 @@ impl NatsSourceConfig {
 pub struct NatsSinkConfig {
     pub servers: Vec<String>,
     pub mode: Mode,
+    pub auth: AuthMode,
+    pub tls: TlsConfig,
     pub stream: Option<String>,
     pub subject: SubjectSpec,
     pub expected_stream: Option<String>,
@@ -257,6 +298,8 @@ impl NatsSinkConfig {
     pub fn from_config(config: &ConnectorConfig) -> Result<Self, ConnectorError> {
         let servers = parse_servers(config)?;
         let mode = parse_or_default::<Mode>(config, "mode")?;
+        let auth = parse_auth(config)?;
+        let tls = parse_tls(config)?;
 
         let subject = match (config.get("subject"), config.get("subject.column")) {
             (Some(s), None) => SubjectSpec::Literal(s.to_string()),
@@ -281,6 +324,8 @@ impl NatsSinkConfig {
         let cfg = Self {
             servers,
             mode,
+            auth,
+            tls,
             stream: config.get("stream").map(str::to_string),
             subject,
             expected_stream: config.get("expected.stream").map(str::to_string),
@@ -414,6 +459,95 @@ fn parse_duration_ms(
 fn parse_int<T: std::str::FromStr>(key: &str, raw: &str) -> Result<T, ConnectorError> {
     raw.parse::<T>()
         .map_err(|_| cfg_err(&format!("{key} must be an integer, got '{raw}'")))
+}
+
+fn parse_auth(config: &ConnectorConfig) -> Result<AuthMode, ConnectorError> {
+    let mode = config.get("auth.mode").unwrap_or("none");
+    match mode {
+        "none" | "" => {
+            // Leftover credentials with auth.mode=none is a muddle. Fail
+            // loudly so the operator chooses one.
+            if config.get("user").is_some()
+                || config.get("password").is_some()
+                || config.get("token").is_some()
+            {
+                return Err(cfg_err(
+                    "[LDB-5063] credentials set but auth.mode=none; \
+                     set auth.mode explicitly or remove the credentials",
+                ));
+            }
+            Ok(AuthMode::None)
+        }
+        "user_pass" => {
+            let user = config
+                .get("user")
+                .ok_or_else(|| cfg_err("[LDB-5060] auth.mode=user_pass requires 'user'"))?
+                .to_string();
+            let password = config
+                .get("password")
+                .ok_or_else(|| cfg_err("[LDB-5060] auth.mode=user_pass requires 'password'"))?
+                .to_string();
+            Ok(AuthMode::UserPass { user, password })
+        }
+        "token" => {
+            let token = config
+                .get("token")
+                .ok_or_else(|| cfg_err("[LDB-5061] auth.mode=token requires 'token'"))?
+                .to_string();
+            Ok(AuthMode::Token(token))
+        }
+        other => Err(cfg_err(&format!(
+            "invalid auth.mode '{other}'; expected none | user_pass | token"
+        ))),
+    }
+}
+
+fn parse_tls(config: &ConnectorConfig) -> Result<TlsConfig, ConnectorError> {
+    let cert_location = config.get("tls.cert.location").map(str::to_string);
+    let key_location = config.get("tls.key.location").map(str::to_string);
+    if cert_location.is_some() != key_location.is_some() {
+        return Err(cfg_err(
+            "[LDB-5062] tls.cert.location and tls.key.location must both be set \
+             (mutual-TLS client cert) or both be unset",
+        ));
+    }
+    Ok(TlsConfig {
+        enabled: parse_bool(config, "tls.enabled", false)?,
+        ca_location: config.get("tls.ca.location").map(str::to_string),
+        cert_location,
+        key_location,
+    })
+}
+
+/// Build `ConnectOptions` from parsed auth + TLS config. Shared by the
+/// source and the sink so they don't drift in how they apply these.
+pub(super) fn build_connect_options(
+    auth: &AuthMode,
+    tls: &TlsConfig,
+) -> async_nats::ConnectOptions {
+    let mut opts = async_nats::ConnectOptions::new();
+    match auth {
+        AuthMode::None => {}
+        AuthMode::UserPass { user, password } => {
+            opts = opts.user_and_password(user.clone(), password.clone());
+        }
+        AuthMode::Token(token) => {
+            opts = opts.token(token.clone());
+        }
+    }
+    // Any TLS-related key turns on the requirement. Operators who want
+    // plain TCP just leave the TLS keys unset.
+    let tls_touched = tls.enabled || tls.ca_location.is_some() || tls.cert_location.is_some();
+    if tls_touched {
+        opts = opts.require_tls(true);
+    }
+    if let Some(ca) = &tls.ca_location {
+        opts = opts.add_root_certificates(ca.into());
+    }
+    if let (Some(cert), Some(key)) = (&tls.cert_location, &tls.key_location) {
+        opts = opts.add_client_certificate(cert.into(), key.into());
+    }
+    opts
 }
 
 #[cfg(test)]
@@ -619,5 +753,147 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("LDB-5030"), "got: {err}");
+    }
+
+    // ── auth ──
+
+    fn jetstream_happy(pairs: &[(&str, &str)]) -> ConnectorConfig {
+        let mut base = vec![
+            ("servers", "nats://a:4222"),
+            ("stream", "S"),
+            ("consumer", "c"),
+            ("subject", "x.>"),
+        ];
+        base.extend_from_slice(pairs);
+        cfg(&base)
+    }
+
+    #[test]
+    fn auth_user_pass_requires_user() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("auth.mode", "user_pass"),
+            ("password", "secret"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5060"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_user_pass_requires_password() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("auth.mode", "user_pass"),
+            ("user", "alice"),
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5060"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_user_pass_happy_path() {
+        let parsed = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("auth.mode", "user_pass"),
+            ("user", "alice"),
+            ("password", "wonderland"),
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.auth,
+            AuthMode::UserPass {
+                user: "alice".into(),
+                password: "wonderland".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn auth_token_requires_token() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("auth.mode", "token")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("LDB-5061"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_token_happy_path() {
+        let parsed = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("auth.mode", "token"),
+            ("token", "abc123"),
+        ]))
+        .unwrap();
+        assert_eq!(parsed.auth, AuthMode::Token("abc123".into()));
+    }
+
+    #[test]
+    fn auth_none_with_stray_credentials_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("user", "alice")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("LDB-5063"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_unknown_mode_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[("auth.mode", "banana")]))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid auth.mode"), "got: {err}");
+    }
+
+    // ── tls ──
+
+    #[test]
+    fn tls_cert_without_key_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[(
+            "tls.cert.location",
+            "/certs/client.pem",
+        )]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5062"), "got: {err}");
+    }
+
+    #[test]
+    fn tls_key_without_cert_rejected() {
+        let err = NatsSourceConfig::from_config(&jetstream_happy(&[(
+            "tls.key.location",
+            "/certs/client.key",
+        )]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("LDB-5062"), "got: {err}");
+    }
+
+    #[test]
+    fn tls_happy_path() {
+        let parsed = NatsSourceConfig::from_config(&jetstream_happy(&[
+            ("tls.enabled", "true"),
+            ("tls.ca.location", "/certs/ca.pem"),
+            ("tls.cert.location", "/certs/client.pem"),
+            ("tls.key.location", "/certs/client.key"),
+        ]))
+        .unwrap();
+        assert!(parsed.tls.enabled);
+        assert_eq!(parsed.tls.ca_location.as_deref(), Some("/certs/ca.pem"));
+        assert_eq!(
+            parsed.tls.cert_location.as_deref(),
+            Some("/certs/client.pem")
+        );
+    }
+
+    #[test]
+    fn auth_and_tls_on_sink() {
+        let parsed = NatsSinkConfig::from_config(&cfg(&[
+            ("servers", "nats://a:4222"),
+            ("subject", "x"),
+            ("auth.mode", "user_pass"),
+            ("user", "alice"),
+            ("password", "wonderland"),
+            ("tls.enabled", "true"),
+        ]))
+        .unwrap();
+        assert!(matches!(parsed.auth, AuthMode::UserPass { .. }));
+        assert!(parsed.tls.enabled);
     }
 }

--- a/crates/laminar-connectors/src/nats/config.rs
+++ b/crates/laminar-connectors/src/nats/config.rs
@@ -314,7 +314,7 @@ impl NatsSinkConfig {
             expected_stream: config.get("expected.stream").map(str::to_string),
             delivery_guarantee,
             dedup_id_column,
-            min_duplicate_window: parse_duration_ms(
+            min_duplicate_window: require_positive_duration(
                 config,
                 "min.duplicate.window.ms",
                 Duration::from_secs(120),

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -1,0 +1,291 @@
+//! NATS connector metrics.
+//!
+//! Mirrors the shape of `KafkaSourceMetrics` / `KafkaSinkMetrics`: a
+//! handful of Prometheus counters + gauges registered on the shared
+//! registry (if any), with a `record_*` method per interesting event
+//! and `to_connector_metrics()` folding down to the SDK's
+//! [`ConnectorMetrics`].
+//!
+//! We intentionally omit per-subject labels. NATS subjects are
+//! wildcard-addressable and often unbounded-cardinality; attaching
+//! them to a counter is a Prometheus footgun. If a user needs
+//! per-subject visibility, they should aggregate at the server side.
+
+use prometheus::{IntCounter, IntGauge, Registry};
+
+use crate::metrics::ConnectorMetrics;
+
+/// Prometheus counters for the NATS source.
+#[derive(Debug, Clone)]
+pub struct NatsSourceMetrics {
+    /// Total records delivered to `poll_batch` callers.
+    pub records_total: IntCounter,
+    /// Total bytes of payload delivered.
+    pub bytes_total: IntCounter,
+    /// Errors from `consumer.fetch()` (the pull loop).
+    pub fetch_errors_total: IntCounter,
+    /// Successful `JetStream` acks.
+    pub acks_total: IntCounter,
+    /// Ack failures (broker rejected, connection dropped mid-ack, etc).
+    pub ack_errors_total: IntCounter,
+    /// Retained message handles not yet acked (pending + sealed).
+    pub pending_acks: IntGauge,
+}
+
+impl NatsSourceMetrics {
+    /// All counters start at zero. If `registry` is `Some`, the metrics
+    /// register on it; otherwise a local throwaway registry is used.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        macro_rules! reg_c {
+            ($name:expr, $help:expr) => {{
+                let c = IntCounter::new($name, $help).unwrap();
+                let _ = reg.register(Box::new(c.clone()));
+                c
+            }};
+        }
+        let pending_acks =
+            IntGauge::new("nats_source_pending_acks", "Unacked JetStream messages").unwrap();
+        let _ = reg.register(Box::new(pending_acks.clone()));
+
+        Self {
+            records_total: reg_c!(
+                "nats_source_records_total",
+                "Records delivered to poll_batch"
+            ),
+            bytes_total: reg_c!("nats_source_bytes_total", "Payload bytes delivered"),
+            fetch_errors_total: reg_c!(
+                "nats_source_fetch_errors_total",
+                "Errors from consumer.fetch()"
+            ),
+            acks_total: reg_c!("nats_source_acks_total", "Successful JetStream acks"),
+            ack_errors_total: reg_c!("nats_source_ack_errors_total", "Failed acks"),
+            pending_acks,
+        }
+    }
+
+    /// Records a poll batch of `records` with `bytes` total payload.
+    pub fn record_poll(&self, records: u64, bytes: u64) {
+        self.records_total.inc_by(records);
+        self.bytes_total.inc_by(bytes);
+    }
+
+    /// Records a fetch-loop error.
+    pub fn record_fetch_error(&self) {
+        self.fetch_errors_total.inc();
+    }
+
+    /// Records one successful ack.
+    pub fn record_ack(&self) {
+        self.acks_total.inc();
+    }
+
+    /// Records one failed ack.
+    pub fn record_ack_error(&self) {
+        self.ack_errors_total.inc();
+    }
+
+    /// Sets the pending-ack gauge to `n`.
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn set_pending_acks(&self, n: usize) {
+        self.pending_acks.set(n as i64);
+    }
+
+    /// Folds to the SDK's [`ConnectorMetrics`].
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+    pub fn to_connector_metrics(&self) -> ConnectorMetrics {
+        let mut m = ConnectorMetrics {
+            records_total: self.records_total.get(),
+            bytes_total: self.bytes_total.get(),
+            errors_total: self.fetch_errors_total.get() + self.ack_errors_total.get(),
+            lag: self.pending_acks.get() as u64,
+            custom: Vec::new(),
+        };
+        m.add_custom("nats.acks", self.acks_total.get() as f64);
+        m.add_custom("nats.ack_errors", self.ack_errors_total.get() as f64);
+        m
+    }
+}
+
+impl Default for NatsSourceMetrics {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+/// Prometheus counters for the NATS sink.
+#[derive(Debug, Clone)]
+pub struct NatsSinkMetrics {
+    /// Total records published (one per row in `write_batch`).
+    pub records_total: IntCounter,
+    /// Total bytes of payload published.
+    pub bytes_total: IntCounter,
+    /// Publish errors (serialize → publish).
+    pub publish_errors_total: IntCounter,
+    /// Publish-ack errors (`JetStream` did not acknowledge within the
+    /// configured timeout, or returned an error status).
+    pub ack_errors_total: IntCounter,
+    /// Publishes the server identified as duplicates (arrived inside
+    /// `duplicate_window` with a repeated `Nats-Msg-Id`).
+    pub dedup_total: IntCounter,
+    /// Outstanding `PublishAckFuture`s.
+    pub pending_futures: IntGauge,
+}
+
+impl NatsSinkMetrics {
+    /// All counters start at zero. If `registry` is `Some`, the metrics
+    /// register on it.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new(registry: Option<&Registry>) -> Self {
+        let local;
+        let reg = if let Some(r) = registry {
+            r
+        } else {
+            local = Registry::new();
+            &local
+        };
+
+        macro_rules! reg_c {
+            ($name:expr, $help:expr) => {{
+                let c = IntCounter::new($name, $help).unwrap();
+                let _ = reg.register(Box::new(c.clone()));
+                c
+            }};
+        }
+        let pending_futures =
+            IntGauge::new("nats_sink_pending_futures", "Outstanding PublishAckFutures").unwrap();
+        let _ = reg.register(Box::new(pending_futures.clone()));
+
+        Self {
+            records_total: reg_c!("nats_sink_records_total", "Records published"),
+            bytes_total: reg_c!("nats_sink_bytes_total", "Payload bytes published"),
+            publish_errors_total: reg_c!("nats_sink_publish_errors_total", "Publish errors"),
+            ack_errors_total: reg_c!("nats_sink_ack_errors_total", "Publish-ack errors"),
+            dedup_total: reg_c!(
+                "nats_sink_dedup_total",
+                "Publishes identified by the server as duplicates"
+            ),
+            pending_futures,
+        }
+    }
+
+    /// Records a successful publish of `records` rows and `bytes` total.
+    pub fn record_publish(&self, records: u64, bytes: u64) {
+        self.records_total.inc_by(records);
+        self.bytes_total.inc_by(bytes);
+    }
+
+    /// Records one publish error.
+    pub fn record_publish_error(&self) {
+        self.publish_errors_total.inc();
+    }
+
+    /// Records one ack error.
+    pub fn record_ack_error(&self) {
+        self.ack_errors_total.inc();
+    }
+
+    /// Records one server-identified duplicate publish.
+    pub fn record_dedup(&self) {
+        self.dedup_total.inc();
+    }
+
+    /// Sets the pending-futures gauge.
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn set_pending_futures(&self, n: usize) {
+        self.pending_futures.set(n as i64);
+    }
+
+    /// Folds to the SDK's [`ConnectorMetrics`].
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+    pub fn to_connector_metrics(&self) -> ConnectorMetrics {
+        let mut m = ConnectorMetrics {
+            records_total: self.records_total.get(),
+            bytes_total: self.bytes_total.get(),
+            errors_total: self.publish_errors_total.get() + self.ack_errors_total.get(),
+            lag: self.pending_futures.get() as u64,
+            custom: Vec::new(),
+        };
+        m.add_custom("nats.dedup", self.dedup_total.get() as f64);
+        m
+    }
+}
+
+impl Default for NatsSinkMetrics {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_initial_zero() {
+        let m = NatsSourceMetrics::new(None);
+        let cm = m.to_connector_metrics();
+        assert_eq!(cm.records_total, 0);
+        assert_eq!(cm.bytes_total, 0);
+        assert_eq!(cm.errors_total, 0);
+        assert_eq!(cm.lag, 0);
+    }
+
+    #[test]
+    fn source_records_increment() {
+        let m = NatsSourceMetrics::new(None);
+        m.record_poll(100, 4096);
+        m.record_poll(50, 1024);
+        m.record_ack();
+        m.record_ack();
+        m.record_fetch_error();
+        m.set_pending_acks(7);
+
+        let cm = m.to_connector_metrics();
+        assert_eq!(cm.records_total, 150);
+        assert_eq!(cm.bytes_total, 5120);
+        assert_eq!(cm.errors_total, 1); // fetch error
+        assert_eq!(cm.lag, 7);
+        assert!(cm.custom.iter().any(|(k, v)| k == "nats.acks" && *v == 2.0));
+    }
+
+    #[test]
+    fn sink_records_and_dedup() {
+        let m = NatsSinkMetrics::new(None);
+        m.record_publish(10, 2048);
+        m.record_dedup();
+        m.record_dedup();
+        m.set_pending_futures(3);
+
+        let cm = m.to_connector_metrics();
+        assert_eq!(cm.records_total, 10);
+        assert_eq!(cm.lag, 3);
+        assert!(cm
+            .custom
+            .iter()
+            .any(|(k, v)| k == "nats.dedup" && *v == 2.0));
+    }
+
+    #[test]
+    fn metrics_register_on_shared_registry() {
+        let reg = Registry::new();
+        let _s = NatsSourceMetrics::new(Some(&reg));
+        let _k = NatsSinkMetrics::new(Some(&reg));
+        let names: Vec<String> = reg.gather().iter().map(|f| f.name().to_string()).collect();
+        assert!(names.contains(&"nats_source_records_total".to_string()));
+        assert!(names.contains(&"nats_sink_records_total".to_string()));
+        assert!(names.contains(&"nats_sink_dedup_total".to_string()));
+    }
+}

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -1,15 +1,5 @@
-//! NATS connector metrics.
-//!
-//! Mirrors the shape of `KafkaSourceMetrics` / `KafkaSinkMetrics`: a
-//! handful of Prometheus counters + gauges registered on the shared
-//! registry (if any), with a `record_*` method per interesting event
-//! and `to_connector_metrics()` folding down to the SDK's
-//! [`ConnectorMetrics`].
-//!
-//! We intentionally omit per-subject labels. NATS subjects are
-//! wildcard-addressable and often unbounded-cardinality; attaching
-//! them to a counter is a Prometheus footgun. If a user needs
-//! per-subject visibility, they should aggregate at the server side.
+//! NATS connector metrics. No per-subject labels — NATS subjects are
+//! wildcard-addressable and often unbounded-cardinality.
 
 use prometheus::{IntCounter, IntGauge, Registry};
 
@@ -17,24 +7,18 @@ use crate::metrics::ConnectorMetrics;
 
 /// Prometheus counters for the NATS source.
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub struct NatsSourceMetrics {
-    /// Total records delivered to `poll_batch` callers.
     pub records_total: IntCounter,
-    /// Total bytes of payload delivered.
     pub bytes_total: IntCounter,
-    /// Errors from `consumer.fetch()` (the pull loop).
     pub fetch_errors_total: IntCounter,
-    /// Successful `JetStream` acks.
     pub acks_total: IntCounter,
-    /// Ack failures (broker rejected, connection dropped mid-ack, etc).
     pub ack_errors_total: IntCounter,
-    /// Retained message handles not yet acked (pending + sealed).
     pub pending_acks: IntGauge,
 }
 
 impl NatsSourceMetrics {
-    /// All counters start at zero. If `registry` is `Some`, the metrics
-    /// register on it; otherwise a local throwaway registry is used.
+    /// Registers the metrics on `registry` if provided.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn new(registry: Option<&Registry>) -> Self {
@@ -73,39 +57,35 @@ impl NatsSourceMetrics {
         }
     }
 
-    /// Records a poll batch of `records` with `bytes` total payload.
+    /// Record a poll batch.
     pub fn record_poll(&self, records: u64, bytes: u64) {
         self.records_total.inc_by(records);
         self.bytes_total.inc_by(bytes);
     }
 
-    /// Records a fetch-loop error.
+    /// Record a fetch-loop error.
     pub fn record_fetch_error(&self) {
         self.fetch_errors_total.inc();
     }
 
-    /// Records one successful ack.
+    /// Record one successful ack.
     pub fn record_ack(&self) {
         self.acks_total.inc();
     }
 
-    /// Records one failed ack.
+    /// Record one failed ack.
     pub fn record_ack_error(&self) {
         self.ack_errors_total.inc();
     }
 
-    /// Sets the pending-ack gauge to `n`.
+    /// Set the pending-ack gauge.
     #[allow(clippy::cast_possible_wrap)]
     pub fn set_pending_acks(&self, n: usize) {
         self.pending_acks.set(n as i64);
     }
 
-    /// Folds to the SDK's [`ConnectorMetrics`].
-    ///
-    /// `lag` is reported as 0 until we poll `consumer.info()` for the
-    /// real broker-side (`last_seq` − `ack_floor`). Our `pending_acks`
-    /// is internal-buffer depth, not consumer lag — surfacing it as
-    /// `lag` would be apples-to-oranges next to the Kafka source.
+    /// Folds to the SDK's [`ConnectorMetrics`]. `lag` stays 0 until
+    /// we poll `consumer.info()` for the real broker-side lag.
     #[must_use]
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
@@ -125,28 +105,20 @@ impl NatsSourceMetrics {
 
 /// Prometheus counters for the NATS sink.
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub struct NatsSinkMetrics {
-    /// Total records published (one per row in `write_batch`).
     pub records_total: IntCounter,
-    /// Total bytes of payload published.
     pub bytes_total: IntCounter,
-    /// Publish errors (serialize → publish).
     pub publish_errors_total: IntCounter,
-    /// Publish-ack errors (`JetStream` did not acknowledge within the
-    /// configured timeout, or returned an error status).
     pub ack_errors_total: IntCounter,
-    /// Publishes the server identified as duplicates (arrived inside
-    /// `duplicate_window` with a repeated `Nats-Msg-Id`).
+    /// Publishes the server dropped as `Nats-Msg-Id` duplicates.
     pub dedup_total: IntCounter,
-    /// Epochs rolled back via `rollback_epoch`.
     pub epochs_rolled_back: IntCounter,
-    /// Outstanding `PublishAckFuture`s.
     pub pending_futures: IntGauge,
 }
 
 impl NatsSinkMetrics {
-    /// All counters start at zero. If `registry` is `Some`, the metrics
-    /// register on it.
+    /// Registers the metrics on `registry` if provided.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn new(registry: Option<&Registry>) -> Self {
@@ -183,35 +155,33 @@ impl NatsSinkMetrics {
         }
     }
 
-    /// Records one successfully published row of `bytes` payload.
-    /// Called per row, not per batch — a partial-failure batch still
-    /// gets accurate success counts.
+    /// Record one successful publish of `bytes`.
     pub fn record_published_row(&self, bytes: u64) {
         self.records_total.inc();
         self.bytes_total.inc_by(bytes);
     }
 
-    /// Records one publish error.
+    /// Record one publish error.
     pub fn record_publish_error(&self) {
         self.publish_errors_total.inc();
     }
 
-    /// Records one ack error.
+    /// Record one ack error.
     pub fn record_ack_error(&self) {
         self.ack_errors_total.inc();
     }
 
-    /// Records one server-identified duplicate publish.
+    /// Record one server-identified duplicate.
     pub fn record_dedup(&self) {
         self.dedup_total.inc();
     }
 
-    /// Records one epoch rollback.
+    /// Record one epoch rollback.
     pub fn record_rollback(&self) {
         self.epochs_rolled_back.inc();
     }
 
-    /// Sets the pending-futures gauge.
+    /// Set the pending-futures gauge.
     #[allow(clippy::cast_possible_wrap)]
     pub fn set_pending_futures(&self, n: usize) {
         self.pending_futures.set(n as i64);

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -101,6 +101,11 @@ impl NatsSourceMetrics {
     }
 
     /// Folds to the SDK's [`ConnectorMetrics`].
+    ///
+    /// `lag` is reported as 0 until we poll `consumer.info()` for the
+    /// real broker-side (`last_seq` − `ack_floor`). Our `pending_acks`
+    /// is internal-buffer depth, not consumer lag — surfacing it as
+    /// `lag` would be apples-to-oranges next to the Kafka source.
     #[must_use]
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
@@ -108,18 +113,13 @@ impl NatsSourceMetrics {
             records_total: self.records_total.get(),
             bytes_total: self.bytes_total.get(),
             errors_total: self.fetch_errors_total.get() + self.ack_errors_total.get(),
-            lag: self.pending_acks.get() as u64,
+            lag: 0,
             custom: Vec::new(),
         };
         m.add_custom("nats.acks", self.acks_total.get() as f64);
         m.add_custom("nats.ack_errors", self.ack_errors_total.get() as f64);
+        m.add_custom("nats.pending_acks", self.pending_acks.get() as f64);
         m
-    }
-}
-
-impl Default for NatsSourceMetrics {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 
@@ -138,6 +138,8 @@ pub struct NatsSinkMetrics {
     /// Publishes the server identified as duplicates (arrived inside
     /// `duplicate_window` with a repeated `Nats-Msg-Id`).
     pub dedup_total: IntCounter,
+    /// Epochs rolled back via `rollback_epoch`.
+    pub epochs_rolled_back: IntCounter,
     /// Outstanding `PublishAckFuture`s.
     pub pending_futures: IntGauge,
 }
@@ -176,13 +178,16 @@ impl NatsSinkMetrics {
                 "nats_sink_dedup_total",
                 "Publishes identified by the server as duplicates"
             ),
+            epochs_rolled_back: reg_c!("nats_sink_epochs_rolled_back_total", "Epochs rolled back"),
             pending_futures,
         }
     }
 
-    /// Records a successful publish of `records` rows and `bytes` total.
-    pub fn record_publish(&self, records: u64, bytes: u64) {
-        self.records_total.inc_by(records);
+    /// Records one successfully published row of `bytes` payload.
+    /// Called per row, not per batch — a partial-failure batch still
+    /// gets accurate success counts.
+    pub fn record_published_row(&self, bytes: u64) {
+        self.records_total.inc();
         self.bytes_total.inc_by(bytes);
     }
 
@@ -199,6 +204,11 @@ impl NatsSinkMetrics {
     /// Records one server-identified duplicate publish.
     pub fn record_dedup(&self) {
         self.dedup_total.inc();
+    }
+
+    /// Records one epoch rollback.
+    pub fn record_rollback(&self) {
+        self.epochs_rolled_back.inc();
     }
 
     /// Sets the pending-futures gauge.
@@ -219,13 +229,11 @@ impl NatsSinkMetrics {
             custom: Vec::new(),
         };
         m.add_custom("nats.dedup", self.dedup_total.get() as f64);
+        m.add_custom(
+            "nats.epochs_rolled_back",
+            self.epochs_rolled_back.get() as f64,
+        );
         m
-    }
-}
-
-impl Default for NatsSinkMetrics {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 
@@ -257,25 +265,37 @@ mod tests {
         assert_eq!(cm.records_total, 150);
         assert_eq!(cm.bytes_total, 5120);
         assert_eq!(cm.errors_total, 1); // fetch error
-        assert_eq!(cm.lag, 7);
+        assert_eq!(cm.lag, 0, "lag stays zero until we poll consumer.info()");
         assert!(cm.custom.iter().any(|(k, v)| k == "nats.acks" && *v == 2.0));
+        assert!(cm
+            .custom
+            .iter()
+            .any(|(k, v)| k == "nats.pending_acks" && *v == 7.0));
     }
 
     #[test]
     fn sink_records_and_dedup() {
         let m = NatsSinkMetrics::new(None);
-        m.record_publish(10, 2048);
+        for _ in 0..10 {
+            m.record_published_row(200);
+        }
         m.record_dedup();
         m.record_dedup();
+        m.record_rollback();
         m.set_pending_futures(3);
 
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 10);
+        assert_eq!(cm.bytes_total, 2000);
         assert_eq!(cm.lag, 3);
         assert!(cm
             .custom
             .iter()
             .any(|(k, v)| k == "nats.dedup" && *v == 2.0));
+        assert!(cm
+            .custom
+            .iter()
+            .any(|(k, v)| k == "nats.epochs_rolled_back" && *v == 1.0));
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -7,10 +7,7 @@ use tracing::warn;
 
 use crate::metrics::ConnectorMetrics;
 
-/// Register a collector on `reg`, logging a warning on failure rather
-/// than silently dropping. `AlreadyReg` means another connector
-/// instance is sharing this registry; the caller's collector is
-/// detached from scrape output and the operator needs to know.
+/// Register on `reg` — warn rather than silently drop on error.
 fn register_collector<C: Collector + Clone + 'static>(reg: &Registry, name: &str, c: &C) {
     match reg.register(Box::new(c.clone())) {
         Ok(()) => {}

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -1,5 +1,5 @@
-//! NATS connector metrics. No per-subject labels — NATS subjects are
-//! wildcard-addressable and often unbounded-cardinality.
+//! NATS connector metrics. No per-subject labels — subjects are
+//! wildcard-addressable and unbounded-cardinality.
 
 use prometheus::core::Collector;
 use prometheus::{Error as PromError, IntCounter, IntGauge, Registry};
@@ -7,16 +7,17 @@ use tracing::warn;
 
 use crate::metrics::ConnectorMetrics;
 
-/// Register on `reg` — warn rather than silently drop on error.
 fn register_collector<C: Collector + Clone + 'static>(reg: &Registry, name: &str, c: &C) {
     match reg.register(Box::new(c.clone())) {
         Ok(()) => {}
-        Err(PromError::AlreadyReg) => warn!(
-            metric = name,
-            "metric already registered on this registry; this instance's \
-             counts will not appear in scrape output — instantiate NATS \
-             connectors on separate registries",
-        ),
+        // Multiple connectors on a shared registry can collide; the
+        // second registration silently drops so its counts won't scrape.
+        Err(PromError::AlreadyReg) => {
+            warn!(
+                metric = name,
+                "metric already registered; use separate registries per connector"
+            );
+        }
         Err(e) => warn!(metric = name, error = ?e, "failed to register metric"),
     }
 }
@@ -31,12 +32,12 @@ pub struct NatsSourceMetrics {
     pub acks_total: IntCounter,
     pub ack_errors_total: IntCounter,
     pub pending_acks: IntGauge,
-    /// Broker-side lag: stream messages not yet delivered to this consumer.
+    /// Stream messages not yet delivered to the consumer.
     pub consumer_lag: IntGauge,
 }
 
 impl NatsSourceMetrics {
-    /// Registers the metrics on `registry` if provided.
+    /// Registers on `registry` if provided; otherwise on a local one.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn new(registry: Option<&Registry>) -> Self {
@@ -66,57 +67,48 @@ impl NatsSourceMetrics {
         register_collector(reg, "nats_source_consumer_lag", &consumer_lag);
 
         Self {
-            records_total: reg_c!(
-                "nats_source_records_total",
-                "Records delivered to poll_batch"
-            ),
+            records_total: reg_c!("nats_source_records_total", "Records delivered"),
             bytes_total: reg_c!("nats_source_bytes_total", "Payload bytes delivered"),
-            fetch_errors_total: reg_c!(
-                "nats_source_fetch_errors_total",
-                "Errors from consumer.fetch()"
-            ),
-            acks_total: reg_c!("nats_source_acks_total", "Successful JetStream acks"),
+            fetch_errors_total: reg_c!("nats_source_fetch_errors_total", "Fetch errors"),
+            acks_total: reg_c!("nats_source_acks_total", "Successful acks"),
             ack_errors_total: reg_c!("nats_source_ack_errors_total", "Failed acks"),
             pending_acks,
             consumer_lag,
         }
     }
 
-    /// Record a poll batch.
+    #[allow(missing_docs)]
     pub fn record_poll(&self, records: u64, bytes: u64) {
         self.records_total.inc_by(records);
         self.bytes_total.inc_by(bytes);
     }
 
-    /// Record a fetch-loop error.
+    #[allow(missing_docs)]
     pub fn record_fetch_error(&self) {
         self.fetch_errors_total.inc();
     }
 
-    /// Record one successful ack.
+    #[allow(missing_docs)]
     pub fn record_ack(&self) {
         self.acks_total.inc();
     }
 
-    /// Record one failed ack.
+    #[allow(missing_docs)]
     pub fn record_ack_error(&self) {
         self.ack_errors_total.inc();
     }
 
-    /// Set the pending-ack gauge.
-    #[allow(clippy::cast_possible_wrap)]
+    #[allow(missing_docs, clippy::cast_possible_wrap)]
     pub fn set_pending_acks(&self, n: usize) {
         self.pending_acks.set(n as i64);
     }
 
-    /// Set the broker-side lag gauge.
-    #[allow(clippy::cast_possible_wrap)]
+    #[allow(missing_docs, clippy::cast_possible_wrap)]
     pub fn set_consumer_lag(&self, n: u64) {
         self.consumer_lag.set(n as i64);
     }
 
-    /// Folds to the SDK's [`ConnectorMetrics`]. `lag` is the broker-
-    /// side pending count from the latest `consumer.info()` poll.
+    /// `lag` comes from the most recent `consumer.info()` poll.
     #[must_use]
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
@@ -142,14 +134,14 @@ pub struct NatsSinkMetrics {
     pub bytes_total: IntCounter,
     pub publish_errors_total: IntCounter,
     pub ack_errors_total: IntCounter,
-    /// Publishes the server dropped as `Nats-Msg-Id` duplicates.
+    /// Publishes the broker dropped as `Nats-Msg-Id` duplicates.
     pub dedup_total: IntCounter,
     pub epochs_rolled_back: IntCounter,
     pub pending_futures: IntGauge,
 }
 
 impl NatsSinkMetrics {
-    /// Registers the metrics on `registry` if provided.
+    /// Registers on `registry` if provided; otherwise on a local one.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn new(registry: Option<&Registry>) -> Self {
@@ -177,50 +169,45 @@ impl NatsSinkMetrics {
             bytes_total: reg_c!("nats_sink_bytes_total", "Payload bytes published"),
             publish_errors_total: reg_c!("nats_sink_publish_errors_total", "Publish errors"),
             ack_errors_total: reg_c!("nats_sink_ack_errors_total", "Publish-ack errors"),
-            dedup_total: reg_c!(
-                "nats_sink_dedup_total",
-                "Publishes identified by the server as duplicates"
-            ),
+            dedup_total: reg_c!("nats_sink_dedup_total", "Broker-dropped duplicates"),
             epochs_rolled_back: reg_c!("nats_sink_epochs_rolled_back_total", "Epochs rolled back"),
             pending_futures,
         }
     }
 
-    /// Record one successful publish of `bytes`.
+    #[allow(missing_docs)]
     pub fn record_published_row(&self, bytes: u64) {
         self.records_total.inc();
         self.bytes_total.inc_by(bytes);
     }
 
-    /// Record one publish error.
+    #[allow(missing_docs)]
     pub fn record_publish_error(&self) {
         self.publish_errors_total.inc();
     }
 
-    /// Record one ack error.
+    #[allow(missing_docs)]
     pub fn record_ack_error(&self) {
         self.ack_errors_total.inc();
     }
 
-    /// Record one server-identified duplicate.
+    #[allow(missing_docs)]
     pub fn record_dedup(&self) {
         self.dedup_total.inc();
     }
 
-    /// Record one epoch rollback.
+    #[allow(missing_docs)]
     pub fn record_rollback(&self) {
         self.epochs_rolled_back.inc();
     }
 
-    /// Set the pending-futures gauge.
-    #[allow(clippy::cast_possible_wrap)]
+    #[allow(missing_docs, clippy::cast_possible_wrap)]
     pub fn set_pending_futures(&self, n: usize) {
         self.pending_futures.set(n as i64);
     }
 
-    /// Folds to the SDK's [`ConnectorMetrics`].
     #[must_use]
-    #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+    #[allow(missing_docs, clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
         let mut m = ConnectorMetrics {
             records_total: self.records_total.get(),

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -1,9 +1,28 @@
 //! NATS connector metrics. No per-subject labels — NATS subjects are
 //! wildcard-addressable and often unbounded-cardinality.
 
-use prometheus::{IntCounter, IntGauge, Registry};
+use prometheus::core::Collector;
+use prometheus::{Error as PromError, IntCounter, IntGauge, Registry};
+use tracing::warn;
 
 use crate::metrics::ConnectorMetrics;
+
+/// Register a collector on `reg`, logging a warning on failure rather
+/// than silently dropping. `AlreadyReg` means another connector
+/// instance is sharing this registry; the caller's collector is
+/// detached from scrape output and the operator needs to know.
+fn register_collector<C: Collector + Clone + 'static>(reg: &Registry, name: &str, c: &C) {
+    match reg.register(Box::new(c.clone())) {
+        Ok(()) => {}
+        Err(PromError::AlreadyReg) => warn!(
+            metric = name,
+            "metric already registered on this registry; this instance's \
+             counts will not appear in scrape output — instantiate NATS \
+             connectors on separate registries",
+        ),
+        Err(e) => warn!(metric = name, error = ?e, "failed to register metric"),
+    }
+}
 
 /// Prometheus counters for the NATS source.
 #[derive(Debug, Clone)]
@@ -35,19 +54,19 @@ impl NatsSourceMetrics {
         macro_rules! reg_c {
             ($name:expr, $help:expr) => {{
                 let c = IntCounter::new($name, $help).unwrap();
-                let _ = reg.register(Box::new(c.clone()));
+                register_collector(reg, $name, &c);
                 c
             }};
         }
         let pending_acks =
             IntGauge::new("nats_source_pending_acks", "Unacked JetStream messages").unwrap();
-        let _ = reg.register(Box::new(pending_acks.clone()));
+        register_collector(reg, "nats_source_pending_acks", &pending_acks);
         let consumer_lag = IntGauge::new(
             "nats_source_consumer_lag",
             "Stream messages not yet delivered to the consumer",
         )
         .unwrap();
-        let _ = reg.register(Box::new(consumer_lag.clone()));
+        register_collector(reg, "nats_source_consumer_lag", &consumer_lag);
 
         Self {
             records_total: reg_c!(
@@ -148,13 +167,13 @@ impl NatsSinkMetrics {
         macro_rules! reg_c {
             ($name:expr, $help:expr) => {{
                 let c = IntCounter::new($name, $help).unwrap();
-                let _ = reg.register(Box::new(c.clone()));
+                register_collector(reg, $name, &c);
                 c
             }};
         }
         let pending_futures =
             IntGauge::new("nats_sink_pending_futures", "Outstanding PublishAckFutures").unwrap();
-        let _ = reg.register(Box::new(pending_futures.clone()));
+        register_collector(reg, "nats_sink_pending_futures", &pending_futures);
 
         Self {
             records_total: reg_c!("nats_sink_records_total", "Records published"),

--- a/crates/laminar-connectors/src/nats/metrics.rs
+++ b/crates/laminar-connectors/src/nats/metrics.rs
@@ -15,6 +15,8 @@ pub struct NatsSourceMetrics {
     pub acks_total: IntCounter,
     pub ack_errors_total: IntCounter,
     pub pending_acks: IntGauge,
+    /// Broker-side lag: stream messages not yet delivered to this consumer.
+    pub consumer_lag: IntGauge,
 }
 
 impl NatsSourceMetrics {
@@ -40,6 +42,12 @@ impl NatsSourceMetrics {
         let pending_acks =
             IntGauge::new("nats_source_pending_acks", "Unacked JetStream messages").unwrap();
         let _ = reg.register(Box::new(pending_acks.clone()));
+        let consumer_lag = IntGauge::new(
+            "nats_source_consumer_lag",
+            "Stream messages not yet delivered to the consumer",
+        )
+        .unwrap();
+        let _ = reg.register(Box::new(consumer_lag.clone()));
 
         Self {
             records_total: reg_c!(
@@ -54,6 +62,7 @@ impl NatsSourceMetrics {
             acks_total: reg_c!("nats_source_acks_total", "Successful JetStream acks"),
             ack_errors_total: reg_c!("nats_source_ack_errors_total", "Failed acks"),
             pending_acks,
+            consumer_lag,
         }
     }
 
@@ -84,8 +93,14 @@ impl NatsSourceMetrics {
         self.pending_acks.set(n as i64);
     }
 
-    /// Folds to the SDK's [`ConnectorMetrics`]. `lag` stays 0 until
-    /// we poll `consumer.info()` for the real broker-side lag.
+    /// Set the broker-side lag gauge.
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn set_consumer_lag(&self, n: u64) {
+        self.consumer_lag.set(n as i64);
+    }
+
+    /// Folds to the SDK's [`ConnectorMetrics`]. `lag` is the broker-
+    /// side pending count from the latest `consumer.info()` poll.
     #[must_use]
     #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
     pub fn to_connector_metrics(&self) -> ConnectorMetrics {
@@ -93,7 +108,7 @@ impl NatsSourceMetrics {
             records_total: self.records_total.get(),
             bytes_total: self.bytes_total.get(),
             errors_total: self.fetch_errors_total.get() + self.ack_errors_total.get(),
-            lag: 0,
+            lag: self.consumer_lag.get().max(0) as u64,
             custom: Vec::new(),
         };
         m.add_custom("nats.acks", self.acks_total.get() as f64);
@@ -231,11 +246,13 @@ mod tests {
         m.record_fetch_error();
         m.set_pending_acks(7);
 
+        m.set_consumer_lag(42);
+
         let cm = m.to_connector_metrics();
         assert_eq!(cm.records_total, 150);
         assert_eq!(cm.bytes_total, 5120);
         assert_eq!(cm.errors_total, 1); // fetch error
-        assert_eq!(cm.lag, 0, "lag stays zero until we poll consumer.info()");
+        assert_eq!(cm.lag, 42, "lag reflects the latest consumer.info() poll");
         assert!(cm.custom.iter().any(|(k, v)| k == "nats.acks" && *v == 2.0));
         assert!(cm
             .custom

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -6,9 +6,11 @@
 //!   at-least-once by default and exactly-once with `Nats-Msg-Id` dedup.
 
 pub mod config;
+pub mod metrics;
 pub mod sink;
 pub mod source;
 
+pub use metrics::{NatsSinkMetrics, NatsSourceMetrics};
 pub use sink::NatsSink;
 pub use source::NatsSource;
 
@@ -32,7 +34,7 @@ pub fn register_nats_source(registry: &ConnectorRegistry) {
     registry.register_source(
         "nats",
         info,
-        Arc::new(|_| Box::new(NatsSource::new(Arc::new(Schema::empty())))),
+        Arc::new(|reg| Box::new(NatsSource::new(Arc::new(Schema::empty()), reg))),
     );
 }
 
@@ -49,7 +51,7 @@ pub fn register_nats_sink(registry: &ConnectorRegistry) {
     registry.register_sink(
         "nats",
         info,
-        Arc::new(|_| Box::new(NatsSink::new(Arc::new(Schema::empty())))),
+        Arc::new(|reg| Box::new(NatsSink::new(Arc::new(Schema::empty()), reg))),
     );
 }
 

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -1,0 +1,201 @@
+//! NATS source and sink connectors.
+//!
+//! Supports two modes:
+//! - `core`: plain NATS pub/sub, non-durable, non-replayable, at-most-once.
+//! - `jetstream` (default): durable streams with pull consumers, replayable,
+//!   at-least-once by default and exactly-once with `Nats-Msg-Id` dedup.
+
+pub mod config;
+pub mod sink;
+pub mod source;
+
+pub use sink::NatsSink;
+pub use source::NatsSource;
+
+use std::sync::Arc;
+
+use arrow_schema::Schema;
+
+use crate::config::{ConfigKeySpec, ConnectorInfo};
+use crate::registry::ConnectorRegistry;
+
+/// Registers the NATS source connector.
+pub fn register_nats_source(registry: &ConnectorRegistry) {
+    let info = ConnectorInfo {
+        name: "nats".to_string(),
+        display_name: "NATS Source".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        is_source: true,
+        is_sink: false,
+        config_keys: source_config_keys(),
+    };
+    registry.register_source(
+        "nats",
+        info,
+        Arc::new(|_| Box::new(NatsSource::new(Arc::new(Schema::empty())))),
+    );
+}
+
+/// Registers the NATS sink connector.
+pub fn register_nats_sink(registry: &ConnectorRegistry) {
+    let info = ConnectorInfo {
+        name: "nats".to_string(),
+        display_name: "NATS Sink".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        is_source: false,
+        is_sink: true,
+        config_keys: sink_config_keys(),
+    };
+    registry.register_sink(
+        "nats",
+        info,
+        Arc::new(|_| Box::new(NatsSink::new(Arc::new(Schema::empty())))),
+    );
+}
+
+fn source_config_keys() -> Vec<ConfigKeySpec> {
+    use ConfigKeySpec as K;
+    vec![
+        K::required("servers", "NATS server URLs, comma-separated"),
+        K::optional("mode", "core | jetstream", "jetstream"),
+        // JetStream
+        K::optional(
+            "stream",
+            "JetStream stream name (required in jetstream mode)",
+            "",
+        ),
+        K::optional(
+            "consumer",
+            "Durable consumer name (required in jetstream mode)",
+            "",
+        ),
+        K::optional("subject", "Single subject or wildcard (e.g., orders.>)", ""),
+        K::optional(
+            "subject.filters",
+            "Comma-separated filter subjects (JS 2.10+)",
+            "",
+        ),
+        K::optional(
+            "deliver.policy",
+            "all | new | by_start_sequence | by_start_time",
+            "all",
+        ),
+        K::optional(
+            "start.sequence",
+            "Stream sequence for by_start_sequence",
+            "",
+        ),
+        K::optional("start.time", "RFC3339 timestamp for by_start_time", ""),
+        K::optional("ack.policy", "explicit | none", "explicit"),
+        K::optional(
+            "ack.wait.ms",
+            "Per-message ack wait in milliseconds",
+            "60000",
+        ),
+        K::optional(
+            "max.deliver",
+            "Max delivery attempts before poison action",
+            "5",
+        ),
+        K::optional(
+            "max.ack.pending",
+            "Max unacked messages (server-side flow control)",
+            "10000",
+        ),
+        K::optional("fetch.batch", "Messages per pull fetch", "500"),
+        K::optional("fetch.max.wait.ms", "Max wait per fetch", "500"),
+        K::optional("fetch.max.bytes", "Max bytes per fetch", "1048576"),
+        // Core
+        K::optional(
+            "queue.group",
+            "Queue group for load balancing (core mode only)",
+            "",
+        ),
+        // Format / metadata
+        K::optional("format", "json | csv | raw", "json"),
+        K::optional(
+            "include.metadata",
+            "Emit _subject, _stream_seq, _timestamp columns",
+            "false",
+        ),
+        K::optional("include.headers", "Emit _headers column (JSON)", "false"),
+        K::optional(
+            "event.time.column",
+            "Column name for event time extraction",
+            "",
+        ),
+        // Error handling
+        K::optional(
+            "poison.dlq.subject",
+            "Republish Term'd messages to this subject",
+            "",
+        ),
+    ]
+}
+
+fn sink_config_keys() -> Vec<ConfigKeySpec> {
+    use ConfigKeySpec as K;
+    vec![
+        K::required("servers", "NATS server URLs, comma-separated"),
+        K::optional("mode", "core | jetstream", "jetstream"),
+        K::optional("stream", "Target stream (used for validation only)", ""),
+        K::optional("subject", "Literal subject for every row", ""),
+        K::optional(
+            "subject.column",
+            "Column name whose value is the subject",
+            "",
+        ),
+        K::optional(
+            "expected.stream",
+            "Nats-Expected-Stream header for fail-fast",
+            "",
+        ),
+        K::optional(
+            "delivery.guarantee",
+            "at_least_once | exactly_once",
+            "at_least_once",
+        ),
+        K::optional(
+            "dedup.id.column",
+            "Column used as Nats-Msg-Id (required for exactly-once)",
+            "",
+        ),
+        K::optional("max.pending", "Max outstanding PubAck futures", "4096"),
+        K::optional("ack.timeout.ms", "Per-publish ack timeout", "30000"),
+        K::optional(
+            "flush.batch.size",
+            "Records buffered before publish flush",
+            "1000",
+        ),
+        K::optional("format", "json | csv | raw", "json"),
+        K::optional(
+            "header.columns",
+            "Comma-separated columns projected to NATS headers",
+            "",
+        ),
+        K::optional(
+            "poison.dlq.subject",
+            "Subject for failed-after-retry publishes",
+            "",
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_source_appears_in_registry() {
+        let registry = ConnectorRegistry::new();
+        register_nats_source(&registry);
+        assert!(registry.list_sources().contains(&"nats".to_string()));
+    }
+
+    #[test]
+    fn register_sink_appears_in_registry() {
+        let registry = ConnectorRegistry::new();
+        register_nats_sink(&registry);
+        assert!(registry.list_sinks().contains(&"nats".to_string()));
+    }
+}

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -55,9 +55,31 @@ pub fn register_nats_sink(registry: &ConnectorRegistry) {
     );
 }
 
-fn source_config_keys() -> Vec<ConfigKeySpec> {
+fn auth_and_tls_keys() -> Vec<ConfigKeySpec> {
     use ConfigKeySpec as K;
     vec![
+        K::optional("auth.mode", "none | user_pass | token", "none"),
+        K::optional("user", "Username (auth.mode=user_pass)", ""),
+        K::optional("password", "Password (auth.mode=user_pass)", ""),
+        K::optional("token", "Bearer token (auth.mode=token)", ""),
+        K::optional("tls.enabled", "Require TLS on the connection", "false"),
+        K::optional(
+            "tls.ca.location",
+            "PEM CA certificate for server verification",
+            "",
+        ),
+        K::optional(
+            "tls.cert.location",
+            "Client certificate for mutual TLS (pairs with tls.key.location)",
+            "",
+        ),
+        K::optional("tls.key.location", "Client private key for mutual TLS", ""),
+    ]
+}
+
+fn source_config_keys() -> Vec<ConfigKeySpec> {
+    use ConfigKeySpec as K;
+    let mut keys = vec![
         K::required("servers", "NATS server URLs, comma-separated"),
         K::optional("mode", "core | jetstream", "jetstream"),
         // JetStream
@@ -132,12 +154,14 @@ fn source_config_keys() -> Vec<ConfigKeySpec> {
             "Republish Term'd messages to this subject",
             "",
         ),
-    ]
+    ];
+    keys.extend(auth_and_tls_keys());
+    keys
 }
 
 fn sink_config_keys() -> Vec<ConfigKeySpec> {
     use ConfigKeySpec as K;
-    vec![
+    let mut keys = vec![
         K::required("servers", "NATS server URLs, comma-separated"),
         K::optional("mode", "core | jetstream", "jetstream"),
         K::optional("stream", "Target stream (used for validation only)", ""),
@@ -186,7 +210,9 @@ fn sink_config_keys() -> Vec<ConfigKeySpec> {
             "Subject for failed-after-retry publishes",
             "",
         ),
-    ]
+    ];
+    keys.extend(auth_and_tls_keys());
+    keys
 }
 
 #[cfg(test)]

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -160,6 +160,12 @@ fn sink_config_keys() -> Vec<ConfigKeySpec> {
             "Column used as Nats-Msg-Id (required for exactly-once)",
             "",
         ),
+        K::optional(
+            "min.duplicate.window.ms",
+            "Minimum stream duplicate_window required for exactly-once \
+             (the sink refuses to start if the stream is configured below this)",
+            "120000",
+        ),
         K::optional("max.pending", "Max outstanding PubAck futures", "4096"),
         K::optional("ack.timeout.ms", "Per-publish ack timeout", "30000"),
         K::optional(

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -129,6 +129,11 @@ fn source_config_keys() -> Vec<ConfigKeySpec> {
         K::optional("fetch.batch", "Messages per pull fetch", "500"),
         K::optional("fetch.max.wait.ms", "Max wait per fetch", "500"),
         K::optional("fetch.max.bytes", "Max bytes per fetch", "1048576"),
+        K::optional(
+            "fetch.error.threshold",
+            "Consecutive fetch errors before the source reports Unhealthy",
+            "10",
+        ),
         // Core
         K::optional(
             "queue.group",

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -193,8 +193,7 @@ fn sink_config_keys() -> Vec<ConfigKeySpec> {
         ),
         K::optional(
             "min.duplicate.window.ms",
-            "Minimum stream duplicate_window required for exactly-once \
-             (the sink refuses to start if the stream is configured below this)",
+            "Minimum stream duplicate_window accepted under exactly-once",
             "120000",
         ),
         K::optional("max.pending", "Max outstanding PubAck futures", "4096"),

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -58,10 +58,15 @@ pub fn register_nats_sink(registry: &ConnectorRegistry) {
 fn auth_and_tls_keys() -> Vec<ConfigKeySpec> {
     use ConfigKeySpec as K;
     vec![
-        K::optional("auth.mode", "none | user_pass | token", "none"),
+        K::optional("auth.mode", "none | user_pass | token | creds_file", "none"),
         K::optional("user", "Username (auth.mode=user_pass)", ""),
         K::optional("password", "Password (auth.mode=user_pass)", ""),
         K::optional("token", "Bearer token (auth.mode=token)", ""),
+        K::optional(
+            "creds.file",
+            "Path to a NATS credentials file (auth.mode=creds_file)",
+            "",
+        ),
         K::optional("tls.enabled", "Require TLS on the connection", "false"),
         K::optional(
             "tls.ca.location",
@@ -133,6 +138,11 @@ fn source_config_keys() -> Vec<ConfigKeySpec> {
             "fetch.error.threshold",
             "Consecutive fetch errors before the source reports Unhealthy",
             "10",
+        ),
+        K::optional(
+            "lag.poll.interval.ms",
+            "Interval between consumer.info() polls for the lag gauge (0 disables)",
+            "10000",
         ),
         // Core
         K::optional(

--- a/crates/laminar-connectors/src/nats/mod.rs
+++ b/crates/laminar-connectors/src/nats/mod.rs
@@ -1,9 +1,6 @@
-//! NATS source and sink connectors.
-//!
-//! Supports two modes:
-//! - `core`: plain NATS pub/sub, non-durable, non-replayable, at-most-once.
-//! - `jetstream` (default): durable streams with pull consumers, replayable,
-//!   at-least-once by default and exactly-once with `Nats-Msg-Id` dedup.
+//! NATS source and sink — `core` (non-durable, at-most-once) or
+//! `jetstream` (default; replayable; at-least-once, or exactly-once
+//! with `Nats-Msg-Id` dedup).
 
 pub mod config;
 pub mod metrics;
@@ -133,7 +130,6 @@ fn source_config_keys() -> Vec<ConfigKeySpec> {
         ),
         K::optional("fetch.batch", "Messages per pull fetch", "500"),
         K::optional("fetch.max.wait.ms", "Max wait per fetch", "500"),
-        K::optional("fetch.max.bytes", "Max bytes per fetch", "1048576"),
         K::optional(
             "fetch.error.threshold",
             "Consecutive fetch errors before the source reports Unhealthy",
@@ -144,31 +140,12 @@ fn source_config_keys() -> Vec<ConfigKeySpec> {
             "Interval between consumer.info() polls for the lag gauge (0 disables)",
             "10000",
         ),
-        // Core
         K::optional(
             "queue.group",
             "Queue group for load balancing (core mode only)",
             "",
         ),
-        // Format / metadata
         K::optional("format", "json | csv | raw", "json"),
-        K::optional(
-            "include.metadata",
-            "Emit _subject, _stream_seq, _timestamp columns",
-            "false",
-        ),
-        K::optional("include.headers", "Emit _headers column (JSON)", "false"),
-        K::optional(
-            "event.time.column",
-            "Column name for event time extraction",
-            "",
-        ),
-        // Error handling
-        K::optional(
-            "poison.dlq.subject",
-            "Republish Term'd messages to this subject",
-            "",
-        ),
     ];
     keys.extend(auth_and_tls_keys());
     keys
@@ -208,20 +185,10 @@ fn sink_config_keys() -> Vec<ConfigKeySpec> {
         ),
         K::optional("max.pending", "Max outstanding PubAck futures", "4096"),
         K::optional("ack.timeout.ms", "Per-publish ack timeout", "30000"),
-        K::optional(
-            "flush.batch.size",
-            "Records buffered before publish flush",
-            "1000",
-        ),
         K::optional("format", "json | csv | raw", "json"),
         K::optional(
             "header.columns",
             "Comma-separated columns projected to NATS headers",
-            "",
-        ),
-        K::optional(
-            "poison.dlq.subject",
-            "Subject for failed-after-retry publishes",
             "",
         ),
     ];

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -69,7 +69,7 @@ impl SinkConnector for NatsSink {
             serde::create_serializer(cfg.format)
                 .map_err(|e| err(&format!("serializer for format {:?}: {e}", cfg.format)))?,
         );
-        let client = build_connect_options(&cfg.auth, &cfg.tls)
+        let client = build_connect_options(&cfg.auth, &cfg.tls)?
             .connect(&cfg.servers)
             .await
             .map_err(|e| err(&format!("nats connect({:?}): {e}", cfg.servers)))?;

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -1,23 +1,38 @@
 //! NATS sink connector.
 //!
-//! This milestone validates and stores the configuration. Publish, ack
-//! tracking, and dedup handling land with the data path.
+//! At-least-once publishing in this milestone. Core-mode publishes are
+//! fire-and-forget; `JetStream` publishes collect `PublishAckFuture`s and
+//! drain them in `flush`/`pre_commit`. Exactly-once via `Nats-Msg-Id`
+//! dedup lands in a follow-up.
 
+use std::collections::VecDeque;
 use std::time::Duration;
 
-use arrow_array::RecordBatch;
+use arrow_array::{cast::AsArray, Array, RecordBatch};
 use arrow_schema::SchemaRef;
+use async_nats::jetstream::{self, context::PublishAckFuture};
+use async_nats::{Client, HeaderMap};
 use async_trait::async_trait;
 
-use super::config::NatsSinkConfig;
+use super::config::{Mode, NatsSinkConfig, SubjectSpec};
 use crate::config::ConnectorConfig;
 use crate::connector::{DeliveryGuarantee, SinkConnector, SinkConnectorCapabilities, WriteResult};
 use crate::error::ConnectorError;
+use crate::serde::{self, RecordSerializer};
 
 /// NATS sink — core and `JetStream` modes behind a single type.
 pub struct NatsSink {
     schema: SchemaRef,
     config: Option<NatsSinkConfig>,
+    serializer: Option<Box<dyn RecordSerializer>>,
+    runtime: Option<Runtime>,
+    /// Publish acks from the in-flight epoch, drained in `flush`/`pre_commit`.
+    pending_acks: VecDeque<PublishAckFuture>,
+}
+
+enum Runtime {
+    Core { client: Client },
+    JetStream { context: jetstream::Context },
 }
 
 impl NatsSink {
@@ -27,6 +42,9 @@ impl NatsSink {
         Self {
             schema,
             config: None,
+            serializer: None,
+            runtime: None,
+            pending_acks: VecDeque::new(),
         }
     }
 
@@ -35,18 +53,135 @@ impl NatsSink {
     pub fn config(&self) -> Option<&NatsSinkConfig> {
         self.config.as_ref()
     }
+
+    fn subject_for_row(&self, batch: &RecordBatch, row: usize) -> Result<String, ConnectorError> {
+        let cfg = self.config.as_ref().expect("open() before write_batch");
+        match &cfg.subject {
+            SubjectSpec::Literal(s) => Ok(s.clone()),
+            SubjectSpec::Column(name) => {
+                let col = batch
+                    .column_by_name(name)
+                    .ok_or_else(|| err(&format!("subject.column '{name}' not in batch schema")))?;
+                let strings = col.as_string_opt::<i32>().ok_or_else(|| {
+                    err(&format!("subject.column '{name}' must be a Utf8 column"))
+                })?;
+                if strings.is_null(row) {
+                    return Err(err(&format!(
+                        "subject.column '{name}' is null at row {row}"
+                    )));
+                }
+                Ok(strings.value(row).to_string())
+            }
+        }
+    }
+
+    fn headers_for_row(
+        &self,
+        batch: &RecordBatch,
+        row: usize,
+    ) -> Result<Option<HeaderMap>, ConnectorError> {
+        let cfg = self.config.as_ref().expect("open() before write_batch");
+        if cfg.header_columns.is_empty() && cfg.expected_stream.is_none() {
+            return Ok(None);
+        }
+        let mut headers = HeaderMap::new();
+        if let Some(s) = cfg.expected_stream.as_deref() {
+            headers.insert("Nats-Expected-Stream", s);
+        }
+        for col_name in &cfg.header_columns {
+            let col = batch
+                .column_by_name(col_name)
+                .ok_or_else(|| err(&format!("header.columns: '{col_name}' not in batch schema")))?;
+            let strings = col
+                .as_string_opt::<i32>()
+                .ok_or_else(|| err(&format!("header.columns '{col_name}' must be Utf8")))?;
+            if !strings.is_null(row) {
+                headers.insert(col_name.as_str(), strings.value(row));
+            }
+        }
+        Ok(Some(headers))
+    }
 }
 
 #[async_trait]
 impl SinkConnector for NatsSink {
     async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
-        self.config = Some(NatsSinkConfig::from_config(config)?);
+        let cfg = NatsSinkConfig::from_config(config)?;
+        self.serializer = Some(
+            serde::create_serializer(cfg.format)
+                .map_err(|e| err(&format!("serializer for format {:?}: {e}", cfg.format)))?,
+        );
+        let client = async_nats::ConnectOptions::new()
+            .connect(&cfg.servers)
+            .await
+            .map_err(|e| err(&format!("nats connect({:?}): {e}", cfg.servers)))?;
+        self.runtime = Some(match cfg.mode {
+            Mode::Core => Runtime::Core { client },
+            Mode::JetStream => {
+                let context = jetstream::new(client);
+                if let Some(stream_name) = cfg.stream.as_deref() {
+                    // Touch the stream now so a bad name fails open(), not
+                    // later on the first publish.
+                    context
+                        .get_stream(stream_name)
+                        .await
+                        .map_err(|e| err(&format!("get_stream('{stream_name}') failed: {e}")))?;
+                }
+                Runtime::JetStream { context }
+            }
+        });
+        self.config = Some(cfg);
         Ok(())
     }
 
-    async fn write_batch(&mut self, _batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
-        // Data path lands in the follow-up.
-        Ok(WriteResult::new(0, 0))
+    async fn write_batch(&mut self, batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
+        let ser = self
+            .serializer
+            .as_ref()
+            .ok_or_else(|| err("serializer not initialized"))?;
+        let records = ser
+            .serialize(batch)
+            .map_err(|e| err(&format!("serialize batch: {e}")))?;
+
+        let mut bytes_total: u64 = 0;
+        let rows = batch.num_rows();
+        for (row, payload) in records.into_iter().enumerate() {
+            if row >= rows {
+                break;
+            }
+            let subject = self.subject_for_row(batch, row)?;
+            let headers = self.headers_for_row(batch, row)?;
+            bytes_total += payload.len() as u64;
+            let payload = bytes::Bytes::from(payload);
+
+            match self.runtime.as_mut() {
+                Some(Runtime::Core { client }) => {
+                    let result = if let Some(h) = headers {
+                        client.publish_with_headers(subject, h, payload).await
+                    } else {
+                        client.publish(subject, payload).await
+                    };
+                    result.map_err(|e| err(&format!("core publish: {e}")))?;
+                }
+                Some(Runtime::JetStream { context }) => {
+                    let fut = if let Some(h) = headers {
+                        context
+                            .publish_with_headers(subject, h, payload)
+                            .await
+                            .map_err(|e| err(&format!("jetstream publish: {e}")))?
+                    } else {
+                        context
+                            .publish(subject, payload)
+                            .await
+                            .map_err(|e| err(&format!("jetstream publish: {e}")))?
+                    };
+                    self.pending_acks.push_back(fut);
+                }
+                None => return Err(err("sink: open() was not called")),
+            }
+        }
+
+        Ok(WriteResult::new(rows, bytes_total))
     }
 
     fn schema(&self) -> SchemaRef {
@@ -66,7 +201,54 @@ impl SinkConnector for NatsSink {
         caps
     }
 
+    async fn flush(&mut self) -> Result<(), ConnectorError> {
+        // Drain whatever has landed without blocking the flow for long.
+        // pre_commit does the strict drain with a user-configured timeout.
+        drain_acks(&mut self.pending_acks, Duration::from_secs(1)).await
+    }
+
+    async fn pre_commit(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+        let timeout = self
+            .config
+            .as_ref()
+            .map_or(Duration::from_secs(30), |c| c.ack_timeout);
+        drain_acks(&mut self.pending_acks, timeout).await
+    }
+
     async fn close(&mut self) -> Result<(), ConnectorError> {
+        // Best-effort drain with the sink's ack timeout.
+        let timeout = self
+            .config
+            .as_ref()
+            .map_or(Duration::from_secs(5), |c| c.ack_timeout);
+        let _ = drain_acks(&mut self.pending_acks, timeout).await;
+        self.runtime = None;
         Ok(())
     }
+}
+
+async fn drain_acks(
+    pending: &mut VecDeque<PublishAckFuture>,
+    timeout: Duration,
+) -> Result<(), ConnectorError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let deadline = tokio::time::Instant::now() + timeout;
+    while let Some(fut) = pending.pop_front() {
+        match tokio::time::timeout_at(deadline, fut).await {
+            Ok(Ok(_ack)) => {}
+            Ok(Err(e)) => return Err(err(&format!("jetstream publish ack: {e}"))),
+            Err(_) => {
+                return Err(err(&format!(
+                    "jetstream publish ack: timed out after {timeout:?} with acks still outstanding"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn err(msg: &str) -> ConnectorError {
+    ConnectorError::ConfigurationError(msg.to_string())
 }

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -19,9 +19,12 @@ use async_trait::async_trait;
 use futures_util::future::try_join_all;
 
 use super::config::{Mode, NatsSinkConfig, SubjectSpec};
+use super::metrics::NatsSinkMetrics;
 use crate::config::ConnectorConfig;
 use crate::connector::{DeliveryGuarantee, SinkConnector, SinkConnectorCapabilities, WriteResult};
 use crate::error::ConnectorError;
+use crate::health::HealthStatus;
+use crate::metrics::ConnectorMetrics;
 use crate::serde::{self, RecordSerializer};
 
 /// NATS sink — core and `JetStream` modes behind a single type.
@@ -30,6 +33,7 @@ pub struct NatsSink {
     config: Option<NatsSinkConfig>,
     serializer: Option<Box<dyn RecordSerializer>>,
     runtime: Option<Runtime>,
+    metrics: NatsSinkMetrics,
     /// Publish acks from the in-flight epoch, drained in `flush`/`pre_commit`.
     pending_acks: VecDeque<PublishAckFuture>,
 }
@@ -41,13 +45,16 @@ enum Runtime {
 
 impl NatsSink {
     /// Creates a new NATS sink with the given input schema.
+    ///
+    /// If `registry` is `Some`, metrics register on it.
     #[must_use]
-    pub fn new(schema: SchemaRef) -> Self {
+    pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             schema,
             config: None,
             serializer: None,
             runtime: None,
+            metrics: NatsSinkMetrics::new(registry),
             pending_acks: VecDeque::new(),
         }
     }
@@ -111,6 +118,7 @@ impl SinkConnector for NatsSink {
             serializer,
             runtime,
             pending_acks,
+            metrics,
             schema: _,
         } = self;
         let cfg = config.as_ref().ok_or_else(|| err("sink: open() first"))?;
@@ -175,25 +183,31 @@ impl SinkConnector for NatsSink {
                     } else {
                         client.publish(subject.to_string(), payload).await
                     };
-                    result.map_err(|e| err(&format!("core publish: {e}")))?;
+                    result.map_err(|e| {
+                        metrics.record_publish_error();
+                        err(&format!("core publish: {e}"))
+                    })?;
                 }
                 Runtime::JetStream { context } => {
                     let fut = if let Some(h) = headers {
                         context
                             .publish_with_headers(subject.to_string(), h, payload)
                             .await
-                            .map_err(|e| err(&format!("jetstream publish: {e}")))?
                     } else {
-                        context
-                            .publish(subject.to_string(), payload)
-                            .await
-                            .map_err(|e| err(&format!("jetstream publish: {e}")))?
+                        context.publish(subject.to_string(), payload).await
                     };
+                    let fut = fut.map_err(|e| {
+                        metrics.record_publish_error();
+                        err(&format!("jetstream publish: {e}"))
+                    })?;
                     pending_acks.push_back(fut);
                 }
             }
         }
 
+        metrics.record_publish(rows as u64, bytes_total);
+        #[allow(clippy::cast_possible_wrap)]
+        metrics.set_pending_futures(pending_acks.len());
         Ok(WriteResult::new(rows, bytes_total))
     }
 
@@ -224,7 +238,12 @@ impl SinkConnector for NatsSink {
                 .map_err(|e| err(&format!("core flush: {e}")))?,
             Some(Runtime::JetStream { .. }) | None => {}
         }
-        drain_acks(&mut self.pending_acks, Duration::from_secs(1)).await
+        drain_acks(
+            &mut self.pending_acks,
+            &self.metrics,
+            Duration::from_secs(1),
+        )
+        .await
     }
 
     async fn pre_commit(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
@@ -232,12 +251,13 @@ impl SinkConnector for NatsSink {
             .config
             .as_ref()
             .map_or(Duration::from_secs(30), |c| c.ack_timeout);
-        drain_acks(&mut self.pending_acks, timeout).await
+        drain_acks(&mut self.pending_acks, &self.metrics, timeout).await
     }
 
     async fn rollback_epoch(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
         // Dedup handles any landed publishes on retry (see LDB-5056).
         self.pending_acks.clear();
+        self.metrics.set_pending_futures(0);
         Ok(())
     }
 
@@ -252,31 +272,70 @@ impl SinkConnector for NatsSink {
         if let Some(Runtime::Core { client }) = self.runtime.as_ref() {
             let _ = client.flush().await;
         }
-        let _ = drain_acks(&mut self.pending_acks, timeout).await;
+        let _ = drain_acks(&mut self.pending_acks, &self.metrics, timeout).await;
         self.runtime = None;
         Ok(())
+    }
+
+    fn health_check(&self) -> HealthStatus {
+        match self.config.as_ref() {
+            None => HealthStatus::Unknown,
+            Some(cfg) => {
+                let cap = cfg.max_pending.max(1) as u64;
+                #[allow(clippy::cast_sign_loss)]
+                let pending = self.metrics.pending_futures.get().max(0) as u64;
+                if pending * 2 >= cap {
+                    HealthStatus::Degraded(format!(
+                        "pending publish acks {pending}/{cap} — ack drain may stall pre_commit"
+                    ))
+                } else {
+                    HealthStatus::Healthy
+                }
+            }
+        }
+    }
+
+    fn metrics(&self) -> ConnectorMetrics {
+        self.metrics.to_connector_metrics()
     }
 }
 
 /// Concurrently drain every `PublishAckFuture` in `pending`, bounded by
 /// `timeout`. Matches the Kafka sink's rollback shape — serial drains
 /// killed throughput. `PublishAckFuture` only implements `IntoFuture`,
-/// hence the explicit conversion.
+/// hence the explicit conversion. Counts server-identified duplicates
+/// via `PubAck.duplicate`.
 async fn drain_acks(
     pending: &mut VecDeque<PublishAckFuture>,
+    metrics: &NatsSinkMetrics,
     timeout: Duration,
 ) -> Result<(), ConnectorError> {
     if pending.is_empty() {
         return Ok(());
     }
     let futures: Vec<_> = pending.drain(..).map(IntoFuture::into_future).collect();
-    match tokio::time::timeout(timeout, try_join_all(futures)).await {
-        Ok(Ok(_acks)) => Ok(()),
-        Ok(Err(e)) => Err(err(&format!("jetstream publish ack: {e}"))),
-        Err(_) => Err(err(&format!(
-            "jetstream publish ack: timed out after {timeout:?}"
-        ))),
-    }
+    let result = match tokio::time::timeout(timeout, try_join_all(futures)).await {
+        Ok(Ok(acks)) => {
+            for ack in acks {
+                if ack.duplicate {
+                    metrics.record_dedup();
+                }
+            }
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            metrics.record_ack_error();
+            Err(err(&format!("jetstream publish ack: {e}")))
+        }
+        Err(_) => {
+            metrics.record_ack_error();
+            Err(err(&format!(
+                "jetstream publish ack: timed out after {timeout:?}"
+            )))
+        }
+    };
+    metrics.set_pending_futures(pending.len());
+    result
 }
 
 fn resolve_utf8<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, ConnectorError> {

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -131,11 +131,18 @@ impl SinkConnector for NatsSink {
             .map(|n| resolve_utf8(batch, n).map(|arr| (n.as_str(), arr)))
             .collect::<Result<_, _>>()?;
         let expected_stream = cfg.expected_stream.as_deref();
-        let dedup_col = cfg
-            .dedup_id_column
-            .as_deref()
-            .map(|n| resolve_utf8(batch, n).map(|arr| (n, arr)))
-            .transpose()?;
+        // Only emit Nats-Msg-Id under exactly-once — that's the delivery
+        // mode whose duplicate_window we validate at open(). Honoring
+        // the column under at-least-once would give silent dedup without
+        // the safety check, which is the worst of both worlds.
+        let dedup_col = if cfg.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+            cfg.dedup_id_column
+                .as_deref()
+                .map(|n| resolve_utf8(batch, n).map(|arr| (n, arr)))
+                .transpose()?
+        } else {
+            None
+        };
 
         let records = ser
             .serialize(batch)
@@ -147,26 +154,13 @@ impl SinkConnector for NatsSink {
             let subject: &str = match (&cfg.subject, subject_col) {
                 (SubjectSpec::Literal(s), _) => s.as_str(),
                 (SubjectSpec::Column(name), Some(arr)) => {
-                    if arr.is_null(row) {
-                        return Err(err(&format!(
-                            "subject.column '{name}' is null at row {row}"
-                        )));
-                    }
-                    arr.value(row)
+                    non_null(arr, row, "subject.column", name)?
                 }
                 (SubjectSpec::Column(_), None) => unreachable!("resolved above"),
             };
-            let msg_id = match dedup_col {
-                Some((name, arr)) => {
-                    if arr.is_null(row) {
-                        return Err(err(&format!(
-                            "dedup.id.column '{name}' is null at row {row}"
-                        )));
-                    }
-                    Some(arr.value(row))
-                }
-                None => None,
-            };
+            let msg_id = dedup_col
+                .map(|(name, arr)| non_null(arr, row, "dedup.id.column", name))
+                .transpose()?;
             let headers = build_headers(expected_stream, msg_id, &header_cols, row);
             let payload_len = payload.len() as u64;
             let payload = bytes::Bytes::from(payload);
@@ -221,9 +215,15 @@ impl SinkConnector for NatsSink {
     }
 
     async fn flush(&mut self) -> Result<(), ConnectorError> {
-        // Drain whatever has landed, bounded by 1s so a slow round-trip
-        // doesn't stall the periodic flush timer. pre_commit uses the
-        // user-configured ack timeout for the strict drain.
+        // Push buffered core publishes to the wire; drain landed JS acks
+        // (bounded so a slow round-trip doesn't stall the flush timer).
+        match self.runtime.as_ref() {
+            Some(Runtime::Core { client }) => client
+                .flush()
+                .await
+                .map_err(|e| err(&format!("core flush: {e}")))?,
+            Some(Runtime::JetStream { .. }) | None => {}
+        }
         drain_acks(&mut self.pending_acks, Duration::from_secs(1)).await
     }
 
@@ -236,12 +236,7 @@ impl SinkConnector for NatsSink {
     }
 
     async fn rollback_epoch(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
-        // Drop the pending futures. Any publish already on the wire will
-        // land on the server; on the next epoch's retry the same
-        // Nats-Msg-Id values dedup them out. Publishes that never landed
-        // simply get resent. Both paths are safe as long as the stream's
-        // duplicate_window covers the rollback-to-retry gap — validated
-        // at open() via LDB-5056.
+        // Dedup handles any landed publishes on retry (see LDB-5056).
         self.pending_acks.clear();
         Ok(())
     }
@@ -251,6 +246,12 @@ impl SinkConnector for NatsSink {
             .config
             .as_ref()
             .map_or(Duration::from_secs(5), |c| c.ack_timeout);
+        // Flush any buffered core publishes before dropping the client —
+        // async-nats queues publishes locally and they'd be lost on a
+        // bare drop.
+        if let Some(Runtime::Core { client }) = self.runtime.as_ref() {
+            let _ = client.flush().await;
+        }
         let _ = drain_acks(&mut self.pending_acks, timeout).await;
         self.runtime = None;
         Ok(())
@@ -284,6 +285,19 @@ fn resolve_utf8<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArra
         .ok_or_else(|| err(&format!("column '{name}' not in batch schema")))?;
     col.as_string_opt::<i32>()
         .ok_or_else(|| err(&format!("column '{name}' must be Utf8")))
+}
+
+fn non_null<'a>(
+    arr: &'a StringArray,
+    row: usize,
+    kind: &str,
+    name: &str,
+) -> Result<&'a str, ConnectorError> {
+    if arr.is_null(row) {
+        Err(err(&format!("{kind} '{name}' is null at row {row}")))
+    } else {
+        Ok(arr.value(row))
+    }
 }
 
 fn build_headers(

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -1,9 +1,11 @@
 //! NATS sink connector.
 //!
-//! At-least-once publishing in this milestone. Core-mode publishes are
-//! fire-and-forget; `JetStream` publishes collect `PublishAckFuture`s and
-//! drain them concurrently in `flush`/`pre_commit`. Exactly-once via
-//! `Nats-Msg-Id` dedup lands in a follow-up.
+//! Core-mode publishes are fire-and-forget. `JetStream` publishes collect
+//! `PublishAckFuture`s and drain them concurrently in `flush`/`pre_commit`.
+//! Exactly-once uses server-side `Nats-Msg-Id` dedup: the sink refuses to
+//! start unless the target stream's `duplicate_window` is at least
+//! `min.duplicate.window.ms`, so rollback redelivery always lands inside
+//! the dedup horizon.
 
 use std::collections::VecDeque;
 use std::future::IntoFuture;
@@ -74,12 +76,25 @@ impl SinkConnector for NatsSink {
             Mode::JetStream => {
                 let context = jetstream::new(client);
                 if let Some(stream_name) = cfg.stream.as_deref() {
-                    // Touch the stream now so a bad name fails open(), not
-                    // later on the first publish.
-                    context
+                    // Touch the stream now so a bad name fails open(),
+                    // not later on the first publish.
+                    let stream = context
                         .get_stream(stream_name)
                         .await
                         .map_err(|e| err(&format!("get_stream('{stream_name}') failed: {e}")))?;
+                    if cfg.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+                        let info = stream.cached_info();
+                        let actual = info.config.duplicate_window;
+                        if actual < cfg.min_duplicate_window {
+                            return Err(err(&format!(
+                                "[LDB-5056] stream '{stream_name}' has duplicate_window={actual:?}, \
+                                 below the configured minimum {:?}. Rollback redelivery could land \
+                                 outside the dedup horizon. Reconfigure the stream or lower \
+                                 'min.duplicate.window.ms'.",
+                                cfg.min_duplicate_window,
+                            )));
+                        }
+                    }
                 }
                 Runtime::JetStream { context }
             }
@@ -116,6 +131,11 @@ impl SinkConnector for NatsSink {
             .map(|n| resolve_utf8(batch, n).map(|arr| (n.as_str(), arr)))
             .collect::<Result<_, _>>()?;
         let expected_stream = cfg.expected_stream.as_deref();
+        let dedup_col = cfg
+            .dedup_id_column
+            .as_deref()
+            .map(|n| resolve_utf8(batch, n).map(|arr| (n, arr)))
+            .transpose()?;
 
         let records = ser
             .serialize(batch)
@@ -136,7 +156,18 @@ impl SinkConnector for NatsSink {
                 }
                 (SubjectSpec::Column(_), None) => unreachable!("resolved above"),
             };
-            let headers = build_headers(expected_stream, &header_cols, row);
+            let msg_id = match dedup_col {
+                Some((name, arr)) => {
+                    if arr.is_null(row) {
+                        return Err(err(&format!(
+                            "dedup.id.column '{name}' is null at row {row}"
+                        )));
+                    }
+                    Some(arr.value(row))
+                }
+                None => None,
+            };
+            let headers = build_headers(expected_stream, msg_id, &header_cols, row);
             let payload_len = payload.len() as u64;
             let payload = bytes::Bytes::from(payload);
             bytes_total += payload_len;
@@ -204,6 +235,17 @@ impl SinkConnector for NatsSink {
         drain_acks(&mut self.pending_acks, timeout).await
     }
 
+    async fn rollback_epoch(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+        // Drop the pending futures. Any publish already on the wire will
+        // land on the server; on the next epoch's retry the same
+        // Nats-Msg-Id values dedup them out. Publishes that never landed
+        // simply get resent. Both paths are safe as long as the stream's
+        // duplicate_window covers the rollback-to-retry gap — validated
+        // at open() via LDB-5056.
+        self.pending_acks.clear();
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<(), ConnectorError> {
         let timeout = self
             .config
@@ -246,15 +288,19 @@ fn resolve_utf8<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArra
 
 fn build_headers(
     expected_stream: Option<&str>,
+    msg_id: Option<&str>,
     header_cols: &[(&str, &StringArray)],
     row: usize,
 ) -> Option<HeaderMap> {
-    if header_cols.is_empty() && expected_stream.is_none() {
+    if header_cols.is_empty() && expected_stream.is_none() && msg_id.is_none() {
         return None;
     }
     let mut h = HeaderMap::new();
     if let Some(s) = expected_stream {
         h.insert("Nats-Expected-Stream", s);
+    }
+    if let Some(id) = msg_id {
+        h.insert("Nats-Msg-Id", id);
     }
     for (name, arr) in header_cols {
         if !arr.is_null(row) {

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -1,7 +1,6 @@
-//! NATS sink connector. Core-mode publishes are fire-and-forget;
-//! `JetStream` collects `PublishAckFuture`s and drains them in
-//! `flush`/`pre_commit`. Exactly-once uses server-side `Nats-Msg-Id`
-//! dedup (see `LDB-5056`).
+//! NATS sink. Core publishes are fire-and-forget; `JetStream` collects
+//! `PublishAckFuture`s and drains them in `flush` / `pre_commit`.
+//! Exactly-once uses server-side `Nats-Msg-Id` dedup (see `LDB-5056`).
 
 use std::collections::VecDeque;
 use std::future::IntoFuture;
@@ -12,7 +11,7 @@ use arrow_schema::SchemaRef;
 use async_nats::jetstream::{self, context::PublishAckFuture};
 use async_nats::{Client, HeaderMap};
 use async_trait::async_trait;
-use futures_util::future::try_join_all;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 
 use super::config::{build_connect_options, Mode, NatsSinkConfig, SubjectSpec};
 use super::metrics::NatsSinkMetrics;
@@ -23,14 +22,14 @@ use crate::health::HealthStatus;
 use crate::metrics::ConnectorMetrics;
 use crate::serde::{self, RecordSerializer};
 
-/// NATS sink — core and `JetStream` modes behind a single type.
+/// NATS sink — core and `JetStream` modes.
 pub struct NatsSink {
     schema: SchemaRef,
     config: Option<NatsSinkConfig>,
     serializer: Option<Box<dyn RecordSerializer>>,
     runtime: Option<Runtime>,
     metrics: NatsSinkMetrics,
-    /// Publish acks from the in-flight epoch, drained in `flush`/`pre_commit`.
+    /// Drained in `flush` / `pre_commit`.
     pending_acks: VecDeque<PublishAckFuture>,
 }
 
@@ -40,8 +39,7 @@ enum Runtime {
 }
 
 impl NatsSink {
-    /// Creates a new NATS sink. Metrics register on `registry` if
-    /// provided.
+    /// Metrics register on `registry` if provided.
     #[must_use]
     pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
@@ -54,7 +52,7 @@ impl NatsSink {
         }
     }
 
-    /// Parsed config — available after [`SinkConnector::open`].
+    /// Available after [`SinkConnector::open`].
     #[must_use]
     pub fn config(&self) -> Option<&NatsSinkConfig> {
         self.config.as_ref()
@@ -105,7 +103,7 @@ impl SinkConnector for NatsSink {
     }
 
     async fn write_batch(&mut self, batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
-        // Split-borrow so `runtime` is &mut while config/serializer stay &.
+        // Split-borrow: `runtime` &mut, config/serializer &.
         let Self {
             config,
             serializer,
@@ -120,7 +118,6 @@ impl SinkConnector for NatsSink {
             .ok_or_else(|| err("sink: open() first"))?;
         let rt = runtime.as_mut().ok_or_else(|| err("sink: open() first"))?;
 
-        // Resolve columns once per batch (not per row).
         let subject_col = match &cfg.subject {
             SubjectSpec::Column(name) => Some(resolve_utf8(batch, name)?),
             SubjectSpec::Literal(_) => None,
@@ -131,8 +128,8 @@ impl SinkConnector for NatsSink {
             .map(|n| resolve_utf8(batch, n).map(|arr| (n.as_str(), arr)))
             .collect::<Result<_, _>>()?;
         let expected_stream = cfg.expected_stream.as_deref();
-        // Nats-Msg-Id only under exactly-once; otherwise dedup would
-        // fire without the LDB-5056 safety check.
+        // `Nats-Msg-Id` only under exactly-once — LDB-5056 validates the
+        // stream's `duplicate_window` at open, and isn't checked otherwise.
         let dedup_col = if cfg.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
             cfg.dedup_id_column
                 .as_deref()
@@ -178,7 +175,6 @@ impl SinkConnector for NatsSink {
                     }
                 }
                 Runtime::JetStream { context } => {
-                    // Mid-batch backpressure.
                     if pending_acks.len() >= cfg.max_pending {
                         drain_acks(pending_acks, metrics, cfg.ack_timeout).await?;
                     }
@@ -227,7 +223,6 @@ impl SinkConnector for NatsSink {
     }
 
     async fn flush(&mut self) -> Result<(), ConnectorError> {
-        // Flush core (to the wire), drain JS acks (bounded).
         match self.runtime.as_ref() {
             Some(Runtime::Core { client }) => client
                 .flush()
@@ -252,7 +247,7 @@ impl SinkConnector for NatsSink {
     }
 
     async fn rollback_epoch(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
-        // Dedup handles any landed publishes on retry (see LDB-5056).
+        // Retry safely: LDB-5056 ensures the dedup window covers this gap.
         self.pending_acks.clear();
         self.metrics.set_pending_futures(0);
         self.metrics.record_rollback();
@@ -264,7 +259,7 @@ impl SinkConnector for NatsSink {
             .config
             .as_ref()
             .map_or(Duration::from_secs(5), |c| c.ack_timeout);
-        // async-nats buffers core publishes locally; flush before drop.
+        // async-nats buffers core publishes client-side; flush before drop.
         if let Some(Runtime::Core { client }) = self.runtime.as_ref() {
             let _ = client.flush().await;
         }
@@ -296,8 +291,10 @@ impl SinkConnector for NatsSink {
     }
 }
 
-/// Concurrently drain `pending`, bounded by `timeout`. Counts
-/// server-identified duplicates via `PubAck.duplicate`.
+/// Drain `pending` concurrently, bounded by `timeout`. On deadline,
+/// each still-unresolved ack bumps `record_ack_error` once; the publish
+/// may have landed server-side, so exactly-once depends on dedup to
+/// swallow the retry.
 async fn drain_acks(
     pending: &mut VecDeque<PublishAckFuture>,
     metrics: &NatsSinkMetrics,
@@ -306,29 +303,42 @@ async fn drain_acks(
     if pending.is_empty() {
         return Ok(());
     }
-    let futures: Vec<_> = pending.drain(..).map(IntoFuture::into_future).collect();
-    let result = match tokio::time::timeout(timeout, try_join_all(futures)).await {
-        Ok(Ok(acks)) => {
-            for ack in acks {
+    let mut set: FuturesUnordered<_> = pending.drain(..).map(IntoFuture::into_future).collect();
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut first_err: Option<ConnectorError> = None;
+
+    loop {
+        if set.is_empty() {
+            break;
+        }
+        match tokio::time::timeout_at(deadline, set.next()).await {
+            Ok(Some(Ok(ack))) => {
                 if ack.duplicate {
                     metrics.record_dedup();
                 }
             }
-            Ok(())
+            Ok(Some(Err(e))) => {
+                metrics.record_ack_error();
+                if first_err.is_none() {
+                    first_err = Some(err(&format!("jetstream publish ack: {e}")));
+                }
+            }
+            Ok(None) => break,
+            Err(_) => {
+                let lost = set.len();
+                for _ in 0..lost {
+                    metrics.record_ack_error();
+                }
+                metrics.set_pending_futures(pending.len());
+                return Err(err(&format!(
+                    "jetstream publish ack: timed out with {lost} still in flight"
+                )));
+            }
         }
-        Ok(Err(e)) => {
-            metrics.record_ack_error();
-            Err(err(&format!("jetstream publish ack: {e}")))
-        }
-        Err(_) => {
-            metrics.record_ack_error();
-            Err(err(&format!(
-                "jetstream publish ack: timed out after {timeout:?}"
-            )))
-        }
-    };
+    }
+
     metrics.set_pending_futures(pending.len());
-    result
+    first_err.map_or(Ok(()), Err)
 }
 
 fn resolve_utf8<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, ConnectorError> {

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -230,12 +230,11 @@ impl SinkConnector for NatsSink {
                 .map_err(|e| err(&format!("core flush: {e}")))?,
             Some(Runtime::JetStream { .. }) | None => {}
         }
-        drain_acks(
-            &mut self.pending_acks,
-            &self.metrics,
-            Duration::from_secs(1),
-        )
-        .await
+        let timeout = self
+            .config
+            .as_ref()
+            .map_or(Duration::from_secs(30), |c| c.ack_timeout);
+        drain_acks(&mut self.pending_acks, &self.metrics, timeout).await
     }
 
     async fn pre_commit(&mut self, _epoch: u64) -> Result<(), ConnectorError> {

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -157,7 +157,7 @@ impl SinkConnector for NatsSink {
             .map_err(|e| err(&format!("serialize batch: {e}")))?;
 
         let mut bytes_total: u64 = 0;
-        let rows = batch.num_rows();
+        let mut rows_written: usize = 0;
         for (row, payload) in records.into_iter().enumerate() {
             let subject: &str = match (&cfg.subject, subject_col) {
                 (SubjectSpec::Literal(s), _) => s.as_str(),
@@ -172,7 +172,6 @@ impl SinkConnector for NatsSink {
             let headers = build_headers(expected_stream, msg_id, &header_cols, row);
             let payload_len = payload.len() as u64;
             let payload = bytes::Bytes::from(payload);
-            bytes_total += payload_len;
 
             match rt {
                 Runtime::Core { client } => {
@@ -183,32 +182,38 @@ impl SinkConnector for NatsSink {
                     } else {
                         client.publish(subject.to_string(), payload).await
                     };
-                    result.map_err(|e| {
+                    if let Err(e) = result {
                         metrics.record_publish_error();
-                        err(&format!("core publish: {e}"))
-                    })?;
+                        return Err(err(&format!("core publish: {e}")));
+                    }
                 }
                 Runtime::JetStream { context } => {
-                    let fut = if let Some(h) = headers {
+                    let publish_result = if let Some(h) = headers {
                         context
                             .publish_with_headers(subject.to_string(), h, payload)
                             .await
                     } else {
                         context.publish(subject.to_string(), payload).await
                     };
-                    let fut = fut.map_err(|e| {
-                        metrics.record_publish_error();
-                        err(&format!("jetstream publish: {e}"))
-                    })?;
-                    pending_acks.push_back(fut);
+                    match publish_result {
+                        Ok(fut) => pending_acks.push_back(fut),
+                        Err(e) => {
+                            metrics.record_publish_error();
+                            return Err(err(&format!("jetstream publish: {e}")));
+                        }
+                    }
                 }
             }
+
+            // Record per-row so partial-failure batches don't vanish
+            // from the success counter.
+            metrics.record_published_row(payload_len);
+            rows_written += 1;
+            bytes_total += payload_len;
         }
 
-        metrics.record_publish(rows as u64, bytes_total);
-        #[allow(clippy::cast_possible_wrap)]
         metrics.set_pending_futures(pending_acks.len());
-        Ok(WriteResult::new(rows, bytes_total))
+        Ok(WriteResult::new(rows_written, bytes_total))
     }
 
     fn schema(&self) -> SchemaRef {
@@ -258,6 +263,7 @@ impl SinkConnector for NatsSink {
         // Dedup handles any landed publishes on retry (see LDB-5056).
         self.pending_acks.clear();
         self.metrics.set_pending_futures(0);
+        self.metrics.record_rollback();
         Ok(())
     }
 

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -178,6 +178,13 @@ impl SinkConnector for NatsSink {
                     }
                 }
                 Runtime::JetStream { context } => {
+                    // Mid-batch backpressure: if we're at max_pending,
+                    // drain before publishing more. Prevents unbounded
+                    // memory growth on large batches and keeps acks
+                    // close to publishes.
+                    if pending_acks.len() >= cfg.max_pending {
+                        drain_acks(pending_acks, metrics, cfg.ack_timeout).await?;
+                    }
                     let publish_result = if let Some(h) = headers {
                         context
                             .publish_with_headers(subject.to_string(), h, payload)

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -2,17 +2,19 @@
 //!
 //! At-least-once publishing in this milestone. Core-mode publishes are
 //! fire-and-forget; `JetStream` publishes collect `PublishAckFuture`s and
-//! drain them in `flush`/`pre_commit`. Exactly-once via `Nats-Msg-Id`
-//! dedup lands in a follow-up.
+//! drain them concurrently in `flush`/`pre_commit`. Exactly-once via
+//! `Nats-Msg-Id` dedup lands in a follow-up.
 
 use std::collections::VecDeque;
+use std::future::IntoFuture;
 use std::time::Duration;
 
-use arrow_array::{cast::AsArray, Array, RecordBatch};
+use arrow_array::{cast::AsArray, Array, RecordBatch, StringArray};
 use arrow_schema::SchemaRef;
 use async_nats::jetstream::{self, context::PublishAckFuture};
 use async_nats::{Client, HeaderMap};
 use async_trait::async_trait;
+use futures_util::future::try_join_all;
 
 use super::config::{Mode, NatsSinkConfig, SubjectSpec};
 use crate::config::ConnectorConfig;
@@ -53,54 +55,6 @@ impl NatsSink {
     pub fn config(&self) -> Option<&NatsSinkConfig> {
         self.config.as_ref()
     }
-
-    fn subject_for_row(&self, batch: &RecordBatch, row: usize) -> Result<String, ConnectorError> {
-        let cfg = self.config.as_ref().expect("open() before write_batch");
-        match &cfg.subject {
-            SubjectSpec::Literal(s) => Ok(s.clone()),
-            SubjectSpec::Column(name) => {
-                let col = batch
-                    .column_by_name(name)
-                    .ok_or_else(|| err(&format!("subject.column '{name}' not in batch schema")))?;
-                let strings = col.as_string_opt::<i32>().ok_or_else(|| {
-                    err(&format!("subject.column '{name}' must be a Utf8 column"))
-                })?;
-                if strings.is_null(row) {
-                    return Err(err(&format!(
-                        "subject.column '{name}' is null at row {row}"
-                    )));
-                }
-                Ok(strings.value(row).to_string())
-            }
-        }
-    }
-
-    fn headers_for_row(
-        &self,
-        batch: &RecordBatch,
-        row: usize,
-    ) -> Result<Option<HeaderMap>, ConnectorError> {
-        let cfg = self.config.as_ref().expect("open() before write_batch");
-        if cfg.header_columns.is_empty() && cfg.expected_stream.is_none() {
-            return Ok(None);
-        }
-        let mut headers = HeaderMap::new();
-        if let Some(s) = cfg.expected_stream.as_deref() {
-            headers.insert("Nats-Expected-Stream", s);
-        }
-        for col_name in &cfg.header_columns {
-            let col = batch
-                .column_by_name(col_name)
-                .ok_or_else(|| err(&format!("header.columns: '{col_name}' not in batch schema")))?;
-            let strings = col
-                .as_string_opt::<i32>()
-                .ok_or_else(|| err(&format!("header.columns '{col_name}' must be Utf8")))?;
-            if !strings.is_null(row) {
-                headers.insert(col_name.as_str(), strings.value(row));
-            }
-        }
-        Ok(Some(headers))
-    }
 }
 
 #[async_trait]
@@ -135,10 +89,34 @@ impl SinkConnector for NatsSink {
     }
 
     async fn write_batch(&mut self, batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
-        let ser = self
-            .serializer
+        // Split-borrow `self` so the runtime can be &mut while we keep
+        // immutable refs to config + serializer.
+        let Self {
+            config,
+            serializer,
+            runtime,
+            pending_acks,
+            schema: _,
+        } = self;
+        let cfg = config.as_ref().ok_or_else(|| err("sink: open() first"))?;
+        let ser = serializer
             .as_ref()
-            .ok_or_else(|| err("serializer not initialized"))?;
+            .ok_or_else(|| err("sink: open() first"))?;
+        let rt = runtime.as_mut().ok_or_else(|| err("sink: open() first"))?;
+
+        // Resolve column references once per batch so the per-row loop
+        // does no hashmap lookups.
+        let subject_col = match &cfg.subject {
+            SubjectSpec::Column(name) => Some(resolve_utf8(batch, name)?),
+            SubjectSpec::Literal(_) => None,
+        };
+        let header_cols: Vec<(&str, &StringArray)> = cfg
+            .header_columns
+            .iter()
+            .map(|n| resolve_utf8(batch, n).map(|arr| (n.as_str(), arr)))
+            .collect::<Result<_, _>>()?;
+        let expected_stream = cfg.expected_stream.as_deref();
+
         let records = ser
             .serialize(batch)
             .map_err(|e| err(&format!("serialize batch: {e}")))?;
@@ -146,38 +124,48 @@ impl SinkConnector for NatsSink {
         let mut bytes_total: u64 = 0;
         let rows = batch.num_rows();
         for (row, payload) in records.into_iter().enumerate() {
-            if row >= rows {
-                break;
-            }
-            let subject = self.subject_for_row(batch, row)?;
-            let headers = self.headers_for_row(batch, row)?;
-            bytes_total += payload.len() as u64;
+            let subject: &str = match (&cfg.subject, subject_col) {
+                (SubjectSpec::Literal(s), _) => s.as_str(),
+                (SubjectSpec::Column(name), Some(arr)) => {
+                    if arr.is_null(row) {
+                        return Err(err(&format!(
+                            "subject.column '{name}' is null at row {row}"
+                        )));
+                    }
+                    arr.value(row)
+                }
+                (SubjectSpec::Column(_), None) => unreachable!("resolved above"),
+            };
+            let headers = build_headers(expected_stream, &header_cols, row);
+            let payload_len = payload.len() as u64;
             let payload = bytes::Bytes::from(payload);
+            bytes_total += payload_len;
 
-            match self.runtime.as_mut() {
-                Some(Runtime::Core { client }) => {
+            match rt {
+                Runtime::Core { client } => {
                     let result = if let Some(h) = headers {
-                        client.publish_with_headers(subject, h, payload).await
+                        client
+                            .publish_with_headers(subject.to_string(), h, payload)
+                            .await
                     } else {
-                        client.publish(subject, payload).await
+                        client.publish(subject.to_string(), payload).await
                     };
                     result.map_err(|e| err(&format!("core publish: {e}")))?;
                 }
-                Some(Runtime::JetStream { context }) => {
+                Runtime::JetStream { context } => {
                     let fut = if let Some(h) = headers {
                         context
-                            .publish_with_headers(subject, h, payload)
+                            .publish_with_headers(subject.to_string(), h, payload)
                             .await
                             .map_err(|e| err(&format!("jetstream publish: {e}")))?
                     } else {
                         context
-                            .publish(subject, payload)
+                            .publish(subject.to_string(), payload)
                             .await
                             .map_err(|e| err(&format!("jetstream publish: {e}")))?
                     };
-                    self.pending_acks.push_back(fut);
+                    pending_acks.push_back(fut);
                 }
-                None => return Err(err("sink: open() was not called")),
             }
         }
 
@@ -202,8 +190,9 @@ impl SinkConnector for NatsSink {
     }
 
     async fn flush(&mut self) -> Result<(), ConnectorError> {
-        // Drain whatever has landed without blocking the flow for long.
-        // pre_commit does the strict drain with a user-configured timeout.
+        // Drain whatever has landed, bounded by 1s so a slow round-trip
+        // doesn't stall the periodic flush timer. pre_commit uses the
+        // user-configured ack timeout for the strict drain.
         drain_acks(&mut self.pending_acks, Duration::from_secs(1)).await
     }
 
@@ -216,7 +205,6 @@ impl SinkConnector for NatsSink {
     }
 
     async fn close(&mut self) -> Result<(), ConnectorError> {
-        // Best-effort drain with the sink's ack timeout.
         let timeout = self
             .config
             .as_ref()
@@ -227,6 +215,10 @@ impl SinkConnector for NatsSink {
     }
 }
 
+/// Concurrently drain every `PublishAckFuture` in `pending`, bounded by
+/// `timeout`. Matches the Kafka sink's rollback shape — serial drains
+/// killed throughput. `PublishAckFuture` only implements `IntoFuture`,
+/// hence the explicit conversion.
 async fn drain_acks(
     pending: &mut VecDeque<PublishAckFuture>,
     timeout: Duration,
@@ -234,19 +226,42 @@ async fn drain_acks(
     if pending.is_empty() {
         return Ok(());
     }
-    let deadline = tokio::time::Instant::now() + timeout;
-    while let Some(fut) = pending.pop_front() {
-        match tokio::time::timeout_at(deadline, fut).await {
-            Ok(Ok(_ack)) => {}
-            Ok(Err(e)) => return Err(err(&format!("jetstream publish ack: {e}"))),
-            Err(_) => {
-                return Err(err(&format!(
-                    "jetstream publish ack: timed out after {timeout:?} with acks still outstanding"
-                )));
-            }
+    let futures: Vec<_> = pending.drain(..).map(IntoFuture::into_future).collect();
+    match tokio::time::timeout(timeout, try_join_all(futures)).await {
+        Ok(Ok(_acks)) => Ok(()),
+        Ok(Err(e)) => Err(err(&format!("jetstream publish ack: {e}"))),
+        Err(_) => Err(err(&format!(
+            "jetstream publish ack: timed out after {timeout:?}"
+        ))),
+    }
+}
+
+fn resolve_utf8<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray, ConnectorError> {
+    let col = batch
+        .column_by_name(name)
+        .ok_or_else(|| err(&format!("column '{name}' not in batch schema")))?;
+    col.as_string_opt::<i32>()
+        .ok_or_else(|| err(&format!("column '{name}' must be Utf8")))
+}
+
+fn build_headers(
+    expected_stream: Option<&str>,
+    header_cols: &[(&str, &StringArray)],
+    row: usize,
+) -> Option<HeaderMap> {
+    if header_cols.is_empty() && expected_stream.is_none() {
+        return None;
+    }
+    let mut h = HeaderMap::new();
+    if let Some(s) = expected_stream {
+        h.insert("Nats-Expected-Stream", s);
+    }
+    for (name, arr) in header_cols {
+        if !arr.is_null(row) {
+            h.insert(*name, arr.value(row));
         }
     }
-    Ok(())
+    Some(h)
 }
 
 fn err(msg: &str) -> ConnectorError {

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -1,0 +1,72 @@
+//! NATS sink connector.
+//!
+//! This milestone validates and stores the configuration. Publish, ack
+//! tracking, and dedup handling land with the data path.
+
+use std::time::Duration;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+
+use super::config::NatsSinkConfig;
+use crate::config::ConnectorConfig;
+use crate::connector::{DeliveryGuarantee, SinkConnector, SinkConnectorCapabilities, WriteResult};
+use crate::error::ConnectorError;
+
+/// NATS sink — core and `JetStream` modes behind a single type.
+pub struct NatsSink {
+    schema: SchemaRef,
+    config: Option<NatsSinkConfig>,
+}
+
+impl NatsSink {
+    /// Creates a new NATS sink with the given input schema.
+    #[must_use]
+    pub fn new(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            config: None,
+        }
+    }
+
+    /// Parsed config — available after [`SinkConnector::open`].
+    #[must_use]
+    pub fn config(&self) -> Option<&NatsSinkConfig> {
+        self.config.as_ref()
+    }
+}
+
+#[async_trait]
+impl SinkConnector for NatsSink {
+    async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
+        self.config = Some(NatsSinkConfig::from_config(config)?);
+        Ok(())
+    }
+
+    async fn write_batch(&mut self, _batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
+        // Data path lands in the follow-up.
+        Ok(WriteResult::new(0, 0))
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn capabilities(&self) -> SinkConnectorCapabilities {
+        let mut caps = SinkConnectorCapabilities::new(Duration::from_secs(5))
+            .with_idempotent()
+            .with_partitioned();
+        if matches!(
+            self.config.as_ref().map(|c| c.delivery_guarantee),
+            Some(DeliveryGuarantee::ExactlyOnce)
+        ) {
+            caps = caps.with_exactly_once().with_two_phase_commit();
+        }
+        caps
+    }
+
+    async fn close(&mut self) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+}

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -178,10 +178,7 @@ impl SinkConnector for NatsSink {
                     }
                 }
                 Runtime::JetStream { context } => {
-                    // Mid-batch backpressure: if we're at max_pending,
-                    // drain before publishing more. Prevents unbounded
-                    // memory growth on large batches and keeps acks
-                    // close to publishes.
+                    // Mid-batch backpressure.
                     if pending_acks.len() >= cfg.max_pending {
                         drain_acks(pending_acks, metrics, cfg.ack_timeout).await?;
                     }

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -1,11 +1,7 @@
-//! NATS sink connector.
-//!
-//! Core-mode publishes are fire-and-forget. `JetStream` publishes collect
-//! `PublishAckFuture`s and drain them concurrently in `flush`/`pre_commit`.
-//! Exactly-once uses server-side `Nats-Msg-Id` dedup: the sink refuses to
-//! start unless the target stream's `duplicate_window` is at least
-//! `min.duplicate.window.ms`, so rollback redelivery always lands inside
-//! the dedup horizon.
+//! NATS sink connector. Core-mode publishes are fire-and-forget;
+//! `JetStream` collects `PublishAckFuture`s and drains them in
+//! `flush`/`pre_commit`. Exactly-once uses server-side `Nats-Msg-Id`
+//! dedup (see `LDB-5056`).
 
 use std::collections::VecDeque;
 use std::future::IntoFuture;
@@ -44,9 +40,8 @@ enum Runtime {
 }
 
 impl NatsSink {
-    /// Creates a new NATS sink with the given input schema.
-    ///
-    /// If `registry` is `Some`, metrics register on it.
+    /// Creates a new NATS sink. Metrics register on `registry` if
+    /// provided.
     #[must_use]
     pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
@@ -83,8 +78,7 @@ impl SinkConnector for NatsSink {
             Mode::JetStream => {
                 let context = jetstream::new(client);
                 if let Some(stream_name) = cfg.stream.as_deref() {
-                    // Touch the stream now so a bad name fails open(),
-                    // not later on the first publish.
+                    // Fail fast on a bad name.
                     let stream = context
                         .get_stream(stream_name)
                         .await
@@ -111,8 +105,7 @@ impl SinkConnector for NatsSink {
     }
 
     async fn write_batch(&mut self, batch: &RecordBatch) -> Result<WriteResult, ConnectorError> {
-        // Split-borrow `self` so the runtime can be &mut while we keep
-        // immutable refs to config + serializer.
+        // Split-borrow so `runtime` is &mut while config/serializer stay &.
         let Self {
             config,
             serializer,
@@ -127,8 +120,7 @@ impl SinkConnector for NatsSink {
             .ok_or_else(|| err("sink: open() first"))?;
         let rt = runtime.as_mut().ok_or_else(|| err("sink: open() first"))?;
 
-        // Resolve column references once per batch so the per-row loop
-        // does no hashmap lookups.
+        // Resolve columns once per batch (not per row).
         let subject_col = match &cfg.subject {
             SubjectSpec::Column(name) => Some(resolve_utf8(batch, name)?),
             SubjectSpec::Literal(_) => None,
@@ -139,10 +131,8 @@ impl SinkConnector for NatsSink {
             .map(|n| resolve_utf8(batch, n).map(|arr| (n.as_str(), arr)))
             .collect::<Result<_, _>>()?;
         let expected_stream = cfg.expected_stream.as_deref();
-        // Only emit Nats-Msg-Id under exactly-once — that's the delivery
-        // mode whose duplicate_window we validate at open(). Honoring
-        // the column under at-least-once would give silent dedup without
-        // the safety check, which is the worst of both worlds.
+        // Nats-Msg-Id only under exactly-once; otherwise dedup would
+        // fire without the LDB-5056 safety check.
         let dedup_col = if cfg.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
             cfg.dedup_id_column
                 .as_deref()
@@ -205,8 +195,7 @@ impl SinkConnector for NatsSink {
                 }
             }
 
-            // Record per-row so partial-failure batches don't vanish
-            // from the success counter.
+            // Per-row so partial failures still credit successes.
             metrics.record_published_row(payload_len);
             rows_written += 1;
             bytes_total += payload_len;
@@ -234,8 +223,7 @@ impl SinkConnector for NatsSink {
     }
 
     async fn flush(&mut self) -> Result<(), ConnectorError> {
-        // Push buffered core publishes to the wire; drain landed JS acks
-        // (bounded so a slow round-trip doesn't stall the flush timer).
+        // Flush core (to the wire), drain JS acks (bounded).
         match self.runtime.as_ref() {
             Some(Runtime::Core { client }) => client
                 .flush()
@@ -272,9 +260,7 @@ impl SinkConnector for NatsSink {
             .config
             .as_ref()
             .map_or(Duration::from_secs(5), |c| c.ack_timeout);
-        // Flush any buffered core publishes before dropping the client —
-        // async-nats queues publishes locally and they'd be lost on a
-        // bare drop.
+        // async-nats buffers core publishes locally; flush before drop.
         if let Some(Runtime::Core { client }) = self.runtime.as_ref() {
             let _ = client.flush().await;
         }
@@ -306,11 +292,8 @@ impl SinkConnector for NatsSink {
     }
 }
 
-/// Concurrently drain every `PublishAckFuture` in `pending`, bounded by
-/// `timeout`. Matches the Kafka sink's rollback shape — serial drains
-/// killed throughput. `PublishAckFuture` only implements `IntoFuture`,
-/// hence the explicit conversion. Counts server-identified duplicates
-/// via `PubAck.duplicate`.
+/// Concurrently drain `pending`, bounded by `timeout`. Counts
+/// server-identified duplicates via `PubAck.duplicate`.
 async fn drain_acks(
     pending: &mut VecDeque<PublishAckFuture>,
     metrics: &NatsSinkMetrics,

--- a/crates/laminar-connectors/src/nats/sink.rs
+++ b/crates/laminar-connectors/src/nats/sink.rs
@@ -18,7 +18,7 @@ use async_nats::{Client, HeaderMap};
 use async_trait::async_trait;
 use futures_util::future::try_join_all;
 
-use super::config::{Mode, NatsSinkConfig, SubjectSpec};
+use super::config::{build_connect_options, Mode, NatsSinkConfig, SubjectSpec};
 use super::metrics::NatsSinkMetrics;
 use crate::config::ConnectorConfig;
 use crate::connector::{DeliveryGuarantee, SinkConnector, SinkConnectorCapabilities, WriteResult};
@@ -74,7 +74,7 @@ impl SinkConnector for NatsSink {
             serde::create_serializer(cfg.format)
                 .map_err(|e| err(&format!("serializer for format {:?}: {e}", cfg.format)))?,
         );
-        let client = async_nats::ConnectOptions::new()
+        let client = build_connect_options(&cfg.auth, &cfg.tls)
             .connect(&cfg.servers)
             .await
             .map_err(|e| err(&format!("nats connect({:?}): {e}", cfg.servers)))?;

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -1,8 +1,7 @@
-//! NATS source connector — `JetStream` pull consumer with
-//! ack-on-commit, or core subscribe (at-most-once). A background reader
-//! task forwards messages to `poll_batch` through an `mpsc` channel;
-//! `JetStream` message handles are retained until `notify_epoch_committed`
-//! fires, then acked in bulk.
+//! NATS source: `JetStream` pull consumer with ack-on-commit, or core
+//! subscribe (at-most-once). A background task forwards messages through
+//! an `mpsc` channel; JS message handles are retained until
+//! `notify_epoch_committed` fires, then acked in bulk.
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -29,7 +28,7 @@ use crate::health::HealthStatus;
 use crate::metrics::ConnectorMetrics;
 use crate::serde::{self, RecordDeserializer};
 
-/// One inbound message. `ack` is `Some` only on the `JetStream` path.
+/// `ack` is `Some` only on the `JetStream` path.
 struct Incoming {
     subject: String,
     payload: Bytes,
@@ -37,18 +36,16 @@ struct Incoming {
     ack: Option<jetstream::Message>,
 }
 
-/// Runtime state populated by `open()` and torn down by `close()`.
 struct Running {
     deserializer: Box<dyn RecordDeserializer>,
     rx: mpsc::Receiver<Incoming>,
-    /// Wakes the reader out of a blocking fetch.
     shutdown: Arc<Notify>,
     /// `Some` on `JetStream`; `None` on core.
     consecutive_errors: Option<Arc<AtomicU32>>,
     handle: JoinHandle<()>,
 }
 
-/// NATS source — core and `JetStream` modes behind a single type.
+/// NATS source — core and `JetStream` modes.
 pub struct NatsSource {
     schema: SchemaRef,
     config: Option<NatsSourceConfig>,
@@ -56,17 +53,15 @@ pub struct NatsSource {
     metrics: NatsSourceMetrics,
     running: Option<Running>,
 
-    // Ack-on-commit bookkeeping.
-    pending: Vec<jetstream::Message>,
-    sealed: VecDeque<Vec<jetstream::Message>>,
-
-    // Per-subject last-observed stream sequence, for checkpointing.
-    offsets: FxHashMap<String, u64>,
+    // Interior mutability so `checkpoint()` (takes `&self`) can seal
+    // `pending` into `sealed` atomically with offset capture.
+    pending: parking_lot::Mutex<Vec<jetstream::Message>>,
+    sealed: parking_lot::Mutex<VecDeque<Vec<jetstream::Message>>>,
+    offsets: parking_lot::Mutex<FxHashMap<String, u64>>,
 }
 
 impl NatsSource {
-    /// Creates a new NATS source. Metrics register on `registry` if
-    /// provided.
+    /// Metrics register on `registry` if provided.
     #[must_use]
     pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
@@ -75,19 +70,19 @@ impl NatsSource {
             data_ready: Arc::new(Notify::new()),
             metrics: NatsSourceMetrics::new(registry),
             running: None,
-            pending: Vec::new(),
-            sealed: VecDeque::new(),
-            offsets: FxHashMap::default(),
+            pending: parking_lot::Mutex::new(Vec::new()),
+            sealed: parking_lot::Mutex::new(VecDeque::new()),
+            offsets: parking_lot::Mutex::new(FxHashMap::default()),
         }
     }
 
     fn update_pending_gauge(&self) {
-        let sealed_total: usize = self.sealed.iter().map(Vec::len).sum();
-        self.metrics
-            .set_pending_acks(self.pending.len() + sealed_total);
+        let pending_len = self.pending.lock().len();
+        let sealed_total: usize = self.sealed.lock().iter().map(Vec::len).sum();
+        self.metrics.set_pending_acks(pending_len + sealed_total);
     }
 
-    /// Parsed config — available after [`SourceConnector::open`].
+    /// Available after [`SourceConnector::open`].
     #[must_use]
     pub fn config(&self) -> Option<&NatsSourceConfig> {
         self.config.as_ref()
@@ -189,13 +184,6 @@ impl NatsSource {
         });
         Ok(())
     }
-
-    fn seal_pending(&mut self) {
-        if !self.pending.is_empty() {
-            let batch = std::mem::take(&mut self.pending);
-            self.sealed.push_back(batch);
-        }
-    }
 }
 
 #[async_trait]
@@ -222,24 +210,36 @@ impl SourceConnector for NatsSource {
 
         let mut payloads: Vec<Bytes> = Vec::new();
         let mut partition: Option<PartitionInfo> = None;
+        let mut new_acks: Vec<jetstream::Message> = Vec::new();
+        let mut offset_updates: Vec<(String, u64)> = Vec::new();
 
         while payloads.len() < max_records {
             let Ok(incoming) = running.rx.try_recv() else {
                 break;
             };
             if let Some(seq) = incoming.stream_seq {
-                self.offsets
-                    .entry(incoming.subject.clone())
-                    .and_modify(|s| *s = (*s).max(seq))
-                    .or_insert(seq);
+                offset_updates.push((incoming.subject.clone(), seq));
                 if partition.is_none() {
                     partition = Some(PartitionInfo::new(&incoming.subject, seq.to_string()));
                 }
             }
             payloads.push(incoming.payload);
             if let Some(msg) = incoming.ack {
-                self.pending.push(msg);
+                new_acks.push(msg);
             }
+        }
+
+        if !offset_updates.is_empty() {
+            let mut offsets = self.offsets.lock();
+            for (subject, seq) in offset_updates {
+                offsets
+                    .entry(subject)
+                    .and_modify(|s| *s = (*s).max(seq))
+                    .or_insert(seq);
+            }
+        }
+        if !new_acks.is_empty() {
+            self.pending.lock().extend(new_acks);
         }
 
         if payloads.is_empty() {
@@ -268,15 +268,25 @@ impl SourceConnector for NatsSource {
     }
 
     fn checkpoint(&self) -> SourceCheckpoint {
+        // Seal now-pending acks into this epoch; anything arriving after
+        // goes into a fresh batch committed with a later epoch. Without
+        // this split, an ack could fire before its manifest record lands.
+        {
+            let mut pending = self.pending.lock();
+            if !pending.is_empty() {
+                let batch = std::mem::take(&mut *pending);
+                self.sealed.lock().push_back(batch);
+            }
+        }
         let mut cp = SourceCheckpoint::default();
-        for (subject, seq) in &self.offsets {
+        for (subject, seq) in &*self.offsets.lock() {
             cp.set_offset(subject.as_str(), seq.to_string());
         }
         cp
     }
 
     async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
-        // Durable consumer's ack floor on the server is authoritative.
+        // Durable consumer ack floor on the server is authoritative.
         Ok(())
     }
 
@@ -299,10 +309,12 @@ impl SourceConnector for NatsSource {
     }
 
     async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
-        // Ack everything sealed so far. Per-msg ack errors don't roll
-        // the epoch back — the broker redelivers on ack_wait.
-        self.seal_pending();
-        while let Some(batch) = self.sealed.pop_front() {
+        // Per-msg ack errors don't roll the epoch back; the broker
+        // redelivers on ack_wait.
+        loop {
+            let Some(batch) = self.sealed.lock().pop_front() else {
+                break;
+            };
             for msg in batch {
                 match msg.ack().await {
                     Ok(()) => self.metrics.record_ack(),
@@ -322,7 +334,7 @@ impl SourceConnector for NatsSource {
             return HealthStatus::Unknown;
         };
 
-        // Unhealthy beats Degraded. Threshold of zero disables the flip.
+        // Threshold of zero disables the flip.
         if cfg.fetch_error_threshold > 0 {
             if let Some(errors) = self
                 .running
@@ -339,8 +351,7 @@ impl SourceConnector for NatsSource {
             }
         }
 
-        // Degraded: pending acks saturate half of `max_ack_pending`. The
-        // broker pauses delivery at 100%; yellow-light before that.
+        // Broker pauses delivery at 100% `max_ack_pending`; flag at 50%.
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let cap = cfg.max_ack_pending.max(1) as u64;
         #[allow(clippy::cast_sign_loss)]
@@ -425,14 +436,14 @@ fn map_ack_policy(p: AckPolicy) -> async_nats::jetstream::consumer::AckPolicy {
     }
 }
 
-/// 500ms, 1s, 2s, 4s, 5s-cap.
+/// 500ms, 1s, 2s, 4s, cap 5s.
 fn fetch_backoff_base(consecutive_errors: u32) -> Duration {
     let exp = consecutive_errors.saturating_sub(1).min(4);
     let ms = 500u64.saturating_mul(1u64 << exp);
     Duration::from_millis(ms.min(5000))
 }
 
-/// `base ± 20%`; `entropy` is any `u64` (tests pass a fixed seed).
+/// `base ± 20%`. Tests pass a fixed `entropy` seed.
 fn with_jitter(base: Duration, entropy: u64) -> Duration {
     let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
     let range = (base_ms / 5).max(1); // 20%
@@ -446,8 +457,8 @@ fn fetch_backoff(consecutive_errors: u32, entropy: u64) -> Duration {
     with_jitter(fetch_backoff_base(consecutive_errors), entropy)
 }
 
-/// Server error 10148 / 10013 means the consumer exists with a
-/// conflicting config — raise LDB-5070 with an operator fix-up.
+/// Server 10148 / 10013 → consumer exists with a conflicting config;
+/// raise LDB-5070 with an operator fix-up.
 fn classify_create_consumer_error(
     e: &async_nats::jetstream::stream::ConsumerError,
     consumer_name: &str,
@@ -473,7 +484,6 @@ fn classify_create_consumer_error(
     }
 }
 
-/// Jitter seed; not cryptographic.
 #[allow(clippy::cast_possible_truncation)]
 fn entropy_now() -> u64 {
     Instant::now().elapsed().as_nanos() as u64
@@ -569,8 +579,8 @@ impl JsReader {
                 forwarded += 1;
             }
 
-            // Reset on any forwarded message; count an all-error
-            // iteration as one failure; leave idle iterations alone.
+            // Reset on progress; an iteration with only errors counts
+            // as one failure; idle iterations don't bump.
             if forwarded > 0 {
                 consecutive_errors.store(0, Ordering::Release);
                 data_ready.notify_one();
@@ -640,12 +650,13 @@ mod tests {
     use arrow_schema::Schema;
 
     #[test]
-    fn seal_pending_moves_to_sealed() {
-        let mut src = NatsSource::new(Arc::new(Schema::empty()), None);
-        // We can't easily construct jetstream::Message without a real
-        // server, so we just test the empty-pending no-op path.
-        src.seal_pending();
-        assert!(src.sealed.is_empty());
+    fn checkpoint_empty_pending_is_noop() {
+        // `jetstream::Message` can't be constructed without a server,
+        // so we only cover the empty path here; non-empty sealing is
+        // exercised in `tests/nats_integration.rs`.
+        let src = NatsSource::new(Arc::new(Schema::empty()), None);
+        let _ = src.checkpoint();
+        assert!(src.sealed.lock().is_empty());
     }
 
     #[test]

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -30,7 +30,7 @@ use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
-use super::config::{AckPolicy, DeliverPolicy, Mode, NatsSourceConfig};
+use super::config::{build_connect_options, AckPolicy, DeliverPolicy, Mode, NatsSourceConfig};
 use super::metrics::NatsSourceMetrics;
 use crate::checkpoint::SourceCheckpoint;
 use crate::config::ConnectorConfig;
@@ -112,7 +112,7 @@ impl NatsSource {
         cfg: &NatsSourceConfig,
         deserializer: Box<dyn RecordDeserializer>,
     ) -> Result<(), ConnectorError> {
-        let client = connect(&cfg.servers).await?;
+        let client = connect(cfg).await?;
         let js = jetstream::new(client);
 
         let stream_name = cfg
@@ -210,7 +210,7 @@ impl NatsSource {
         cfg: &NatsSourceConfig,
         deserializer: Box<dyn RecordDeserializer>,
     ) -> Result<(), ConnectorError> {
-        let client = connect(&cfg.servers).await?;
+        let client = connect(cfg).await?;
         let subject = cfg
             .subject
             .clone()
@@ -427,11 +427,11 @@ fn err(msg: &str) -> ConnectorError {
     ConnectorError::ConfigurationError(msg.to_string())
 }
 
-async fn connect(servers: &[String]) -> Result<async_nats::Client, ConnectorError> {
-    async_nats::ConnectOptions::new()
-        .connect(servers)
+async fn connect(cfg: &NatsSourceConfig) -> Result<async_nats::Client, ConnectorError> {
+    build_connect_options(&cfg.auth, &cfg.tls)
+        .connect(&cfg.servers)
         .await
-        .map_err(|e| err(&format!("nats connect({servers:?}): {e}")))
+        .map_err(|e| err(&format!("nats connect({:?}): {e}", cfg.servers)))
 }
 
 fn build_pull_config(

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use arrow_schema::SchemaRef;
 use async_nats::jetstream::{self, consumer::pull};
 use async_trait::async_trait;
+use bytes::Bytes;
 use crossfire::{mpsc, AsyncRx};
 use futures_util::StreamExt;
 use rustc_hash::FxHashMap;
@@ -41,22 +42,27 @@ use crate::serde::{self, RecordDeserializer};
 /// (at-most-once, no server-side ack protocol).
 struct Incoming {
     subject: String,
-    payload: Vec<u8>,
-    stream_seq: u64,
+    payload: Bytes,
+    stream_seq: Option<u64>,
     ack: Option<jetstream::Message>,
+}
+
+/// Runtime state created by [`SourceConnector::open`] and torn down in
+/// [`SourceConnector::close`]. Keeping these together avoids a handful of
+/// parallel `Option<>` fields on `NatsSource`.
+struct Running {
+    deserializer: Box<dyn RecordDeserializer>,
+    rx: AsyncRx<mpsc::Array<Incoming>>,
+    shutdown: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
 }
 
 /// NATS source — core and `JetStream` modes behind a single type.
 pub struct NatsSource {
     schema: SchemaRef,
     config: Option<NatsSourceConfig>,
-
-    // Runtime state — populated by open().
-    deserializer: Option<Box<dyn RecordDeserializer>>,
-    rx: Option<AsyncRx<mpsc::Array<Incoming>>>,
-    reader_shutdown: Option<Arc<AtomicBool>>,
-    reader_handle: Option<JoinHandle<()>>,
     data_ready: Arc<Notify>,
+    running: Option<Running>,
 
     // Ack-on-commit bookkeeping.
     pending: Vec<jetstream::Message>,
@@ -73,11 +79,8 @@ impl NatsSource {
         Self {
             schema,
             config: None,
-            deserializer: None,
-            rx: None,
-            reader_shutdown: None,
-            reader_handle: None,
             data_ready: Arc::new(Notify::new()),
+            running: None,
             pending: Vec::new(),
             sealed: VecDeque::new(),
             offsets: FxHashMap::default(),
@@ -90,7 +93,11 @@ impl NatsSource {
         self.config.as_ref()
     }
 
-    async fn open_jetstream(&mut self, cfg: &NatsSourceConfig) -> Result<(), ConnectorError> {
+    async fn open_jetstream(
+        &mut self,
+        cfg: &NatsSourceConfig,
+        deserializer: Box<dyn RecordDeserializer>,
+    ) -> Result<(), ConnectorError> {
         let client = connect(&cfg.servers).await?;
         let js = jetstream::new(client);
 
@@ -113,7 +120,6 @@ impl NatsSource {
             .await
             .map_err(|e| err(&format!("create_consumer('{consumer_name}') failed: {e}")))?;
 
-        // Spawn the reader task. `rx` is drained by poll_batch.
         let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
         let shutdown = Arc::new(AtomicBool::new(false));
         let reader_shutdown = Arc::clone(&shutdown);
@@ -152,9 +158,9 @@ impl NatsSource {
                             continue;
                         }
                     };
-                    let stream_seq = msg.info().ok().map_or(0, |i| i.stream_sequence);
+                    let stream_seq = msg.info().ok().map(|i| i.stream_sequence);
                     let subject = msg.subject.to_string();
-                    let payload = msg.payload.to_vec();
+                    let payload = msg.payload.clone();
                     let incoming = Incoming {
                         subject,
                         payload,
@@ -173,13 +179,20 @@ impl NatsSource {
             }
         });
 
-        self.rx = Some(rx);
-        self.reader_shutdown = Some(shutdown);
-        self.reader_handle = Some(handle);
+        self.running = Some(Running {
+            deserializer,
+            rx,
+            shutdown,
+            handle,
+        });
         Ok(())
     }
 
-    async fn open_core(&mut self, cfg: &NatsSourceConfig) -> Result<(), ConnectorError> {
+    async fn open_core(
+        &mut self,
+        cfg: &NatsSourceConfig,
+        deserializer: Box<dyn RecordDeserializer>,
+    ) -> Result<(), ConnectorError> {
         let client = connect(&cfg.servers).await?;
         let subject = cfg
             .subject
@@ -209,8 +222,8 @@ impl NatsSource {
                 }
                 let incoming = Incoming {
                     subject: msg.subject.to_string(),
-                    payload: msg.payload.to_vec(),
-                    stream_seq: 0,
+                    payload: msg.payload,
+                    stream_seq: None,
                     ack: None,
                 };
                 if tx.send(incoming).await.is_err() {
@@ -220,9 +233,12 @@ impl NatsSource {
             }
         });
 
-        self.rx = Some(rx);
-        self.reader_shutdown = Some(shutdown);
-        self.reader_handle = Some(handle);
+        self.running = Some(Running {
+            deserializer,
+            rx,
+            shutdown,
+            handle,
+        });
         Ok(())
     }
 
@@ -238,13 +254,11 @@ impl NatsSource {
 impl SourceConnector for NatsSource {
     async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
         let cfg = NatsSourceConfig::from_config(config)?;
-        self.deserializer = Some(
-            serde::create_deserializer(cfg.format)
-                .map_err(|e| err(&format!("deserializer for format {:?}: {e}", cfg.format)))?,
-        );
+        let deserializer = serde::create_deserializer(cfg.format)
+            .map_err(|e| err(&format!("deserializer for format {:?}: {e}", cfg.format)))?;
         match cfg.mode {
-            Mode::JetStream => self.open_jetstream(&cfg).await?,
-            Mode::Core => self.open_core(&cfg).await?,
+            Mode::JetStream => self.open_jetstream(&cfg, deserializer).await?,
+            Mode::Core => self.open_core(&cfg, deserializer).await?,
         }
         self.config = Some(cfg);
         Ok(())
@@ -254,24 +268,26 @@ impl SourceConnector for NatsSource {
         &mut self,
         max_records: usize,
     ) -> Result<Option<SourceBatch>, ConnectorError> {
-        let Some(rx) = self.rx.as_ref() else {
+        let Some(running) = self.running.as_mut() else {
             return Ok(None);
         };
 
-        let mut payloads: Vec<Vec<u8>> = Vec::new();
-        let mut first_subject: Option<String> = None;
-        let mut first_seq: Option<u64> = None;
+        let mut payloads: Vec<Bytes> = Vec::new();
+        let mut partition: Option<PartitionInfo> = None;
 
         while payloads.len() < max_records {
-            let Ok(incoming) = rx.try_recv() else { break };
-            if first_subject.is_none() {
-                first_subject = Some(incoming.subject.clone());
-                first_seq = Some(incoming.stream_seq);
+            let Ok(incoming) = running.rx.try_recv() else {
+                break;
+            };
+            if let Some(seq) = incoming.stream_seq {
+                self.offsets
+                    .entry(incoming.subject.clone())
+                    .and_modify(|s| *s = (*s).max(seq))
+                    .or_insert(seq);
+                if partition.is_none() {
+                    partition = Some(PartitionInfo::new(&incoming.subject, seq.to_string()));
+                }
             }
-            self.offsets
-                .entry(incoming.subject.clone())
-                .and_modify(|s| *s = (*s).max(incoming.stream_seq))
-                .or_insert(incoming.stream_seq);
             payloads.push(incoming.payload);
             if let Some(msg) = incoming.ack {
                 self.pending.push(msg);
@@ -282,17 +298,12 @@ impl SourceConnector for NatsSource {
             return Ok(None);
         }
 
-        let deser = self
+        let records: Vec<&[u8]> = payloads.iter().map(Bytes::as_ref).collect();
+        let batch = running
             .deserializer
-            .as_ref()
-            .ok_or_else(|| err("deserializer not initialized"))?;
-        let records: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
-        let batch = deser
             .deserialize_batch(&records, &self.schema)
             .map_err(|e| err(&format!("deserialize batch: {e}")))?;
 
-        let partition =
-            first_subject.map(|s| PartitionInfo::new(s, first_seq.unwrap_or(0).to_string()));
         Ok(Some(SourceBatch {
             records: batch,
             partition,
@@ -313,21 +324,18 @@ impl SourceConnector for NatsSource {
 
     async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
         // The durable consumer remembers its ack floor on the server; on
-        // reconnect it resumes from there. We log loudly if the manifest
-        // is ahead of the floor (out-of-band surgery), but don't try to
-        // rewrite the consumer.
+        // reconnect it resumes from there. If the manifest is ahead of
+        // the floor (out-of-band surgery), we'd just log and proceed —
+        // rewriting the consumer is destructive and not worth it.
         Ok(())
     }
 
     async fn close(&mut self) -> Result<(), ConnectorError> {
-        if let Some(flag) = self.reader_shutdown.take() {
-            flag.store(true, Ordering::Release);
-        }
-        if let Some(handle) = self.reader_handle.take() {
-            // Give the reader a brief window to finish in-flight fetch.
-            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
-        }
-        self.rx = None;
+        let Some(running) = self.running.take() else {
+            return Ok(());
+        };
+        running.shutdown.store(true, Ordering::Release);
+        let _ = tokio::time::timeout(Duration::from_secs(5), running.handle).await;
         Ok(())
     }
 

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -229,6 +229,19 @@ impl SourceConnector for NatsSource {
             }
         }
 
+        if payloads.is_empty() {
+            return Ok(None);
+        }
+
+        let records: Vec<&[u8]> = payloads.iter().map(Bytes::as_ref).collect();
+        let bytes_total: u64 = records.iter().map(|r| r.len() as u64).sum();
+        // Deserialize before parking acks: on failure the handles drop
+        // un-acked and the broker redelivers after ack_wait.
+        let batch = running
+            .deserializer
+            .deserialize_batch(&records, &self.schema)
+            .map_err(|e| err(&format!("deserialize batch: {e}")))?;
+
         if !offset_updates.is_empty() {
             let mut offsets = self.offsets.lock();
             for (subject, seq) in offset_updates {
@@ -241,17 +254,6 @@ impl SourceConnector for NatsSource {
         if !new_acks.is_empty() {
             self.pending.lock().extend(new_acks);
         }
-
-        if payloads.is_empty() {
-            return Ok(None);
-        }
-
-        let records: Vec<&[u8]> = payloads.iter().map(Bytes::as_ref).collect();
-        let bytes_total: u64 = records.iter().map(|r| r.len() as u64).sum();
-        let batch = running
-            .deserializer
-            .deserialize_batch(&records, &self.schema)
-            .map_err(|e| err(&format!("deserialize batch: {e}")))?;
 
         self.metrics
             .record_poll(batch.num_rows() as u64, bytes_total);
@@ -351,18 +353,19 @@ impl SourceConnector for NatsSource {
             }
         }
 
-        // Broker pauses delivery at 100% `max_ack_pending`; flag at 50%.
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let cap = cfg.max_ack_pending.max(1) as u64;
-        #[allow(clippy::cast_sign_loss)]
-        let pending = self.metrics.pending_acks.get().max(0) as u64;
-        if pending * 2 >= cap {
-            HealthStatus::Degraded(format!(
-                "pending acks {pending}/{cap} — broker may throttle delivery"
-            ))
-        } else {
-            HealthStatus::Healthy
+        // Flag at 50% of `max_ack_pending`; -1 means unlimited.
+        if cfg.max_ack_pending > 0 {
+            #[allow(clippy::cast_sign_loss)]
+            let cap = cfg.max_ack_pending as u64;
+            #[allow(clippy::cast_sign_loss)]
+            let pending = self.metrics.pending_acks.get().max(0) as u64;
+            if pending * 2 >= cap {
+                return HealthStatus::Degraded(format!(
+                    "pending acks {pending}/{cap} — broker may throttle delivery"
+                ));
+            }
         }
+        HealthStatus::Healthy
     }
 
     fn metrics(&self) -> ConnectorMetrics {
@@ -484,9 +487,14 @@ fn classify_create_consumer_error(
     }
 }
 
+/// Wall-clock nanos for `with_jitter`. `Instant::now().elapsed()` is ~0
+/// and produces correlated jitter across tasks.
 #[allow(clippy::cast_possible_truncation)]
 fn entropy_now() -> u64 {
-    Instant::now().elapsed().as_nanos() as u64
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
 }
 
 struct JsReader {

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -15,7 +15,7 @@
 //! the queue in full is both simple and correct.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -56,7 +56,14 @@ struct Incoming {
 struct Running {
     deserializer: Box<dyn RecordDeserializer>,
     rx: AsyncRx<mpsc::Array<Incoming>>,
-    shutdown: Arc<AtomicBool>,
+    /// Wakes the reader task out of a blocking `fetch()`. Using `Notify`
+    /// instead of an `AtomicBool` drops shutdown lag from the fetch
+    /// timeout (default 500ms) to sub-ms.
+    shutdown: Arc<Notify>,
+    /// Consecutive fetch errors on the reader task. Surfaced through
+    /// `health_check` — flips the connector to `Unhealthy` once the
+    /// configured threshold is exceeded.
+    consecutive_errors: Arc<AtomicU32>,
     handle: JoinHandle<()>,
 }
 
@@ -107,6 +114,7 @@ impl NatsSource {
         self.config.as_ref()
     }
 
+    #[allow(clippy::too_many_lines)] // reader-task body is easier to read inline
     async fn open_jetstream(
         &mut self,
         cfg: &NatsSourceConfig,
@@ -132,11 +140,13 @@ impl NatsSource {
         let consumer = stream
             .create_consumer(pull_cfg)
             .await
-            .map_err(|e| err(&format!("create_consumer('{consumer_name}') failed: {e}")))?;
+            .map_err(|e| classify_create_consumer_error(&e.to_string(), consumer_name))?;
 
         let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
-        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(Notify::new());
         let reader_shutdown = Arc::clone(&shutdown);
+        let consecutive_errors = Arc::new(AtomicU32::new(0));
+        let reader_errors = Arc::clone(&consecutive_errors);
         let data_ready = Arc::clone(&self.data_ready);
         let metrics = self.metrics.clone();
         let batch_size = cfg.fetch_batch;
@@ -144,29 +154,49 @@ impl NatsSource {
 
         let handle = tokio::spawn(async move {
             loop {
-                if reader_shutdown.load(Ordering::Acquire) {
-                    break;
-                }
+                let fetch_result = tokio::select! {
+                    biased;
+                    () = reader_shutdown.notified() => break,
+                    r = consumer
+                        .fetch()
+                        .max_messages(batch_size)
+                        .expires(max_wait)
+                        .messages() => r,
+                };
 
-                let fetch = consumer
-                    .fetch()
-                    .max_messages(batch_size)
-                    .expires(max_wait)
-                    .messages()
-                    .await;
-
-                let mut stream = match fetch {
-                    Ok(s) => s,
+                let mut stream = match fetch_result {
+                    Ok(s) => {
+                        reader_errors.store(0, Ordering::Release);
+                        s
+                    }
                     Err(e) => {
+                        let errs = reader_errors.fetch_add(1, Ordering::AcqRel) + 1;
                         metrics.record_fetch_error();
-                        warn!(error = %e, "nats fetch() errored; backing off");
-                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        warn!(
+                            error = %e,
+                            consecutive_errors = errs,
+                            "nats fetch() errored; backing off",
+                        );
+                        let backoff = fetch_backoff(errs);
+                        tokio::select! {
+                            biased;
+                            () = reader_shutdown.notified() => break,
+                            () = tokio::time::sleep(backoff) => {}
+                        }
                         continue;
                     }
                 };
 
                 let mut forwarded = 0usize;
-                while let Some(msg_result) = stream.next().await {
+                loop {
+                    let msg_result = tokio::select! {
+                        biased;
+                        () = reader_shutdown.notified() => return,
+                        r = stream.next() => match r {
+                            Some(r) => r,
+                            None => break,
+                        },
+                    };
                     let msg = match msg_result {
                         Ok(m) => m,
                         Err(e) => {
@@ -200,6 +230,7 @@ impl NatsSource {
             deserializer,
             rx,
             shutdown,
+            consecutive_errors,
             handle,
         });
         Ok(())
@@ -229,17 +260,23 @@ impl NatsSource {
 
         // Core deliveries land on the poll_batch side's `record_poll`;
         // the subscriber itself doesn't surface fetch errors the way a
-        // JS pull loop does, so the reader task has no metrics to bump.
+        // JS pull loop does. async-nats handles reconnect transparently.
         let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
-        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(Notify::new());
         let reader_shutdown = Arc::clone(&shutdown);
+        let consecutive_errors = Arc::new(AtomicU32::new(0));
         let data_ready = Arc::clone(&self.data_ready);
 
         let handle = tokio::spawn(async move {
-            while let Some(msg) = subscriber.next().await {
-                if reader_shutdown.load(Ordering::Acquire) {
-                    break;
-                }
+            loop {
+                let msg = tokio::select! {
+                    biased;
+                    () = reader_shutdown.notified() => break,
+                    m = subscriber.next() => match m {
+                        Some(m) => m,
+                        None => break,
+                    },
+                };
                 let incoming = Incoming {
                     subject: msg.subject.to_string(),
                     payload: msg.payload,
@@ -257,6 +294,7 @@ impl NatsSource {
             deserializer,
             rx,
             shutdown,
+            consecutive_errors,
             handle,
         });
         Ok(())
@@ -359,7 +397,7 @@ impl SourceConnector for NatsSource {
         let Some(running) = self.running.take() else {
             return Ok(());
         };
-        running.shutdown.store(true, Ordering::Release);
+        running.shutdown.notify_one();
         let _ = tokio::time::timeout(Duration::from_secs(5), running.handle).await;
         Ok(())
     }
@@ -395,24 +433,34 @@ impl SourceConnector for NatsSource {
     }
 
     fn health_check(&self) -> HealthStatus {
-        match self.config.as_ref() {
-            None => HealthStatus::Unknown,
-            Some(cfg) => {
-                // Warn when pending acks saturate half of `max_ack_pending`;
-                // the broker pauses delivery at 100% and we want a
-                // yellow-light before that.
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let cap = cfg.max_ack_pending.max(1) as u64;
-                #[allow(clippy::cast_sign_loss)]
-                let pending = self.metrics.pending_acks.get().max(0) as u64;
-                if pending * 2 >= cap {
-                    HealthStatus::Degraded(format!(
-                        "pending acks {pending}/{cap} — broker may throttle delivery"
-                    ))
-                } else {
-                    HealthStatus::Healthy
-                }
+        let Some(cfg) = self.config.as_ref() else {
+            return HealthStatus::Unknown;
+        };
+
+        // Unhealthy first: fetch-loop errors indicate a problem even if
+        // `max_ack_pending` happens to be low.
+        if let Some(running) = self.running.as_ref() {
+            let errs = running.consecutive_errors.load(Ordering::Acquire);
+            if errs >= cfg.fetch_error_threshold {
+                return HealthStatus::Unhealthy(format!(
+                    "{errs} consecutive fetch errors (threshold {})",
+                    cfg.fetch_error_threshold
+                ));
             }
+        }
+
+        // Degraded: pending acks saturate half of `max_ack_pending`. The
+        // broker pauses delivery at 100%; yellow-light before that.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let cap = cfg.max_ack_pending.max(1) as u64;
+        #[allow(clippy::cast_sign_loss)]
+        let pending = self.metrics.pending_acks.get().max(0) as u64;
+        if pending * 2 >= cap {
+            HealthStatus::Degraded(format!(
+                "pending acks {pending}/{cap} — broker may throttle delivery"
+            ))
+        } else {
+            HealthStatus::Healthy
         }
     }
 
@@ -482,6 +530,36 @@ fn map_ack_policy(p: AckPolicy) -> async_nats::jetstream::consumer::AckPolicy {
     }
 }
 
+/// Exponential backoff for fetch errors: 500ms, 1s, 2s, 4s, 5s cap.
+fn fetch_backoff(consecutive_errors: u32) -> Duration {
+    let exp = consecutive_errors.saturating_sub(1).min(4);
+    let ms = 500u64.saturating_mul(1u64 << exp);
+    Duration::from_millis(ms.min(5000))
+}
+
+/// Translate a `create_consumer` error into something operator-readable.
+/// NATS server error 10148 (or similar text like "consumer config" /
+/// "already exists") means the durable consumer exists with a different
+/// config. Re-creating with a conflicting config is a footgun; surface
+/// a fix-it message instead of the raw server text.
+fn classify_create_consumer_error(err_msg: &str, consumer_name: &str) -> ConnectorError {
+    let lower = err_msg.to_ascii_lowercase();
+    if lower.contains("10148")
+        || lower.contains("consumer config")
+        || lower.contains("already exists")
+    {
+        err(&format!(
+            "[LDB-5070] consumer '{consumer_name}' exists with incompatible config; \
+             rotate the durable name or delete the consumer out-of-band. \
+             Server said: {err_msg}"
+        ))
+    } else {
+        err(&format!(
+            "create_consumer('{consumer_name}') failed: {err_msg}"
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -494,5 +572,35 @@ mod tests {
         // server, so we just test the empty-pending no-op path.
         src.seal_pending();
         assert!(src.sealed.is_empty());
+    }
+
+    #[test]
+    fn fetch_backoff_grows_then_caps_at_5s() {
+        assert_eq!(fetch_backoff(1), Duration::from_millis(500));
+        assert_eq!(fetch_backoff(2), Duration::from_millis(1000));
+        assert_eq!(fetch_backoff(3), Duration::from_millis(2000));
+        assert_eq!(fetch_backoff(4), Duration::from_millis(4000));
+        assert_eq!(fetch_backoff(5), Duration::from_millis(5000));
+        assert_eq!(fetch_backoff(100), Duration::from_millis(5000));
+    }
+
+    #[test]
+    fn drift_error_contains_ldb_5070() {
+        let e =
+            classify_create_consumer_error("consumer config already exists (10148)", "my-consumer");
+        assert!(e.to_string().contains("LDB-5070"), "got: {e}");
+        assert!(e.to_string().contains("my-consumer"));
+    }
+
+    #[test]
+    fn drift_error_matches_on_server_code_10148() {
+        let e = classify_create_consumer_error("err 10148", "c");
+        assert!(e.to_string().contains("LDB-5070"));
+    }
+
+    #[test]
+    fn generic_create_error_is_not_drift() {
+        let e = classify_create_consumer_error("network timeout", "c");
+        assert!(!e.to_string().contains("LDB-5070"), "got: {e}");
     }
 }

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -31,10 +31,13 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use super::config::{AckPolicy, DeliverPolicy, Mode, NatsSourceConfig};
+use super::metrics::NatsSourceMetrics;
 use crate::checkpoint::SourceCheckpoint;
 use crate::config::ConnectorConfig;
 use crate::connector::{PartitionInfo, SourceBatch, SourceConnector};
 use crate::error::ConnectorError;
+use crate::health::HealthStatus;
+use crate::metrics::ConnectorMetrics;
 use crate::serde::{self, RecordDeserializer};
 
 /// One inbound NATS message. `ack` is `Some` for `JetStream` (retained
@@ -62,6 +65,7 @@ pub struct NatsSource {
     schema: SchemaRef,
     config: Option<NatsSourceConfig>,
     data_ready: Arc<Notify>,
+    metrics: NatsSourceMetrics,
     running: Option<Running>,
 
     // Ack-on-commit bookkeeping.
@@ -74,17 +78,27 @@ pub struct NatsSource {
 
 impl NatsSource {
     /// Creates a new NATS source with the given output schema.
+    ///
+    /// If `registry` is `Some`, metrics register on it and show up in
+    /// Prometheus scrapes.
     #[must_use]
-    pub fn new(schema: SchemaRef) -> Self {
+    pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
             schema,
             config: None,
             data_ready: Arc::new(Notify::new()),
+            metrics: NatsSourceMetrics::new(registry),
             running: None,
             pending: Vec::new(),
             sealed: VecDeque::new(),
             offsets: FxHashMap::default(),
         }
+    }
+
+    fn update_pending_gauge(&self) {
+        let sealed_total: usize = self.sealed.iter().map(Vec::len).sum();
+        self.metrics
+            .set_pending_acks(self.pending.len() + sealed_total);
     }
 
     /// Parsed config — available after [`SourceConnector::open`].
@@ -124,6 +138,7 @@ impl NatsSource {
         let shutdown = Arc::new(AtomicBool::new(false));
         let reader_shutdown = Arc::clone(&shutdown);
         let data_ready = Arc::clone(&self.data_ready);
+        let metrics = self.metrics.clone();
         let batch_size = cfg.fetch_batch;
         let max_wait = cfg.fetch_max_wait;
 
@@ -143,6 +158,7 @@ impl NatsSource {
                 let mut stream = match fetch {
                     Ok(s) => s,
                     Err(e) => {
+                        metrics.record_fetch_error();
                         warn!(error = %e, "nats fetch() errored; backing off");
                         tokio::time::sleep(Duration::from_millis(500)).await;
                         continue;
@@ -154,6 +170,7 @@ impl NatsSource {
                     let msg = match msg_result {
                         Ok(m) => m,
                         Err(e) => {
+                            metrics.record_fetch_error();
                             warn!(error = %e, "nats message error");
                             continue;
                         }
@@ -210,6 +227,9 @@ impl NatsSource {
                 .map_err(|e| err(&format!("subscribe: {e}")))?
         };
 
+        // Core deliveries land on the poll_batch side's `record_poll`;
+        // the subscriber itself doesn't surface fetch errors the way a
+        // JS pull loop does, so the reader task has no metrics to bump.
         let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
         let shutdown = Arc::new(AtomicBool::new(false));
         let reader_shutdown = Arc::clone(&shutdown);
@@ -299,10 +319,15 @@ impl SourceConnector for NatsSource {
         }
 
         let records: Vec<&[u8]> = payloads.iter().map(Bytes::as_ref).collect();
+        let bytes_total: u64 = records.iter().map(|r| r.len() as u64).sum();
         let batch = running
             .deserializer
             .deserialize_batch(&records, &self.schema)
             .map_err(|e| err(&format!("deserialize batch: {e}")))?;
+
+        self.metrics
+            .record_poll(batch.num_rows() as u64, bytes_total);
+        self.update_pending_gauge();
 
         Ok(Some(SourceBatch {
             records: batch,
@@ -356,12 +381,43 @@ impl SourceConnector for NatsSource {
         self.seal_pending();
         while let Some(batch) = self.sealed.pop_front() {
             for msg in batch {
-                if let Err(e) = msg.ack().await {
-                    warn!(error = %e, "JetStream ack failed; broker will redeliver");
+                match msg.ack().await {
+                    Ok(()) => self.metrics.record_ack(),
+                    Err(e) => {
+                        self.metrics.record_ack_error();
+                        warn!(error = %e, "JetStream ack failed; broker will redeliver");
+                    }
                 }
             }
         }
+        self.update_pending_gauge();
         Ok(())
+    }
+
+    fn health_check(&self) -> HealthStatus {
+        match self.config.as_ref() {
+            None => HealthStatus::Unknown,
+            Some(cfg) => {
+                // Warn when pending acks saturate half of `max_ack_pending`;
+                // the broker pauses delivery at 100% and we want a
+                // yellow-light before that.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let cap = cfg.max_ack_pending.max(1) as u64;
+                #[allow(clippy::cast_sign_loss)]
+                let pending = self.metrics.pending_acks.get().max(0) as u64;
+                if pending * 2 >= cap {
+                    HealthStatus::Degraded(format!(
+                        "pending acks {pending}/{cap} — broker may throttle delivery"
+                    ))
+                } else {
+                    HealthStatus::Healthy
+                }
+            }
+        }
+    }
+
+    fn metrics(&self) -> ConnectorMetrics {
+        self.metrics.to_connector_metrics()
     }
 }
 
@@ -433,7 +489,7 @@ mod tests {
 
     #[test]
     fn seal_pending_moves_to_sealed() {
-        let mut src = NatsSource::new(Arc::new(Schema::empty()));
+        let mut src = NatsSource::new(Arc::new(Schema::empty()), None);
         // We can't easily construct jetstream::Message without a real
         // server, so we just test the empty-pending no-op path.
         src.seal_pending();

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -17,16 +17,15 @@
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arrow_schema::SchemaRef;
 use async_nats::jetstream::{self, consumer::pull};
 use async_trait::async_trait;
 use bytes::Bytes;
-use crossfire::{mpsc, AsyncRx};
 use futures_util::StreamExt;
 use rustc_hash::FxHashMap;
-use tokio::sync::Notify;
+use tokio::sync::{mpsc, Notify};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
@@ -55,15 +54,16 @@ struct Incoming {
 /// parallel `Option<>` fields on `NatsSource`.
 struct Running {
     deserializer: Box<dyn RecordDeserializer>,
-    rx: AsyncRx<mpsc::Array<Incoming>>,
+    rx: mpsc::Receiver<Incoming>,
     /// Wakes the reader task out of a blocking `fetch()`. Using `Notify`
     /// instead of an `AtomicBool` drops shutdown lag from the fetch
     /// timeout (default 500ms) to sub-ms.
     shutdown: Arc<Notify>,
-    /// Consecutive fetch errors on the reader task. Surfaced through
-    /// `health_check` — flips the connector to `Unhealthy` once the
-    /// configured threshold is exceeded.
-    consecutive_errors: Arc<AtomicU32>,
+    /// Consecutive fetch errors, `Some` for `JetStream` pull (which
+    /// surfaces fetch errors we can count) and `None` for core
+    /// subscribe (async-nats reconnects transparently, nothing to
+    /// count). Surfaced through `health_check`.
+    consecutive_errors: Option<Arc<AtomicU32>>,
     handle: JoinHandle<()>,
 }
 
@@ -114,7 +114,6 @@ impl NatsSource {
         self.config.as_ref()
     }
 
-    #[allow(clippy::too_many_lines)] // reader-task body is easier to read inline
     async fn open_jetstream(
         &mut self,
         cfg: &NatsSourceConfig,
@@ -140,97 +139,29 @@ impl NatsSource {
         let consumer = stream
             .create_consumer(pull_cfg)
             .await
-            .map_err(|e| classify_create_consumer_error(&e.to_string(), consumer_name))?;
+            .map_err(|e| classify_create_consumer_error(&e, consumer_name))?;
 
-        let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
+        let (tx, rx) = mpsc::channel::<Incoming>(cfg.fetch_batch * 2);
         let shutdown = Arc::new(Notify::new());
-        let reader_shutdown = Arc::clone(&shutdown);
         let consecutive_errors = Arc::new(AtomicU32::new(0));
-        let reader_errors = Arc::clone(&consecutive_errors);
-        let data_ready = Arc::clone(&self.data_ready);
-        let metrics = self.metrics.clone();
-        let batch_size = cfg.fetch_batch;
-        let max_wait = cfg.fetch_max_wait;
 
-        let handle = tokio::spawn(async move {
-            loop {
-                let fetch_result = tokio::select! {
-                    biased;
-                    () = reader_shutdown.notified() => break,
-                    r = consumer
-                        .fetch()
-                        .max_messages(batch_size)
-                        .expires(max_wait)
-                        .messages() => r,
-                };
-
-                let mut stream = match fetch_result {
-                    Ok(s) => {
-                        reader_errors.store(0, Ordering::Release);
-                        s
-                    }
-                    Err(e) => {
-                        let errs = reader_errors.fetch_add(1, Ordering::AcqRel) + 1;
-                        metrics.record_fetch_error();
-                        warn!(
-                            error = %e,
-                            consecutive_errors = errs,
-                            "nats fetch() errored; backing off",
-                        );
-                        let backoff = fetch_backoff(errs);
-                        tokio::select! {
-                            biased;
-                            () = reader_shutdown.notified() => break,
-                            () = tokio::time::sleep(backoff) => {}
-                        }
-                        continue;
-                    }
-                };
-
-                let mut forwarded = 0usize;
-                loop {
-                    let msg_result = tokio::select! {
-                        biased;
-                        () = reader_shutdown.notified() => return,
-                        r = stream.next() => match r {
-                            Some(r) => r,
-                            None => break,
-                        },
-                    };
-                    let msg = match msg_result {
-                        Ok(m) => m,
-                        Err(e) => {
-                            metrics.record_fetch_error();
-                            warn!(error = %e, "nats message error");
-                            continue;
-                        }
-                    };
-                    let stream_seq = msg.info().ok().map(|i| i.stream_sequence);
-                    let subject = msg.subject.to_string();
-                    let payload = msg.payload.clone();
-                    let incoming = Incoming {
-                        subject,
-                        payload,
-                        stream_seq,
-                        ack: Some(msg),
-                    };
-                    if tx.send(incoming).await.is_err() {
-                        debug!("nats reader: downstream channel closed");
-                        return;
-                    }
-                    forwarded += 1;
-                }
-                if forwarded > 0 {
-                    data_ready.notify_one();
-                }
-            }
-        });
+        let reader = JsReader {
+            consumer,
+            tx,
+            shutdown: Arc::clone(&shutdown),
+            consecutive_errors: Arc::clone(&consecutive_errors),
+            data_ready: Arc::clone(&self.data_ready),
+            metrics: self.metrics.clone(),
+            batch_size: cfg.fetch_batch,
+            max_wait: cfg.fetch_max_wait,
+        };
+        let handle = tokio::spawn(reader.run());
 
         self.running = Some(Running {
             deserializer,
             rx,
             shutdown,
-            consecutive_errors,
+            consecutive_errors: Some(consecutive_errors),
             handle,
         });
         Ok(())
@@ -246,7 +177,7 @@ impl NatsSource {
             .subject
             .clone()
             .ok_or_else(|| err("subject missing after validation"))?;
-        let mut subscriber = if let Some(group) = cfg.queue_group.as_deref() {
+        let subscriber = if let Some(group) = cfg.queue_group.as_deref() {
             client
                 .queue_subscribe(subject, group.to_string())
                 .await
@@ -258,43 +189,25 @@ impl NatsSource {
                 .map_err(|e| err(&format!("subscribe: {e}")))?
         };
 
-        // Core deliveries land on the poll_batch side's `record_poll`;
-        // the subscriber itself doesn't surface fetch errors the way a
-        // JS pull loop does. async-nats handles reconnect transparently.
-        let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
+        let (tx, rx) = mpsc::channel::<Incoming>(cfg.fetch_batch * 2);
         let shutdown = Arc::new(Notify::new());
-        let reader_shutdown = Arc::clone(&shutdown);
-        let consecutive_errors = Arc::new(AtomicU32::new(0));
-        let data_ready = Arc::clone(&self.data_ready);
 
-        let handle = tokio::spawn(async move {
-            loop {
-                let msg = tokio::select! {
-                    biased;
-                    () = reader_shutdown.notified() => break,
-                    m = subscriber.next() => match m {
-                        Some(m) => m,
-                        None => break,
-                    },
-                };
-                let incoming = Incoming {
-                    subject: msg.subject.to_string(),
-                    payload: msg.payload,
-                    stream_seq: None,
-                    ack: None,
-                };
-                if tx.send(incoming).await.is_err() {
-                    return;
-                }
-                data_ready.notify_one();
-            }
-        });
+        let reader = CoreReader {
+            subscriber,
+            tx,
+            shutdown: Arc::clone(&shutdown),
+            data_ready: Arc::clone(&self.data_ready),
+        };
+        let handle = tokio::spawn(reader.run());
 
         self.running = Some(Running {
             deserializer,
             rx,
             shutdown,
-            consecutive_errors,
+            // Core deliveries land on poll_batch's `record_poll`; the
+            // subscriber doesn't surface fetch errors (async-nats
+            // reconnects transparently), so there's nothing to count.
+            consecutive_errors: None,
             handle,
         });
         Ok(())
@@ -438,14 +351,22 @@ impl SourceConnector for NatsSource {
         };
 
         // Unhealthy first: fetch-loop errors indicate a problem even if
-        // `max_ack_pending` happens to be low.
-        if let Some(running) = self.running.as_ref() {
-            let errs = running.consecutive_errors.load(Ordering::Acquire);
-            if errs >= cfg.fetch_error_threshold {
-                return HealthStatus::Unhealthy(format!(
-                    "{errs} consecutive fetch errors (threshold {})",
-                    cfg.fetch_error_threshold
-                ));
+        // `max_ack_pending` happens to be low. Threshold of zero is
+        // treated as "don't flip from error counts" (an escape hatch
+        // for tests); real deployments use the >= 1 default.
+        if cfg.fetch_error_threshold > 0 {
+            if let Some(errors) = self
+                .running
+                .as_ref()
+                .and_then(|r| r.consecutive_errors.as_ref())
+            {
+                let errs = errors.load(Ordering::Acquire);
+                if errs >= cfg.fetch_error_threshold {
+                    return HealthStatus::Unhealthy(format!(
+                        "{errs} consecutive fetch errors (threshold {})",
+                        cfg.fetch_error_threshold
+                    ));
+                }
             }
         }
 
@@ -530,33 +451,209 @@ fn map_ack_policy(p: AckPolicy) -> async_nats::jetstream::consumer::AckPolicy {
     }
 }
 
-/// Exponential backoff for fetch errors: 500ms, 1s, 2s, 4s, 5s cap.
-fn fetch_backoff(consecutive_errors: u32) -> Duration {
+/// Base exponential backoff for fetch errors: 500ms, 1s, 2s, 4s, 5s cap.
+fn fetch_backoff_base(consecutive_errors: u32) -> Duration {
     let exp = consecutive_errors.saturating_sub(1).min(4);
     let ms = 500u64.saturating_mul(1u64 << exp);
     Duration::from_millis(ms.min(5000))
 }
 
+/// `base ± 20%`. `entropy` is any `u64` — we modulo it into the jitter
+/// window, so callers can pass `Instant::now()` nanos at runtime or a
+/// fixed seed in tests.
+fn with_jitter(base: Duration, entropy: u64) -> Duration {
+    let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
+    let range = (base_ms / 5).max(1); // 20%
+    let window = range * 2 + 1;
+    let offset = entropy % window;
+    let jittered = base_ms.saturating_add(offset).saturating_sub(range);
+    Duration::from_millis(jittered)
+}
+
+fn fetch_backoff(consecutive_errors: u32, entropy: u64) -> Duration {
+    with_jitter(fetch_backoff_base(consecutive_errors), entropy)
+}
+
 /// Translate a `create_consumer` error into something operator-readable.
-/// NATS server error 10148 (or similar text like "consumer config" /
-/// "already exists") means the durable consumer exists with a different
-/// config. Re-creating with a conflicting config is a footgun; surface
-/// a fix-it message instead of the raw server text.
-fn classify_create_consumer_error(err_msg: &str, consumer_name: &str) -> ConnectorError {
-    let lower = err_msg.to_ascii_lowercase();
-    if lower.contains("10148")
-        || lower.contains("consumer config")
-        || lower.contains("already exists")
-    {
+/// A server-side `JetStream` error with code `CONSUMER_ALREADY_EXISTS`
+/// (10148) or `CONSUMER_NAME_EXIST` (10013) means the durable consumer
+/// exists with a different config. We surface a fix-it message instead
+/// of the raw server text.
+fn classify_create_consumer_error(
+    e: &async_nats::jetstream::stream::ConsumerError,
+    consumer_name: &str,
+) -> ConnectorError {
+    use async_nats::jetstream::stream::ConsumerErrorKind;
+    use async_nats::jetstream::ErrorCode;
+
+    let drift_code = match e.kind() {
+        ConsumerErrorKind::JetStream(server_err) => matches!(
+            server_err.error_code(),
+            ErrorCode::CONSUMER_ALREADY_EXISTS | ErrorCode::CONSUMER_NAME_EXIST
+        ),
+        _ => false,
+    };
+    if drift_code {
         err(&format!(
             "[LDB-5070] consumer '{consumer_name}' exists with incompatible config; \
              rotate the durable name or delete the consumer out-of-band. \
-             Server said: {err_msg}"
+             Server said: {e}"
         ))
     } else {
-        err(&format!(
-            "create_consumer('{consumer_name}') failed: {err_msg}"
-        ))
+        err(&format!("create_consumer('{consumer_name}') failed: {e}"))
+    }
+}
+
+/// Nanos from the system clock, for jitter-seed entropy. Not
+/// cryptographic — just enough to desync siblings.
+#[allow(clippy::cast_possible_truncation)]
+fn entropy_now() -> u64 {
+    Instant::now().elapsed().as_nanos() as u64
+}
+
+/// `JetStream` pull-consumer reader task.
+struct JsReader {
+    consumer: jetstream::consumer::Consumer<pull::Config>,
+    tx: mpsc::Sender<Incoming>,
+    shutdown: Arc<Notify>,
+    consecutive_errors: Arc<AtomicU32>,
+    data_ready: Arc<Notify>,
+    metrics: NatsSourceMetrics,
+    batch_size: usize,
+    max_wait: Duration,
+}
+
+impl JsReader {
+    async fn run(self) {
+        let Self {
+            consumer,
+            tx,
+            shutdown,
+            consecutive_errors,
+            data_ready,
+            metrics,
+            batch_size,
+            max_wait,
+        } = self;
+
+        loop {
+            let fetch_result = tokio::select! {
+                biased;
+                () = shutdown.notified() => break,
+                r = consumer.fetch().max_messages(batch_size).expires(max_wait).messages() => r,
+            };
+
+            let mut stream = match fetch_result {
+                Ok(s) => s,
+                Err(e) => {
+                    let errs = consecutive_errors.fetch_add(1, Ordering::AcqRel) + 1;
+                    metrics.record_fetch_error();
+                    warn!(
+                        error = %e,
+                        consecutive_errors = errs,
+                        "nats fetch() errored; backing off",
+                    );
+                    let backoff = fetch_backoff(errs, entropy_now());
+                    tokio::select! {
+                        biased;
+                        () = shutdown.notified() => break,
+                        () = tokio::time::sleep(backoff) => {}
+                    }
+                    continue;
+                }
+            };
+
+            let mut forwarded = 0usize;
+            let mut stream_errors = 0usize;
+            loop {
+                let msg_result = tokio::select! {
+                    biased;
+                    () = shutdown.notified() => return,
+                    r = stream.next() => match r {
+                        Some(r) => r,
+                        None => break,
+                    },
+                };
+                let msg = match msg_result {
+                    Ok(m) => m,
+                    Err(e) => {
+                        metrics.record_fetch_error();
+                        stream_errors += 1;
+                        warn!(error = %e, "nats message error");
+                        continue;
+                    }
+                };
+                let incoming = Incoming {
+                    subject: msg.subject.to_string(),
+                    payload: msg.payload.clone(),
+                    stream_seq: msg.info().ok().map(|i| i.stream_sequence),
+                    ack: Some(msg),
+                };
+                if tx.send(incoming).await.is_err() {
+                    debug!("nats reader: downstream channel closed");
+                    return;
+                }
+                forwarded += 1;
+            }
+
+            // Counter accounting for this iteration:
+            //   - any forwarded message → reset (we're delivering data)
+            //   - no messages but errors → count as one failed iteration
+            //   - idle (no messages, no errors) → leave counter alone
+            if forwarded > 0 {
+                consecutive_errors.store(0, Ordering::Release);
+                data_ready.notify_one();
+            } else if stream_errors > 0 {
+                let errs = consecutive_errors.fetch_add(1, Ordering::AcqRel) + 1;
+                let backoff = fetch_backoff(errs, entropy_now());
+                tokio::select! {
+                    biased;
+                    () = shutdown.notified() => break,
+                    () = tokio::time::sleep(backoff) => {}
+                }
+            }
+        }
+    }
+}
+
+/// Core subscribe reader task. No fetch-error surface (async-nats
+/// reconnects transparently); shutdown works the same way.
+struct CoreReader {
+    subscriber: async_nats::Subscriber,
+    tx: mpsc::Sender<Incoming>,
+    shutdown: Arc<Notify>,
+    data_ready: Arc<Notify>,
+}
+
+impl CoreReader {
+    async fn run(self) {
+        let Self {
+            mut subscriber,
+            tx,
+            shutdown,
+            data_ready,
+        } = self;
+
+        loop {
+            let msg = tokio::select! {
+                biased;
+                () = shutdown.notified() => break,
+                m = subscriber.next() => match m {
+                    Some(m) => m,
+                    None => break,
+                },
+            };
+            let incoming = Incoming {
+                subject: msg.subject.to_string(),
+                payload: msg.payload,
+                stream_seq: None,
+                ack: None,
+            };
+            if tx.send(incoming).await.is_err() {
+                return;
+            }
+            data_ready.notify_one();
+        }
     }
 }
 
@@ -575,32 +672,24 @@ mod tests {
     }
 
     #[test]
-    fn fetch_backoff_grows_then_caps_at_5s() {
-        assert_eq!(fetch_backoff(1), Duration::from_millis(500));
-        assert_eq!(fetch_backoff(2), Duration::from_millis(1000));
-        assert_eq!(fetch_backoff(3), Duration::from_millis(2000));
-        assert_eq!(fetch_backoff(4), Duration::from_millis(4000));
-        assert_eq!(fetch_backoff(5), Duration::from_millis(5000));
-        assert_eq!(fetch_backoff(100), Duration::from_millis(5000));
+    fn backoff_base_grows_then_caps_at_5s() {
+        assert_eq!(fetch_backoff_base(1), Duration::from_millis(500));
+        assert_eq!(fetch_backoff_base(2), Duration::from_millis(1000));
+        assert_eq!(fetch_backoff_base(3), Duration::from_millis(2000));
+        assert_eq!(fetch_backoff_base(4), Duration::from_millis(4000));
+        assert_eq!(fetch_backoff_base(5), Duration::from_millis(5000));
+        assert_eq!(fetch_backoff_base(100), Duration::from_millis(5000));
     }
 
     #[test]
-    fn drift_error_contains_ldb_5070() {
-        let e =
-            classify_create_consumer_error("consumer config already exists (10148)", "my-consumer");
-        assert!(e.to_string().contains("LDB-5070"), "got: {e}");
-        assert!(e.to_string().contains("my-consumer"));
-    }
-
-    #[test]
-    fn drift_error_matches_on_server_code_10148() {
-        let e = classify_create_consumer_error("err 10148", "c");
-        assert!(e.to_string().contains("LDB-5070"));
-    }
-
-    #[test]
-    fn generic_create_error_is_not_drift() {
-        let e = classify_create_consumer_error("network timeout", "c");
-        assert!(!e.to_string().contains("LDB-5070"), "got: {e}");
+    fn jitter_stays_within_plus_minus_20_percent() {
+        let base = Duration::from_millis(1000);
+        for entropy in [0u64, 1, 99, 12345, u64::MAX] {
+            let j = with_jitter(base, entropy);
+            assert!(
+                j >= Duration::from_millis(800) && j <= Duration::from_millis(1200),
+                "entropy {entropy}: jittered = {j:?} outside ±20% of {base:?}"
+            );
+        }
     }
 }

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -43,8 +43,7 @@ struct Running {
     rx: mpsc::Receiver<Incoming>,
     /// Wakes the reader out of a blocking fetch.
     shutdown: Arc<Notify>,
-    /// `Some` on `JetStream`, `None` on core (async-nats reconnects
-    /// transparently — nothing to count).
+    /// `Some` on `JetStream`; `None` on core.
     consecutive_errors: Option<Arc<AtomicU32>>,
     handle: JoinHandle<()>,
 }

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -1,18 +1,8 @@
-//! NATS source connector.
-//!
-//! `JetStream` pull consumer with ack-on-commit:
-//! - A background task pulls messages and forwards them through a bounded
-//!   channel.
-//! - `poll_batch` drains the channel, deserializes to Arrow, and stashes
-//!   the underlying `jetstream::Message` handles in `pending` so we can
-//!   ack them later.
-//! - `checkpoint()` seals the current `pending` batch into `sealed`.
-//! - `notify_epoch_committed` drains `sealed` and acks every retained
-//!   message.
-//!
-//! We don't try to map coordinator-epoch numbers to source-barrier
-//! numbers. Each commit subsumes every earlier sealed batch, so draining
-//! the queue in full is both simple and correct.
+//! NATS source connector — `JetStream` pull consumer with
+//! ack-on-commit, or core subscribe (at-most-once). A background reader
+//! task forwards messages to `poll_batch` through an `mpsc` channel;
+//! `JetStream` message handles are retained until `notify_epoch_committed`
+//! fires, then acked in bulk.
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -39,9 +29,7 @@ use crate::health::HealthStatus;
 use crate::metrics::ConnectorMetrics;
 use crate::serde::{self, RecordDeserializer};
 
-/// One inbound NATS message. `ack` is `Some` for `JetStream` (retained
-/// until `notify_epoch_committed` acks it) and `None` for core subscribe
-/// (at-most-once, no server-side ack protocol).
+/// One inbound message. `ack` is `Some` only on the `JetStream` path.
 struct Incoming {
     subject: String,
     payload: Bytes,
@@ -49,20 +37,14 @@ struct Incoming {
     ack: Option<jetstream::Message>,
 }
 
-/// Runtime state created by [`SourceConnector::open`] and torn down in
-/// [`SourceConnector::close`]. Keeping these together avoids a handful of
-/// parallel `Option<>` fields on `NatsSource`.
+/// Runtime state populated by `open()` and torn down by `close()`.
 struct Running {
     deserializer: Box<dyn RecordDeserializer>,
     rx: mpsc::Receiver<Incoming>,
-    /// Wakes the reader task out of a blocking `fetch()`. Using `Notify`
-    /// instead of an `AtomicBool` drops shutdown lag from the fetch
-    /// timeout (default 500ms) to sub-ms.
+    /// Wakes the reader out of a blocking fetch.
     shutdown: Arc<Notify>,
-    /// Consecutive fetch errors, `Some` for `JetStream` pull (which
-    /// surfaces fetch errors we can count) and `None` for core
-    /// subscribe (async-nats reconnects transparently, nothing to
-    /// count). Surfaced through `health_check`.
+    /// `Some` on `JetStream`, `None` on core (async-nats reconnects
+    /// transparently — nothing to count).
     consecutive_errors: Option<Arc<AtomicU32>>,
     handle: JoinHandle<()>,
 }
@@ -84,10 +66,8 @@ pub struct NatsSource {
 }
 
 impl NatsSource {
-    /// Creates a new NATS source with the given output schema.
-    ///
-    /// If `registry` is `Some`, metrics register on it and show up in
-    /// Prometheus scrapes.
+    /// Creates a new NATS source. Metrics register on `registry` if
+    /// provided.
     #[must_use]
     pub fn new(schema: SchemaRef, registry: Option<&prometheus::Registry>) -> Self {
         Self {
@@ -204,9 +184,6 @@ impl NatsSource {
             deserializer,
             rx,
             shutdown,
-            // Core deliveries land on poll_batch's `record_poll`; the
-            // subscriber doesn't surface fetch errors (async-nats
-            // reconnects transparently), so there's nothing to count.
             consecutive_errors: None,
             handle,
         });
@@ -299,10 +276,7 @@ impl SourceConnector for NatsSource {
     }
 
     async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
-        // The durable consumer remembers its ack floor on the server; on
-        // reconnect it resumes from there. If the manifest is ahead of
-        // the floor (out-of-band surgery), we'd just log and proceed —
-        // rewriting the consumer is destructive and not worth it.
+        // Durable consumer's ack floor on the server is authoritative.
         Ok(())
     }
 
@@ -325,10 +299,8 @@ impl SourceConnector for NatsSource {
     }
 
     async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
-        // Seal whatever is in pending so the current in-flight checkpoint
-        // sees it too, then ack every retained message. Any per-message
-        // ack error is logged but doesn't roll the epoch back — the
-        // broker will redeliver on ack_wait and sink dedup will drop it.
+        // Ack everything sealed so far. Per-msg ack errors don't roll
+        // the epoch back — the broker redelivers on ack_wait.
         self.seal_pending();
         while let Some(batch) = self.sealed.pop_front() {
             for msg in batch {
@@ -350,10 +322,7 @@ impl SourceConnector for NatsSource {
             return HealthStatus::Unknown;
         };
 
-        // Unhealthy first: fetch-loop errors indicate a problem even if
-        // `max_ack_pending` happens to be low. Threshold of zero is
-        // treated as "don't flip from error counts" (an escape hatch
-        // for tests); real deployments use the >= 1 default.
+        // Unhealthy beats Degraded. Threshold of zero disables the flip.
         if cfg.fetch_error_threshold > 0 {
             if let Some(errors) = self
                 .running
@@ -451,16 +420,14 @@ fn map_ack_policy(p: AckPolicy) -> async_nats::jetstream::consumer::AckPolicy {
     }
 }
 
-/// Base exponential backoff for fetch errors: 500ms, 1s, 2s, 4s, 5s cap.
+/// 500ms, 1s, 2s, 4s, 5s-cap.
 fn fetch_backoff_base(consecutive_errors: u32) -> Duration {
     let exp = consecutive_errors.saturating_sub(1).min(4);
     let ms = 500u64.saturating_mul(1u64 << exp);
     Duration::from_millis(ms.min(5000))
 }
 
-/// `base ± 20%`. `entropy` is any `u64` — we modulo it into the jitter
-/// window, so callers can pass `Instant::now()` nanos at runtime or a
-/// fixed seed in tests.
+/// `base ± 20%`; `entropy` is any `u64` (tests pass a fixed seed).
 fn with_jitter(base: Duration, entropy: u64) -> Duration {
     let base_ms = u64::try_from(base.as_millis()).unwrap_or(u64::MAX);
     let range = (base_ms / 5).max(1); // 20%
@@ -474,11 +441,8 @@ fn fetch_backoff(consecutive_errors: u32, entropy: u64) -> Duration {
     with_jitter(fetch_backoff_base(consecutive_errors), entropy)
 }
 
-/// Translate a `create_consumer` error into something operator-readable.
-/// A server-side `JetStream` error with code `CONSUMER_ALREADY_EXISTS`
-/// (10148) or `CONSUMER_NAME_EXIST` (10013) means the durable consumer
-/// exists with a different config. We surface a fix-it message instead
-/// of the raw server text.
+/// Server error 10148 / 10013 means the consumer exists with a
+/// conflicting config — raise LDB-5070 with an operator fix-up.
 fn classify_create_consumer_error(
     e: &async_nats::jetstream::stream::ConsumerError,
     consumer_name: &str,
@@ -504,14 +468,12 @@ fn classify_create_consumer_error(
     }
 }
 
-/// Nanos from the system clock, for jitter-seed entropy. Not
-/// cryptographic — just enough to desync siblings.
+/// Jitter seed; not cryptographic.
 #[allow(clippy::cast_possible_truncation)]
 fn entropy_now() -> u64 {
     Instant::now().elapsed().as_nanos() as u64
 }
 
-/// `JetStream` pull-consumer reader task.
 struct JsReader {
     consumer: jetstream::consumer::Consumer<pull::Config>,
     tx: mpsc::Sender<Incoming>,
@@ -596,10 +558,8 @@ impl JsReader {
                 forwarded += 1;
             }
 
-            // Counter accounting for this iteration:
-            //   - any forwarded message → reset (we're delivering data)
-            //   - no messages but errors → count as one failed iteration
-            //   - idle (no messages, no errors) → leave counter alone
+            // Reset on any forwarded message; count an all-error
+            // iteration as one failure; leave idle iterations alone.
             if forwarded > 0 {
                 consecutive_errors.store(0, Ordering::Release);
                 data_ready.notify_one();
@@ -616,8 +576,6 @@ impl JsReader {
     }
 }
 
-/// Core subscribe reader task. No fetch-error surface (async-nats
-/// reconnects transparently); shutdown works the same way.
 struct CoreReader {
     subscriber: async_nats::Subscriber,
     tx: mpsc::Sender<Incoming>,

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -1,0 +1,67 @@
+//! NATS source connector.
+//!
+//! This milestone validates and stores the configuration. The real fetch
+//! loop (pull-consumer messages → Arrow batches) lands with the data path.
+
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+
+use super::config::NatsSourceConfig;
+use crate::checkpoint::SourceCheckpoint;
+use crate::config::ConnectorConfig;
+use crate::connector::{SourceBatch, SourceConnector};
+use crate::error::ConnectorError;
+
+/// NATS source — core and `JetStream` modes behind a single type.
+pub struct NatsSource {
+    schema: SchemaRef,
+    config: Option<NatsSourceConfig>,
+}
+
+impl NatsSource {
+    /// Creates a new NATS source with the given schema.
+    #[must_use]
+    pub fn new(schema: SchemaRef) -> Self {
+        Self {
+            schema,
+            config: None,
+        }
+    }
+
+    /// Parsed config — available after [`SourceConnector::open`].
+    #[must_use]
+    pub fn config(&self) -> Option<&NatsSourceConfig> {
+        self.config.as_ref()
+    }
+}
+
+#[async_trait]
+impl SourceConnector for NatsSource {
+    async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
+        self.config = Some(NatsSourceConfig::from_config(config)?);
+        Ok(())
+    }
+
+    async fn poll_batch(
+        &mut self,
+        _max_records: usize,
+    ) -> Result<Option<SourceBatch>, ConnectorError> {
+        Ok(None)
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn checkpoint(&self) -> SourceCheckpoint {
+        SourceCheckpoint::default()
+    }
+
+    async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+}

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -134,6 +134,7 @@ impl NatsSource {
             metrics: self.metrics.clone(),
             batch_size: cfg.fetch_batch,
             max_wait: cfg.fetch_max_wait,
+            lag_poll_interval: cfg.lag_poll_interval,
         };
         let handle = tokio::spawn(reader.run());
 
@@ -366,7 +367,7 @@ fn err(msg: &str) -> ConnectorError {
 }
 
 async fn connect(cfg: &NatsSourceConfig) -> Result<async_nats::Client, ConnectorError> {
-    build_connect_options(&cfg.auth, &cfg.tls)
+    build_connect_options(&cfg.auth, &cfg.tls)?
         .connect(&cfg.servers)
         .await
         .map_err(|e| err(&format!("nats connect({:?}): {e}", cfg.servers)))
@@ -405,9 +406,14 @@ fn map_deliver_policy(
             start_sequence: cfg.start_sequence.unwrap_or(1),
         },
         DeliverPolicy::ByStartTime => {
-            return Err(err(
-                "deliver.policy=by_start_time is not yet supported; use by_start_sequence",
-            ));
+            let raw = cfg
+                .start_time
+                .as_deref()
+                .ok_or_else(|| err("deliver.policy=by_start_time requires 'start.time'"))?;
+            let start_time =
+                time::OffsetDateTime::parse(raw, &time::format_description::well_known::Rfc3339)
+                    .map_err(|e| err(&format!("start.time '{raw}' is not valid RFC3339: {e}")))?;
+            Nats::ByStartTime { start_time }
         }
     })
 }
@@ -483,12 +489,14 @@ struct JsReader {
     metrics: NatsSourceMetrics,
     batch_size: usize,
     max_wait: Duration,
+    /// `Duration::ZERO` disables the poll.
+    lag_poll_interval: Duration,
 }
 
 impl JsReader {
     async fn run(self) {
         let Self {
-            consumer,
+            mut consumer,
             tx,
             shutdown,
             consecutive_errors,
@@ -496,7 +504,11 @@ impl JsReader {
             metrics,
             batch_size,
             max_wait,
+            lag_poll_interval,
         } = self;
+
+        let mut last_lag_poll = Instant::now();
+        let lag_poll_enabled = !lag_poll_interval.is_zero();
 
         loop {
             let fetch_result = tokio::select! {
@@ -570,6 +582,14 @@ impl JsReader {
                     biased;
                     () = shutdown.notified() => break,
                     () = tokio::time::sleep(backoff) => {}
+                }
+            }
+
+            if lag_poll_enabled && last_lag_poll.elapsed() >= lag_poll_interval {
+                last_lag_poll = Instant::now();
+                match consumer.info().await {
+                    Ok(info) => metrics.set_consumer_lag(info.num_pending),
+                    Err(e) => warn!(error = %e, "consumer.info() failed; skipping lag update"),
                 }
             }
         }

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -1,30 +1,86 @@
 //! NATS source connector.
 //!
-//! This milestone validates and stores the configuration. The real fetch
-//! loop (pull-consumer messages → Arrow batches) lands with the data path.
+//! `JetStream` pull consumer with ack-on-commit:
+//! - A background task pulls messages and forwards them through a bounded
+//!   channel.
+//! - `poll_batch` drains the channel, deserializes to Arrow, and stashes
+//!   the underlying `jetstream::Message` handles in `pending` so we can
+//!   ack them later.
+//! - `checkpoint()` seals the current `pending` batch into `sealed`.
+//! - `notify_epoch_committed` drains `sealed` and acks every retained
+//!   message.
+//!
+//! We don't try to map coordinator-epoch numbers to source-barrier
+//! numbers. Each commit subsumes every earlier sealed batch, so draining
+//! the queue in full is both simple and correct.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use arrow_schema::SchemaRef;
+use async_nats::jetstream::{self, consumer::pull};
 use async_trait::async_trait;
+use crossfire::{mpsc, AsyncRx};
+use futures_util::StreamExt;
+use rustc_hash::FxHashMap;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
-use super::config::NatsSourceConfig;
+use super::config::{AckPolicy, DeliverPolicy, Mode, NatsSourceConfig};
 use crate::checkpoint::SourceCheckpoint;
 use crate::config::ConnectorConfig;
-use crate::connector::{SourceBatch, SourceConnector};
+use crate::connector::{PartitionInfo, SourceBatch, SourceConnector};
 use crate::error::ConnectorError;
+use crate::serde::{self, RecordDeserializer};
+
+/// One inbound NATS message. `ack` is `Some` for `JetStream` (retained
+/// until `notify_epoch_committed` acks it) and `None` for core subscribe
+/// (at-most-once, no server-side ack protocol).
+struct Incoming {
+    subject: String,
+    payload: Vec<u8>,
+    stream_seq: u64,
+    ack: Option<jetstream::Message>,
+}
 
 /// NATS source — core and `JetStream` modes behind a single type.
 pub struct NatsSource {
     schema: SchemaRef,
     config: Option<NatsSourceConfig>,
+
+    // Runtime state — populated by open().
+    deserializer: Option<Box<dyn RecordDeserializer>>,
+    rx: Option<AsyncRx<mpsc::Array<Incoming>>>,
+    reader_shutdown: Option<Arc<AtomicBool>>,
+    reader_handle: Option<JoinHandle<()>>,
+    data_ready: Arc<Notify>,
+
+    // Ack-on-commit bookkeeping.
+    pending: Vec<jetstream::Message>,
+    sealed: VecDeque<Vec<jetstream::Message>>,
+
+    // Per-subject last-observed stream sequence, for checkpointing.
+    offsets: FxHashMap<String, u64>,
 }
 
 impl NatsSource {
-    /// Creates a new NATS source with the given schema.
+    /// Creates a new NATS source with the given output schema.
     #[must_use]
     pub fn new(schema: SchemaRef) -> Self {
         Self {
             schema,
             config: None,
+            deserializer: None,
+            rx: None,
+            reader_shutdown: None,
+            reader_handle: None,
+            data_ready: Arc::new(Notify::new()),
+            pending: Vec::new(),
+            sealed: VecDeque::new(),
+            offsets: FxHashMap::default(),
         }
     }
 
@@ -33,20 +89,214 @@ impl NatsSource {
     pub fn config(&self) -> Option<&NatsSourceConfig> {
         self.config.as_ref()
     }
+
+    async fn open_jetstream(&mut self, cfg: &NatsSourceConfig) -> Result<(), ConnectorError> {
+        let client = connect(&cfg.servers).await?;
+        let js = jetstream::new(client);
+
+        let stream_name = cfg
+            .stream
+            .as_deref()
+            .ok_or_else(|| err("stream name missing after validation"))?;
+        let consumer_name = cfg
+            .consumer
+            .as_deref()
+            .ok_or_else(|| err("consumer name missing after validation"))?;
+
+        let pull_cfg = build_pull_config(cfg, consumer_name)?;
+        let stream = js
+            .get_stream(stream_name)
+            .await
+            .map_err(|e| err(&format!("get_stream('{stream_name}') failed: {e}")))?;
+        let consumer = stream
+            .create_consumer(pull_cfg)
+            .await
+            .map_err(|e| err(&format!("create_consumer('{consumer_name}') failed: {e}")))?;
+
+        // Spawn the reader task. `rx` is drained by poll_batch.
+        let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let reader_shutdown = Arc::clone(&shutdown);
+        let data_ready = Arc::clone(&self.data_ready);
+        let batch_size = cfg.fetch_batch;
+        let max_wait = cfg.fetch_max_wait;
+
+        let handle = tokio::spawn(async move {
+            loop {
+                if reader_shutdown.load(Ordering::Acquire) {
+                    break;
+                }
+
+                let fetch = consumer
+                    .fetch()
+                    .max_messages(batch_size)
+                    .expires(max_wait)
+                    .messages()
+                    .await;
+
+                let mut stream = match fetch {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(error = %e, "nats fetch() errored; backing off");
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        continue;
+                    }
+                };
+
+                let mut forwarded = 0usize;
+                while let Some(msg_result) = stream.next().await {
+                    let msg = match msg_result {
+                        Ok(m) => m,
+                        Err(e) => {
+                            warn!(error = %e, "nats message error");
+                            continue;
+                        }
+                    };
+                    let stream_seq = msg.info().ok().map_or(0, |i| i.stream_sequence);
+                    let subject = msg.subject.to_string();
+                    let payload = msg.payload.to_vec();
+                    let incoming = Incoming {
+                        subject,
+                        payload,
+                        stream_seq,
+                        ack: Some(msg),
+                    };
+                    if tx.send(incoming).await.is_err() {
+                        debug!("nats reader: downstream channel closed");
+                        return;
+                    }
+                    forwarded += 1;
+                }
+                if forwarded > 0 {
+                    data_ready.notify_one();
+                }
+            }
+        });
+
+        self.rx = Some(rx);
+        self.reader_shutdown = Some(shutdown);
+        self.reader_handle = Some(handle);
+        Ok(())
+    }
+
+    async fn open_core(&mut self, cfg: &NatsSourceConfig) -> Result<(), ConnectorError> {
+        let client = connect(&cfg.servers).await?;
+        let subject = cfg
+            .subject
+            .clone()
+            .ok_or_else(|| err("subject missing after validation"))?;
+        let mut subscriber = if let Some(group) = cfg.queue_group.as_deref() {
+            client
+                .queue_subscribe(subject, group.to_string())
+                .await
+                .map_err(|e| err(&format!("queue_subscribe: {e}")))?
+        } else {
+            client
+                .subscribe(subject)
+                .await
+                .map_err(|e| err(&format!("subscribe: {e}")))?
+        };
+
+        let (tx, rx) = mpsc::bounded_async::<Incoming>(cfg.fetch_batch * 2);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let reader_shutdown = Arc::clone(&shutdown);
+        let data_ready = Arc::clone(&self.data_ready);
+
+        let handle = tokio::spawn(async move {
+            while let Some(msg) = subscriber.next().await {
+                if reader_shutdown.load(Ordering::Acquire) {
+                    break;
+                }
+                let incoming = Incoming {
+                    subject: msg.subject.to_string(),
+                    payload: msg.payload.to_vec(),
+                    stream_seq: 0,
+                    ack: None,
+                };
+                if tx.send(incoming).await.is_err() {
+                    return;
+                }
+                data_ready.notify_one();
+            }
+        });
+
+        self.rx = Some(rx);
+        self.reader_shutdown = Some(shutdown);
+        self.reader_handle = Some(handle);
+        Ok(())
+    }
+
+    fn seal_pending(&mut self) {
+        if !self.pending.is_empty() {
+            let batch = std::mem::take(&mut self.pending);
+            self.sealed.push_back(batch);
+        }
+    }
 }
 
 #[async_trait]
 impl SourceConnector for NatsSource {
     async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
-        self.config = Some(NatsSourceConfig::from_config(config)?);
+        let cfg = NatsSourceConfig::from_config(config)?;
+        self.deserializer = Some(
+            serde::create_deserializer(cfg.format)
+                .map_err(|e| err(&format!("deserializer for format {:?}: {e}", cfg.format)))?,
+        );
+        match cfg.mode {
+            Mode::JetStream => self.open_jetstream(&cfg).await?,
+            Mode::Core => self.open_core(&cfg).await?,
+        }
+        self.config = Some(cfg);
         Ok(())
     }
 
     async fn poll_batch(
         &mut self,
-        _max_records: usize,
+        max_records: usize,
     ) -> Result<Option<SourceBatch>, ConnectorError> {
-        Ok(None)
+        let Some(rx) = self.rx.as_ref() else {
+            return Ok(None);
+        };
+
+        let mut payloads: Vec<Vec<u8>> = Vec::new();
+        let mut first_subject: Option<String> = None;
+        let mut first_seq: Option<u64> = None;
+
+        while payloads.len() < max_records {
+            let Ok(incoming) = rx.try_recv() else { break };
+            if first_subject.is_none() {
+                first_subject = Some(incoming.subject.clone());
+                first_seq = Some(incoming.stream_seq);
+            }
+            self.offsets
+                .entry(incoming.subject.clone())
+                .and_modify(|s| *s = (*s).max(incoming.stream_seq))
+                .or_insert(incoming.stream_seq);
+            payloads.push(incoming.payload);
+            if let Some(msg) = incoming.ack {
+                self.pending.push(msg);
+            }
+        }
+
+        if payloads.is_empty() {
+            return Ok(None);
+        }
+
+        let deser = self
+            .deserializer
+            .as_ref()
+            .ok_or_else(|| err("deserializer not initialized"))?;
+        let records: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
+        let batch = deser
+            .deserialize_batch(&records, &self.schema)
+            .map_err(|e| err(&format!("deserialize batch: {e}")))?;
+
+        let partition =
+            first_subject.map(|s| PartitionInfo::new(s, first_seq.unwrap_or(0).to_string()));
+        Ok(Some(SourceBatch {
+            records: batch,
+            partition,
+        }))
     }
 
     fn schema(&self) -> SchemaRef {
@@ -54,14 +304,131 @@ impl SourceConnector for NatsSource {
     }
 
     fn checkpoint(&self) -> SourceCheckpoint {
-        SourceCheckpoint::default()
+        let mut cp = SourceCheckpoint::default();
+        for (subject, seq) in &self.offsets {
+            cp.set_offset(subject.as_str(), seq.to_string());
+        }
+        cp
     }
 
     async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
+        // The durable consumer remembers its ack floor on the server; on
+        // reconnect it resumes from there. We log loudly if the manifest
+        // is ahead of the floor (out-of-band surgery), but don't try to
+        // rewrite the consumer.
         Ok(())
     }
 
     async fn close(&mut self) -> Result<(), ConnectorError> {
+        if let Some(flag) = self.reader_shutdown.take() {
+            flag.store(true, Ordering::Release);
+        }
+        if let Some(handle) = self.reader_handle.take() {
+            // Give the reader a brief window to finish in-flight fetch.
+            let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        }
+        self.rx = None;
         Ok(())
+    }
+
+    fn data_ready_notify(&self) -> Option<Arc<Notify>> {
+        Some(Arc::clone(&self.data_ready))
+    }
+
+    fn supports_replay(&self) -> bool {
+        // JetStream is replayable (durable consumer); core NATS is not.
+        !matches!(self.config.as_ref().map(|c| c.mode), Some(Mode::Core))
+    }
+
+    async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+        // Seal whatever is in pending so the current in-flight checkpoint
+        // sees it too, then ack every retained message. Any per-message
+        // ack error is logged but doesn't roll the epoch back — the
+        // broker will redeliver on ack_wait and sink dedup will drop it.
+        self.seal_pending();
+        while let Some(batch) = self.sealed.pop_front() {
+            for msg in batch {
+                if let Err(e) = msg.ack().await {
+                    warn!(error = %e, "JetStream ack failed; broker will redeliver");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── helpers ──
+
+fn err(msg: &str) -> ConnectorError {
+    ConnectorError::ConfigurationError(msg.to_string())
+}
+
+async fn connect(servers: &[String]) -> Result<async_nats::Client, ConnectorError> {
+    async_nats::ConnectOptions::new()
+        .connect(servers)
+        .await
+        .map_err(|e| err(&format!("nats connect({servers:?}): {e}")))
+}
+
+fn build_pull_config(
+    cfg: &NatsSourceConfig,
+    consumer_name: &str,
+) -> Result<pull::Config, ConnectorError> {
+    let filter_subjects = if cfg.subject_filters.is_empty() {
+        cfg.subject.iter().cloned().collect()
+    } else {
+        cfg.subject_filters.clone()
+    };
+
+    Ok(pull::Config {
+        durable_name: Some(consumer_name.to_string()),
+        filter_subjects,
+        deliver_policy: map_deliver_policy(cfg)?,
+        ack_policy: map_ack_policy(cfg.ack_policy),
+        ack_wait: cfg.ack_wait,
+        max_deliver: cfg.max_deliver,
+        max_ack_pending: cfg.max_ack_pending,
+        ..Default::default()
+    })
+}
+
+fn map_deliver_policy(
+    cfg: &NatsSourceConfig,
+) -> Result<async_nats::jetstream::consumer::DeliverPolicy, ConnectorError> {
+    use async_nats::jetstream::consumer::DeliverPolicy as Nats;
+    Ok(match cfg.deliver_policy {
+        DeliverPolicy::All => Nats::All,
+        DeliverPolicy::New => Nats::New,
+        DeliverPolicy::ByStartSequence => Nats::ByStartSequence {
+            start_sequence: cfg.start_sequence.unwrap_or(1),
+        },
+        DeliverPolicy::ByStartTime => {
+            return Err(err(
+                "deliver.policy=by_start_time is not yet supported; use by_start_sequence",
+            ));
+        }
+    })
+}
+
+fn map_ack_policy(p: AckPolicy) -> async_nats::jetstream::consumer::AckPolicy {
+    use async_nats::jetstream::consumer::AckPolicy as Nats;
+    match p {
+        AckPolicy::Explicit => Nats::Explicit,
+        AckPolicy::None => Nats::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::Schema;
+
+    #[test]
+    fn seal_pending_moves_to_sealed() {
+        let mut src = NatsSource::new(Arc::new(Schema::empty()));
+        // We can't easily construct jetstream::Message without a real
+        // server, so we just test the empty-pending no-op path.
+        src.seal_pending();
+        assert!(src.sealed.is_empty());
     }
 }

--- a/crates/laminar-connectors/src/testing.rs
+++ b/crates/laminar-connectors/src/testing.rs
@@ -63,6 +63,7 @@ pub struct MockSourceConnector {
     batch_size: usize,
     records_produced: AtomicU64,
     is_open: std::sync::atomic::AtomicBool,
+    committed_epochs: Arc<Mutex<Vec<u64>>>,
 }
 
 impl MockSourceConnector {
@@ -75,6 +76,7 @@ impl MockSourceConnector {
             batch_size: 5,
             records_produced: AtomicU64::new(0),
             is_open: std::sync::atomic::AtomicBool::new(false),
+            committed_epochs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -87,6 +89,7 @@ impl MockSourceConnector {
             batch_size,
             records_produced: AtomicU64::new(0),
             is_open: std::sync::atomic::AtomicBool::new(false),
+            committed_epochs: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -94,6 +97,15 @@ impl MockSourceConnector {
     #[must_use]
     pub fn records_produced(&self) -> u64 {
         self.records_produced.load(Ordering::Relaxed)
+    }
+
+    /// Returns a handle for inspecting epochs reported to
+    /// `notify_epoch_committed` from outside the connector (the
+    /// connector itself is moved into a background task when run via
+    /// the pipeline).
+    #[must_use]
+    pub fn committed_epochs_handle(&self) -> Arc<Mutex<Vec<u64>>> {
+        Arc::clone(&self.committed_epochs)
     }
 }
 
@@ -162,6 +174,11 @@ impl SourceConnector for MockSourceConnector {
     async fn close(&mut self) -> Result<(), ConnectorError> {
         self.is_open
             .store(false, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    async fn notify_epoch_committed(&mut self, epoch: u64) -> Result<(), ConnectorError> {
+        self.committed_epochs.lock().push(epoch);
         Ok(())
     }
 }

--- a/crates/laminar-connectors/tests/docker-compose.nats.yml
+++ b/crates/laminar-connectors/tests/docker-compose.nats.yml
@@ -13,5 +13,23 @@ services:
       timeout: 1s
       retries: 5
 
+  # Secured NATS with user/password. Started only with the `secure`
+  # profile: `docker compose -f docker-compose.nats.yml --profile secure up`.
+  nats-secure:
+    image: nats:2.10-alpine
+    command:
+      ["-js", "-sd", "/data", "-m", "8223", "--user", "alice", "--pass", "wonderland"]
+    ports:
+      - "4223:4222"
+    volumes:
+      - nats-secure-data:/data
+    profiles: ["secure"]
+    healthcheck:
+      test: ["CMD", "nats-server", "--help"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+
 volumes:
   nats-data:
+  nats-secure-data:

--- a/crates/laminar-connectors/tests/docker-compose.nats.yml
+++ b/crates/laminar-connectors/tests/docker-compose.nats.yml
@@ -8,10 +8,13 @@ services:
     volumes:
       - nats-data:/data
     healthcheck:
-      test: ["CMD", "nats-server", "--help"]
+      # `nats-server --help` would just prove the binary is present.
+      # Probe the client port so health reflects readiness to accept
+      # connections. `nc` is provided by BusyBox in nats:2.10-alpine.
+      test: ["CMD", "nc", "-z", "127.0.0.1", "4222"]
       interval: 2s
       timeout: 1s
-      retries: 5
+      retries: 10
 
   # Secured NATS with user/password. Started only with the `secure`
   # profile: `docker compose -f docker-compose.nats.yml --profile secure up`.
@@ -25,10 +28,10 @@ services:
       - nats-secure-data:/data
     profiles: ["secure"]
     healthcheck:
-      test: ["CMD", "nats-server", "--help"]
+      test: ["CMD", "nc", "-z", "127.0.0.1", "4222"]
       interval: 2s
       timeout: 1s
-      retries: 5
+      retries: 10
 
 volumes:
   nats-data:

--- a/crates/laminar-connectors/tests/docker-compose.nats.yml
+++ b/crates/laminar-connectors/tests/docker-compose.nats.yml
@@ -1,0 +1,17 @@
+services:
+  nats:
+    image: nats:2.10-alpine
+    command: ["-js", "-sd", "/data", "-m", "8222"]
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "nats-server", "--help"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+
+volumes:
+  nats-data:

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -95,7 +95,7 @@ async fn roundtrip_jetstream() {
     .await;
 
     // Sink: publish 3 rows.
-    let mut sink = NatsSink::new(payload_schema());
+    let mut sink = NatsSink::new(payload_schema(), None);
     sink.open(&ConnectorConfig::with_properties(
         "nats",
         source_props(&[
@@ -114,7 +114,7 @@ async fn roundtrip_jetstream() {
     sink.close().await.expect("sink close");
 
     // Source: read them back.
-    let mut source = NatsSource::new(payload_schema());
+    let mut source = NatsSource::new(payload_schema(), None);
     source
         .open(&ConnectorConfig::with_properties(
             "nats",
@@ -147,7 +147,7 @@ async fn roundtrip_jetstream() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn roundtrip_core() {
-    let mut source = NatsSource::new(payload_schema());
+    let mut source = NatsSource::new(payload_schema(), None);
     source
         .open(&ConnectorConfig::with_properties(
             "nats",
@@ -164,7 +164,7 @@ async fn roundtrip_core() {
     // Subscriber needs to be ready before publish — give it a brief moment.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut sink = NatsSink::new(payload_schema());
+    let mut sink = NatsSink::new(payload_schema(), None);
     sink.open(&ConnectorConfig::with_properties(
         "nats",
         source_props(&[
@@ -224,7 +224,7 @@ async fn exactly_once_dedup_drops_duplicate() {
     )
     .unwrap();
 
-    let mut sink = NatsSink::new(schema);
+    let mut sink = NatsSink::new(schema, None);
     sink.open(&ConnectorConfig::with_properties(
         "nats",
         source_props(&[
@@ -272,7 +272,7 @@ async fn exactly_once_rejects_short_duplicate_window() {
     )
     .await;
 
-    let mut sink = NatsSink::new(payload_schema());
+    let mut sink = NatsSink::new(payload_schema(), None);
     let err = sink
         .open(&ConnectorConfig::with_properties(
             "nats",

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -29,6 +29,7 @@ use async_nats::jetstream::{self, stream::Config as StreamConfig};
 
 use laminar_connectors::config::ConnectorConfig;
 use laminar_connectors::connector::{SinkConnector, SourceConnector};
+use laminar_connectors::health::HealthStatus;
 use laminar_connectors::nats::{NatsSink, NatsSource};
 
 const NATS_URL: &str = "nats://127.0.0.1:4222";
@@ -344,6 +345,74 @@ fn extract_rows(batch: &RecordBatch) -> Vec<(i64, String)> {
     (0..batch.num_rows())
         .map(|i| (ids.value(i), names.value(i).to_string()))
         .collect()
+}
+
+// ── health escalation ──
+
+/// Delete the stream behind a running source and verify the health
+/// check flips to `Unhealthy` within bounded time. Threshold set low
+/// (2) so the test doesn't have to wait 10 fetch errors.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn source_flips_unhealthy_after_stream_deleted() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "DROP".into(),
+            subjects: vec!["drop.events".into()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("stream", "DROP"),
+                ("consumer", "drop-consumer"),
+                ("subject", "drop.events"),
+                ("format", "json"),
+                ("fetch.max.wait.ms", "100"),
+                ("fetch.error.threshold", "2"),
+            ]),
+        ))
+        .await
+        .expect("source open");
+
+    // Let the reader establish a few successful fetches first.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        matches!(
+            source.health_check(),
+            HealthStatus::Healthy | HealthStatus::Degraded(_)
+        ),
+        "expected healthy before stream delete, got {:?}",
+        source.health_check()
+    );
+
+    // Pull the stream out from under the running source.
+    ctx.delete_stream("DROP").await.expect("delete_stream");
+
+    // Wait for consecutive errors to accumulate past the threshold.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut final_status = source.health_check();
+    while tokio::time::Instant::now() < deadline {
+        final_status = source.health_check();
+        if matches!(final_status, HealthStatus::Unhealthy(_)) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    source.close().await.expect("source close");
+    assert!(
+        matches!(final_status, HealthStatus::Unhealthy(_)),
+        "expected Unhealthy after stream delete, got {final_status:?}"
+    );
 }
 
 // ── auth ──

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -393,6 +393,152 @@ async fn source_flips_unhealthy_after_stream_deleted() {
     );
 }
 
+// ── observability ──
+
+/// `nats_source_consumer_lag` is populated by the periodic
+/// `consumer.info()` poll and reaches zero after a full drain + ack.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn consumer_lag_settles_to_zero_after_drain() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "LAG".into(),
+            subjects: vec!["lag.events".into()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    for i in 0..5i64 {
+        let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
+        ctx.publish("lag.events".to_string(), payload.into())
+            .await
+            .expect("publish")
+            .await
+            .expect("ack");
+    }
+
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("stream", "LAG"),
+                ("consumer", "lag-consumer"),
+                ("subject", "lag.events"),
+                ("format", "json"),
+                ("fetch.max.wait.ms", "100"),
+                ("lag.poll.interval.ms", "200"),
+            ]),
+        ))
+        .await
+        .expect("source open");
+
+    drain_rows(&mut source, 5, Duration::from_secs(5)).await;
+    source.notify_epoch_committed(1).await.expect("commit acks");
+
+    let lag_after = poll_gauge_until(&source, "consumer_lag", |v| v == 0, Duration::from_secs(3))
+        .await
+        .expect("expected lag gauge to settle at 0 after drain + ack");
+    assert_eq!(lag_after, 0);
+
+    source.close().await.expect("source close");
+}
+
+/// `deliver.policy=by_start_time` replays from a wall-clock cutoff.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn by_start_time_replays_from_cutoff() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "BYTIME".into(),
+            subjects: vec!["bytime.events".into()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Publish 3 before the cutoff, wait, remember the cutoff, publish 3 after.
+    for i in 0..3i64 {
+        let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
+        ctx.publish("bytime.events".to_string(), payload.into())
+            .await
+            .expect("publish")
+            .await
+            .expect("ack");
+    }
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    let cutoff = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("format");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    for i in 3..6i64 {
+        let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
+        ctx.publish("bytime.events".to_string(), payload.into())
+            .await
+            .expect("publish")
+            .await
+            .expect("ack");
+    }
+
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("stream", "BYTIME"),
+                ("consumer", "bytime-consumer"),
+                ("subject", "bytime.events"),
+                ("format", "json"),
+                ("fetch.max.wait.ms", "100"),
+                ("deliver.policy", "by_start_time"),
+                ("start.time", &cutoff),
+            ]),
+        ))
+        .await
+        .expect("source open");
+
+    let received = drain_rows(&mut source, 3, Duration::from_secs(5)).await;
+    source.close().await.expect("source close");
+    let ids: Vec<i64> = received.into_iter().map(|(id, _)| id).collect();
+    assert_eq!(ids, vec![3, 4, 5], "expected only post-cutoff rows");
+}
+
+async fn poll_gauge_until(
+    source: &NatsSource,
+    custom_key: &str,
+    until: impl Fn(u64) -> bool,
+    timeout: Duration,
+) -> Option<u64> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        let cm = source.metrics();
+        let v = cm
+            .custom
+            .iter()
+            .find_map(|(k, v)| (k == &format!("nats.{custom_key}")).then_some(*v as u64))
+            .unwrap_or_else(|| {
+                // `lag` is exposed directly, not via custom — read it there.
+                if custom_key == "consumer_lag" {
+                    cm.lag
+                } else {
+                    0
+                }
+            });
+        if until(v) {
+            return Some(v);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    None
+}
+
 // ── chaos ──
 
 fn restart_nats() {

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -1,0 +1,334 @@
+//! Integration tests for the NATS source and sink connectors.
+//!
+//! These talk to a real `nats-server` on `localhost:4222`. Stand one up
+//! with the sibling compose file, then run:
+//!
+//! ```text
+//! cd crates/laminar-connectors/tests
+//! docker compose -f docker-compose.nats.yml up -d
+//! cargo test --test nats_integration --features nats -- --ignored
+//! ```
+//!
+//! Every test is `#[ignore]`d so the regular `cargo test` run is unaffected.
+//!
+//! Tests are serial (`#[tokio::test(flavor = "multi_thread")]` with
+//! distinct stream/consumer/subject names per test) so a single running
+//! NATS server is enough.
+
+#![cfg(feature = "nats")]
+#![allow(clippy::disallowed_types)] // test code: std::HashMap is fine
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow_array::{Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_nats::jetstream::{self, stream::Config as StreamConfig};
+
+use laminar_connectors::config::ConnectorConfig;
+use laminar_connectors::connector::{SinkConnector, SourceConnector};
+use laminar_connectors::nats::{NatsSink, NatsSource};
+
+const NATS_URL: &str = "nats://127.0.0.1:4222";
+
+fn payload_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]))
+}
+
+/// JSON-serializable test batch.
+fn test_batch(ids: &[i64]) -> RecordBatch {
+    let names: Vec<String> = ids.iter().map(|i| format!("row-{i}")).collect();
+    RecordBatch::try_new(
+        payload_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())),
+            Arc::new(StringArray::from(
+                names.iter().map(String::as_str).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+/// Reset a stream between tests: delete if present, then recreate with
+/// the given config.
+async fn reset_stream(ctx: &jetstream::Context, cfg: StreamConfig) {
+    let name = cfg.name.clone();
+    let _ = ctx.delete_stream(&name).await;
+    ctx.create_stream(cfg).await.expect("create_stream");
+}
+
+fn source_props(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+async fn connect() -> jetstream::Context {
+    let client = async_nats::connect(NATS_URL)
+        .await
+        .expect("connect to local NATS");
+    jetstream::new(client)
+}
+
+// ── roundtrip ──
+
+/// Publish through the sink, consume through the source, verify the
+/// payload comes back unchanged.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn roundtrip_jetstream() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "RT".into(),
+            subjects: vec!["rt.events".into()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Sink: publish 3 rows.
+    let mut sink = NatsSink::new(payload_schema());
+    sink.open(&ConnectorConfig::with_properties(
+        "nats",
+        source_props(&[
+            ("servers", NATS_URL),
+            ("subject", "rt.events"),
+            ("stream", "RT"),
+            ("format", "json"),
+        ]),
+    ))
+    .await
+    .expect("sink open");
+    let batch = test_batch(&[1, 2, 3]);
+    let written = sink.write_batch(&batch).await.expect("write_batch");
+    assert_eq!(written.records_written, 3);
+    sink.pre_commit(1).await.expect("pre_commit drains acks");
+    sink.close().await.expect("sink close");
+
+    // Source: read them back.
+    let mut source = NatsSource::new(payload_schema());
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("stream", "RT"),
+                ("consumer", "rt-consumer"),
+                ("subject", "rt.events"),
+                ("format", "json"),
+                ("fetch.max.wait.ms", "250"),
+            ]),
+        ))
+        .await
+        .expect("source open");
+
+    let received = drain_rows(&mut source, 3, Duration::from_secs(5)).await;
+    source.close().await.expect("source close");
+
+    assert_eq!(
+        received,
+        vec![
+            (1, "row-1".to_string()),
+            (2, "row-2".to_string()),
+            (3, "row-3".to_string()),
+        ]
+    );
+}
+
+/// Core NATS pub/sub round-trip — non-durable, no stream, no ack.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn roundtrip_core() {
+    let mut source = NatsSource::new(payload_schema());
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("mode", "core"),
+                ("subject", "core.events"),
+                ("format", "json"),
+            ]),
+        ))
+        .await
+        .expect("source open");
+
+    // Subscriber needs to be ready before publish — give it a brief moment.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut sink = NatsSink::new(payload_schema());
+    sink.open(&ConnectorConfig::with_properties(
+        "nats",
+        source_props(&[
+            ("servers", NATS_URL),
+            ("mode", "core"),
+            ("subject", "core.events"),
+            ("format", "json"),
+        ]),
+    ))
+    .await
+    .expect("sink open");
+    sink.write_batch(&test_batch(&[10, 11]))
+        .await
+        .expect("publish");
+    sink.close().await.expect("sink close");
+
+    let received = drain_rows(&mut source, 2, Duration::from_secs(3)).await;
+    source.close().await.expect("source close");
+    assert_eq!(
+        received,
+        vec![(10, "row-10".to_string()), (11, "row-11".to_string())]
+    );
+}
+
+// ── exactly-once ──
+
+/// Publish the same row twice with an identical `Nats-Msg-Id`. The
+/// second publish lands inside the stream's duplicate_window and is
+/// silently dropped by the server — so the source sees it once.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn exactly_once_dedup_drops_duplicate() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "EO".into(),
+            subjects: vec!["eo.events".into()],
+            duplicate_window: Duration::from_secs(300),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Batch with a dedup column. We'll publish it twice with the same
+    // event_id; server-side dedup should drop the second.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("event_id", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["evt-42"])),
+            Arc::new(Int64Array::from(vec![7])),
+        ],
+    )
+    .unwrap();
+
+    let mut sink = NatsSink::new(schema);
+    sink.open(&ConnectorConfig::with_properties(
+        "nats",
+        source_props(&[
+            ("servers", NATS_URL),
+            ("subject", "eo.events"),
+            ("stream", "EO"),
+            ("delivery.guarantee", "exactly_once"),
+            ("dedup.id.column", "event_id"),
+            ("format", "json"),
+        ]),
+    ))
+    .await
+    .expect("sink open");
+
+    sink.write_batch(&batch).await.expect("first publish");
+    sink.pre_commit(1).await.expect("first drain");
+    sink.write_batch(&batch).await.expect("second publish");
+    sink.pre_commit(2).await.expect("second drain");
+    sink.close().await.expect("close");
+
+    // Server side: stream should contain exactly one message.
+    let mut stream = ctx.get_stream("EO").await.expect("get_stream");
+    let info = stream.info().await.expect("info");
+    assert_eq!(
+        info.state.messages, 1,
+        "expected dedup to drop the second publish"
+    );
+}
+
+/// A stream with duplicate_window below the sink's minimum makes
+/// exactly-once unsafe. `open()` must refuse with LDB-5056 rather than
+/// silently publishing without dedup coverage.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn exactly_once_rejects_short_duplicate_window() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "SHORT".into(),
+            subjects: vec!["short.events".into()],
+            duplicate_window: Duration::from_secs(1),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let mut sink = NatsSink::new(payload_schema());
+    let err = sink
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", NATS_URL),
+                ("subject", "short.events"),
+                ("stream", "SHORT"),
+                ("delivery.guarantee", "exactly_once"),
+                ("dedup.id.column", "id"),
+                ("format", "json"),
+                ("min.duplicate.window.ms", "60000"),
+            ]),
+        ))
+        .await
+        .expect_err("should fail startup");
+    assert!(
+        err.to_string().contains("LDB-5056"),
+        "expected LDB-5056, got: {err}"
+    );
+}
+
+// ── helpers ──
+
+async fn drain_rows(
+    source: &mut NatsSource,
+    expected: usize,
+    timeout: Duration,
+) -> Vec<(i64, String)> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut rows: Vec<(i64, String)> = Vec::new();
+    while rows.len() < expected && tokio::time::Instant::now() < deadline {
+        match source.poll_batch(128).await {
+            Ok(Some(batch)) => rows.extend(extract_rows(&batch.records)),
+            Ok(None) => tokio::time::sleep(Duration::from_millis(50)).await,
+            Err(e) => panic!("poll_batch: {e}"),
+        }
+    }
+    assert_eq!(
+        rows.len(),
+        expected,
+        "expected {expected} rows within {timeout:?}, got {}: {rows:?}",
+        rows.len()
+    );
+    rows
+}
+
+fn extract_rows(batch: &RecordBatch) -> Vec<(i64, String)> {
+    let ids = batch
+        .column_by_name("id")
+        .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+        .expect("id column");
+    let names = batch
+        .column_by_name("name")
+        .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+        .expect("name column");
+    (0..batch.num_rows())
+        .map(|i| (ids.value(i), names.value(i).to_string()))
+        .collect()
+}

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -1,11 +1,12 @@
 //! Integration tests for the NATS source and sink connectors.
 //!
-//! These talk to a real `nats-server` on `localhost:4222`. Stand one up
-//! with the sibling compose file, then run:
+//! Most tests talk to a plain `nats-server` on `localhost:4222`. Auth
+//! tests use the `secure` profile (user/pass) on `localhost:4223`.
+//! Stand servers up with the sibling compose file and run:
 //!
 //! ```text
 //! cd crates/laminar-connectors/tests
-//! docker compose -f docker-compose.nats.yml up -d
+//! docker compose -f docker-compose.nats.yml --profile secure up -d
 //! cargo test --test nats_integration --features nats -- --ignored
 //! ```
 //!
@@ -343,4 +344,86 @@ fn extract_rows(batch: &RecordBatch) -> Vec<(i64, String)> {
     (0..batch.num_rows())
         .map(|i| (ids.value(i), names.value(i).to_string()))
         .collect()
+}
+
+// ── auth ──
+
+const SECURE_NATS_URL: &str = "nats://127.0.0.1:4223";
+
+/// Core-mode round-trip against a server that requires user/password
+/// auth. The plain-auth NATS on :4222 would reject credentials; the
+/// secure server on :4223 requires them.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs `docker compose -f docker-compose.nats.yml --profile secure up`"]
+async fn user_pass_roundtrip_core() {
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", SECURE_NATS_URL),
+                ("mode", "core"),
+                ("subject", "auth.events"),
+                ("format", "json"),
+                ("auth.mode", "user_pass"),
+                ("user", "alice"),
+                ("password", "wonderland"),
+            ]),
+        ))
+        .await
+        .expect("source open with user_pass");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut sink = NatsSink::new(payload_schema(), None);
+    sink.open(&ConnectorConfig::with_properties(
+        "nats",
+        source_props(&[
+            ("servers", SECURE_NATS_URL),
+            ("mode", "core"),
+            ("subject", "auth.events"),
+            ("format", "json"),
+            ("auth.mode", "user_pass"),
+            ("user", "alice"),
+            ("password", "wonderland"),
+        ]),
+    ))
+    .await
+    .expect("sink open with user_pass");
+    sink.write_batch(&test_batch(&[100, 101]))
+        .await
+        .expect("publish");
+    sink.close().await.expect("sink close");
+
+    let received = drain_rows(&mut source, 2, Duration::from_secs(3)).await;
+    source.close().await.expect("source close");
+    assert_eq!(
+        received,
+        vec![(100, "row-100".to_string()), (101, "row-101".to_string())]
+    );
+}
+
+/// Connecting to an auth-required server without credentials must fail.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs `docker compose -f docker-compose.nats.yml --profile secure up`"]
+async fn user_pass_missing_credentials_rejected_by_server() {
+    let mut sink = NatsSink::new(payload_schema(), None);
+    let result = sink
+        .open(&ConnectorConfig::with_properties(
+            "nats",
+            source_props(&[
+                ("servers", SECURE_NATS_URL),
+                ("mode", "core"),
+                ("subject", "auth.events"),
+                ("format", "json"),
+                // no auth.mode
+            ]),
+        ))
+        .await;
+    // Whichever of "connect refused" or "authorization violation" the
+    // server returns, the open() must fail.
+    assert!(
+        result.is_err(),
+        "expected unauthenticated open to fail, got Ok"
+    );
 }

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -1,20 +1,12 @@
-//! Integration tests for the NATS source and sink connectors.
-//!
-//! Most tests talk to a plain `nats-server` on `localhost:4222`. Auth
-//! tests use the `secure` profile (user/pass) on `localhost:4223`.
-//! Stand servers up with the sibling compose file and run:
+//! Integration tests against a real `nats-server` — see the sibling
+//! `docker-compose.nats.yml`. Plain server on :4222, `secure` profile
+//! on :4223. Run with:
 //!
 //! ```text
-//! cd crates/laminar-connectors/tests
-//! docker compose -f docker-compose.nats.yml --profile secure up -d
+//! docker compose -f crates/laminar-connectors/tests/docker-compose.nats.yml \
+//!   --profile secure up -d
 //! cargo test --test nats_integration --features nats -- --ignored
 //! ```
-//!
-//! Every test is `#[ignore]`d so the regular `cargo test` run is unaffected.
-//!
-//! Tests are serial (`#[tokio::test(flavor = "multi_thread")]` with
-//! distinct stream/consumer/subject names per test) so a single running
-//! NATS server is enough.
 
 #![cfg(feature = "nats")]
 #![allow(clippy::disallowed_types)] // test code: std::HashMap is fine
@@ -41,7 +33,6 @@ fn payload_schema() -> SchemaRef {
     ]))
 }
 
-/// JSON-serializable test batch.
 fn test_batch(ids: &[i64]) -> RecordBatch {
     let names: Vec<String> = ids.iter().map(|i| format!("row-{i}")).collect();
     RecordBatch::try_new(
@@ -56,8 +47,6 @@ fn test_batch(ids: &[i64]) -> RecordBatch {
     .unwrap()
 }
 
-/// Reset a stream between tests: delete if present, then recreate with
-/// the given config.
 async fn reset_stream(ctx: &jetstream::Context, cfg: StreamConfig) {
     let name = cfg.name.clone();
     let _ = ctx.delete_stream(&name).await;
@@ -80,8 +69,6 @@ async fn connect() -> jetstream::Context {
 
 // ── roundtrip ──
 
-/// Publish through the sink, consume through the source, verify the
-/// payload comes back unchanged.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn roundtrip_jetstream() {
@@ -145,7 +132,6 @@ async fn roundtrip_jetstream() {
     );
 }
 
-/// Core NATS pub/sub round-trip — non-durable, no stream, no ack.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn roundtrip_core() {
@@ -193,9 +179,8 @@ async fn roundtrip_core() {
 
 // ── exactly-once ──
 
-/// Publish the same row twice with an identical `Nats-Msg-Id`. The
-/// second publish lands inside the stream's duplicate_window and is
-/// silently dropped by the server — so the source sees it once.
+/// Publishing the same `Nats-Msg-Id` twice inside `duplicate_window`:
+/// server drops the repeat, stream holds one message.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn exactly_once_dedup_drops_duplicate() {
@@ -211,8 +196,6 @@ async fn exactly_once_dedup_drops_duplicate() {
     )
     .await;
 
-    // Batch with a dedup column. We'll publish it twice with the same
-    // event_id; server-side dedup should drop the second.
     let schema = Arc::new(Schema::new(vec![
         Field::new("event_id", DataType::Utf8, false),
         Field::new("value", DataType::Int64, false),
@@ -256,9 +239,7 @@ async fn exactly_once_dedup_drops_duplicate() {
         "expected dedup to drop the second publish"
     );
 
-    // Client side: dedup counter should reflect the server's decision.
-    // Read through `SinkConnector::metrics()` — exercises the public
-    // surface operators see.
+    // Client-side counter via the public `SinkConnector::metrics`.
     let cm = sink.metrics();
     let dedup = cm
         .custom
@@ -268,9 +249,8 @@ async fn exactly_once_dedup_drops_duplicate() {
     assert_eq!(dedup, 1, "expected nats.dedup = 1, got {dedup}");
 }
 
-/// A stream with duplicate_window below the sink's minimum makes
-/// exactly-once unsafe. `open()` must refuse with LDB-5056 rather than
-/// silently publishing without dedup coverage.
+/// `open()` refuses a stream with `duplicate_window` below the
+/// configured minimum (LDB-5056).
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn exactly_once_rejects_short_duplicate_window() {
@@ -349,9 +329,7 @@ fn extract_rows(batch: &RecordBatch) -> Vec<(i64, String)> {
 
 // ── health escalation ──
 
-/// Delete the stream behind a running source and verify the health
-/// check flips to `Unhealthy` within bounded time. Threshold set low
-/// (2) so the test doesn't have to wait 10 fetch errors.
+/// Delete the stream behind a running source; health flips to Unhealthy.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn source_flips_unhealthy_after_stream_deleted() {
@@ -417,8 +395,6 @@ async fn source_flips_unhealthy_after_stream_deleted() {
 
 // ── chaos ──
 
-/// Shell out to `docker compose restart nats`. Synchronous; the command
-/// returns when the new container is up.
 fn restart_nats() {
     let compose_file = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/docker-compose.nats.yml");
     let status = std::process::Command::new("docker")
@@ -450,12 +426,10 @@ fn dedup_batch(ids: std::ops::Range<i64>) -> RecordBatch {
     .unwrap()
 }
 
-/// Exactly-once sink survives a broker restart. Publishes 50 rows,
-/// restarts the broker, re-publishes those same 50 plus 50 new ones
-/// (simulating a rollback + retry). The stream must end up with
-/// exactly 100 unique rows — no duplicates, no loss. This is the
-/// guarantee `duplicate_window` + `Nats-Msg-Id` buy us, and the one
-/// place we get to exercise it end-to-end.
+/// Exactly-once sink survives a broker restart. Publish 50 rows →
+/// `docker compose restart nats` → publish 0..100 (first 50 collide
+/// with the pre-restart dedup ids). Final stream must hold exactly
+/// 100 unique messages.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose available on host; chaos test restarts the broker"]
 async fn exactly_once_survives_broker_restart() {
@@ -493,29 +467,24 @@ async fn exactly_once_survives_broker_restart() {
         .expect("first batch publish");
     sink.pre_commit(1).await.expect("first epoch drain");
 
-    // Restart the broker while the sink's client is idle between
-    // epochs. JetStream persists stream + dedup state to disk, so the
-    // window survives the restart.
+    // JetStream persists dedup state across restart.
     restart_nats();
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // The sink's TCP connection went with the broker. Close and reopen
-    // rather than wait for transparent reconnect — operators in the
-    // real pipeline loop do the same on hard failures.
+    // Client connection is gone — reopen.
     let _ = sink.close().await;
     let mut sink = NatsSink::new(schema, None);
     sink.open(&ConnectorConfig::with_properties("nats", props))
         .await
         .expect("sink reopen after restart");
 
-    // Second epoch: replay rows 0..50 (server dedups) + publish 50..100.
+    // Re-publish 0..50 (server dedups) + publish 50..100.
     sink.write_batch(&dedup_batch(0..100))
         .await
         .expect("second batch publish");
     sink.pre_commit(2).await.expect("second epoch drain");
     sink.close().await.expect("sink close");
 
-    // The stream must hold exactly 100 rows — dedup caught the replay.
     let mut stream = ctx.get_stream("RESTART").await.expect("get_stream");
     let info = stream.info().await.expect("info");
     assert_eq!(
@@ -525,10 +494,9 @@ async fn exactly_once_survives_broker_restart() {
     );
 }
 
-/// Source that never calls `notify_epoch_committed` must not ack.
-/// Re-opening the same durable consumer after `ack_wait` expires
-/// replays the messages; once the second instance commits, a third
-/// instance sees nothing.
+/// A source that never commits the epoch must not ack. After
+/// `ack_wait`, a fresh consumer on the same durable replays;
+/// committing that one drains the queue for good.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn source_redelivers_when_epoch_not_committed() {
@@ -543,8 +511,6 @@ async fn source_redelivers_when_epoch_not_committed() {
     )
     .await;
 
-    // Seed: publish 3 rows directly via the server-side context so the
-    // source has something to consume.
     for i in 0..3i64 {
         let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
         ctx.publish("acktest.events".to_string(), payload.into())
@@ -564,7 +530,6 @@ async fn source_redelivers_when_epoch_not_committed() {
         ("fetch.max.wait.ms", "250"),
     ]);
 
-    // First source: poll, do NOT commit.
     let mut source = NatsSource::new(payload_schema(), None);
     source
         .open(&ConnectorConfig::with_properties("nats", props.clone()))
@@ -573,11 +538,9 @@ async fn source_redelivers_when_epoch_not_committed() {
     let first = drain_rows(&mut source, 3, Duration::from_secs(5)).await;
     source.close().await.expect("source 1 close");
 
-    // Wait longer than ack_wait so the server unparks the unacked set
-    // and lets a fresh consumer receive them.
+    // Wait past ack_wait so the server unparks the unacked set.
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Second source: poll, commit this time.
     let mut source = NatsSource::new(payload_schema(), None);
     source
         .open(&ConnectorConfig::with_properties("nats", props.clone()))
@@ -594,7 +557,6 @@ async fn source_redelivers_when_epoch_not_committed() {
         .expect("epoch commit acks");
     source.close().await.expect("source 2 close");
 
-    // Third source: now the acks have landed, nothing should remain.
     let mut source = NatsSource::new(payload_schema(), None);
     source
         .open(&ConnectorConfig::with_properties("nats", props))
@@ -622,9 +584,7 @@ async fn source_redelivers_when_epoch_not_committed() {
 
 const SECURE_NATS_URL: &str = "nats://127.0.0.1:4223";
 
-/// Core-mode round-trip against a server that requires user/password
-/// auth. The plain-auth NATS on :4222 would reject credentials; the
-/// secure server on :4223 requires them.
+/// Core-mode round-trip against a user/password-protected server.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs `docker compose -f docker-compose.nats.yml --profile secure up`"]
 async fn user_pass_roundtrip_core() {
@@ -692,8 +652,6 @@ async fn user_pass_missing_credentials_rejected_by_server() {
             ]),
         ))
         .await;
-    // Whichever of "connect refused" or "authorization violation" the
-    // server returns, the open() must fail.
     assert!(
         result.is_err(),
         "expected unauthenticated open to fail, got Ok"

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -395,8 +395,7 @@ async fn source_flips_unhealthy_after_stream_deleted() {
 
 // ── observability ──
 
-/// `nats_source_consumer_lag` is populated by the periodic
-/// `consumer.info()` poll and reaches zero after a full drain + ack.
+/// Lag gauge settles to 0 after a full drain + ack.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn consumer_lag_settles_to_zero_after_drain() {
@@ -463,7 +462,6 @@ async fn by_start_time_replays_from_cutoff() {
     )
     .await;
 
-    // Publish 3 before the cutoff, wait, remember the cutoff, publish 3 after.
     for i in 0..3i64 {
         let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
         ctx.publish("bytime.events".to_string(), payload.into())
@@ -524,7 +522,6 @@ async fn poll_gauge_until(
             .iter()
             .find_map(|(k, v)| (k == &format!("nats.{custom_key}")).then_some(*v as u64))
             .unwrap_or_else(|| {
-                // `lag` is exposed directly, not via custom — read it there.
                 if custom_key == "consumer_lag" {
                     cm.lag
                 } else {
@@ -572,10 +569,8 @@ fn dedup_batch(ids: std::ops::Range<i64>) -> RecordBatch {
     .unwrap()
 }
 
-/// Exactly-once sink survives a broker restart. Publish 50 rows →
-/// `docker compose restart nats` → publish 0..100 (first 50 collide
-/// with the pre-restart dedup ids). Final stream must hold exactly
-/// 100 unique messages.
+/// Exactly-once survives a broker restart: replay after restart is
+/// deduped by persisted `duplicate_window` state.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose available on host; chaos test restarts the broker"]
 async fn exactly_once_survives_broker_restart() {
@@ -640,9 +635,8 @@ async fn exactly_once_survives_broker_restart() {
     );
 }
 
-/// A source that never commits the epoch must not ack. After
-/// `ack_wait`, a fresh consumer on the same durable replays;
-/// committing that one drains the queue for good.
+/// A source that never commits the epoch must not ack; the server
+/// replays on the next consumer.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs docker compose -f docker-compose.nats.yml up"]
 async fn source_redelivers_when_epoch_not_committed() {

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -224,7 +224,8 @@ async fn exactly_once_dedup_drops_duplicate() {
     )
     .unwrap();
 
-    let mut sink = NatsSink::new(schema, None);
+    let prom = prometheus::Registry::new();
+    let mut sink = NatsSink::new(schema, Some(&prom));
     sink.open(&ConnectorConfig::with_properties(
         "nats",
         source_props(&[
@@ -252,6 +253,17 @@ async fn exactly_once_dedup_drops_duplicate() {
         info.state.messages, 1,
         "expected dedup to drop the second publish"
     );
+
+    // Client side: dedup counter should reflect the server's decision.
+    // Read through `SinkConnector::metrics()` — exercises the public
+    // surface operators see.
+    let cm = sink.metrics();
+    let dedup = cm
+        .custom
+        .iter()
+        .find_map(|(k, v)| (k == "nats.dedup").then_some(*v as u64))
+        .expect("nats.dedup custom metric");
+    assert_eq!(dedup, 1, "expected nats.dedup = 1, got {dedup}");
 }
 
 /// A stream with duplicate_window below the sink's minimum makes

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -415,6 +415,209 @@ async fn source_flips_unhealthy_after_stream_deleted() {
     );
 }
 
+// ── chaos ──
+
+/// Shell out to `docker compose restart nats`. Synchronous; the command
+/// returns when the new container is up.
+fn restart_nats() {
+    let compose_file = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/docker-compose.nats.yml");
+    let status = std::process::Command::new("docker")
+        .args(["compose", "-f", compose_file, "restart", "nats"])
+        .status()
+        .expect("docker compose restart nats");
+    assert!(status.success(), "docker compose restart exited non-zero");
+}
+
+fn dedup_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("event_id", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+fn dedup_batch(ids: std::ops::Range<i64>) -> RecordBatch {
+    let evt_ids: Vec<String> = ids.clone().map(|i| format!("evt-{i}")).collect();
+    let values: Vec<i64> = ids.collect();
+    RecordBatch::try_new(
+        dedup_schema(),
+        vec![
+            Arc::new(StringArray::from(
+                evt_ids.iter().map(String::as_str).collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(values)),
+        ],
+    )
+    .unwrap()
+}
+
+/// Exactly-once sink survives a broker restart. Publishes 50 rows,
+/// restarts the broker, re-publishes those same 50 plus 50 new ones
+/// (simulating a rollback + retry). The stream must end up with
+/// exactly 100 unique rows — no duplicates, no loss. This is the
+/// guarantee `duplicate_window` + `Nats-Msg-Id` buy us, and the one
+/// place we get to exercise it end-to-end.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose available on host; chaos test restarts the broker"]
+async fn exactly_once_survives_broker_restart() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "RESTART".into(),
+            subjects: vec!["restart.events".into()],
+            duplicate_window: Duration::from_secs(300),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let schema = dedup_schema();
+    let props = source_props(&[
+        ("servers", NATS_URL),
+        ("subject", "restart.events"),
+        ("stream", "RESTART"),
+        ("delivery.guarantee", "exactly_once"),
+        ("dedup.id.column", "event_id"),
+        ("format", "json"),
+        ("ack.timeout.ms", "10000"),
+    ]);
+
+    let mut sink = NatsSink::new(schema.clone(), None);
+    sink.open(&ConnectorConfig::with_properties("nats", props.clone()))
+        .await
+        .expect("sink open");
+
+    // First epoch: publish rows 0..50.
+    sink.write_batch(&dedup_batch(0..50))
+        .await
+        .expect("first batch publish");
+    sink.pre_commit(1).await.expect("first epoch drain");
+
+    // Restart the broker while the sink's client is idle between
+    // epochs. JetStream persists stream + dedup state to disk, so the
+    // window survives the restart.
+    restart_nats();
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // The sink's TCP connection went with the broker. Close and reopen
+    // rather than wait for transparent reconnect — operators in the
+    // real pipeline loop do the same on hard failures.
+    let _ = sink.close().await;
+    let mut sink = NatsSink::new(schema, None);
+    sink.open(&ConnectorConfig::with_properties("nats", props))
+        .await
+        .expect("sink reopen after restart");
+
+    // Second epoch: replay rows 0..50 (server dedups) + publish 50..100.
+    sink.write_batch(&dedup_batch(0..100))
+        .await
+        .expect("second batch publish");
+    sink.pre_commit(2).await.expect("second epoch drain");
+    sink.close().await.expect("sink close");
+
+    // The stream must hold exactly 100 rows — dedup caught the replay.
+    let mut stream = ctx.get_stream("RESTART").await.expect("get_stream");
+    let info = stream.info().await.expect("info");
+    assert_eq!(
+        info.state.messages, 100,
+        "expected 100 unique messages after dedup; got {}",
+        info.state.messages
+    );
+}
+
+/// Source that never calls `notify_epoch_committed` must not ack.
+/// Re-opening the same durable consumer after `ack_wait` expires
+/// replays the messages; once the second instance commits, a third
+/// instance sees nothing.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs docker compose -f docker-compose.nats.yml up"]
+async fn source_redelivers_when_epoch_not_committed() {
+    let ctx = connect().await;
+    reset_stream(
+        &ctx,
+        StreamConfig {
+            name: "ACKTEST".into(),
+            subjects: vec!["acktest.events".into()],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Seed: publish 3 rows directly via the server-side context so the
+    // source has something to consume.
+    for i in 0..3i64 {
+        let payload = format!(r#"{{"id": {i}, "name": "row-{i}"}}"#);
+        ctx.publish("acktest.events".to_string(), payload.into())
+            .await
+            .expect("publish")
+            .await
+            .expect("ack");
+    }
+
+    let props = source_props(&[
+        ("servers", NATS_URL),
+        ("stream", "ACKTEST"),
+        ("consumer", "acktest-consumer"),
+        ("subject", "acktest.events"),
+        ("format", "json"),
+        ("ack.wait.ms", "2000"),
+        ("fetch.max.wait.ms", "250"),
+    ]);
+
+    // First source: poll, do NOT commit.
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties("nats", props.clone()))
+        .await
+        .expect("source 1 open");
+    let first = drain_rows(&mut source, 3, Duration::from_secs(5)).await;
+    source.close().await.expect("source 1 close");
+
+    // Wait longer than ack_wait so the server unparks the unacked set
+    // and lets a fresh consumer receive them.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Second source: poll, commit this time.
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties("nats", props.clone()))
+        .await
+        .expect("source 2 open");
+    let second = drain_rows(&mut source, 3, Duration::from_secs(5)).await;
+    assert_eq!(
+        first, second,
+        "expected the same messages redelivered after no-commit close"
+    );
+    source
+        .notify_epoch_committed(1)
+        .await
+        .expect("epoch commit acks");
+    source.close().await.expect("source 2 close");
+
+    // Third source: now the acks have landed, nothing should remain.
+    let mut source = NatsSource::new(payload_schema(), None);
+    source
+        .open(&ConnectorConfig::with_properties("nats", props))
+        .await
+        .expect("source 3 open");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let mut saw_redelivery = false;
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(Some(batch)) = source.poll_batch(10).await {
+            if batch.records.num_rows() > 0 {
+                saw_redelivery = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    source.close().await.expect("source 3 close");
+    assert!(
+        !saw_redelivery,
+        "expected no messages after source 2 committed — got a redelivery"
+    );
+}
+
 // ── auth ──
 
 const SECURE_NATS_URL: &str = "nats://127.0.0.1:4223";

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -30,6 +30,7 @@ delta-lake-all = ["delta-lake", "delta-lake-s3", "delta-lake-azure", "delta-lake
 parquet-lookup = ["laminar-connectors/parquet-lookup"]
 files = ["laminar-connectors/files"]
 otel = ["laminar-connectors/otel"]
+nats = ["laminar-connectors/nats"]
 cluster-unstable = ["laminar-core/cluster-unstable", "laminar-sql/cluster-unstable"]
 # Phase 0 failure-scenario gates. Each flips on when the corresponding
 # phase of `docs/plans/cluster-production-readiness.md` lands; the

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -481,6 +481,11 @@ impl LaminarDB {
         {
             laminar_connectors::otel::register_otel_source(registry);
         }
+        #[cfg(feature = "nats")]
+        {
+            laminar_connectors::nats::register_nats_source(registry);
+            laminar_connectors::nats::register_nats_sink(registry);
+        }
     }
 
     /// Handle `CREATE LOOKUP TABLE` by registering the table in the
@@ -2494,6 +2499,11 @@ mod tests {
         #[cfg(feature = "otel")]
         {
             expected_sources += 1; // otel source
+        }
+        #[cfg(feature = "nats")]
+        {
+            expected_sources += 1; // nats source
+            expected_sinks += 1; // nats sink
         }
 
         assert_eq!(registry.list_sources().len(), expected_sources);

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -64,7 +64,8 @@ pub trait PipelineCallback: Send + 'static {
     /// Get the current pipeline watermark.
     fn current_watermark(&self) -> i64;
 
-    /// Perform a periodic (timer-based) checkpoint. Returns true if checkpoint was triggered.
+    /// Perform a periodic (timer-based) checkpoint. Returns `Some(epoch)`
+    /// on successful commit, `None` if skipped or failed.
     ///
     /// **Semantics: at-least-once.** Timer-based checkpoints capture source
     /// offsets *before* operator state. On recovery the consumer replays
@@ -75,22 +76,30 @@ pub trait PipelineCallback: Send + 'static {
     /// which captures offsets and operator state at a consistent cut across
     /// all sources.
     ///
+    /// The returned epoch is the monotonic checkpoint epoch number that
+    /// was just committed. The coordinator propagates it to each source's
+    /// [`SourceConnector::notify_epoch_committed`] so sources can release
+    /// external state bound to the epoch (e.g., ack messages).
+    ///
     /// [`checkpoint_with_barrier`]: PipelineCallback::checkpoint_with_barrier
+    /// [`SourceConnector::notify_epoch_committed`]: laminar_connectors::connector::SourceConnector::notify_epoch_committed
     async fn maybe_checkpoint(
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool;
+    ) -> Option<u64>;
 
     /// Called when all sources have aligned on a barrier.
     ///
-    /// Receives source checkpoints captured at the barrier point (consistent).
-    /// The callback should snapshot operator state and persist the checkpoint.
-    /// Returns true if the checkpoint succeeded.
+    /// Receives source checkpoints captured at the barrier point
+    /// (consistent). The callback snapshots operator state and persists
+    /// the checkpoint. Returns `Some(epoch)` on successful commit, `None`
+    /// on failure — the caller re-drives via the periodic path on
+    /// failure.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool;
+    ) -> Option<u64>;
 
     /// Record cycle metrics.
     fn record_cycle(&self, events_ingested: u64, batches: u64, elapsed_ns: u64);

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -65,7 +65,7 @@ pub trait PipelineCallback: Send + 'static {
     fn current_watermark(&self) -> i64;
 
     /// Perform a periodic (timer-based) checkpoint. Returns `Some(epoch)`
-    /// on successful commit, `None` if skipped or failed.
+    /// on successful commit, `None` otherwise.
     ///
     /// **Semantics: at-least-once.** Timer-based checkpoints capture source
     /// offsets *before* operator state. On recovery the consumer replays
@@ -76,26 +76,16 @@ pub trait PipelineCallback: Send + 'static {
     /// which captures offsets and operator state at a consistent cut across
     /// all sources.
     ///
-    /// The returned epoch is the monotonic checkpoint epoch number that
-    /// was just committed. The coordinator propagates it to each source's
-    /// [`SourceConnector::notify_epoch_committed`] so sources can release
-    /// external state bound to the epoch (e.g., ack messages).
-    ///
     /// [`checkpoint_with_barrier`]: PipelineCallback::checkpoint_with_barrier
-    /// [`SourceConnector::notify_epoch_committed`]: laminar_connectors::connector::SourceConnector::notify_epoch_committed
     async fn maybe_checkpoint(
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64>;
 
-    /// Called when all sources have aligned on a barrier.
-    ///
-    /// Receives source checkpoints captured at the barrier point
-    /// (consistent). The callback snapshots operator state and persists
-    /// the checkpoint. Returns `Some(epoch)` on successful commit, `None`
-    /// on failure — the caller re-drives via the periodic path on
-    /// failure.
+    /// Called when all sources have aligned on a barrier. Returns
+    /// `Some(epoch)` on successful commit, `None` on failure — the
+    /// caller retries on the next interval.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -26,7 +26,8 @@ use std::time::{Duration, Instant};
 use arrow_array::RecordBatch;
 use crossfire::{mpsc, AsyncRx};
 use laminar_connectors::checkpoint::SourceCheckpoint;
-use laminar_connectors::connector::DeliveryGuarantee;
+use laminar_connectors::connector::{DeliveryGuarantee, SourceBatch};
+use laminar_connectors::error::ConnectorError;
 use laminar_core::alloc::{PriorityClass, PriorityGuard};
 use laminar_core::checkpoint::{CheckpointBarrier, CheckpointBarrierInjector};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -72,14 +73,9 @@ struct SourceHandle {
     join: tokio::task::JoinHandle<()>,
     /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
-    /// Pushes the most-recently-committed epoch to the source task so the
-    /// connector can release external state tied to that epoch (e.g.,
-    /// `JetStream` acks, Kafka committed offsets). `watch` gives
-    /// latest-wins semantics: because epochs are monotonic and a commit
-    /// at `N` subsumes all `< N`, a source that misses intermediate
-    /// values is still correct. Value `0` is the sentinel for "no epoch
-    /// committed yet".
-    epoch_committed_tx: tokio::sync::watch::Sender<u64>,
+    /// Latest committed epoch; source acks on pickup. Monotonic, so
+    /// watch's skip-latest semantics are safe.
+    epoch_committed_tx: tokio::sync::watch::Sender<Option<u64>>,
 }
 
 /// Simplified pipeline coordinator — single tokio task, no core threads.
@@ -161,15 +157,18 @@ impl PendingBarrier {
 /// Fallback timeout for idle wake.
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// What woke a source task's select loop.
+enum SourceWake {
+    Shutdown,
+    EpochCommitted(u64),
+    Polled(Result<Option<SourceBatch>, ConnectorError>),
+}
+
 impl StreamingCoordinator {
-    /// Publish a committed-epoch number to every source task. Called
-    /// after a successful checkpoint so connectors that tie external
-    /// state to epoch commits (e.g., `JetStream` ack-on-commit) can
-    /// release that state. Send errors — a task whose receiver has been
-    /// dropped — are ignored; the task is shutting down anyway.
+    /// Fan out a committed epoch to every source so they can ack.
     fn broadcast_epoch_committed(&self, epoch: u64) {
         for handle in &self.source_handles {
-            let _ = handle.epoch_committed_tx.send(epoch);
+            let _ = handle.epoch_committed_tx.send(Some(epoch));
         }
     }
 
@@ -259,49 +258,42 @@ impl StreamingCoordinator {
             let barrier_injector = CheckpointBarrierInjector::new();
             let barrier_handle = barrier_injector.handle();
 
-            // Epoch-committed channel: coordinator publishes the most
-            // recently committed epoch; task dispatches to
-            // `connector.notify_epoch_committed`. Initial value `0` is
-            // the "no commit yet" sentinel and is skipped.
             let (epoch_committed_tx, mut epoch_committed_rx) =
-                tokio::sync::watch::channel::<u64>(0);
+                tokio::sync::watch::channel::<Option<u64>>(None);
 
             let join = tokio::spawn(async move {
                 let mut epoch: u64 = 0;
 
-                // Poll loop — tokio::select! ensures shutdown cancels a
-                // long-running poll_batch or notify_epoch_committed without
-                // waiting for it to return.
+                // Ack a fresh commit before polling more — keeps
+                // max_ack_pending headroom for the broker.
                 loop {
-                    let poll_result = tokio::select! {
+                    let wake = tokio::select! {
                         biased;
-                        () = task_shutdown_clone.notified() => break,
-                        // A new committed epoch takes priority over more
-                        // polling — releasing external state (e.g.,
-                        // JetStream acks) frees up pending-ack budget so
-                        // the broker can keep delivering.
-                        changed = epoch_committed_rx.changed() => {
-                            if changed.is_err() {
-                                // Sender dropped; coordinator is shutting
-                                // down. Shutdown notify will fire next.
-                                continue;
-                            }
-                            let committed = *epoch_committed_rx.borrow_and_update();
-                            if committed > 0 {
-                                if let Err(err) =
-                                    connector.notify_epoch_committed(committed).await
-                                {
-                                    tracing::warn!(
-                                        source = %src_name,
-                                        error = %err,
-                                        epoch = committed,
-                                        "notify_epoch_committed failed",
-                                    );
-                                }
+                        () = task_shutdown_clone.notified() => SourceWake::Shutdown,
+                        r = epoch_committed_rx.changed() => match r {
+                            Ok(()) => match *epoch_committed_rx.borrow_and_update() {
+                                Some(e) => SourceWake::EpochCommitted(e),
+                                None => continue,
+                            },
+                            Err(_) => SourceWake::Shutdown,
+                        },
+                        r = connector.poll_batch(max_poll) => SourceWake::Polled(r),
+                    };
+
+                    let poll_result = match wake {
+                        SourceWake::Shutdown => break,
+                        SourceWake::EpochCommitted(e) => {
+                            if let Err(err) = connector.notify_epoch_committed(e).await {
+                                tracing::warn!(
+                                    source = %src_name,
+                                    error = %err,
+                                    epoch = e,
+                                    "notify_epoch_committed failed",
+                                );
                             }
                             continue;
                         }
-                        result = connector.poll_batch(max_poll) => result,
+                        SourceWake::Polled(r) => r,
                     };
 
                     match poll_result {

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -72,6 +72,14 @@ struct SourceHandle {
     join: tokio::task::JoinHandle<()>,
     /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
+    /// Pushes the most-recently-committed epoch to the source task so the
+    /// connector can release external state tied to that epoch (e.g.,
+    /// `JetStream` acks, Kafka committed offsets). `watch` gives
+    /// latest-wins semantics: because epochs are monotonic and a commit
+    /// at `N` subsumes all `< N`, a source that misses intermediate
+    /// values is still correct. Value `0` is the sentinel for "no epoch
+    /// committed yet".
+    epoch_committed_tx: tokio::sync::watch::Sender<u64>,
 }
 
 /// Simplified pipeline coordinator — single tokio task, no core threads.
@@ -154,6 +162,17 @@ impl PendingBarrier {
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
 impl StreamingCoordinator {
+    /// Publish a committed-epoch number to every source task. Called
+    /// after a successful checkpoint so connectors that tie external
+    /// state to epoch commits (e.g., `JetStream` ack-on-commit) can
+    /// release that state. Send errors — a task whose receiver has been
+    /// dropped — are ignored; the task is shutting down anyway.
+    fn broadcast_epoch_committed(&self, epoch: u64) {
+        for handle in &self.source_handles {
+            let _ = handle.epoch_committed_tx.send(epoch);
+        }
+    }
+
     /// Create a new streaming coordinator.
     ///
     /// Spawns a tokio task for each source that polls the connector and
@@ -240,15 +259,48 @@ impl StreamingCoordinator {
             let barrier_injector = CheckpointBarrierInjector::new();
             let barrier_handle = barrier_injector.handle();
 
+            // Epoch-committed channel: coordinator publishes the most
+            // recently committed epoch; task dispatches to
+            // `connector.notify_epoch_committed`. Initial value `0` is
+            // the "no commit yet" sentinel and is skipped.
+            let (epoch_committed_tx, mut epoch_committed_rx) =
+                tokio::sync::watch::channel::<u64>(0);
+
             let join = tokio::spawn(async move {
                 let mut epoch: u64 = 0;
 
                 // Poll loop — tokio::select! ensures shutdown cancels a
-                // long-running poll_batch without waiting for it to return.
+                // long-running poll_batch or notify_epoch_committed without
+                // waiting for it to return.
                 loop {
                     let poll_result = tokio::select! {
                         biased;
                         () = task_shutdown_clone.notified() => break,
+                        // A new committed epoch takes priority over more
+                        // polling — releasing external state (e.g.,
+                        // JetStream acks) frees up pending-ack budget so
+                        // the broker can keep delivering.
+                        changed = epoch_committed_rx.changed() => {
+                            if changed.is_err() {
+                                // Sender dropped; coordinator is shutting
+                                // down. Shutdown notify will fire next.
+                                continue;
+                            }
+                            let committed = *epoch_committed_rx.borrow_and_update();
+                            if committed > 0 {
+                                if let Err(err) =
+                                    connector.notify_epoch_committed(committed).await
+                                {
+                                    tracing::warn!(
+                                        source = %src_name,
+                                        error = %err,
+                                        epoch = committed,
+                                        "notify_epoch_committed failed",
+                                    );
+                                }
+                            }
+                            continue;
+                        }
                         result = connector.poll_batch(max_poll) => result,
                     };
 
@@ -330,6 +382,7 @@ impl StreamingCoordinator {
                 shutdown: task_shutdown,
                 join,
                 barrier_injector,
+                epoch_committed_tx,
             });
             source_names.push(arc_name);
         }
@@ -640,8 +693,9 @@ impl StreamingCoordinator {
                     })
                 })
                 .collect();
-            if callback.maybe_checkpoint(true, source_offsets).await {
-                tracing::info!("final checkpoint completed before shutdown");
+            if let Some(epoch) = callback.maybe_checkpoint(true, source_offsets).await {
+                tracing::info!(epoch, "final checkpoint completed before shutdown");
+                self.broadcast_epoch_committed(epoch);
             }
         }
     }
@@ -754,8 +808,9 @@ impl StreamingCoordinator {
         // Check if all sources aligned.
         if self.pending_barrier.sources_aligned.len() >= self.pending_barrier.sources_total {
             let checkpoints = std::mem::take(&mut self.pending_barrier.source_checkpoints);
-            let ok = callback.checkpoint_with_barrier(checkpoints).await;
-            if !ok {
+            if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
+                self.broadcast_epoch_committed(epoch);
+            } else {
                 tracing::warn!(
                     checkpoint_id = self.pending_barrier.checkpoint_id,
                     "barrier checkpoint failed, will retry on next interval"
@@ -784,7 +839,9 @@ impl StreamingCoordinator {
         // Leader-side nodes short-circuit here (no checkpoint_interval
         // configured in the tests that drive `db.checkpoint()` manually).
         let offsets = FxHashMap::default();
-        callback.maybe_checkpoint(false, offsets).await;
+        if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
+            self.broadcast_epoch_committed(epoch);
+        }
 
         let should_checkpoint = self
             .config
@@ -802,8 +859,9 @@ impl StreamingCoordinator {
         if self.source_handles.is_empty() {
             // No sources — timer-based checkpoint only.
             let offsets = FxHashMap::default();
-            if callback.maybe_checkpoint(false, offsets).await {
+            if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
                 self.last_checkpoint = Instant::now();
+                self.broadcast_epoch_committed(epoch);
             }
             return;
         }
@@ -887,20 +945,22 @@ mod tests {
             &mut self,
             force: bool,
             _source_offsets: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             if force {
                 if let Some(ref flag) = self.force_checkpoint_flag {
                     flag.store(true, std::sync::atomic::Ordering::SeqCst);
                 }
+                Some(1)
+            } else {
+                None
             }
-            force
         }
 
         async fn checkpoint_with_barrier(
             &mut self,
             _source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
-            true
+        ) -> Option<u64> {
+            Some(1)
         }
 
         fn record_cycle(&self, _events: u64, _batches: u64, _elapsed_ns: u64) {}
@@ -1288,13 +1348,13 @@ mod tests {
             &mut self,
             force: bool,
             offsets: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             self.inner.maybe_checkpoint(force, offsets).await
         }
         async fn checkpoint_with_barrier(
             &mut self,
             cp: FxHashMap<String, SourceCheckpoint>,
-        ) -> bool {
+        ) -> Option<u64> {
             self.inner.checkpoint_with_barrier(cp).await
         }
         fn record_cycle(&self, e: u64, b: u64, ns: u64) {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -247,9 +247,7 @@ impl ConnectorPipelineCallback {
         };
 
         let mut guard = self.coordinator.lock().await;
-        let Some(ref mut coord) = *guard else {
-            return None;
-        };
+        let coord = (*guard).as_mut()?;
         // Phase 1.3: stamp this instance's current pipeline watermark
         // into the coordinator so the next `BarrierAck` carries it.
         // i64::MIN means unset; don't propagate — leader treats us as

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -753,24 +753,41 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        let committed_epoch: Option<u64> = {
+        let mut committed = None;
+        if force {
+            // Blocking checkpoint at shutdown.
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
                 match coord.checkpoint_with_offsets(request).await {
                     Ok(result) if result.success => {
-                        if force {
-                            tracing::info!(
-                                epoch = result.epoch,
-                                "Final pipeline checkpoint saved"
-                            );
-                        } else {
-                            tracing::info!(
-                                epoch = result.epoch,
-                                duration_ms = result.duration.as_millis(),
-                                "Pipeline checkpoint completed"
-                            );
-                        }
-                        Some(result.epoch)
+                        tracing::info!(epoch = result.epoch, "Final pipeline checkpoint saved");
+                        committed = Some(result.epoch);
+                    }
+                    Ok(result) => {
+                        tracing::warn!(
+                            epoch = result.epoch,
+                            error = ?result.error,
+                            "Final checkpoint failed"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Final checkpoint error");
+                    }
+                }
+            }
+        } else {
+            // Periodic checkpoint — run inline (single-threaded runtime, no
+            // parallelism to exploit with tokio::spawn).
+            let mut guard = self.coordinator.lock().await;
+            if let Some(ref mut coord) = *guard {
+                match coord.checkpoint_with_offsets(request).await {
+                    Ok(result) if result.success => {
+                        tracing::info!(
+                            epoch = result.epoch,
+                            duration_ms = result.duration.as_millis(),
+                            "Pipeline checkpoint completed"
+                        );
+                        committed = Some(result.epoch);
                     }
                     Ok(result) => {
                         tracing::warn!(
@@ -778,20 +795,16 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             error = ?result.error,
                             "Pipeline checkpoint failed"
                         );
-                        None
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Checkpoint error");
-                        None
                     }
                 }
-            } else {
-                None
             }
-        };
+        }
 
         self.last_checkpoint = std::time::Instant::now();
-        committed_epoch
+        committed
     }
 
     async fn checkpoint_with_barrier(

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -198,16 +198,16 @@ impl ConnectorPipelineCallback {
         &mut self,
         controller: Arc<laminar_core::cluster::control::ClusterController>,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use laminar_core::cluster::control::Phase;
 
         let ann = match controller.observe_barrier().await {
             Ok(Some(a)) if a.phase == Phase::Prepare => a,
-            _ => return false,
+            _ => return None,
         };
         if self.last_follower_epoch.is_some_and(|e| e >= ann.epoch) {
-            return false;
+            return None;
         }
         self.last_follower_epoch = Some(ann.epoch);
 
@@ -215,7 +215,7 @@ impl ConnectorPipelineCallback {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(error = %e, "follower state capture failed — skipping");
-                return false;
+                return None;
             }
         };
         let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
@@ -248,7 +248,7 @@ impl ConnectorPipelineCallback {
 
         let mut guard = self.coordinator.lock().await;
         let Some(ref mut coord) = *guard else {
-            return false;
+            return None;
         };
         // Phase 1.3: stamp this instance's current pipeline watermark
         // into the coordinator so the next `BarrierAck` carries it.
@@ -258,22 +258,23 @@ impl ConnectorPipelineCallback {
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
         coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
+        let follower_epoch = ann.epoch;
         match coord
             .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
             .await
         {
             Ok(true) => {
-                tracing::info!("follower checkpoint committed");
+                tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
                 self.last_checkpoint = std::time::Instant::now();
-                true
+                Some(follower_epoch)
             }
             Ok(false) => {
                 tracing::warn!("follower checkpoint aborted (leader signalled Abort)");
-                false
+                None
             }
             Err(e) => {
                 tracing::warn!(error = %e, "follower checkpoint errored");
-                false
+                None
             }
         }
     }
@@ -632,7 +633,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
@@ -680,11 +681,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
         {
             tracing::debug!("skipping timer checkpoint under exactly-once (use barriers)");
-            return false;
+            return None;
         }
 
         if self.prom.cycles.get() == 0 {
-            return false;
+            return None;
         }
 
         // After a sink timeout, skip one checkpoint cycle so that source
@@ -694,15 +695,15 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if !force && self.sink_timed_out {
             self.sink_timed_out = false;
             tracing::info!("skipping checkpoint after sink timeout to preserve replay window");
-            return false;
+            return None;
         }
 
         if !force {
             let Some(interval) = self.checkpoint_interval else {
-                return false; // no auto-checkpointing configured
+                return None; // no auto-checkpointing configured
             };
             if self.last_checkpoint.elapsed() < interval {
-                return false;
+                return None;
             }
         }
 
@@ -729,7 +730,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             Ok(states) => states,
             Err(e) => {
                 tracing::warn!(error = %e, "Stream executor checkpoint failed — skipping checkpoint");
-                return false;
+                return None;
             }
         };
 
@@ -752,38 +753,24 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        if force {
-            // Blocking checkpoint at shutdown.
+        let committed_epoch: Option<u64> = {
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
                 match coord.checkpoint_with_offsets(request).await {
                     Ok(result) if result.success => {
-                        tracing::info!(epoch = result.epoch, "Final pipeline checkpoint saved");
-                    }
-                    Ok(result) => {
-                        tracing::warn!(
-                            epoch = result.epoch,
-                            error = ?result.error,
-                            "Final checkpoint failed"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Final checkpoint error");
-                    }
-                }
-            }
-        } else {
-            // Periodic checkpoint — run inline (single-threaded runtime, no
-            // parallelism to exploit with tokio::spawn).
-            let mut guard = self.coordinator.lock().await;
-            if let Some(ref mut coord) = *guard {
-                match coord.checkpoint_with_offsets(request).await {
-                    Ok(result) if result.success => {
-                        tracing::info!(
-                            epoch = result.epoch,
-                            duration_ms = result.duration.as_millis(),
-                            "Pipeline checkpoint completed"
-                        );
+                        if force {
+                            tracing::info!(
+                                epoch = result.epoch,
+                                "Final pipeline checkpoint saved"
+                            );
+                        } else {
+                            tracing::info!(
+                                epoch = result.epoch,
+                                duration_ms = result.duration.as_millis(),
+                                "Pipeline checkpoint completed"
+                            );
+                        }
+                        Some(result.epoch)
                     }
                     Ok(result) => {
                         tracing::warn!(
@@ -791,27 +778,31 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             error = ?result.error,
                             "Pipeline checkpoint failed"
                         );
+                        None
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, "Checkpoint error");
+                        None
                     }
                 }
+            } else {
+                None
             }
-        }
+        };
 
         self.last_checkpoint = std::time::Instant::now();
-        true
+        committed_epoch
     }
 
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
         if self.prom.cycles.get() == 0 {
-            return false;
+            return None;
         }
 
         // Clear after one suppression — the timer-based path that also
@@ -821,7 +812,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             tracing::warn!(
                 "skipping barrier checkpoint after sink timeout to preserve replay window"
             );
-            return false;
+            return None;
         }
 
         // Capture table source offsets.
@@ -841,7 +832,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             Ok(states) => states,
             Err(e) => {
                 tracing::warn!(error = %e, "Stream executor barrier checkpoint failed — skipping");
-                return false;
+                return None;
             }
         };
 
@@ -883,7 +874,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         "Barrier-aligned checkpoint completed"
                     );
                     self.last_checkpoint = std::time::Instant::now();
-                    return true;
+                    return Some(result.epoch);
                 }
                 Ok(result) => {
                     tracing::warn!(
@@ -898,7 +889,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        false
+        None
     }
 
     fn record_cycle(&self, events_ingested: u64, _batches: u64, elapsed_ns: u64) {

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -183,17 +183,10 @@ async fn test_barrier_aligned_checkpoint_fires() {
     );
 }
 
-/// Verifies that after a barrier-aligned checkpoint commits, every
-/// registered source's `SourceConnector::notify_epoch_committed` is
-/// called with the committed epoch number.
-///
-/// Regression guard for PR: `notify_epoch_committed` SDK hook. Without
-/// the wiring, JetStream-style sources would never release pending acks
-/// and `max_ack_pending` would saturate.
+/// After a barrier checkpoint commits, each source's
+/// `notify_epoch_committed` should fire with a monotonic epoch.
 #[tokio::test]
 async fn test_notify_epoch_committed_propagates_to_sources() {
-    use parking_lot::Mutex;
-
     let src_a = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
     let src_b = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
     let epochs_a = src_a.committed_epochs_handle();
@@ -246,35 +239,15 @@ async fn test_notify_epoch_committed_propagates_to_sources() {
     shutdown_clone.notify_one();
     handle.await.unwrap();
 
-    fn observed(handle: &Arc<Mutex<Vec<u64>>>) -> Vec<u64> {
-        handle.lock().clone()
-    }
-
-    let a = observed(&epochs_a);
-    let b = observed(&epochs_b);
-
-    assert!(
-        !a.is_empty(),
-        "src_a should have received at least one notify_epoch_committed call, got {a:?}"
-    );
-    assert!(
-        !b.is_empty(),
-        "src_b should have received at least one notify_epoch_committed call, got {b:?}"
-    );
-
-    // Epochs must be monotonically non-decreasing. `watch` has
-    // latest-wins semantics so intermediate values may be skipped —
-    // that is correct behavior and the assertion tolerates it.
-    for window in a.windows(2) {
+    for (label, epochs) in [("src_a", &epochs_a), ("src_b", &epochs_b)] {
+        let observed = epochs.lock().clone();
         assert!(
-            window[0] <= window[1],
-            "src_a epochs must be non-decreasing, got {a:?}"
+            !observed.is_empty(),
+            "{label}: expected at least one notify_epoch_committed call, got {observed:?}"
         );
-    }
-    for window in b.windows(2) {
         assert!(
-            window[0] <= window[1],
-            "src_b epochs must be non-decreasing, got {b:?}"
+            observed.windows(2).all(|w| w[0] <= w[1]),
+            "{label}: epochs must be non-decreasing, got {observed:?}"
         );
     }
 }

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -88,20 +88,25 @@ impl PipelineCallback for BarrierTrackingCallback {
             String,
             laminar_connectors::checkpoint::SourceCheckpoint,
         >,
-    ) -> bool {
+    ) -> Option<u64> {
         if force {
             self.force_checkpoints += 1;
-            return true;
+            return Some(self.force_checkpoints);
         }
-        self.should_trigger.load(Ordering::Relaxed)
+        if self.should_trigger.load(Ordering::Relaxed) {
+            Some(1)
+        } else {
+            None
+        }
     }
 
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> bool {
+    ) -> Option<u64> {
+        let epoch = self.barrier_checkpoints.len() as u64 + 1;
         self.barrier_checkpoints.push(source_checkpoints);
-        true
+        Some(epoch)
     }
 
     fn record_cycle(&self, _events_ingested: u64, _batches: u64, _elapsed_ns: u64) {}
@@ -176,6 +181,102 @@ async fn test_barrier_aligned_checkpoint_fires() {
         total > 0,
         "pipeline should have processed records, got {total}"
     );
+}
+
+/// Verifies that after a barrier-aligned checkpoint commits, every
+/// registered source's `SourceConnector::notify_epoch_committed` is
+/// called with the committed epoch number.
+///
+/// Regression guard for PR: `notify_epoch_committed` SDK hook. Without
+/// the wiring, JetStream-style sources would never release pending acks
+/// and `max_ack_pending` would saturate.
+#[tokio::test]
+async fn test_notify_epoch_committed_propagates_to_sources() {
+    use parking_lot::Mutex;
+
+    let src_a = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
+    let src_b = laminar_connectors::testing::MockSourceConnector::with_batches(50, 10);
+    let epochs_a = src_a.committed_epochs_handle();
+    let epochs_b = src_b.committed_epochs_handle();
+
+    let sources = vec![
+        SourceRegistration {
+            name: "src_a".to_string(),
+            connector: Box::new(src_a),
+            config: laminar_connectors::config::ConnectorConfig::new("mock"),
+            supports_replay: true,
+            restore_checkpoint: None,
+        },
+        SourceRegistration {
+            name: "src_b".to_string(),
+            connector: Box::new(src_b),
+            config: laminar_connectors::config::ConnectorConfig::new("mock"),
+            supports_replay: true,
+            restore_checkpoint: None,
+        },
+    ];
+
+    let shutdown = Arc::new(Notify::new());
+    let shutdown_clone = Arc::clone(&shutdown);
+
+    let config = PipelineConfig {
+        fallback_poll_interval: Duration::from_millis(1),
+        batch_window: Duration::ZERO,
+        checkpoint_interval: Some(Duration::from_millis(10)),
+        barrier_alignment_timeout: Duration::from_secs(5),
+        ..PipelineConfig::default()
+    };
+
+    let (_control_tx, control_rx) =
+        crossfire::mpsc::bounded_async::<laminar_db::pipeline::ControlMsg>(64);
+    let coordinator = StreamingCoordinator::new(sources, config, shutdown, control_rx)
+        .await
+        .unwrap();
+
+    let should_trigger = Arc::new(AtomicBool::new(true));
+    let record_counter = Arc::new(AtomicU64::new(0));
+    let callback =
+        BarrierTrackingCallback::new(Arc::clone(&should_trigger), Arc::clone(&record_counter));
+
+    let handle = tokio::spawn(async move {
+        coordinator.run(callback).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    shutdown_clone.notify_one();
+    handle.await.unwrap();
+
+    fn observed(handle: &Arc<Mutex<Vec<u64>>>) -> Vec<u64> {
+        handle.lock().clone()
+    }
+
+    let a = observed(&epochs_a);
+    let b = observed(&epochs_b);
+
+    assert!(
+        !a.is_empty(),
+        "src_a should have received at least one notify_epoch_committed call, got {a:?}"
+    );
+    assert!(
+        !b.is_empty(),
+        "src_b should have received at least one notify_epoch_committed call, got {b:?}"
+    );
+
+    // Epochs must be monotonically non-decreasing. `watch` has
+    // latest-wins semantics so intermediate values may be skipped —
+    // that is correct behavior and the assertion tolerates it.
+    for window in a.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "src_a epochs must be non-decreasing, got {a:?}"
+        );
+    }
+    for window in b.windows(2) {
+        assert!(
+            window[0] <= window[1],
+            "src_b epochs must be non-decreasing, got {b:?}"
+        );
+    }
 }
 
 /// Test that checkpoint persisted via barrier path can be recovered.

--- a/docs/plans/nats-connector-production-readiness.md
+++ b/docs/plans/nats-connector-production-readiness.md
@@ -1,0 +1,161 @@
+# NATS connector — production readiness
+
+Five small, independently-mergeable PRs that take `feat/nats-connector-source-sink`
+from MVP to a v1 an operator would deploy. The branch today is a working
+reference implementation with zero auth, zero metrics, unbounded retry,
+no chaos coverage, and no throughput numbers.
+
+## Guiding principles
+
+- Match existing patterns. Metrics mirror `KafkaSourceMetrics` /
+  `KafkaSinkMetrics`. Auth follows the enum + validation shape used by
+  the Kafka connector's `SecurityProtocol` / `SaslMechanism`.
+- Block-merge only what's in the "required for v1" list below. Anything
+  else goes on the deferred list and stays there.
+- Every PR ships with tests. Unit for parsing. Integration where
+  behavior involves a real server.
+
+## PR A — Auth + TLS
+
+### Scope
+- Config: `auth.mode = none | user_pass | token | tls` (in v1).
+  Additional keys: `user`, `password`, `token`, `tls.ca.location`,
+  `tls.cert.location`, `tls.key.location`, `tls.insecure_skip_verify`.
+- Wire into `async_nats::ConnectOptions`: `.user_and_password()`,
+  `.token()`, `.add_root_certificates()`, `.add_client_certificate()`,
+  `.require_tls()`.
+- Validation: `auth.mode=user_pass` requires both `user` and
+  `password`; mutually-exclusive keys caught at parse time. New LDB
+  codes `LDB-5060`–`LDB-5065`.
+
+### Deferred (not v1)
+- `nkey`, `jwt`, `creds_file` — real production features, niche.
+- OAuth / JWT callback signers.
+
+### Tests
+- Unit: every mutual-exclusion rule, every required-when rule.
+- Integration: extend `docker-compose.nats.yml` with a secured profile
+  (`--profile secure`) that starts `nats-server --user alice --pass bob`
+  + TLS certs; round-trip under each mode.
+
+### Merge criterion
+All new unit tests + at least `user_pass` and `tls` integration tests
+green. ~400 LOC.
+
+## PR B — Metrics + HealthStatus
+
+### Scope
+- `NatsSourceMetrics` and `NatsSinkMetrics` modeled on Kafka metrics.
+- Source counters: `nats_source_records_total`,
+  `nats_source_fetch_errors_total`, `nats_source_acks_total`,
+  `nats_source_ack_errors_total`. Gauges: `nats_source_pending_acks`,
+  `nats_source_channel_depth`.
+- Sink counters: `nats_sink_records_total`,
+  `nats_sink_publish_errors_total`, `nats_sink_ack_errors_total`,
+  `nats_sink_dedup_total` (from `PubAck.duplicate`). Gauges:
+  `nats_sink_pending_futures`.
+- `HealthStatus` impls: `Healthy` while data flowing + pending within
+  budget; `Degraded` on sustained back-pressure (>50% pending
+  saturation over a rolling window); `Unhealthy` after N consecutive
+  fetch errors (see PR C).
+- Thread `Option<&prometheus::Registry>` through `NatsSource::new` and
+  `NatsSink::new`. Update factory in `mod.rs`.
+
+### Open questions
+- Label cardinality. `records_total{subject}` is a NATS footgun given
+  wildcard subject spaces. Default to **no per-subject label**; add a
+  `metrics.per.subject.label=false` switch for opt-in.
+- `Degraded` threshold (50%, rolling window size) — expose as config
+  or hardcode?
+
+### Tests
+- Unit: metric increments via a direct `prometheus::Registry`.
+- Integration: verify `nats_sink_dedup_total = 1` after the existing
+  dedup integration test.
+
+### Merge criterion
+Operator can `curl /metrics` and see every new counter. ~450 LOC.
+
+## PR C — Bounded reconnect + drift handling
+
+### Scope
+- Source fetch loop: track consecutive errors, exponential backoff
+  500ms → 5s cap, flip `HealthStatus::Unhealthy` after
+  `fetch.error.threshold` (default 10) consecutive errors. Reset on
+  success.
+- Consumer config drift: on `create_consumer` error, parse async-nats
+  error kind; surface
+  `LDB-5070 consumer '{name}' exists with incompatible config;
+   rotate the durable name or delete the consumer out-of-band`.
+- Shutdown latency: replace the `AtomicBool` + between-fetch check
+  with `tokio::select!` that cancels `fetch()` directly. Lag drops
+  from `fetch.max.wait.ms` to sub-ms.
+
+### Deferred
+- Periodic `duplicate_window` revalidation.
+
+### Tests
+- Unit: drift-error parsing against mocked error variants.
+- Integration: delete the stream behind a running source, observe
+  `HealthStatus::Unhealthy` within bounded time.
+
+### Merge criterion
+Fetch-error threshold test green. ~250 LOC.
+
+## PR D — Chaos integration test
+
+### Scope
+- `exactly_once_under_broker_restart`: publish a burst,
+  `docker compose restart nats` mid-burst, resume, verify stream
+  contains the exact set of ids (no loss, no dup).
+- `source_acks_only_after_commit`: publish, consume up to barrier,
+  simulate `checkpoint()` without `notify_epoch_committed`, kill the
+  source, restart, verify redelivery.
+
+### Deferred
+- Full-pipeline kill-mid-epoch — that's a `laminar-db` test, not a
+  connector test.
+
+### Tests
+Shell out to `docker compose restart` / `stop` via
+`std::process::Command`. `#[ignore]`-gated.
+
+### Merge criterion
+Both tests green 10 consecutive runs locally.
+Label as Linux-CI-only (Docker Desktop on Windows has known SIGKILL
+flakiness). ~300 LOC.
+
+## PR E — Throughput benchmark
+
+### Scope
+- `benches/nats_throughput.rs` using `criterion`, gated
+  `required-features = ["nats"]`.
+- `sink_publish_jetstream` — baseline for regression detection.
+- `source_consume_jetstream`.
+- Workflow documented, numbers captured in `docs/BENCHMARKS.md`.
+
+### Merge criterion
+Benches compile + run + produce numbers. No threshold assertion
+(criterion surfaces regressions across runs). ~200 LOC.
+
+## Sequencing
+
+```
+A (Auth)    ──┐
+              ├──→ D (Chaos) ──→ E (Bench)
+B (Metrics) ──┤
+              │
+C (Reconnect)─┘
+```
+
+A, B, C independent. D depends on B (metrics are what chaos tests
+assert on) and C (bounded reconnect is what "survives broker restart"
+means). E last — benches against a hardened connector.
+
+## Start order
+
+**B first** — broadest utility, surfaces runtime behavior we've only
+inferred from code reading, unblocks D. Operator visibility is the
+single largest current gap.
+
+Then A, C, D, E in that order.

--- a/docs/plans/nats-connector.md
+++ b/docs/plans/nats-connector.md
@@ -1,0 +1,363 @@
+# NATS connector
+
+Source + sink connector for NATS, covering Core NATS and JetStream, plus a
+cluster-discovery backend on JetStream KV.
+
+## Goals
+
+- One `nats` connector type, two modes: `core` (non-durable pub/sub) and
+  `jetstream` (durable streams, default).
+- At-least-once by default; exactly-once on JetStream with user-supplied
+  message id.
+- Per-subject lanes for watermarks and offset tracking — matches how the
+  Kafka source treats partitions.
+- Cluster coordination backend using JetStream KV as a peer to
+  `kafka-discovery`, not a replacement.
+
+## Non-goals (v1)
+
+- Push consumers. Pull only.
+- Ephemeral consumers. Durable name required.
+- Subject templates with placeholders (`orders.{region}.created`).
+  Literal subject or single `subject.column` only.
+- Protobuf format. Deferred to a cross-cutting "protobuf format"
+  effort covering Kafka/NATS/files.
+- Avro without the `kafka` feature. Reuses the existing
+  `SchemaRegistryClient`; fails at open() otherwise.
+
+## Crate layout
+
+```
+crates/laminar-connectors/src/nats/
+├── mod.rs          // registration
+├── config.rs       // source + sink config + enums
+├── source.rs       // NatsSource — mode dispatch inside
+├── sink.rs         // NatsSink  — mode dispatch inside
+├── subject.rs      // literal | column → subject
+├── dedup.rs        // Nats-Msg-Id accessor from configured column
+├── discovery.rs    // JetStream KV cluster-discovery backend
+└── metrics.rs
+```
+
+Features:
+
+```toml
+nats           = ["dep:async-nats"]
+nats-discovery = ["nats", "laminar-core/cluster-unstable"]
+```
+
+Pinned: `async-nats = "0.47"`.
+
+Registration sits beside Kafka in
+`crates/laminar-db/src/db.rs::register_builtin_connectors`, gated by
+`#[cfg(feature = "nats")]`.
+
+## SDK prerequisite — PR #1
+
+Add one method to `SourceConnector` with a default no-op. The coordinator
+calls it after the manifest is persisted and after the sink's
+`commit_epoch` returns. NATS uses it to ack the full set of messages for
+the committed epoch.
+
+```rust
+async fn notify_epoch_committed(&mut self, _epoch: u64)
+    -> Result<(), ConnectorError> { Ok(()) }
+```
+
+Kafka is **not** migrated in this PR. Today's timer-based commit stays.
+The migration to epoch-gated commits is a separate hardening PR
+sequenced after #1 stabilizes — it is not behavior-neutral and deserves
+its own release note.
+
+## Source
+
+### Config (WITH-clause keys)
+
+```
+-- connection
+servers                nats://a:4222,nats://b:4222            (required)
+mode                   core | jetstream                       (default jetstream)
+auth.mode              none | user_pass | token | nkey | jwt | creds_file
+<auth fields>          routed through storage credential resolver
+tls.*                  ca / cert / key / key.password
+
+-- jetstream
+stream                 ORDERS                                  (required jetstream)
+subject                orders.>                                (core required; JS optional filter)
+subject.filters        orders.us.*,orders.eu.*                 (JS multi-filter, 2.10+)
+consumer               laminar-orders                          (required durable name)
+deliver.policy         all | new | by_start_sequence | by_start_time
+start.sequence | start.time                                    (only when matching policy)
+ack.policy             explicit | none                         (default explicit)
+ack.wait.ms            60000                                   (see validation)
+max.deliver            5
+max.ack.pending        10000
+fetch.batch            500
+fetch.max.wait.ms      500
+fetch.max.bytes        1048576
+
+-- core
+queue.group            laminar-workers                         (core only, load balance)
+
+-- format & metadata
+format                 json | csv | raw | avro                 (avro needs kafka feature)
+include.metadata       false                                   (_subject, _stream_seq, _consumer_seq,
+                                                                _timestamp, _num_delivered)
+include.headers        false                                   (_headers as JSON)
+event.time.column      ""
+schema.registry.*      (same keys as Kafka; only live with kafka feature)
+
+-- error handling
+poison.dlq.subject     orders.dead                             (Term on max_deliver + republish)
+```
+
+### Per-subject lanes
+
+`PartitionInfo.id = <subject>`. The source opens a lane on first
+observation of a subject (or eagerly for each declared `subject.filters`
+entry). `OffsetTracker` keys by subject → last `stream_seq`. The
+watermark tracker treats each subject as an independent lane for
+idle-partition detection, matching `KafkaWatermarkTracker`.
+
+### Lifecycle (jetstream)
+
+1. `open()`:
+   - Build `async_nats::ConnectOptions` from auth/tls, `connect()`.
+   - `jetstream::new(client)`, `get_stream(stream).await` for validation.
+   - `create_or_update_consumer` with `consumer::pull::Config`.
+   - Run validation rules below; fail fast with `LDB-5xxx` on any
+     violation.
+   - Spawn reader task: loops on `consumer.fetch().batch(N).expires(T).messages()`,
+     pushes `(payload, AckHandle, subject, stream_seq, timestamp, headers)`
+     into a bounded `crossfire::mpsc::Array`. **Reader never acks.**
+2. `poll_batch(max)`:
+   - Drain the queue into per-subject deserializer inputs + metadata
+     columns.
+   - Deserialize via the shared `RecordDeserializer`.
+   - Record every `AckHandle` in the current epoch's pending set (keyed
+     by epoch number).
+   - Update `OffsetTracker` per subject.
+3. `checkpoint()`:
+   - Emit `SourceCheckpoint { consumer, per_subject_seq }`.
+4. `restore(cp)`:
+   - Trust the server-side ack floor. The durable consumer resumes
+     delivery from its floor on reconnect. If the manifest's seq is
+     strictly greater than the server floor (possible only after
+     out-of-band consumer surgery), log loudly at warn and proceed from
+     the server floor — don't try to "rewrite" the consumer.
+5. `notify_epoch_committed(e)`:
+   - Ack **every** `AckHandle` in epoch `e`'s pending set. Not the
+     high watermark — the full set. JetStream's ack floor only advances
+     over contiguous prefixes; gaps cause permanent redelivery of
+     already-processed messages.
+6. `close()`: drain reader, drop client.
+
+### Core mode
+
+`client.subscribe(subject)` or `queue_subscribe(subject, queue_group)`.
+Override `supports_replay() → false`. Checkpoint is a no-op. Reject at
+plan time if `DELIVERY = EXACTLY_ONCE` is combined with `mode=core`.
+
+### Startup validation (hard-fail with `LDB-5xxx`)
+
+- `mode=core` with `delivery.guarantee=exactly_once`.
+- `mode=jetstream`, exactly-once requested, no `dedup.id.column` on the
+  paired sink.
+- `checkpoint_interval + 5s ≥ ack.wait.ms`.
+- `ack.wait.ms * max.deliver ≥ stream.duplicate_window` on the paired
+  sink side — rollback redelivery must stay inside the dedup window.
+- Consumer exists with conflicting immutable fields
+  (`filter_subjects`, `ack_policy`, `deliver_policy`). Error text tells
+  the operator to rotate the durable name or delete the consumer
+  out-of-band.
+- `format=avro` without the `kafka` feature.
+
+### Back-pressure surfaces
+
+`max_ack_pending` saturation pauses delivery server-side silently.
+Surface as:
+
+- `laminar_nats_source_pending_acks` gauge.
+- `HealthStatus::Degraded { reason: "max_ack_pending saturated" }`
+  when the pending count is within 5% of the cap for >30s.
+
+### Consumer config drift
+
+`create_or_update_consumer` returns `ErrConsumerCreate` on
+immutable-field conflict. Surface as
+`ConnectorError::Configuration("consumer '{name}' exists with
+incompatible config; rotate the durable name or delete out-of-band")`.
+
+## Sink
+
+### Config
+
+```
+servers, mode, auth.*, tls.*
+stream                 ORDERS_OUT                              (for validation)
+subject                orders.processed                        (literal) OR
+subject.column         out_subject                             (per-row)
+expected.stream        ORDERS_OUT                              (Nats-Expected-Stream header)
+
+delivery.guarantee     at_least_once | exactly_once
+dedup.id.column        event_id                                (required for exactly_once)
+
+max.pending            4096                                    (PubAck outstanding)
+ack.timeout.ms         30000
+flush.batch.size       1000
+
+format                 json | csv | raw | avro
+header.columns         trace_id,tenant
+poison.dlq.subject     orders.failed
+```
+
+### Lifecycle
+
+- `open()`: connect → `jetstream::new()`. Query stream config; validate
+  `duplicate_window` against source-side `ack.wait * max.deliver`.
+- `write_batch`: for each row compute subject, headers (header.columns +
+  `Nats-Msg-Id = <row[dedup.id.column]>` when exactly-once),
+  serialized payload; call `jetstream.publish_with_headers`; push the
+  returned `PublishAckFuture` into a `VecDeque` capped at `max.pending`.
+- `pre_commit`: `try_join_all` on the deque with `ack.timeout.ms` each;
+  any non-duplicate error fails the epoch. Duplicate acks are counted
+  (metric) and accepted.
+- `commit_epoch`: no-op on the NATS side; bump `last_committed_epoch`.
+- `rollback_epoch`: drop in-flight buffer. Already-landed publishes are
+  covered by server dedup on retry (validated at open()).
+- `close()`: flush the deque with a bounded deadline.
+
+### Capabilities
+
+```rust
+SinkConnectorCapabilities::new(Duration::from_secs(5))
+    .with_idempotent()        // always in JS mode
+    .with_exactly_once()      // when dedup.id.column set
+    .with_two_phase_commit()  // pre_commit awaits all PubAckFutures
+    .with_partitioned()       // subject-per-row
+```
+
+No `changelog` / `upsert` — NATS is append-only.
+
+### Core sink
+
+`client.publish`. Capabilities declare at-least-once best-effort only.
+`pre_commit` is a no-op. Reject plan-time if paired with
+`exactly_once`.
+
+## Cluster discovery (`nats-discovery` feature)
+
+Alternative to `kafka-discovery`. A cluster picks **one** coordinator
+backend at boot; mixing Kafka and NATS coordination inside a single
+cluster is not supported and is rejected at startup.
+
+### Backend selection
+
+```
+cluster.coordinator    kafka | nats        (required when cluster mode is enabled)
+```
+
+Resolution order:
+
+- Both features compiled in → config key selects the backend.
+- Only one feature compiled in → config key must match the compiled
+  backend or `open()` fails.
+- Both config keys set, or `cluster.coordinator` points at a backend
+  whose feature is not compiled in → hard-fail at startup with
+  `LDB-5xxx`.
+- Leader detects a peer announcing a different coordinator backend
+  (visible in the heartbeat payload) → fence the cluster: refuse to
+  publish an assignment and raise `HealthStatus::Unhealthy`. Prevents
+  a mid-flight misconfiguration from silently splitting the cluster
+  across two coordination planes.
+
+### KV buckets
+
+- `_laminar_nodes` — TTL 30s, key = `node_id`, value = heartbeat payload
+  (addr, epoch, assignment_version). Each node refreshes every 10s;
+  dead nodes auto-expire.
+- `_laminar_leader` — single key `leader`, value = `node_id`. Election
+  via `create` on the key (CAS fail = someone else won). Leader
+  refreshes TTL; on expiry, watchers race to claim.
+- `_laminar_assignments` — key = version number, value =
+  `AssignmentSnapshot`. Written with `PutMode::Create` so concurrent
+  leader writes cannot clobber. Same struct and versioned layout as the
+  existing cluster primitives.
+
+### Node watch loop
+
+Subscribe to `_laminar_assignments` updates. On new version, call
+`LaminarDB::adopt_assignment_snapshot` (already present). Leader
+election and assignment publication reuse the existing debounced
+rebalance controller from #342.
+
+### Bucket lifecycle
+
+Auto-create on first use with `replicas=3, history=5, ttl=30s`.
+Overridable via:
+
+```
+nats.discovery.bucket.replicas       3
+nats.discovery.bucket.history        5
+nats.discovery.nodes.ttl.ms          30000
+nats.discovery.leader.ttl.ms         15000
+```
+
+Operators who prefer preprovisioning use
+`laminar-cli cluster init --coordinator=nats --servers=...`; the
+runtime then refuses to create buckets and errors on missing ones.
+
+### Why JetStream KV over Kafka for this
+
+- Native CAS on `create` — leader election without compacted-topic
+  hacks.
+- Native TTL on heartbeats — no consumer-group liveness dance.
+- Sub-ms watch notifications vs Kafka poll.
+
+### Scope
+
+Opt-in, `cluster-unstable` feature flag for honesty. Peer to
+`kafka-discovery` at compile time, mutually exclusive at run time.
+Shops with Kafka stay on `kafka-discovery`; NATS-only shops pick
+`nats-discovery`. No hybrid.
+
+## Test matrix
+
+Five scenarios. All gated behind `--features nats` and `--ignored`
+(testcontainers, `nats:2.10-alpine`). Same stance as the Mongo tests.
+
+1. **Round-trip**: publish via sink → consume via source → identity.
+2. **Broker kill mid-epoch**: kill `nats-server` during a write batch,
+   restart, verify no loss and no duplicates downstream.
+3. **LaminarDB kill after pre_commit, before manifest**: restart,
+   rollback path fires, verify no duplicate rows.
+4. **Forced redelivery**: sleep the sink past `ack.wait`, verify source
+   redelivers, sink dedup drops, `duplicate` metric non-zero.
+5. **Startup validation**: each of the six hard-fail rules raises the
+   correct `LDB-5xxx` code with the documented message.
+
+Discovery (nats-discovery feature):
+
+6. **Three-node convergence**: kill leader, verify a new leader claims
+   the TTL'd key and publishes a new assignment version that the
+   remaining nodes adopt.
+
+## Staging
+
+| PR | Scope | Merge criterion |
+|---|---|---|
+| 1 | `SourceConnector::notify_epoch_committed` hook + coordinator wiring. Kafka untouched. | All existing connector tests green. |
+| 2 | `nats` feature. Core + JetStream pull source, at-least-once sink. Per-subject lanes. Startup validation. Back-pressure + drift surfaces. | Scenarios 1, 2, 4, 5. |
+| 3 | JetStream sink exactly-once via `Nats-Msg-Id`. `duplicate_window` validation. | Scenario 3 + full exactly-once matrix. |
+| 4 | `nats-discovery` feature. KV-based nodes / leader / assignments. | Scenario 6. |
+
+Kafka commit-timer → epoch-based migration: separate PR, sequenced
+after PR 1 has been live at least one release cycle.
+
+## Open items
+
+- Default KV bucket replicas (`3`) assumes a 3-node JetStream cluster.
+  Single-node dev deployments need `1`. Propose: auto-detect via
+  `jetstream.account_info()` topology and pick accordingly; fall back
+  to `replicas=1` with a startup warning if the account reports fewer
+  than 3 servers.


### PR DESCRIPTION
## Summary

Adds a NATS connector to the `laminar-connectors` crate, behind a new `nats` cargo feature. Covers core NATS pub/sub and JetStream pull consumers, with an exactly-once sink backed by server-side `Nats-Msg-Id` deduplication. Ships production hardening: auth + TLS, Prometheus metrics, bounded reconnect with health escalation, and integration tests that verify behavior end-to-end against a real `nats-server` — including a chaos test that restarts the broker mid-run.

Foundational SDK change in the first commit: a default-no-op `SourceConnector::notify_epoch_committed(epoch)` hook the coordinator calls after the checkpoint manifest persists and every exactly-once sink commits the epoch. Lets sources ack external state (JetStream messages) at the same moment the rest of the pipeline considers the epoch durable. Kafka is untouched — its timer-based commit path stays.

## What's in

### SDK
- `SourceConnector::notify_epoch_committed(epoch: u64)` trait method with default no-op.
- `StreamingCoordinator` broadcasts the committed epoch to every source task via `tokio::sync::watch<Option<u64>>`.
- Callback return types moved from `bool` to `Option<u64>` so the coordinator knows which epoch just committed.

### NATS connector
- `nats` cargo feature, `async-nats 0.47`.
- Two modes: `core` (subscribe / queue-subscribe, at-most-once) and `jetstream` (durable pull consumer, at-least-once or exactly-once).
- Per-subject lane tracking via `PartitionInfo.id = <subject>`.
- JSON / CSV / raw payloads via the shared `RecordDeserializer` / `RecordSerializer` traits.
- Startup validation for 11 distinct misconfigurations (`LDB-5030` through `LDB-5070`).

### Exactly-once sink
- `Nats-Msg-Id` header per row from a user-named `dedup.id.column`.
- `open()` queries the target stream and refuses to start when `duplicate_window` is shorter than `min.duplicate.window.ms` (`LDB-5056`).
- `rollback_epoch` drops in-flight `PublishAckFuture`s; server dedup covers any publishes that already landed on retry.
- `pre_commit` drains the deque concurrently via `futures::future::try_join_all`.
- `capabilities()` advertises `exactly_once + two_phase_commit` only under `delivery.guarantee=exactly_once`.

### Auth + TLS
- `auth.mode = none | user_pass | token`, with TLS and mutual TLS independent of auth.
- Shared `build_connect_options(auth, tls)` helper so source and sink can't drift.

### Observability
- `NatsSourceMetrics` / `NatsSinkMetrics` modeled on the Kafka metrics structs. Counters, gauges, and Prometheus registration.
- `HealthStatus` flips `Unhealthy` on sustained fetch errors (threshold configurable), `Degraded` on pending-ack saturation.

### Resilience
- Exponential backoff with ±20% jitter on fetch errors.
- `Arc<tokio::sync::Notify>` shutdown that cancels in-flight fetches directly (sub-ms lag).
- Typed matching on `ConsumerErrorKind::JetStream(_)` + `ErrorCode` for drift detection — no string matching on server text.

### Tests
- 35 unit tests covering config validation, backoff curve, jitter window, health transitions, metrics increments, and drift classification.
- 9 integration tests against `nats:2.10-alpine` via `docker-compose.nats.yml`:
  - JetStream round-trip
  - Core round-trip
  - Exactly-once dedup drops duplicate
  - Duplicate-window validation rejects unsafe streams
  - Source flips Unhealthy after stream deletion
  - Source redelivers when epoch is not committed
  - Exactly-once sink survives broker restart (chaos)
  - User/password round-trip against secured server
  - Unauthenticated connect rejected by secured server

## What's out (deferred)

- `nkey`, `jwt`, `creds_file` auth modes.
- `deliver.policy=by_start_time` (errors loudly at open until supported).
- Schema Registry / Avro for NATS payloads.
- Throughput benchmarks (criterion).
- NATS-based cluster discovery (`nats-discovery` feature).

## Verification

- `cargo check --all --no-default-features` — clean
- `cargo clippy -p laminar-connectors --features nats --no-default-features --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc -p laminar-connectors --features nats --no-default-features --no-deps` — clean
- All 35 unit tests pass
- All 9 integration tests pass against a real `nats:2.10-alpine` (two consecutive runs, no flakes)

## Test plan

- [ ] Run \`docker compose -f crates/laminar-connectors/tests/docker-compose.nats.yml --profile secure up -d\` and verify both `nats-1` and `nats-secure-1` containers report healthy.
- [ ] Run \`cargo test -p laminar-connectors --features nats --no-default-features --test nats_integration -- --ignored --test-threads=1\` and confirm 9/9 pass.
- [ ] Scrape \`/metrics\` from a running pipeline and confirm `nats_source_*` / `nats_sink_*` counters appear.
- [ ] Break a stream out-of-band and confirm `health_check` returns `Unhealthy` with operator-readable text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NATS connector (core + JetStream) with at-least-once and exactly-once (dedup) delivery, TLS/auth, observability, and health checks.
  * Source-side notification for committed epochs and connector-level metrics (source & sink).
* **Bug Fixes / Reliability**
  * Improved ack/drain semantics, pending-ack handling, and health reporting under backlog/fetch errors.
* **Tests**
  * End-to-end NATS integration tests with Docker Compose (secure/insecure).
* **Documentation**
  * Design and production-readiness plans for the NATS connector.
* **Chores**
  * Optional Cargo feature flags to enable the NATS connector; connector registration gated by feature.
* **API**
  * Checkpoint callbacks now return the committed epoch (Some(epoch)/None) rather than a boolean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->