### PR TITLE
feat: iceberg auto.create end-to-end + NATS payments demo

### DIFF
--- a/crates/laminar-connectors/src/lakehouse/iceberg_config.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg_config.rs
@@ -47,13 +47,9 @@ pub struct IcebergCatalogConfig {
     pub catalog_type: IcebergCatalogType,
     /// REST catalog URI (e.g., `http://polaris:8181`).
     pub catalog_uri: String,
-    /// For Hadoop-style catalogs this is the warehouse URL (`s3://bucket/wh`).
-    /// For REST catalogs (Lakekeeper, Polaris) it's the warehouse name and the
-    /// REST server resolves storage internally.
+    /// Warehouse URL (Hadoop-style: `s3://bucket/wh`) or name (REST catalogs).
     pub warehouse: String,
-    /// Storage backend the catalog will return URLs for. `None` falls back to
-    /// inferring from the warehouse URL scheme (works for Hadoop-style); set
-    /// explicitly for REST catalogs where `warehouse` is a name, not a URL.
+    /// Explicit storage backend. Required when `warehouse` is a name.
     pub storage_type: Option<String>,
     /// Iceberg namespace (e.g., `prod` or `prod.analytics`).
     pub namespace: String,

--- a/crates/laminar-connectors/src/lakehouse/iceberg_config.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg_config.rs
@@ -47,8 +47,14 @@ pub struct IcebergCatalogConfig {
     pub catalog_type: IcebergCatalogType,
     /// REST catalog URI (e.g., `http://polaris:8181`).
     pub catalog_uri: String,
-    /// Warehouse location (e.g., `s3://bucket/warehouse`).
+    /// For Hadoop-style catalogs this is the warehouse URL (`s3://bucket/wh`).
+    /// For REST catalogs (Lakekeeper, Polaris) it's the warehouse name and the
+    /// REST server resolves storage internally.
     pub warehouse: String,
+    /// Storage backend the catalog will return URLs for. `None` falls back to
+    /// inferring from the warehouse URL scheme (works for Hadoop-style); set
+    /// explicitly for REST catalogs where `warehouse` is a name, not a URL.
+    pub storage_type: Option<String>,
     /// Iceberg namespace (e.g., `prod` or `prod.analytics`).
     pub namespace: String,
     /// Table name within the namespace.
@@ -73,6 +79,7 @@ impl IcebergCatalogConfig {
 
         let catalog_uri = config.require("catalog.uri")?.to_string();
         let warehouse = config.require("warehouse")?.to_string();
+        let storage_type = config.get("storage.type").map(str::to_string);
         let namespace = config.require("namespace")?.to_string();
         let table_name = config.require("table.name")?.to_string();
 
@@ -82,6 +89,7 @@ impl IcebergCatalogConfig {
             catalog_type,
             catalog_uri,
             warehouse,
+            storage_type,
             namespace,
             table_name,
             properties,

--- a/crates/laminar-connectors/src/lakehouse/iceberg_io.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg_io.rs
@@ -20,12 +20,8 @@ use super::iceberg_config::{IcebergCatalogConfig, IcebergCatalogType};
 use crate::error::ConnectorError;
 
 /// Selects the `OpenDalStorageFactory` for the table-data URLs the catalog
-/// will return. Supported backends: `s3`, `s3a`, `fs`.
-///
-/// Explicit `storage.type` wins. Otherwise the scheme is inferred from
-/// the warehouse URL — `s3://`, `s3a://`, `file://`. Anything else
-/// requires an explicit `storage.type` (REST catalogs use a logical
-/// warehouse name; the scheme can't be inferred).
+/// will return. Explicit `storage.type` wins; otherwise inferred from the
+/// `s3://` / `s3a://` / `file://` warehouse URL.
 fn storage_factory(
     warehouse: &str,
     storage_type: Option<&str>,
@@ -221,7 +217,7 @@ pub fn get_last_committed_epoch(table: &Table, writer_id: &str) -> Option<u64> {
     table.metadata().properties().get(&key)?.parse().ok()
 }
 
-/// Creates an Iceberg table if it does not already exist.
+/// Creates an Iceberg table (and namespace) if it does not already exist.
 ///
 /// # Errors
 ///
@@ -302,7 +298,9 @@ mod tests {
     fn test_storage_factory_bare_path_requires_explicit_storage_type() {
         // Trimmed `/` and `./` inference: REST catalogs use logical names
         // and we don't want a silent default to local fs.
-        let err = storage_factory("/tmp/warehouse", None).unwrap_err().to_string();
+        let err = storage_factory("/tmp/warehouse", None)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("LDB-5100"), "got: {err}");
     }
 
@@ -321,7 +319,9 @@ mod tests {
 
     #[test]
     fn test_storage_factory_rejects_unknown_storage_type() {
-        let err = storage_factory("demo", Some("hdfs")).unwrap_err().to_string();
+        let err = storage_factory("demo", Some("hdfs"))
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("LDB-5101"), "got: {err}");
     }
 

--- a/crates/laminar-connectors/src/lakehouse/iceberg_io.rs
+++ b/crates/laminar-connectors/src/lakehouse/iceberg_io.rs
@@ -19,25 +19,52 @@ use tokio_stream::StreamExt;
 use super::iceberg_config::{IcebergCatalogConfig, IcebergCatalogType};
 use crate::error::ConnectorError;
 
-/// Selects the correct `OpenDalStorageFactory` based on the warehouse URL scheme.
-fn storage_factory_for_warehouse(warehouse: &str) -> Arc<dyn iceberg::io::StorageFactory> {
-    if warehouse.starts_with("s3://") || warehouse.starts_with("s3a://") {
-        // Note: configured_scheme must be the bare scheme name (e.g. "s3"),
-        // NOT "s3://". The iceberg-storage-opendal crate's create_operator()
-        // builds the prefix via `format!("{}://{}/", configured_scheme, bucket)`,
-        // so including "://" here would produce "s3://://bucket/" — an invalid URL.
-        let scheme = if warehouse.starts_with("s3a://") {
-            "s3a".to_string()
-        } else {
-            "s3".to_string()
-        };
-        Arc::new(OpenDalStorageFactory::S3 {
+/// Selects the `OpenDalStorageFactory` for the table-data URLs the catalog
+/// will return. Supported backends: `s3`, `s3a`, `fs`.
+///
+/// Explicit `storage.type` wins. Otherwise the scheme is inferred from
+/// the warehouse URL — `s3://`, `s3a://`, `file://`. Anything else
+/// requires an explicit `storage.type` (REST catalogs use a logical
+/// warehouse name; the scheme can't be inferred).
+fn storage_factory(
+    warehouse: &str,
+    storage_type: Option<&str>,
+) -> Result<Arc<dyn iceberg::io::StorageFactory>, ConnectorError> {
+    let scheme = storage_type
+        .map(str::to_lowercase)
+        .or_else(|| {
+            if warehouse.starts_with("s3a://") {
+                Some("s3a".to_string())
+            } else if warehouse.starts_with("s3://") {
+                Some("s3".to_string())
+            } else if warehouse.starts_with("file://") {
+                Some("fs".to_string())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            ConnectorError::ConfigurationError(format!(
+                "[LDB-5100] cannot infer storage backend from warehouse '{warehouse}'; \
+                 set storage.type = 's3' | 's3a' | 'fs'"
+            ))
+        })?;
+
+    // configured_scheme is the bare scheme ("s3"), NOT "s3://" —
+    // iceberg-storage-opendal formats the prefix as `{scheme}://{bucket}/`.
+    let factory: Arc<dyn iceberg::io::StorageFactory> = match scheme.as_str() {
+        "s3" | "s3a" => Arc::new(OpenDalStorageFactory::S3 {
             configured_scheme: scheme,
             customized_credential_load: None,
-        })
-    } else {
-        Arc::new(OpenDalStorageFactory::Fs)
-    }
+        }),
+        "fs" => Arc::new(OpenDalStorageFactory::Fs),
+        other => {
+            return Err(ConnectorError::ConfigurationError(format!(
+                "[LDB-5101] unsupported storage.type '{other}'; expected s3 | s3a | fs"
+            )));
+        }
+    };
+    Ok(factory)
 }
 
 /// Builds a REST catalog from configuration.
@@ -56,7 +83,7 @@ pub async fn build_catalog(
 async fn build_rest_catalog(
     config: &IcebergCatalogConfig,
 ) -> Result<Arc<dyn Catalog>, ConnectorError> {
-    let storage_factory = storage_factory_for_warehouse(&config.warehouse);
+    let storage_factory = storage_factory(&config.warehouse, config.storage_type.as_deref())?;
 
     let mut props = HashMap::new();
     props.insert("uri".to_string(), config.catalog_uri.clone());
@@ -218,9 +245,12 @@ pub async fn ensure_table_exists(
         return Ok(());
     }
 
-    let iceberg_schema = iceberg::arrow::arrow_schema_to_schema(arrow_schema).map_err(|e| {
-        ConnectorError::SchemaMismatch(format!("arrow→iceberg schema conversion: {e}"))
-    })?;
+    // Pipeline-derived Arrow schemas don't carry `PARQUET:field_id`
+    // metadata; let iceberg-rust assign sequential IDs.
+    let iceberg_schema = iceberg::arrow::arrow_schema_to_schema_auto_assign_ids(arrow_schema)
+        .map_err(|e| {
+            ConnectorError::SchemaMismatch(format!("arrow→iceberg schema conversion: {e}"))
+        })?;
 
     if !catalog
         .namespace_exists(&ns)
@@ -251,24 +281,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_storage_factory_dispatch_s3() {
-        let factory = storage_factory_for_warehouse("s3://bucket/warehouse");
-        let debug = format!("{factory:?}");
-        assert!(debug.contains("S3"), "expected S3 factory, got: {debug}");
+    fn test_storage_factory_infers_s3_from_warehouse_url() {
+        let f = storage_factory("s3://bucket/warehouse", None).unwrap();
+        assert!(format!("{f:?}").contains("S3"));
     }
 
     #[test]
-    fn test_storage_factory_dispatch_s3a() {
-        let factory = storage_factory_for_warehouse("s3a://bucket/warehouse");
-        let debug = format!("{factory:?}");
-        assert!(debug.contains("S3"), "expected S3 factory, got: {debug}");
+    fn test_storage_factory_infers_s3a_from_warehouse_url() {
+        let f = storage_factory("s3a://bucket/warehouse", None).unwrap();
+        assert!(format!("{f:?}").contains("S3"));
     }
 
     #[test]
-    fn test_storage_factory_dispatch_local() {
-        let factory = storage_factory_for_warehouse("/tmp/warehouse");
-        let debug = format!("{factory:?}");
-        assert!(debug.contains("Fs"), "expected Fs factory, got: {debug}");
+    fn test_storage_factory_infers_fs_from_file_url() {
+        let f = storage_factory("file:///tmp/warehouse", None).unwrap();
+        assert!(format!("{f:?}").contains("Fs"));
+    }
+
+    #[test]
+    fn test_storage_factory_bare_path_requires_explicit_storage_type() {
+        // Trimmed `/` and `./` inference: REST catalogs use logical names
+        // and we don't want a silent default to local fs.
+        let err = storage_factory("/tmp/warehouse", None).unwrap_err().to_string();
+        assert!(err.contains("LDB-5100"), "got: {err}");
+    }
+
+    #[test]
+    fn test_storage_factory_explicit_overrides_inference() {
+        // Lakekeeper-style: warehouse is a name, storage backend is S3.
+        let f = storage_factory("demo", Some("s3")).unwrap();
+        assert!(format!("{f:?}").contains("S3"));
+    }
+
+    #[test]
+    fn test_storage_factory_unknown_warehouse_without_storage_type_errors() {
+        let err = storage_factory("demo", None).unwrap_err().to_string();
+        assert!(err.contains("LDB-5100"), "got: {err}");
+    }
+
+    #[test]
+    fn test_storage_factory_rejects_unknown_storage_type() {
+        let err = storage_factory("demo", Some("hdfs")).unwrap_err().to_string();
+        assert!(err.contains("LDB-5101"), "got: {err}");
     }
 
     #[test]

--- a/crates/laminar-connectors/src/lakehouse/mod.rs
+++ b/crates/laminar-connectors/src/lakehouse/mod.rs
@@ -540,11 +540,16 @@ fn iceberg_sink_config_keys() -> Vec<ConfigKeySpec> {
         ),
         ConfigKeySpec::required(
             "warehouse",
-            "Warehouse location (e.g., s3://bucket/warehouse)",
+            "Warehouse name (REST catalog) or URL (Hadoop catalog, e.g. s3://bucket/wh)",
         ),
         ConfigKeySpec::required("namespace", "Iceberg namespace (e.g., prod)"),
         ConfigKeySpec::required("table.name", "Table name within the namespace"),
         ConfigKeySpec::optional("catalog.type", "Catalog type: rest", "rest"),
+        ConfigKeySpec::optional(
+            "storage.type",
+            "Storage backend (s3 | s3a | fs). Required when warehouse is a name, not a URL",
+            "",
+        ),
         ConfigKeySpec::optional(
             "compression",
             "Parquet compression: zstd, snappy, none",

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -191,6 +191,10 @@ impl NatsSource {
 impl SourceConnector for NatsSource {
     async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
         let cfg = NatsSourceConfig::from_config(config)?;
+        // SQL DDL schema overrides the registry placeholder.
+        if let Some(schema) = config.arrow_schema() {
+            self.schema = schema;
+        }
         let deserializer = serde::create_deserializer(cfg.format)
             .map_err(|e| err(&format!("deserializer for format {:?}: {e}", cfg.format)))?;
         match cfg.mode {

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -546,7 +546,8 @@ impl CoreWindowState {
         }
         let intermediate_schema = Arc::new(Schema::new(intermediate_fields));
 
-        let mut output_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
+        let mut output_fields =
+            laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
         for f in intermediate_schema.fields() {
             output_fields.push(f.as_ref().clone());
         }
@@ -561,7 +562,8 @@ impl CoreWindowState {
                     })?;
                 compiled.push(phys);
             }
-            let mut final_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
+            let mut final_fields =
+                laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
             for f in top_schema.fields() {
                 final_fields.push(f.as_ref().clone());
             }

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -546,10 +546,7 @@ impl CoreWindowState {
         }
         let intermediate_schema = Arc::new(Schema::new(intermediate_fields));
 
-        let mut output_fields: Vec<Field> = vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
-        ];
+        let mut output_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
         for f in intermediate_schema.fields() {
             output_fields.push(f.as_ref().clone());
         }
@@ -564,10 +561,7 @@ impl CoreWindowState {
                     })?;
                 compiled.push(phys);
             }
-            let mut final_fields = vec![
-                Field::new("window_start", DataType::Int64, false),
-                Field::new("window_end", DataType::Int64, false),
-            ];
+            let mut final_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
             for f in top_schema.fields() {
                 final_fields.push(f.as_ref().clone());
             }

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -458,7 +458,8 @@ impl IncrementalEowcState {
             None
         };
 
-        let mut output_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
+        let mut output_fields =
+            laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
         for (name, dt) in group_col_names.iter().zip(group_types.iter()) {
             output_fields.push(Field::new(name, dt.clone(), true));
         }

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -458,10 +458,7 @@ impl IncrementalEowcState {
             None
         };
 
-        let mut output_fields: Vec<Field> = vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
-        ];
+        let mut output_fields = laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
         for (name, dt) in group_col_names.iter().zip(group_types.iter()) {
             output_fields.push(Field::new(name, dt.clone(), true));
         }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -750,8 +750,15 @@ impl LaminarDB {
                 continue;
             }
             let mut config = build_sink_config(reg)?;
-            if let Some(schema) = stream_output_schemas.get(&reg.input) {
-                let schema_str = crate::pipeline_callback::encode_arrow_schema(schema);
+            // Resolve the upstream schema from a stream first, then fall back
+            // to a source — `CREATE SINK ... FROM <name>` accepts either.
+            let upstream_schema = stream_output_schemas.get(&reg.input).cloned().or_else(|| {
+                self.catalog
+                    .get_source(&reg.input)
+                    .map(|e| e.schema.clone())
+            });
+            if let Some(schema) = upstream_schema {
+                let schema_str = crate::pipeline_callback::encode_arrow_schema(&schema);
                 config.set("_arrow_schema".to_string(), schema_str);
             }
             let mut sink = self

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -14,6 +14,79 @@ use crate::db::{
 };
 use crate::error::DbError;
 
+/// Resolves each `CREATE STREAM`'s output Arrow schema by planning its SQL.
+/// Windowed streams get the standard `window_start, window_end` prefix.
+async fn resolve_stream_output_schemas(
+    ctx: &datafusion::prelude::SessionContext,
+    stream_regs: &HashMap<String, crate::connector_manager::StreamRegistration>,
+) -> Result<HashMap<String, arrow_schema::SchemaRef>, DbError> {
+    use arrow_schema::Schema;
+    use datafusion::datasource::empty::EmptyTable;
+
+    let mut out: HashMap<String, arrow_schema::SchemaRef> =
+        HashMap::with_capacity(stream_regs.len());
+    let mut pending: Vec<&crate::connector_manager::StreamRegistration> =
+        stream_regs.values().collect();
+
+    // Each pass plans every stream that DataFusion can plan now. Stream-on-
+    // stream dependencies are resolved by registering each resolved stream
+    // as an EmptyTable so downstream streams can plan against its schema.
+    // Stop when no progress = unresolvable refs (cycle or unknown table).
+    while !pending.is_empty() {
+        let mut next: Vec<&crate::connector_manager::StreamRegistration> = Vec::new();
+        let mut progressed = false;
+        for reg in pending {
+            let Ok(plan) = ctx.state().create_logical_plan(&reg.query_sql).await else {
+                next.push(reg);
+                continue;
+            };
+
+            let mut fields = if reg.window_config.is_some() {
+                laminar_sql::translator::WindowOperatorConfig::output_prefix_fields()
+            } else {
+                Vec::new()
+            };
+            for f in plan.schema().fields() {
+                fields.push((**f).clone());
+            }
+            let schema = Arc::new(Schema::new(fields));
+
+            if !ctx.table_exist(&reg.name).unwrap_or(false) {
+                ctx.register_table(&reg.name, Arc::new(EmptyTable::new(schema.clone())))
+                    .map_err(|e| {
+                        DbError::Pipeline(format!(
+                            "could not register placeholder for stream '{}': {e}",
+                            reg.name
+                        ))
+                    })?;
+            }
+            out.insert(reg.name.clone(), schema);
+            progressed = true;
+        }
+
+        if !progressed {
+            let mut unresolved: Vec<&str> = next.iter().map(|r| r.name.as_str()).collect();
+            unresolved.sort_unstable();
+            // Surface the actual planner error from the first unresolved
+            // stream — it's the actionable diagnosis (missing table,
+            // bad SQL, etc.).
+            let first = next[0];
+            let err = ctx
+                .state()
+                .create_logical_plan(&first.query_sql)
+                .await
+                .err()
+                .map_or_else(|| "unknown error".to_string(), |e| e.to_string());
+            return Err(DbError::Pipeline(format!(
+                "unresolvable stream dependency among [{}]: {err}",
+                unresolved.join(", ")
+            )));
+        }
+        pending = next;
+    }
+    Ok(out)
+}
+
 pub(crate) fn url_to_checkpoint_prefix(url: &str) -> String {
     // Strip scheme
     let after_scheme = url.find("://").map_or(url, |i| &url[i + 3..]);
@@ -646,6 +719,12 @@ impl LaminarDB {
             }
         }
 
+        // Resolve each stream's output schema with DataFusion so sinks
+        // downstream see it via `_arrow_schema` (mirrors the source path
+        // above).
+        let stream_output_schemas =
+            resolve_stream_output_schemas(&self.ctx, &stream_regs).await?;
+
         // Build sinks. Each runs in its own tokio task with a bounded
         // command channel and shares one event channel back to the
         // pipeline callback.
@@ -665,7 +744,11 @@ impl LaminarDB {
             if reg.connector_type.is_none() {
                 continue;
             }
-            let config = build_sink_config(reg)?;
+            let mut config = build_sink_config(reg)?;
+            if let Some(schema) = stream_output_schemas.get(&reg.input) {
+                let schema_str = crate::pipeline_callback::encode_arrow_schema(schema);
+                config.set("_arrow_schema".to_string(), schema_str);
+            }
             let mut sink = self
                 .connector_registry
                 .create_sink(&config, prom_registry.as_deref())
@@ -1437,5 +1520,140 @@ impl LaminarDB {
             .store(STATE_STOPPED, std::sync::atomic::Ordering::Release);
         self.close();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod resolver_tests {
+    use super::resolve_stream_output_schemas;
+    use crate::connector_manager::StreamRegistration;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::datasource::empty::EmptyTable;
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn ctx_with_payments() -> SessionContext {
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("method", DataType::Utf8, false),
+            Field::new("amount_usd", DataType::Float64, false),
+            Field::new("status", DataType::Utf8, false),
+            Field::new(
+                "event_time",
+                DataType::Timestamp(arrow_schema::TimeUnit::Nanosecond, None),
+                false,
+            ),
+        ]));
+        ctx.register_table("payments", Arc::new(EmptyTable::new(schema)))
+            .unwrap();
+        ctx.register_udf(datafusion_expr::ScalarUDF::from(
+            laminar_sql::datafusion::TumbleWindowStart::new(),
+        ));
+        ctx
+    }
+
+    fn reg(name: &str, sql: &str, windowed: bool) -> StreamRegistration {
+        StreamRegistration {
+            name: name.to_string(),
+            query_sql: sql.to_string(),
+            emit_clause: None,
+            // Resolver only checks `is_some()`; the size doesn't matter.
+            window_config: windowed.then(|| {
+                laminar_sql::translator::WindowOperatorConfig::tumbling(
+                    "event_time".into(),
+                    Duration::ZERO,
+                )
+            }),
+            order_config: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn windowed_stream_gets_window_start_end_prefix() {
+        let ctx = ctx_with_payments();
+        let mut regs = std::collections::HashMap::new();
+        regs.insert(
+            "agg".to_string(),
+            reg(
+                "agg",
+                "SELECT region, COUNT(*) AS n FROM payments \
+                 GROUP BY tumble(event_time, INTERVAL '1' MINUTE), region",
+                true,
+            ),
+        );
+
+        let out = resolve_stream_output_schemas(&ctx, &regs).await.unwrap();
+        let names: Vec<&str> = out["agg"]
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(&names[..2], &["window_start", "window_end"]);
+        assert_eq!(out["agg"].field(0).data_type(), &DataType::Int64);
+        assert!(names.contains(&"region") && names.contains(&"n"));
+    }
+
+    #[tokio::test]
+    async fn non_windowed_stream_has_no_prefix() {
+        let ctx = ctx_with_payments();
+        let mut regs = std::collections::HashMap::new();
+        regs.insert(
+            "passthrough".to_string(),
+            reg("passthrough", "SELECT region, amount_usd FROM payments", false),
+        );
+
+        let out = resolve_stream_output_schemas(&ctx, &regs).await.unwrap();
+        let names: Vec<&str> = out["passthrough"]
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["region", "amount_usd"]);
+    }
+
+    #[tokio::test]
+    async fn chained_streams_resolve_via_iterative_planning() {
+        // `b` reads from `a`; iteration order doesn't matter — the loop
+        // re-tries `b` after `a` is registered.
+        let ctx = ctx_with_payments();
+        let mut regs = std::collections::HashMap::new();
+        regs.insert(
+            "b".to_string(),
+            reg("b", "SELECT region, n + 1 AS n_plus_one FROM a", false),
+        );
+        regs.insert(
+            "a".to_string(),
+            reg(
+                "a",
+                "SELECT region, COUNT(*) AS n FROM payments GROUP BY region",
+                false,
+            ),
+        );
+
+        let out = resolve_stream_output_schemas(&ctx, &regs).await.unwrap();
+        let b_names: Vec<&str> = out["b"]
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(b_names, vec!["region", "n_plus_one"]);
+    }
+
+    #[tokio::test]
+    async fn unresolvable_streams_surface_planner_error() {
+        let ctx = ctx_with_payments();
+        let mut regs = std::collections::HashMap::new();
+        // Cycle: a→b, b→a. Planning stalls; we report the unresolved set.
+        regs.insert("a".to_string(), reg("a", "SELECT * FROM b", false));
+        regs.insert("b".to_string(), reg("b", "SELECT * FROM a", false));
+
+        let err = resolve_stream_output_schemas(&ctx, &regs)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unresolvable stream dependency"), "got: {err}");
+        assert!(err.contains('a') && err.contains('b'), "got: {err}");
     }
 }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -15,7 +15,9 @@ use crate::db::{
 use crate::error::DbError;
 
 /// Resolves each `CREATE STREAM`'s output Arrow schema by planning its SQL.
-/// Windowed streams get the standard `window_start, window_end` prefix.
+/// Windowed streams get the `window_start, window_end` prefix. Temporary
+/// `EmptyTable` placeholders let downstream streams plan against upstream
+/// streams; they are removed before returning.
 async fn resolve_stream_output_schemas(
     ctx: &datafusion::prelude::SessionContext,
     stream_regs: &HashMap<String, crate::connector_manager::StreamRegistration>,
@@ -27,64 +29,68 @@ async fn resolve_stream_output_schemas(
         HashMap::with_capacity(stream_regs.len());
     let mut pending: Vec<&crate::connector_manager::StreamRegistration> =
         stream_regs.values().collect();
+    // Placeholders we own and must clean up; pre-existing tables are left alone.
+    let mut placeholders: Vec<String> = Vec::new();
 
-    // Each pass plans every stream that DataFusion can plan now. Stream-on-
-    // stream dependencies are resolved by registering each resolved stream
-    // as an EmptyTable so downstream streams can plan against its schema.
-    // Stop when no progress = unresolvable refs (cycle or unknown table).
-    while !pending.is_empty() {
-        let mut next: Vec<&crate::connector_manager::StreamRegistration> = Vec::new();
-        let mut progressed = false;
-        for reg in pending {
-            let Ok(plan) = ctx.state().create_logical_plan(&reg.query_sql).await else {
-                next.push(reg);
-                continue;
-            };
+    let result: Result<(), DbError> = async {
+        while !pending.is_empty() {
+            let mut next: Vec<&crate::connector_manager::StreamRegistration> = Vec::new();
+            let mut progressed = false;
+            for reg in pending {
+                let Ok(plan) = ctx.state().create_logical_plan(&reg.query_sql).await else {
+                    next.push(reg);
+                    continue;
+                };
 
-            let mut fields = if reg.window_config.is_some() {
-                laminar_sql::translator::WindowOperatorConfig::output_prefix_fields()
-            } else {
-                Vec::new()
-            };
-            for f in plan.schema().fields() {
-                fields.push((**f).clone());
+                let mut fields = if reg.window_config.is_some() {
+                    laminar_sql::translator::WindowOperatorConfig::output_prefix_fields()
+                } else {
+                    Vec::new()
+                };
+                for f in plan.schema().fields() {
+                    fields.push((**f).clone());
+                }
+                let schema = Arc::new(Schema::new(fields));
+
+                if !ctx.table_exist(&reg.name).unwrap_or(false) {
+                    ctx.register_table(&reg.name, Arc::new(EmptyTable::new(schema.clone())))
+                        .map_err(|e| {
+                            DbError::Pipeline(format!(
+                                "could not register placeholder for stream '{}': {e}",
+                                reg.name
+                            ))
+                        })?;
+                    placeholders.push(reg.name.clone());
+                }
+                out.insert(reg.name.clone(), schema);
+                progressed = true;
             }
-            let schema = Arc::new(Schema::new(fields));
 
-            if !ctx.table_exist(&reg.name).unwrap_or(false) {
-                ctx.register_table(&reg.name, Arc::new(EmptyTable::new(schema.clone())))
-                    .map_err(|e| {
-                        DbError::Pipeline(format!(
-                            "could not register placeholder for stream '{}': {e}",
-                            reg.name
-                        ))
-                    })?;
+            if !progressed {
+                let mut unresolved: Vec<&str> = next.iter().map(|r| r.name.as_str()).collect();
+                unresolved.sort_unstable();
+                let err = ctx
+                    .state()
+                    .create_logical_plan(&next[0].query_sql)
+                    .await
+                    .err()
+                    .map_or_else(|| "unknown error".to_string(), |e| e.to_string());
+                return Err(DbError::Pipeline(format!(
+                    "unresolvable stream dependency among [{}]: {err}",
+                    unresolved.join(", ")
+                )));
             }
-            out.insert(reg.name.clone(), schema);
-            progressed = true;
+            pending = next;
         }
-
-        if !progressed {
-            let mut unresolved: Vec<&str> = next.iter().map(|r| r.name.as_str()).collect();
-            unresolved.sort_unstable();
-            // Surface the actual planner error from the first unresolved
-            // stream — it's the actionable diagnosis (missing table,
-            // bad SQL, etc.).
-            let first = next[0];
-            let err = ctx
-                .state()
-                .create_logical_plan(&first.query_sql)
-                .await
-                .err()
-                .map_or_else(|| "unknown error".to_string(), |e| e.to_string());
-            return Err(DbError::Pipeline(format!(
-                "unresolvable stream dependency among [{}]: {err}",
-                unresolved.join(", ")
-            )));
-        }
-        pending = next;
+        Ok(())
     }
-    Ok(out)
+    .await;
+
+    for name in &placeholders {
+        let _ = ctx.deregister_table(name);
+    }
+
+    result.map(|()| out)
 }
 
 pub(crate) fn url_to_checkpoint_prefix(url: &str) -> String {
@@ -722,8 +728,7 @@ impl LaminarDB {
         // Resolve each stream's output schema with DataFusion so sinks
         // downstream see it via `_arrow_schema` (mirrors the source path
         // above).
-        let stream_output_schemas =
-            resolve_stream_output_schemas(&self.ctx, &stream_regs).await?;
+        let stream_output_schemas = resolve_stream_output_schemas(&self.ctx, &stream_regs).await?;
 
         // Build sinks. Each runs in its own tokio task with a bounded
         // command channel and shares one event channel back to the
@@ -1601,7 +1606,11 @@ mod resolver_tests {
         let mut regs = std::collections::HashMap::new();
         regs.insert(
             "passthrough".to_string(),
-            reg("passthrough", "SELECT region, amount_usd FROM payments", false),
+            reg(
+                "passthrough",
+                "SELECT region, amount_usd FROM payments",
+                false,
+            ),
         );
 
         let out = resolve_stream_output_schemas(&ctx, &regs).await.unwrap();
@@ -1639,6 +1648,12 @@ mod resolver_tests {
             .map(|f| f.name().as_str())
             .collect();
         assert_eq!(b_names, vec!["region", "n_plus_one"]);
+
+        // Placeholders must not leak into the public ctx — `subscribe()`
+        // is the data path for streams; `SELECT * FROM <stream>` should
+        // not silently return zero rows from a left-over EmptyTable.
+        assert!(!ctx.table_exist("a").unwrap_or(false));
+        assert!(!ctx.table_exist("b").unwrap_or(false));
     }
 
     #[tokio::test]

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -96,6 +96,7 @@ default = [
     "postgres-sink",
     "mysql-cdc",
     "mongodb-cdc",
+    "nats",
     "files",
     "parquet-lookup",
     "otel",
@@ -109,6 +110,7 @@ postgres-cdc = ["laminar-db/postgres-cdc"]
 postgres-sink = ["laminar-db/postgres-sink"]
 mysql-cdc = ["laminar-db/mysql-cdc"]
 mongodb-cdc = ["laminar-db/mongodb-cdc"]
+nats = ["laminar-db/nats"]
 delta-lake = ["laminar-db/delta-lake"]
 delta-lake-s3 = ["delta-lake", "laminar-db/delta-lake-s3"]
 delta-lake-azure = ["delta-lake", "laminar-db/delta-lake-azure"]

--- a/crates/laminar-sql/src/translator/window_translator.rs
+++ b/crates/laminar-sql/src/translator/window_translator.rs
@@ -129,10 +129,7 @@ impl std::fmt::Display for WindowOperatorConfig {
 
 impl WindowOperatorConfig {
     /// Fields the window operator prepends to every output batch.
-    ///
-    /// This is the canonical contract that downstream consumers (sink schema
-    /// resolvers, schema validators) and runtime emitters (`CoreWindowState`,
-    /// `IncrementalEowcState`) must agree on.
+    /// Single source of truth for the windowed-stream output contract.
     #[must_use]
     pub fn output_prefix_fields() -> Vec<Field> {
         vec![

--- a/crates/laminar-sql/src/translator/window_translator.rs
+++ b/crates/laminar-sql/src/translator/window_translator.rs
@@ -5,6 +5,8 @@
 
 use std::time::Duration;
 
+use arrow_schema::{DataType, Field};
+
 use crate::parser::{
     EmitClause, EmitStrategy, LateDataClause, ParseError, WindowFunction, WindowRewriter,
 };
@@ -126,6 +128,19 @@ impl std::fmt::Display for WindowOperatorConfig {
 }
 
 impl WindowOperatorConfig {
+    /// Fields the window operator prepends to every output batch.
+    ///
+    /// This is the canonical contract that downstream consumers (sink schema
+    /// resolvers, schema validators) and runtime emitters (`CoreWindowState`,
+    /// `IncrementalEowcState`) must agree on.
+    #[must_use]
+    pub fn output_prefix_fields() -> Vec<Field> {
+        vec![
+            Field::new("window_start", DataType::Int64, false),
+            Field::new("window_end", DataType::Int64, false),
+        ]
+    }
+
     /// Create a new tumbling window configuration.
     #[must_use]
     pub fn tumbling(time_column: String, size: Duration) -> Self {

--- a/examples/nats-payments/.gitignore
+++ b/examples/nats-payments/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+data/

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -1,0 +1,79 @@
+# LaminarDB — NATS → Iceberg payments demo
+
+Payment events stream off a NATS subject. LaminarDB tumbles them into
+1-minute windows by region+method and writes the rollup to Iceberg via a
+REST catalog (Lakekeeper). Results queryable from DuckDB.
+
+No Kafka. No Redpanda. No JVM. Two binaries do the work
+(`nats-server` + `laminardb`); three containers (MinIO, Postgres,
+Lakekeeper) provide the lakehouse.
+
+## Run it
+
+```bash
+# 1. NATS + MinIO + Postgres + Lakekeeper. The lakekeeper-init container
+#    bootstraps the catalog and creates the `demo` warehouse pointing at
+#    the `warehouse` MinIO bucket.
+docker compose -f examples/nats-payments/docker-compose.yml up -d
+
+# 2. Build laminardb (skip postgres-cdc/mysql-cdc — they pull native
+#    OpenSSL via Perl on Windows). NATS, Iceberg, and websocket are all
+#    you need for this demo.
+cargo build --release -p laminar-server \
+    --no-default-features \
+    --features mimalloc,nats,iceberg,websocket
+
+# 3. Run the server.
+./target/release/laminardb --config examples/nats-payments/config.toml
+
+# 4. In another terminal, start the publisher.
+pip install nats-py
+python examples/nats-payments/gen.py
+
+# 5. Wait ~60 seconds (one tumbling minute closes), then query.
+pip install duckdb
+python examples/nats-payments/query.py
+```
+
+## What the pipeline does
+
+```sql
+SELECT
+    region, method,
+    COUNT(*)                                            AS payment_count,
+    SUM(amount_usd)                                     AS total_usd,
+    AVG(amount_usd)                                     AS avg_usd,
+    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+FROM payments
+GROUP BY
+    TUMBLE(event_time, INTERVAL '1' MINUTE),
+    region, method
+EMIT ON WINDOW CLOSE
+```
+
+`window_start` and `window_end` are auto-projected at the head of the
+SELECT by the streaming-windowed-GROUP-BY rewriter, so the Iceberg
+table ends up with eight columns.
+
+## Explore
+
+- Lakekeeper UI  → http://localhost:8182
+- MinIO console  → http://localhost:9001  (minioadmin / minioadmin)
+- NATS monitor   → http://localhost:8222
+- LaminarDB HTTP → http://127.0.0.1:8080
+
+## Tear down
+
+```bash
+docker compose -f examples/nats-payments/docker-compose.yml down -v
+```
+
+## Files
+
+| File                 | Purpose                                                |
+|----------------------|--------------------------------------------------------|
+| `config.toml`        | Source, pipeline, sink — what `laminardb` actually reads |
+| `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
+| `docker-compose.yml` | NATS + MinIO + Postgres + Lakekeeper                   |
+| `gen.py`             | NATS publisher — `pip install nats-py`                 |
+| `query.py`           | DuckDB reader — `pip install duckdb`                   |

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -80,18 +80,19 @@ python examples/nats-payments/bench.py
 Sample output (10K/s sustained):
 
 ```
-    time   ingest/s   flushed/s  commits   total_in   total_out
-14:32:01    10,012        0        0      10,012          0
-14:32:02    10,005        0        0      20,017          0
+    time   ingest/s   emitted/s  commits   total_in  total_emit
+15:14:01    10,012        0        12      610,012          0
+15:14:02    10,005        0        13      620,017          0
 ...
-14:33:00    10,001    1,920       1     601,210      1,920
+15:14:12    10,001       16        14      720,118         16
 ```
 
-`ingest/s` is the NATS source's record counter delta; `flushed/s` is
-rows staged to Iceberg in that second; `commits` is the cumulative
-Iceberg snapshot count — incremented when a window closes and the
-sink commits. The `commits` column is the visible "engine commit
-cadence" indicator; cadence is bounded by `[checkpoint] interval`.
+`ingest/s` is the NATS source delta; `emitted/s` is the rows the
+windowed pipeline produced this second (~16 per closed minute since
+we have 4 regions × 4 methods); `commits` is the cumulative sink
+commit count. Each minute boundary triggers an emission spike and a
+commit. `commits` cadence between window-close events tracks
+`[checkpoint] interval`.
 
 ## Explore
 

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -1,12 +1,29 @@
-# LaminarDB — NATS → Iceberg payments demo
+# LaminarDB — payments + fraud-check streaming demo
 
-Payment events stream off a NATS subject. LaminarDB tumbles them into
-1-minute windows by region+method and writes the rollup to Iceberg via a
-REST catalog (Lakekeeper). Results queryable from DuckDB.
+Two correlated payment streams over NATS:
+
+* `payments.initiated`  — a payment is created (someone hits Pay)
+* `payments.scored`     — the fraud system returns a score 50ms–1s later
+
+LaminarDB joins them on the fly and writes two Iceberg tables:
+
+1. **`payments_summary`** — rolling 1-minute volume by region and method.
+2. **`payments_with_fraud_score`** — interval join (2-second window).
+   Each row is one payment matched to its fraud score, with the
+   wall-clock latency between the two events.
+
+The headline number, computed live as payments flow:
+
+```
+region    scored   p50_ms   p95_ms   p99_ms   blocked   review
+us-east   41,832       72      198      482       248      613
+us-west   41,201       74      201      497       247      615
+eu-west   40,907       75      210      521       251      609
+ap-south  40,615       78      215      540       243      598
+```
 
 Two Rust binaries do the streaming work (`nats-server` + `laminardb`);
 three containers (RustFS, Postgres, Lakekeeper) provide the lakehouse.
-RustFS is the S3-compatible Rust object store standing in for MinIO.
 
 ## Prerequisite
 
@@ -23,14 +40,10 @@ running container.
 ## Run it
 
 ```bash
-# 1. NATS + RustFS + Postgres + Lakekeeper. The lakekeeper-init container
-#    bootstraps the catalog and creates the `demo` warehouse pointing at
-#    the `warehouse` RustFS bucket.
+# 1. NATS + RustFS + Postgres + Lakekeeper.
 docker compose -f examples/nats-payments/docker-compose.yml up -d
 
-# 2. Build laminardb (skip postgres-cdc/mysql-cdc — they pull native
-#    OpenSSL via Perl on Windows). NATS, Iceberg, and websocket are all
-#    you need for this demo.
+# 2. Build laminardb.
 cargo build --release -p laminar-server \
     --no-default-features \
     --features mimalloc,nats,iceberg,websocket
@@ -38,36 +51,49 @@ cargo build --release -p laminar-server \
 # 3. Run the server.
 ./target/release/laminardb --config examples/nats-payments/config.toml
 
-# 4. In another terminal, start the publisher (defaults to 10K msg/s).
+# 4. In another terminal, start the publisher (default 10K payments/s).
 pip install nats-py
-python examples/nats-payments/gen.py            # 10_000/s, 4 producers
+python examples/nats-payments/gen.py
 # python examples/nats-payments/gen.py --rate 50000   # 50K/s
 # python examples/nats-payments/gen.py --rate 0       # flat-out
 
-# 5. Wait ~90 seconds (one tumbling minute closes + first commit), then query.
+# 5. Wait ~90 seconds, then query.
 pip install duckdb
 python examples/nats-payments/query.py
 ```
 
-## What the pipeline does
+## What the pipelines do
+
+### `payments_summary` — tumbling 1-minute rollup
 
 ```sql
-SELECT
-    region, method,
-    COUNT(*)                                            AS payment_count,
-    SUM(amount_usd)                                     AS total_usd,
-    AVG(amount_usd)                                     AS avg_usd,
-    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+SELECT region, method, COUNT(*), SUM(amount_usd), AVG(amount_usd)
 FROM payments
-GROUP BY
-    TUMBLE(event_time, INTERVAL '1' MINUTE),
-    region, method
+GROUP BY TUMBLE(event_time, INTERVAL '1' MINUTE), region, method
 EMIT ON WINDOW CLOSE
 ```
 
-`window_start` and `window_end` are auto-projected at the head of the
-SELECT by the streaming-windowed-GROUP-BY rewriter, so the Iceberg
-table ends up with eight columns.
+`window_start, window_end` auto-projected by the rewriter.
+
+### `payments_with_fraud_score` — stream-to-stream interval join
+
+```sql
+SELECT
+    p.payment_id, p.region, p.method, p.amount_usd,
+    f.fraud_score, f.outcome,
+    p.event_time                                              AS initiated_at,
+    f.event_time                                              AS scored_at,
+    CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms
+FROM payments p
+JOIN fraud_checks f
+    ON p.payment_id = f.payment_id
+    AND f.event_time BETWEEN p.event_time AND p.event_time + INTERVAL '2' SECOND
+```
+
+Routes through laminardb's `IntervalJoinOperator`. Both streams need
+advancing watermarks for the operator to emit. Payments whose score
+arrives outside the 2-second window — or never — fall out of this
+table; that's the operationally meaningful "fraud system slow" signal.
 
 ## Throughput
 
@@ -81,18 +107,16 @@ Sample output (10K/s sustained):
 
 ```
     time   ingest/s   emitted/s  commits   total_in  total_emit
-15:14:01    10,012        0        12      610,012          0
-15:14:02    10,005        0        13      620,017          0
+15:14:01    19,800        0        12      610,012          0
+15:14:02    19,795        0        13      620,017          0
 ...
-15:14:12    10,001       16        14      720,118         16
+15:14:12    19,801    9,800       14      720,118     45,300
 ```
 
-`ingest/s` is the NATS source delta; `emitted/s` is the rows the
-windowed pipeline produced this second (~16 per closed minute since
-we have 4 regions × 4 methods); `commits` is the cumulative sink
-commit count. Each minute boundary triggers an emission spike and a
-commit. `commits` cadence between window-close events tracks
-`[checkpoint] interval`.
+`ingest/s` is the combined source delta (payments + fraud_checks
+≈ 2× the publisher rate); `emitted/s` is rows out of both pipelines
+(join hits + windowed rollup); `commits` is the cumulative sink
+commit count.
 
 ## Explore
 
@@ -111,9 +135,9 @@ docker compose -f examples/nats-payments/docker-compose.yml down -v
 
 | File                 | Purpose                                                |
 |----------------------|--------------------------------------------------------|
-| `config.toml`        | Source, pipeline, sink — what `laminardb` actually reads |
-| `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
+| `config.toml`        | Sources, pipelines, sinks                              |
+| `pipeline.sql`       | Reference copies of the two SELECT statements          |
 | `docker-compose.yml` | NATS + RustFS + Postgres + Lakekeeper                  |
-| `gen.py`             | NATS publisher — `pip install nats-py`                 |
+| `gen.py`             | NATS publisher (payments + fraud-score producers)      |
 | `bench.py`           | live `/metrics` scraper for ingest + commit rates      |
-| `query.py`           | DuckDB Iceberg reader + latency percentiles            |
+| `query.py`           | DuckDB Iceberg reader + fraud-latency percentiles      |

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -4,10 +4,21 @@ Payment events stream off a NATS subject. LaminarDB tumbles them into
 1-minute windows by region+method and writes the rollup to Iceberg via a
 REST catalog (Lakekeeper). Results queryable from DuckDB.
 
-No Kafka. No Redpanda. No JVM. No Go. Two Rust binaries do the work
-(`nats-server` + `laminardb`); three containers (RustFS, Postgres,
-Lakekeeper) provide the lakehouse — RustFS is the S3-compatible Rust
-object store standing in for MinIO.
+Two Rust binaries do the streaming work (`nats-server` + `laminardb`);
+three containers (RustFS, Postgres, Lakekeeper) provide the lakehouse.
+RustFS is the S3-compatible Rust object store standing in for MinIO.
+
+## Prerequisite
+
+Lakekeeper bakes its in-cluster RustFS endpoint (`http://rustfs:9000`)
+into Iceberg manifest paths. Add a hosts entry on your machine so
+DuckDB can resolve it from the host:
+
+    # /etc/hosts (Linux/macOS) or C:\Windows\System32\drivers\etc\hosts
+    127.0.0.1   rustfs
+
+The published `9000:9000` port forwards the host-side `rustfs:9000` to
+the container.
 
 ## Run it
 
@@ -31,7 +42,7 @@ cargo build --release -p laminar-server \
 pip install nats-py
 python examples/nats-payments/gen.py
 
-# 5. Wait ~60 seconds (one tumbling minute closes), then query.
+# 5. Wait ~90 seconds (one tumbling minute closes + first commit), then query.
 pip install duckdb
 python examples/nats-payments/query.py
 ```

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -8,18 +8,6 @@ Two Rust binaries do the streaming work (`nats-server` + `laminardb`);
 three containers (RustFS, Postgres, Lakekeeper) provide the lakehouse.
 RustFS is the S3-compatible Rust object store standing in for MinIO.
 
-## Prerequisite
-
-Lakekeeper bakes its in-cluster RustFS endpoint (`http://rustfs:9000`)
-into Iceberg manifest paths. Add a hosts entry on your machine so
-DuckDB can resolve it from the host:
-
-    # /etc/hosts (Linux/macOS) or C:\Windows\System32\drivers\etc\hosts
-    127.0.0.1   rustfs
-
-The published `9000:9000` port forwards the host-side `rustfs:9000` to
-the container.
-
 ## Run it
 
 ```bash

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -8,6 +8,18 @@ Two Rust binaries do the streaming work (`nats-server` + `laminardb`);
 three containers (RustFS, Postgres, Lakekeeper) provide the lakehouse.
 RustFS is the S3-compatible Rust object store standing in for MinIO.
 
+## Prerequisite
+
+Lakekeeper bakes its in-cluster RustFS endpoint (`http://rustfs:9000`)
+into Iceberg manifest paths. Add a hosts entry on your machine so
+DuckDB can resolve the name from the host:
+
+    # /etc/hosts (Linux/macOS) or C:\Windows\System32\drivers\etc\hosts
+    127.0.0.1   rustfs
+
+The published `9000:9000` Docker port forwards `rustfs:9000` to the
+running container.
+
 ## Run it
 
 ```bash

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -69,12 +69,11 @@ EMIT ON WINDOW CLOSE
 SELECT by the streaming-windowed-GROUP-BY rewriter, so the Iceberg
 table ends up with eight columns.
 
-## Throughput + latency
+## Throughput
 
-Two ways to see the engine work:
+Live throughput off the `/metrics` endpoint:
 
 ```bash
-# Live throughput off the /metrics endpoint (Ctrl-C for summary).
 python examples/nats-payments/bench.py
 ```
 
@@ -88,22 +87,11 @@ Sample output (10K/s sustained):
 14:33:00    10,001    1,920       1     601,210      1,920
 ```
 
-Latency percentiles, computed off committed Iceberg rows:
-
-```
-python examples/nats-payments/query.py | tail -20
-```
-
-```
-  n  p50_close_ms  p95_close_ms  p99_close_ms  p50_e2e_ms  p95_e2e_ms  p99_e2e_ms
- 32         3000         5500          6000        4200        7200        8100
-```
-
-* `close_latency_ms` — between `window_end` and the emit timestamp the
-  pipeline stamped on the row. How long after the window logically
-  closed did the engine commit. Bounded by `[checkpoint] interval`.
-* `end_to_end_ms` — between the freshest `event_time` in the window and
-  the emit timestamp. Publish → readable in Iceberg.
+`ingest/s` is the NATS source's record counter delta; `flushed/s` is
+rows staged to Iceberg in that second; `commits` is the cumulative
+Iceberg snapshot count — incremented when a window closes and the
+sink commits. The `commits` column is the visible "engine commit
+cadence" indicator; cadence is bounded by `[checkpoint] interval`.
 
 ## Explore
 

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -57,7 +57,10 @@ python examples/nats-payments/gen.py
 # python examples/nats-payments/gen.py --rate 50000   # 50K/s
 # python examples/nats-payments/gen.py --rate 0       # flat-out
 
-# 5. Wait ~90 seconds, then query.
+# 5. Wait ~90 seconds, then stop the publisher (Ctrl-C the gen.py
+#    terminal) and query. Stopping the publisher first avoids
+#    contention between DuckDB's reads and laminardb's ongoing
+#    writes against RustFS.
 pip install duckdb
 python examples/nats-payments/query.py
 ```

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -38,9 +38,11 @@ cargo build --release -p laminar-server \
 # 3. Run the server.
 ./target/release/laminardb --config examples/nats-payments/config.toml
 
-# 4. In another terminal, start the publisher.
+# 4. In another terminal, start the publisher (defaults to 10K msg/s).
 pip install nats-py
-python examples/nats-payments/gen.py
+python examples/nats-payments/gen.py            # 10_000/s, 4 producers
+# python examples/nats-payments/gen.py --rate 50000   # 50K/s
+# python examples/nats-payments/gen.py --rate 0       # flat-out
 
 # 5. Wait ~90 seconds (one tumbling minute closes + first commit), then query.
 pip install duckdb
@@ -67,6 +69,42 @@ EMIT ON WINDOW CLOSE
 SELECT by the streaming-windowed-GROUP-BY rewriter, so the Iceberg
 table ends up with eight columns.
 
+## Throughput + latency
+
+Two ways to see the engine work:
+
+```bash
+# Live throughput off the /metrics endpoint (Ctrl-C for summary).
+python examples/nats-payments/bench.py
+```
+
+Sample output (10K/s sustained):
+
+```
+    time   ingest/s   flushed/s  commits   total_in   total_out
+14:32:01    10,012        0        0      10,012          0
+14:32:02    10,005        0        0      20,017          0
+...
+14:33:00    10,001    1,920       1     601,210      1,920
+```
+
+Latency percentiles, computed off committed Iceberg rows:
+
+```
+python examples/nats-payments/query.py | tail -20
+```
+
+```
+  n  p50_close_ms  p95_close_ms  p99_close_ms  p50_e2e_ms  p95_e2e_ms  p99_e2e_ms
+ 32         3000         5500          6000        4200        7200        8100
+```
+
+* `close_latency_ms` — between `window_end` and the emit timestamp the
+  pipeline stamped on the row. How long after the window logically
+  closed did the engine commit. Bounded by `[checkpoint] interval`.
+* `end_to_end_ms` — between the freshest `event_time` in the window and
+  the emit timestamp. Publish → readable in Iceberg.
+
 ## Explore
 
 - Lakekeeper UI  → http://localhost:8182
@@ -88,4 +126,5 @@ docker compose -f examples/nats-payments/docker-compose.yml down -v
 | `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
 | `docker-compose.yml` | NATS + RustFS + Postgres + Lakekeeper                  |
 | `gen.py`             | NATS publisher — `pip install nats-py`                 |
-| `query.py`           | DuckDB reader — `pip install duckdb`                   |
+| `bench.py`           | live `/metrics` scraper for ingest + commit rates      |
+| `query.py`           | DuckDB Iceberg reader + latency percentiles            |

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -4,16 +4,17 @@ Payment events stream off a NATS subject. LaminarDB tumbles them into
 1-minute windows by region+method and writes the rollup to Iceberg via a
 REST catalog (Lakekeeper). Results queryable from DuckDB.
 
-No Kafka. No Redpanda. No JVM. Two binaries do the work
-(`nats-server` + `laminardb`); three containers (MinIO, Postgres,
-Lakekeeper) provide the lakehouse.
+No Kafka. No Redpanda. No JVM. No Go. Two Rust binaries do the work
+(`nats-server` + `laminardb`); three containers (RustFS, Postgres,
+Lakekeeper) provide the lakehouse — RustFS is the S3-compatible Rust
+object store standing in for MinIO.
 
 ## Run it
 
 ```bash
-# 1. NATS + MinIO + Postgres + Lakekeeper. The lakekeeper-init container
+# 1. NATS + RustFS + Postgres + Lakekeeper. The lakekeeper-init container
 #    bootstraps the catalog and creates the `demo` warehouse pointing at
-#    the `warehouse` MinIO bucket.
+#    the `warehouse` RustFS bucket.
 docker compose -f examples/nats-payments/docker-compose.yml up -d
 
 # 2. Build laminardb (skip postgres-cdc/mysql-cdc — they pull native
@@ -58,7 +59,7 @@ table ends up with eight columns.
 ## Explore
 
 - Lakekeeper UI  → http://localhost:8182
-- MinIO console  → http://localhost:9001  (minioadmin / minioadmin)
+- RustFS console → http://localhost:9001  (rustfsadmin / rustfsadmin)
 - NATS monitor   → http://localhost:8222
 - LaminarDB HTTP → http://127.0.0.1:8080
 
@@ -74,6 +75,6 @@ docker compose -f examples/nats-payments/docker-compose.yml down -v
 |----------------------|--------------------------------------------------------|
 | `config.toml`        | Source, pipeline, sink — what `laminardb` actually reads |
 | `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
-| `docker-compose.yml` | NATS + MinIO + Postgres + Lakekeeper                   |
+| `docker-compose.yml` | NATS + RustFS + Postgres + Lakekeeper                  |
 | `gen.py`             | NATS publisher — `pip install nats-py`                 |
 | `query.py`           | DuckDB reader — `pip install duckdb`                   |

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -43,7 +43,7 @@ pip install nats-py
 python examples/nats-payments/gen.py
 
 # 5. Wait ~90 seconds (one tumbling minute closes + first commit), then query.
-pip install "pyiceberg[s3fs,pyarrow]"
+pip install duckdb
 python examples/nats-payments/query.py
 ```
 
@@ -88,4 +88,4 @@ docker compose -f examples/nats-payments/docker-compose.yml down -v
 | `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
 | `docker-compose.yml` | NATS + RustFS + Postgres + Lakekeeper                  |
 | `gen.py`             | NATS publisher — `pip install nats-py`                 |
-| `query.py`           | PyIceberg reader — `pip install "pyiceberg[s3fs,pyarrow]"` |
+| `query.py`           | DuckDB reader — `pip install duckdb`                   |

--- a/examples/nats-payments/README.md
+++ b/examples/nats-payments/README.md
@@ -43,7 +43,7 @@ pip install nats-py
 python examples/nats-payments/gen.py
 
 # 5. Wait ~90 seconds (one tumbling minute closes + first commit), then query.
-pip install duckdb
+pip install "pyiceberg[s3fs,pyarrow]"
 python examples/nats-payments/query.py
 ```
 
@@ -88,4 +88,4 @@ docker compose -f examples/nats-payments/docker-compose.yml down -v
 | `pipeline.sql`       | Reference copy of the SELECT (config has the live one) |
 | `docker-compose.yml` | NATS + RustFS + Postgres + Lakekeeper                  |
 | `gen.py`             | NATS publisher — `pip install nats-py`                 |
-| `query.py`           | DuckDB reader — `pip install duckdb`                   |
+| `query.py`           | PyIceberg reader — `pip install "pyiceberg[s3fs,pyarrow]"` |

--- a/examples/nats-payments/bench.py
+++ b/examples/nats-payments/bench.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
 Scrapes laminardb's /metrics endpoint once a second and prints the
-ingest and commit rates alongside running totals.
+ingest, emit, and commit rates alongside running totals.
 
     python bench.py
 
-Throughput numbers come from LaminarDB's Prometheus counters:
-    nats_source_records_total       — events ingested by the source
-    lakehouse_sink_rows_flushed_total — rows staged to Iceberg
-    lakehouse_sink_commits_total      — committed snapshots
+Counters scraped (laminardb_-prefixed Prometheus metrics):
+    events_ingested_total            — events received by the source
+    events_emitted_total             — rows produced by the pipeline
+    sink_commit_duration_seconds_count — sink commits (histogram count)
 
 Stop with Ctrl-C; prints averages.
 """
@@ -21,9 +21,9 @@ import urllib.request
 METRICS_URL = "http://127.0.0.1:8080/metrics"
 
 PATTERNS = {
-    "ingest":  re.compile(r"^laminardb_nats_source_records_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
-    "flushed": re.compile(r"^laminardb_lakehouse_sink_rows_flushed_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
-    "commits": re.compile(r"^laminardb_lakehouse_sink_commits_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "ingest":  re.compile(r"^laminardb_events_ingested_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "emitted": re.compile(r"^laminardb_events_emitted_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "commits": re.compile(r"^laminardb_sink_commit_duration_seconds_count(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
 }
 
 
@@ -39,8 +39,8 @@ def scrape() -> dict[str, float]:
 
 def main():
     print(f"scraping {METRICS_URL} (Ctrl-C to stop)\n")
-    print(f"{'time':>8}  {'ingest/s':>10}  {'flushed/s':>10}  {'commits':>7}  "
-          f"{'total_in':>12}  {'total_out':>12}")
+    print(f"{'time':>8}  {'ingest/s':>10}  {'emitted/s':>10}  {'commits':>7}  "
+          f"{'total_in':>12}  {'total_emit':>10}")
     try:
         prev = scrape()
         prev_t = time.monotonic()
@@ -52,12 +52,12 @@ def main():
             now = time.monotonic()
             dt = now - prev_t
             ingest_rate  = (cur["ingest"]  - prev["ingest"])  / dt
-            flushed_rate = (cur["flushed"] - prev["flushed"]) / dt
+            emitted_rate = (cur["emitted"] - prev["emitted"]) / dt
             print(
                 f"{time.strftime('%H:%M:%S'):>8}  "
-                f"{ingest_rate:>10,.0f}  {flushed_rate:>10,.0f}  "
+                f"{ingest_rate:>10,.0f}  {emitted_rate:>10,.0f}  "
                 f"{int(cur['commits']):>7,d}  "
-                f"{int(cur['ingest']):>12,d}  {int(cur['flushed']):>12,d}"
+                f"{int(cur['ingest']):>12,d}  {int(cur['emitted']):>10,d}"
             )
             prev = cur
             prev_t = now
@@ -69,7 +69,7 @@ def main():
         f"\n{elapsed:.1f}s — "
         f"ingested {int(final['ingest']) - int(baseline['ingest']):,d} "
         f"(avg {(final['ingest'] - baseline['ingest']) / elapsed:,.0f}/s), "
-        f"flushed {int(final['flushed']) - int(baseline['flushed']):,d}, "
+        f"emitted {int(final['emitted']) - int(baseline['emitted']):,d}, "
         f"commits {int(final['commits']) - int(baseline['commits']):,d}"
     )
 

--- a/examples/nats-payments/bench.py
+++ b/examples/nats-payments/bench.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Scrapes laminardb's /metrics endpoint once a second and prints the
+ingest and commit rates alongside running totals.
+
+    python bench.py
+
+Throughput numbers come from LaminarDB's Prometheus counters:
+    nats_source_records_total       — events ingested by the source
+    lakehouse_sink_rows_flushed_total — rows staged to Iceberg
+    lakehouse_sink_commits_total      — committed snapshots
+
+Stop with Ctrl-C; prints averages.
+"""
+
+import re
+import sys
+import time
+import urllib.request
+
+METRICS_URL = "http://127.0.0.1:8080/metrics"
+
+PATTERNS = {
+    "ingest":  re.compile(r"^nats_source_records_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "flushed": re.compile(r"^lakehouse_sink_rows_flushed_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "commits": re.compile(r"^lakehouse_sink_commits_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+}
+
+
+def scrape() -> dict[str, float]:
+    with urllib.request.urlopen(METRICS_URL, timeout=2) as r:
+        body = r.read().decode()
+    out = {}
+    for k, pat in PATTERNS.items():
+        m = pat.search(body)
+        out[k] = float(m.group(1)) if m else 0.0
+    return out
+
+
+def main():
+    print(f"scraping {METRICS_URL} (Ctrl-C to stop)\n")
+    print(f"{'time':>8}  {'ingest/s':>10}  {'flushed/s':>10}  {'commits':>7}  "
+          f"{'total_in':>12}  {'total_out':>12}")
+    try:
+        prev = scrape()
+        prev_t = time.monotonic()
+        baseline = prev.copy()
+        baseline_t = prev_t
+        while True:
+            time.sleep(1.0)
+            cur = scrape()
+            now = time.monotonic()
+            dt = now - prev_t
+            ingest_rate  = (cur["ingest"]  - prev["ingest"])  / dt
+            flushed_rate = (cur["flushed"] - prev["flushed"]) / dt
+            print(
+                f"{time.strftime('%H:%M:%S'):>8}  "
+                f"{ingest_rate:>10,.0f}  {flushed_rate:>10,.0f}  "
+                f"{int(cur['commits']):>7,d}  "
+                f"{int(cur['ingest']):>12,d}  {int(cur['flushed']):>12,d}"
+            )
+            prev = cur
+            prev_t = now
+    except KeyboardInterrupt:
+        pass
+    elapsed = time.monotonic() - baseline_t
+    final = scrape()
+    print(
+        f"\n{elapsed:.1f}s — "
+        f"ingested {int(final['ingest']) - int(baseline['ingest']):,d} "
+        f"(avg {(final['ingest'] - baseline['ingest']) / elapsed:,.0f}/s), "
+        f"flushed {int(final['flushed']) - int(baseline['flushed']):,d}, "
+        f"commits {int(final['commits']) - int(baseline['commits']):,d}"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except urllib.error.URLError as e:
+        sys.exit(f"could not reach {METRICS_URL}: {e}")

--- a/examples/nats-payments/bench.py
+++ b/examples/nats-payments/bench.py
@@ -21,9 +21,9 @@ import urllib.request
 METRICS_URL = "http://127.0.0.1:8080/metrics"
 
 PATTERNS = {
-    "ingest":  re.compile(r"^nats_source_records_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
-    "flushed": re.compile(r"^lakehouse_sink_rows_flushed_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
-    "commits": re.compile(r"^lakehouse_sink_commits_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "ingest":  re.compile(r"^laminardb_nats_source_records_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "flushed": re.compile(r"^laminardb_lakehouse_sink_rows_flushed_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
+    "commits": re.compile(r"^laminardb_lakehouse_sink_commits_total(?:\{[^}]*\})?\s+(\d+(?:\.\d+)?)", re.M),
 }
 
 

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -126,10 +126,13 @@ SELECT
     f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
-    -- Subtract nanos-since-epoch directly. Timestamp - Timestamp returns
-    -- an Interval(MonthDayNano) whose BIGINT cast doesn't give the
-    -- elapsed nanos we want.
-    (CAST(f.event_time AS BIGINT) - CAST(p.event_time AS BIGINT)) / 1000000 AS score_latency_ms
+    -- date_part('epoch', ts) returns Float64 seconds since epoch with
+    -- subseconds preserved. Casting Timestamp - Timestamp to BIGINT
+    -- doesn't yield elapsed nanos in DataFusion 52.
+    CAST(
+        (date_part('epoch', f.event_time) - date_part('epoch', p.event_time)) * 1000
+        AS BIGINT
+    ) AS score_latency_ms
 FROM payments p
 JOIN fraud_checks f
     ON p.payment_id = f.payment_id

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -126,7 +126,10 @@ SELECT
     f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
-    CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms
+    -- Subtract nanos-since-epoch directly. Timestamp - Timestamp returns
+    -- an Interval(MonthDayNano) whose BIGINT cast doesn't give the
+    -- elapsed nanos we want.
+    (CAST(f.event_time AS BIGINT) - CAST(p.event_time AS BIGINT)) / 1000000 AS score_latency_ms
 FROM payments p
 JOIN fraud_checks f
     ON p.payment_id = f.payment_id

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -86,9 +86,9 @@ SELECT
     AVG(amount_usd)                                     AS avg_usd,
     SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count,
     -- Iceberg v2 stores microsecond timestamps; DataFusion's now() and
-    -- MAX(event_time) are nanosecond — cast to keep the table on v2.
-    arrow_cast(MAX(event_time), 'Timestamp(Microsecond, None)') AS max_event_time,
-    arrow_cast(now(),           'Timestamp(Microsecond, None)') AS emitted_at
+    -- MAX(event_time) are nanosecond — narrow with to_timestamp_micros.
+    to_timestamp_micros(MAX(event_time)) AS max_event_time,
+    to_timestamp_micros(now())           AS emitted_at
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -84,11 +84,7 @@ SELECT
     COUNT(*)                                            AS payment_count,
     SUM(amount_usd)                                     AS total_usd,
     AVG(amount_usd)                                     AS avg_usd,
-    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count,
-    -- Iceberg v2 stores microsecond timestamps; DataFusion's now() and
-    -- MAX(event_time) are nanosecond — narrow with to_timestamp_micros.
-    to_timestamp_micros(MAX(event_time)) AS max_event_time,
-    to_timestamp_micros(now())           AS emitted_at
+    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -85,8 +85,10 @@ SELECT
     SUM(amount_usd)                                     AS total_usd,
     AVG(amount_usd)                                     AS avg_usd,
     SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count,
-    MAX(event_time)                                     AS max_event_time,
-    now()                                               AS emitted_at
+    -- Iceberg v2 stores microsecond timestamps; DataFusion's now() and
+    -- MAX(event_time) are nanosecond — cast to keep the table on v2.
+    arrow_cast(MAX(event_time), 'Timestamp(Microsecond, None)') AS max_event_time,
+    arrow_cast(now(),           'Timestamp(Microsecond, None)') AS emitted_at
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -15,7 +15,7 @@ bind = "127.0.0.1:8080"
 backend = "in_process"
 
 [checkpoint]
-interval = "30s"
+interval = "5s"
 
 # ── Source ────────────────────────────────────────────────────────────
 # NATS core-mode subscriber. Mode is "core" (no JetStream) so the demo
@@ -84,7 +84,9 @@ SELECT
     COUNT(*)                                            AS payment_count,
     SUM(amount_usd)                                     AS total_usd,
     AVG(amount_usd)                                     AS avg_usd,
-    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count,
+    MAX(event_time)                                     AS max_event_time,
+    now()                                               AS emitted_at
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -116,10 +116,10 @@ namespace       = "finance"
 "auto.create"   = "true"
 compression     = "zstd"
 
-# MinIO credentials for OpenDAL FileIO (Lakekeeper does not vend creds
+# RustFS credentials for OpenDAL FileIO (Lakekeeper does not vend creds
 # in this profile — sts-enabled=false in docker-compose.yml).
 "catalog.property.s3.endpoint"          = "http://localhost:9000"
-"catalog.property.s3.access-key-id"     = "minioadmin"
-"catalog.property.s3.secret-access-key" = "minioadmin"
+"catalog.property.s3.access-key-id"     = "rustfsadmin"
+"catalog.property.s3.secret-access-key" = "rustfsadmin"
 "catalog.property.s3.region"            = "us-east-1"
 "catalog.property.s3.path-style-access" = "true"

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -1,0 +1,125 @@
+# LaminarDB demo — NATS payments → Iceberg.
+#
+# Build:
+#   cargo build --release -p laminar-server \
+#       --no-default-features --features mimalloc,nats,iceberg,websocket
+#
+# Run:
+#   ./target/release/laminardb --config examples/nats-payments/config.toml
+
+[server]
+mode = "embedded"
+bind = "127.0.0.1:8080"
+
+[state]
+backend = "in_process"
+
+[checkpoint]
+interval = "30s"
+
+# ── Source ────────────────────────────────────────────────────────────
+# NATS core-mode subscriber. Mode is "core" (no JetStream) so the demo
+# needs nothing more than `nats-server` running on :4222.
+#
+# JSON payloads are decoded against the schema declared below. event_time
+# is RFC3339 → arrow_cast::parse::string_to_timestamp_nanos handles it.
+
+[[source]]
+name = "payments"
+connector = "nats"
+format = "json"
+
+[source.properties]
+servers = "nats://localhost:4222"
+mode    = "core"
+subject = "payments.events"
+
+[[source.schema]]
+name = "payment_id"
+type = "VARCHAR"
+nullable = false
+
+[[source.schema]]
+name = "region"
+type = "VARCHAR"
+nullable = false
+
+[[source.schema]]
+name = "method"
+type = "VARCHAR"
+nullable = false
+
+[[source.schema]]
+name = "amount_usd"
+type = "DOUBLE"
+nullable = false
+
+[[source.schema]]
+name = "status"
+type = "VARCHAR"
+nullable = false
+
+[[source.schema]]
+name = "event_time"
+type = "TIMESTAMP"
+nullable = false
+
+[source.watermark]
+column = "event_time"
+max_out_of_orderness = "10s"
+
+# ── Pipeline ──────────────────────────────────────────────────────────
+# Tumbling 1-minute windows by region+method. window_start/window_end are
+# auto-projected at the head of the SELECT by the windowed-GROUP-BY
+# rewriter, so the sink writes 8 columns:
+#   window_start, window_end, region, method,
+#   payment_count, total_usd, avg_usd, failed_count
+
+[[pipeline]]
+name = "payment_summary"
+sql = """
+SELECT
+    region,
+    method,
+    COUNT(*)                                            AS payment_count,
+    SUM(amount_usd)                                     AS total_usd,
+    AVG(amount_usd)                                     AS avg_usd,
+    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+FROM payments
+GROUP BY
+    TUMBLE(event_time, INTERVAL '1' MINUTE),
+    region,
+    method
+EMIT ON WINDOW CLOSE
+"""
+
+# ── Sink ──────────────────────────────────────────────────────────────
+# Iceberg REST catalog (Lakekeeper). With auto.create=true the sink defers
+# load_table to the first non-empty batch and creates the table from the
+# batch schema, so no pre-existing table or namespace is required.
+
+[[sink]]
+name = "payment_summary_iceberg"
+pipeline = "payment_summary"
+connector = "iceberg"
+
+[sink.properties]
+# Lakekeeper resolves `warehouse` (NAME, not S3 path) to a prefix UUID via
+# GET /v1/config?warehouse=<name>. `storage.type = "s3"` tells the sink
+# what backend the catalog will return URLs for — REST-catalog warehouses
+# use a logical name so the scheme can't be inferred from `warehouse`.
+"catalog.uri"   = "http://localhost:8181/catalog"
+warehouse       = "demo"
+"storage.type"  = "s3"
+namespace       = "finance"
+"table.name"    = "payment_summary"
+"auto.create"   = "true"
+compression     = "zstd"
+
+# MinIO credentials for OpenDAL FileIO (Lakekeeper does not vend creds
+# in this profile — sts-enabled=false in docker-compose.yml).
+"catalog.property.s3.endpoint"          = "http://localhost:9000"
+"catalog.property.s3.access-key-id"     = "minioadmin"
+"catalog.property.s3.secret-access-key" = "minioadmin"
+"catalog.property.s3.region"            = "us-east-1"
+"catalog.property.s3.path-style-access" = "true"

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -1,4 +1,4 @@
-# LaminarDB demo — NATS payments → Iceberg.
+# LaminarDB demo — payments + fraud-check stream-to-stream join.
 #
 # Build:
 #   cargo build --release -p laminar-server \
@@ -17,12 +17,8 @@ backend = "in_process"
 [checkpoint]
 interval = "5s"
 
-# ── Source ────────────────────────────────────────────────────────────
-# NATS core-mode subscriber. Mode is "core" (no JetStream) so the demo
-# needs nothing more than `nats-server` running on :4222.
-#
-# JSON payloads are decoded against the schema declared below. event_time
-# is RFC3339 → arrow_cast::parse::string_to_timestamp_nanos handles it.
+# ── Sources ───────────────────────────────────────────────────────────
+# Two NATS subjects, one per stream. They correlate on payment_id.
 
 [[source]]
 name = "payments"
@@ -32,33 +28,24 @@ format = "json"
 [source.properties]
 servers = "nats://localhost:4222"
 mode    = "core"
-subject = "payments.events"
+subject = "payments.initiated"
 
 [[source.schema]]
 name = "payment_id"
-type = "VARCHAR"
+type = "BIGINT"
 nullable = false
-
 [[source.schema]]
 name = "region"
 type = "VARCHAR"
 nullable = false
-
 [[source.schema]]
 name = "method"
 type = "VARCHAR"
 nullable = false
-
 [[source.schema]]
 name = "amount_usd"
 type = "DOUBLE"
 nullable = false
-
-[[source.schema]]
-name = "status"
-type = "VARCHAR"
-nullable = false
-
 [[source.schema]]
 name = "event_time"
 type = "TIMESTAMP"
@@ -66,25 +53,56 @@ nullable = false
 
 [source.watermark]
 column = "event_time"
-max_out_of_orderness = "10s"
+max_out_of_orderness = "2s"
 
-# ── Pipeline ──────────────────────────────────────────────────────────
-# Tumbling 1-minute windows by region+method. window_start/window_end are
-# auto-projected at the head of the SELECT by the windowed-GROUP-BY
-# rewriter, so the sink writes 8 columns:
-#   window_start, window_end, region, method,
-#   payment_count, total_usd, avg_usd, failed_count
 
+[[source]]
+name = "fraud_checks"
+connector = "nats"
+format = "json"
+
+[source.properties]
+servers = "nats://localhost:4222"
+mode    = "core"
+subject = "payments.scored"
+
+[[source.schema]]
+name = "payment_id"
+type = "BIGINT"
+nullable = false
+[[source.schema]]
+name = "region"
+type = "VARCHAR"
+nullable = false
+[[source.schema]]
+name = "fraud_score"
+type = "DOUBLE"
+nullable = false
+[[source.schema]]
+name = "outcome"
+type = "VARCHAR"
+nullable = false
+[[source.schema]]
+name = "event_time"
+type = "TIMESTAMP"
+nullable = false
+
+[source.watermark]
+column = "event_time"
+max_out_of_orderness = "2s"
+
+# ── Pipelines ─────────────────────────────────────────────────────────
+
+# 1) Tumbling 1-minute rollup over the payments stream.
 [[pipeline]]
-name = "payment_summary"
+name = "payments_summary"
 sql = """
 SELECT
     region,
     method,
-    COUNT(*)                                            AS payment_count,
-    SUM(amount_usd)                                     AS total_usd,
-    AVG(amount_usd)                                     AS avg_usd,
-    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+    COUNT(*)          AS payment_count,
+    SUM(amount_usd)   AS total_usd,
+    AVG(amount_usd)   AS avg_usd
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),
@@ -93,31 +111,63 @@ GROUP BY
 EMIT ON WINDOW CLOSE
 """
 
-# ── Sink ──────────────────────────────────────────────────────────────
-# Iceberg REST catalog (Lakekeeper). With auto.create=true the sink defers
-# load_table to the first non-empty batch and creates the table from the
-# batch schema, so no pre-existing table or namespace is required.
+# 2) Stream-to-stream interval join: a payment matched with its fraud
+#    score within 2 seconds. score_latency_ms is the headline number —
+#    "how long did the fraud system take?", per row.
+[[pipeline]]
+name = "payments_with_fraud_score"
+sql = """
+SELECT
+    p.payment_id,
+    p.region,
+    p.method,
+    p.amount_usd,
+    f.fraud_score,
+    f.outcome,
+    p.event_time                                              AS initiated_at,
+    f.event_time                                              AS scored_at,
+    CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms
+FROM payments p
+JOIN fraud_checks f
+    ON p.payment_id = f.payment_id
+    AND f.event_time BETWEEN p.event_time AND p.event_time + INTERVAL '2' SECOND
+"""
+
+# ── Sinks ─────────────────────────────────────────────────────────────
 
 [[sink]]
-name = "payment_summary_iceberg"
-pipeline = "payment_summary"
+name = "payments_summary_iceberg"
+pipeline = "payments_summary"
 connector = "iceberg"
 
 [sink.properties]
-# Lakekeeper resolves `warehouse` (NAME, not S3 path) to a prefix UUID via
-# GET /v1/config?warehouse=<name>. `storage.type = "s3"` tells the sink
-# what backend the catalog will return URLs for — REST-catalog warehouses
-# use a logical name so the scheme can't be inferred from `warehouse`.
 "catalog.uri"   = "http://localhost:8181/catalog"
 warehouse       = "demo"
 "storage.type"  = "s3"
 namespace       = "finance"
-"table.name"    = "payment_summary"
+"table.name"    = "payments_summary"
 "auto.create"   = "true"
 compression     = "zstd"
+"catalog.property.s3.endpoint"          = "http://localhost:9000"
+"catalog.property.s3.access-key-id"     = "rustfsadmin"
+"catalog.property.s3.secret-access-key" = "rustfsadmin"
+"catalog.property.s3.region"            = "us-east-1"
+"catalog.property.s3.path-style-access" = "true"
 
-# RustFS credentials for OpenDAL FileIO (Lakekeeper does not vend creds
-# in this profile — sts-enabled=false in docker-compose.yml).
+
+[[sink]]
+name = "payments_with_fraud_score_iceberg"
+pipeline = "payments_with_fraud_score"
+connector = "iceberg"
+
+[sink.properties]
+"catalog.uri"   = "http://localhost:8181/catalog"
+warehouse       = "demo"
+"storage.type"  = "s3"
+namespace       = "finance"
+"table.name"    = "payments_with_fraud_score"
+"auto.create"   = "true"
+compression     = "zstd"
 "catalog.property.s3.endpoint"          = "http://localhost:9000"
 "catalog.property.s3.access-key-id"     = "rustfsadmin"
 "catalog.property.s3.secret-access-key" = "rustfsadmin"

--- a/examples/nats-payments/config.toml
+++ b/examples/nats-payments/config.toml
@@ -118,12 +118,12 @@ EMIT ON WINDOW CLOSE
 name = "payments_with_fraud_score"
 sql = """
 SELECT
-    p.payment_id,
-    p.region,
-    p.method,
-    p.amount_usd,
-    f.fraud_score,
-    f.outcome,
+    p.payment_id  AS payment_id,
+    p.region      AS region,
+    p.method      AS method,
+    p.amount_usd  AS amount_usd,
+    f.fraud_score AS fraud_score,
+    f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
     CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms

--- a/examples/nats-payments/docker-compose.yml
+++ b/examples/nats-payments/docker-compose.yml
@@ -32,13 +32,12 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 5s
       timeout: 3s
-      retries: 20
+      retries: 6
       start_period: 10s
 
-  # Creates the `warehouse` bucket once RustFS is healthy. Uses the AWS
-  # CLI rather than `mc` (the MinIO client doesn't talk to RustFS).
+  # Creates the `warehouse` bucket once RustFS is healthy.
   rustfs-init:
-    image: amazon/aws-cli:latest
+    image: amazon/aws-cli:2.13.39
     container_name: rustfs-init
     depends_on:
       rustfs:
@@ -94,6 +93,7 @@ services:
       LAKEKEEPER__PG_DATABASE_URL_WRITE: postgresql://postgres:postgres@postgres:5432/postgres
       LAKEKEEPER__PG_ENCRYPTION_KEY: demo-encryption-key-32-chars-ok!
       LAKEKEEPER__BASE_URI: http://localhost:8181
+      LAKEKEEPER__ALLOW_ORIGIN: "*"
     ports:
       - "8181:8181"   # catalog API
       - "8182:8182"   # UI

--- a/examples/nats-payments/docker-compose.yml
+++ b/examples/nats-payments/docker-compose.yml
@@ -35,7 +35,9 @@ services:
       retries: 6
       start_period: 10s
 
-  # Creates the `warehouse` bucket once RustFS is healthy.
+  # Creates the `warehouse` bucket once RustFS is healthy. Public-read
+  # so DuckDB's httpfs can fetch Iceberg manifest URLs (which Lakekeeper
+  # bakes as plain http:// links, not signed s3:// references).
   rustfs-init:
     image: amazon/aws-cli:2.13.39
     container_name: rustfs-init
@@ -50,7 +52,22 @@ services:
       - /bin/sh
       - -c
       - |
+        set -eu
         aws --endpoint-url http://rustfs:9000 s3 mb s3://warehouse || true
+        cat >/tmp/policy.json <<'JSON'
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "PublicRead",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": ["s3:GetObject"],
+            "Resource": "arn:aws:s3:::warehouse/*"
+          }]
+        }
+        JSON
+        aws --endpoint-url http://rustfs:9000 s3api put-bucket-policy \
+            --bucket warehouse --policy file:///tmp/policy.json || true
 
   postgres:
     image: postgres:16

--- a/examples/nats-payments/docker-compose.yml
+++ b/examples/nats-payments/docker-compose.yml
@@ -1,0 +1,159 @@
+# NATS → Iceberg payments demo.
+#
+# Zero JVM. Two Rust binaries (nats-server + laminardb) do the work.
+# Three containers for the lakehouse: MinIO, Postgres, Lakekeeper.
+
+services:
+
+  # NATS — `--jetstream` is on so the same broker also serves users who
+  # later switch to JetStream durable consumers, but this demo uses
+  # mode=core (plain pub/sub).
+  nats:
+    image: nats:2.10
+    container_name: nats
+    command: ["--jetstream", "--http_port", "8222"]
+    ports:
+      - "4222:4222"   # client
+      - "8222:8222"   # monitoring
+
+  # MinIO — S3-compatible object store for the Iceberg warehouse.
+  minio:
+    image: quay.io/minio/minio:latest
+    container_name: minio
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # console
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # Creates the `warehouse` bucket once MinIO is healthy.
+  minio-init:
+    image: minio/mc:latest
+    container_name: minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc mb -p local/warehouse || true &&
+        mc anonymous set none local/warehouse
+
+  # Postgres — Lakekeeper's metadata store.
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # Schema migrations for Lakekeeper's metadata tables. Runs once.
+  lakekeeper-migrate:
+    image: quay.io/lakekeeper/catalog:latest-main
+    container_name: lakekeeper-migrate
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgresql://postgres:postgres@postgres:5432/postgres
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgresql://postgres:postgres@postgres:5432/postgres
+      LAKEKEEPER__PG_ENCRYPTION_KEY: demo-encryption-key-32-chars-ok!
+    command: ["migrate"]
+    restart: "no"
+
+  # Lakekeeper — Apache Iceberg REST catalog backed by Postgres.
+  lakekeeper:
+    image: quay.io/lakekeeper/catalog:latest-main
+    container_name: lakekeeper
+    depends_on:
+      lakekeeper-migrate:
+        condition: service_completed_successfully
+      minio:
+        condition: service_healthy
+    environment:
+      LAKEKEEPER__PG_DATABASE_URL_READ: postgresql://postgres:postgres@postgres:5432/postgres
+      LAKEKEEPER__PG_DATABASE_URL_WRITE: postgresql://postgres:postgres@postgres:5432/postgres
+      LAKEKEEPER__PG_ENCRYPTION_KEY: demo-encryption-key-32-chars-ok!
+      LAKEKEEPER__BASE_URI: http://localhost:8181
+    ports:
+      - "8181:8181"   # catalog API
+      - "8182:8182"   # UI
+    command: ["serve"]
+    # No healthcheck: lakekeeper ships as a distroless image with no
+    # shell or curl/wget, so any HEALTHCHECK CMD fails. The init
+    # container below polls /health itself before bootstrapping.
+
+  # One-shot bootstrap + warehouse creation. Idempotent.
+  lakekeeper-init:
+    image: curlimages/curl:8.10.1
+    container_name: lakekeeper-init
+    depends_on:
+      lakekeeper:
+        condition: service_started
+    restart: "no"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        echo "Waiting for Lakekeeper /health..."
+        for i in $$(seq 1 60); do
+          if curl -fsS http://lakekeeper:8181/health >/dev/null 2>&1; then
+            echo "Lakekeeper is up."
+            break
+          fi
+          sleep 1
+        done
+
+        echo "Bootstrapping Lakekeeper..."
+        curl -fsS -X POST http://lakekeeper:8181/management/v1/bootstrap \
+          -H 'content-type: application/json' \
+          -d '{"accept-terms-of-use":true}' || true
+
+        echo "Creating warehouse 'demo'..."
+        curl -fsS -X POST http://lakekeeper:8181/management/v1/warehouse \
+          -H 'content-type: application/json' \
+          -d @- <<'JSON' || true
+        {
+          "warehouse-name": "demo",
+          "project-id": "00000000-0000-0000-0000-000000000000",
+          "storage-profile": {
+            "type": "s3",
+            "bucket": "warehouse",
+            "key-prefix": "finance",
+            "endpoint": "http://minio:9000",
+            "region": "us-east-1",
+            "path-style-access": true,
+            "flavor": "minio",
+            "sts-enabled": false
+          },
+          "storage-credential": {
+            "type": "s3",
+            "credential-type": "access-key",
+            "aws-access-key-id": "minioadmin",
+            "aws-secret-access-key": "minioadmin"
+          }
+        }
+        JSON
+
+        # The iceberg sink will create the `finance` namespace itself when
+        # `auto.create = "true"`, so no namespace bootstrap here.
+
+        echo "Lakekeeper init done."

--- a/examples/nats-payments/docker-compose.yml
+++ b/examples/nats-payments/docker-compose.yml
@@ -1,13 +1,11 @@
 # NATS → Iceberg payments demo.
 #
-# Zero JVM. Two Rust binaries (nats-server + laminardb) do the work.
-# Three containers for the lakehouse: MinIO, Postgres, Lakekeeper.
+# Zero JVM, zero Go. Two Rust binaries (nats-server + laminardb) do the
+# work; three containers for the lakehouse: RustFS (Rust S3 store),
+# Postgres, Lakekeeper.
 
 services:
 
-  # NATS — `--jetstream` is on so the same broker also serves users who
-  # later switch to JetStream durable consumers, but this demo uses
-  # mode=core (plain pub/sub).
   nats:
     image: nats:2.10
     container_name: nats
@@ -16,39 +14,45 @@ services:
       - "4222:4222"   # client
       - "8222:8222"   # monitoring
 
-  # MinIO — S3-compatible object store for the Iceberg warehouse.
-  minio:
-    image: quay.io/minio/minio:latest
-    container_name: minio
-    command: ["server", "/data", "--console-address", ":9001"]
+  # RustFS — S3-compatible object store written in Rust.
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: rustfs
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      RUSTFS_VOLUMES: /data
+      RUSTFS_ADDRESS: 0.0.0.0:9000
+      RUSTFS_CONSOLE_ADDRESS: 0.0.0.0:9001
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_ACCESS_KEY: rustfsadmin
+      RUSTFS_SECRET_KEY: rustfsadmin
     ports:
       - "9000:9000"   # S3 API
       - "9001:9001"   # console
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 5s
       timeout: 3s
-      retries: 10
+      retries: 20
+      start_period: 10s
 
-  # Creates the `warehouse` bucket once MinIO is healthy.
-  minio-init:
-    image: minio/mc:latest
-    container_name: minio-init
+  # Creates the `warehouse` bucket once RustFS is healthy. Uses the AWS
+  # CLI rather than `mc` (the MinIO client doesn't talk to RustFS).
+  rustfs-init:
+    image: amazon/aws-cli:latest
+    container_name: rustfs-init
     depends_on:
-      minio:
+      rustfs:
         condition: service_healthy
+    environment:
+      AWS_ACCESS_KEY_ID: rustfsadmin
+      AWS_SECRET_ACCESS_KEY: rustfsadmin
+      AWS_DEFAULT_REGION: us-east-1
     entrypoint:
       - /bin/sh
       - -c
       - |
-        mc alias set local http://minio:9000 minioadmin minioadmin &&
-        mc mb -p local/warehouse || true &&
-        mc anonymous set none local/warehouse
+        aws --endpoint-url http://rustfs:9000 s3 mb s3://warehouse || true
 
-  # Postgres — Lakekeeper's metadata store.
   postgres:
     image: postgres:16
     container_name: postgres
@@ -64,7 +68,6 @@ services:
       timeout: 3s
       retries: 10
 
-  # Schema migrations for Lakekeeper's metadata tables. Runs once.
   lakekeeper-migrate:
     image: quay.io/lakekeeper/catalog:latest-main
     container_name: lakekeeper-migrate
@@ -78,14 +81,13 @@ services:
     command: ["migrate"]
     restart: "no"
 
-  # Lakekeeper — Apache Iceberg REST catalog backed by Postgres.
   lakekeeper:
     image: quay.io/lakekeeper/catalog:latest-main
     container_name: lakekeeper
     depends_on:
       lakekeeper-migrate:
         condition: service_completed_successfully
-      minio:
+      rustfs:
         condition: service_healthy
     environment:
       LAKEKEEPER__PG_DATABASE_URL_READ: postgresql://postgres:postgres@postgres:5432/postgres
@@ -97,16 +99,18 @@ services:
       - "8182:8182"   # UI
     command: ["serve"]
     # No healthcheck: lakekeeper ships as a distroless image with no
-    # shell or curl/wget, so any HEALTHCHECK CMD fails. The init
-    # container below polls /health itself before bootstrapping.
+    # shell or curl/wget. The init container polls /health itself.
 
-  # One-shot bootstrap + warehouse creation. Idempotent.
+  # Bootstraps Lakekeeper and creates the `demo` warehouse pointing at
+  # the `warehouse` bucket in RustFS. Idempotent.
   lakekeeper-init:
     image: curlimages/curl:8.10.1
     container_name: lakekeeper-init
     depends_on:
       lakekeeper:
         condition: service_started
+      rustfs-init:
+        condition: service_completed_successfully
     restart: "no"
     entrypoint:
       - /bin/sh
@@ -138,17 +142,17 @@ services:
             "type": "s3",
             "bucket": "warehouse",
             "key-prefix": "finance",
-            "endpoint": "http://minio:9000",
+            "endpoint": "http://rustfs:9000",
             "region": "us-east-1",
             "path-style-access": true,
-            "flavor": "minio",
+            "flavor": "s3-compat",
             "sts-enabled": false
           },
           "storage-credential": {
             "type": "s3",
             "credential-type": "access-key",
-            "aws-access-key-id": "minioadmin",
-            "aws-secret-access-key": "minioadmin"
+            "aws-access-key-id": "rustfsadmin",
+            "aws-secret-access-key": "rustfsadmin"
           }
         }
         JSON

--- a/examples/nats-payments/gen.py
+++ b/examples/nats-payments/gen.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """
-Publishes fake payment events to NATS subject `payments.events` at ~50 msg/sec.
+Multi-producer NATS publisher. Pace-limited to a target rate.
 
     pip install nats-py
-    python gen.py
+    python gen.py                 # default: 10_000 msg/s, 4 producers
+    python gen.py --rate 50000    # 50K/s
+    python gen.py --rate 0        # flat-out, no pacing
 
-Stop with Ctrl-C.
+Stop with Ctrl-C; prints sent count, elapsed, achieved rate.
 """
 
+import argparse
 import asyncio
 import json
 import random
+import time
 from datetime import datetime, timezone
 
 import nats
@@ -21,39 +25,93 @@ SUBJECT = "payments.events"
 
 REGIONS = ["us-east", "us-west", "eu-west", "ap-south"]
 METHODS = ["card", "bank_transfer", "crypto", "wallet"]
-
-# Heavily weighted toward 'completed' so failed_count stays a minority signal.
 STATUSES = ["completed"] * 17 + ["failed"] * 2 + ["pending"] * 1
 
 
-async def main() -> None:
-    nc = await nats.connect(NATS_URL)
-    print(f"Connected to NATS — publishing to {SUBJECT}")
-    count = 0
+def make_event() -> bytes:
+    return json.dumps(
+        {
+            "payment_id": f"pay-{random.randint(1_000_000, 9_999_999)}",
+            "region":     random.choice(REGIONS),
+            "method":     random.choice(METHODS),
+            "amount_usd": round(random.uniform(5.0, 2000.0), 2),
+            "status":     random.choice(STATUSES),
+            "event_time": datetime.now(timezone.utc).isoformat(),
+        }
+    ).encode()
+
+
+async def producer(idx: int, target_per_sec: float, sent: list[int], stop: asyncio.Event):
+    nc = await nats.connect(NATS_URL, pending_size=64 * 1024 * 1024)
+    batch = 200
+    start = time.monotonic()
+    local = 0
     try:
-        while True:
-            event = {
-                "payment_id": f"pay-{random.randint(1_000_000, 9_999_999)}",
-                "region":     random.choice(REGIONS),
-                "method":     random.choice(METHODS),
-                "amount_usd": round(random.uniform(5.0, 2000.0), 2),
-                "status":     random.choice(STATUSES),
-                "event_time": datetime.now(timezone.utc).isoformat(),
-            }
-            await nc.publish(SUBJECT, json.dumps(event).encode())
-            count += 1
-            if count % 100 == 0:
-                print(
-                    f"  {count} events  —  {event['region']:<8} "
-                    f"{event['method']:<14} ${event['amount_usd']:>8.2f}"
-                )
-            await asyncio.sleep(0.02)
+        while not stop.is_set():
+            for _ in range(batch):
+                await nc.publish(SUBJECT, make_event())
+            local += batch
+            sent[idx] = local
+
+            if target_per_sec > 0:
+                expected = local / target_per_sec
+                elapsed = time.monotonic() - start
+                if expected > elapsed:
+                    await asyncio.sleep(expected - elapsed)
     finally:
+        await nc.flush()
         await nc.drain()
 
 
-if __name__ == "__main__":
+async def main(rate: int, producers: int):
+    per_producer = rate / producers if rate > 0 else 0
+    sent = [0] * producers
+    stop = asyncio.Event()
+
+    print(
+        f"Publishing to {SUBJECT} — {producers} producers, "
+        f"target {rate:,}/s ({per_producer:,.0f}/s each)"
+        if rate > 0
+        else f"Publishing to {SUBJECT} — {producers} producers, flat-out"
+    )
+
+    tasks = [
+        asyncio.create_task(producer(i, per_producer, sent, stop))
+        for i in range(producers)
+    ]
+
+    started = time.monotonic()
+    last_total = 0
+    last_t = started
     try:
-        asyncio.run(main())
+        while True:
+            await asyncio.sleep(1.0)
+            total = sum(sent)
+            now = time.monotonic()
+            inst = (total - last_total) / (now - last_t)
+            print(f"  sent={total:>10,d}  rate={inst:>10,.0f}/s")
+            last_total, last_t = total, now
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        pass
+    finally:
+        stop.set()
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        elapsed = time.monotonic() - started
+        total = sum(sent)
+        print(
+            f"\nstopped — sent {total:,d} in {elapsed:.1f}s "
+            f"(avg {total/elapsed:,.0f}/s)"
+        )
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rate", type=int, default=10_000, help="target msg/sec (0 = flat-out)")
+    ap.add_argument("--producers", type=int, default=4)
+    args = ap.parse_args()
+    try:
+        asyncio.run(main(args.rate, args.producers))
     except KeyboardInterrupt:
         pass

--- a/examples/nats-payments/gen.py
+++ b/examples/nats-payments/gen.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """
-Multi-producer NATS publisher. Pace-limited to a target rate.
+Multi-producer NATS publisher. Two correlated streams:
+
+* payments.initiated — a payment is created
+* payments.scored    — fraud system returns a score 50ms-1s later;
+                        2% never score (fraud service errored)
 
     pip install nats-py
-    python gen.py                 # default: 10_000 msg/s, 4 producers
+    python gen.py                 # 10_000 payments/s
     python gen.py --rate 50000    # 50K/s
-    python gen.py --rate 0        # flat-out, no pacing
 
-Stop with Ctrl-C; prints sent count, elapsed, achieved rate.
+Stop with Ctrl-C; prints sent counts.
 """
 
 import argparse
@@ -21,40 +24,64 @@ import nats
 
 
 NATS_URL = "nats://localhost:4222"
-SUBJECT = "payments.events"
+PAYMENT_SUBJECT = "payments.initiated"
+SCORE_SUBJECT   = "payments.scored"
 
 REGIONS = ["us-east", "us-west", "eu-west", "ap-south"]
 METHODS = ["card", "bank_transfer", "crypto", "wallet"]
-STATUSES = ["completed"] * 17 + ["failed"] * 2 + ["pending"] * 1
 
 
-def make_event() -> bytes:
-    return json.dumps(
-        {
-            "payment_id": f"pay-{random.randint(1_000_000, 9_999_999)}",
-            "region":     random.choice(REGIONS),
-            "method":     random.choice(METHODS),
-            "amount_usd": round(random.uniform(5.0, 2000.0), 2),
-            "status":     random.choice(STATUSES),
-            "event_time": datetime.now(timezone.utc).isoformat(),
-        }
-    ).encode()
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
-async def producer(idx: int, target_per_sec: float, sent: list[int], stop: asyncio.Event):
+def score_outcome(score: float) -> str:
+    if score >= 0.85:
+        return "blocked"
+    if score >= 0.50:
+        return "review"
+    return "approved"
+
+
+async def payment_producer(rate: float, sent: list[int], idx: int,
+                           score_q: asyncio.Queue, stop: asyncio.Event):
     nc = await nats.connect(NATS_URL, pending_size=64 * 1024 * 1024)
     batch = 200
     start = time.monotonic()
     local = 0
     try:
         while not stop.is_set():
+            now = time.monotonic()
             for _ in range(batch):
-                await nc.publish(SUBJECT, make_event())
+                pid = random.randint(1_000_000_000, 9_999_999_999)
+                region = random.choice(REGIONS)
+                method = random.choice(METHODS)
+                amount = round(random.uniform(5.0, 2000.0), 2)
+                evt = {
+                    "payment_id": pid,
+                    "region":     region,
+                    "method":     method,
+                    "amount_usd": amount,
+                    "event_time": now_iso(),
+                }
+                await nc.publish(PAYMENT_SUBJECT, json.dumps(evt).encode())
+
+                # Schedule the fraud score follow-up.
+                roll = random.random()
+                if roll < 0.02:
+                    continue                         # 2% never score
+                if roll < 0.80:
+                    delay = random.uniform(0.05, 0.20)   # 78% fast: 50-200ms
+                else:
+                    delay = random.uniform(0.20, 1.0)    # 20% slow: 200ms-1s
+                # Score distribution: most low risk, a long tail high.
+                score = min(1.0, max(0.0, random.gauss(0.20, 0.18)))
+                score_q.put_nowait((now + delay, pid, region, score))
             local += batch
             sent[idx] = local
 
-            if target_per_sec > 0:
-                expected = local / target_per_sec
+            if rate > 0:
+                expected = local / rate
                 elapsed = time.monotonic() - start
                 if expected > elapsed:
                     await asyncio.sleep(expected - elapsed)
@@ -63,52 +90,92 @@ async def producer(idx: int, target_per_sec: float, sent: list[int], stop: async
         await nc.drain()
 
 
+async def score_producer(sent: list[int], score_q: asyncio.Queue,
+                         stop: asyncio.Event):
+    nc = await nats.connect(NATS_URL, pending_size=64 * 1024 * 1024)
+    pending: list[tuple[float, int, str, float]] = []
+    try:
+        while not stop.is_set() or pending or not score_q.empty():
+            while True:
+                try:
+                    pending.append(score_q.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+
+            now = time.monotonic()
+            ready, later = [], []
+            for item in pending:
+                (ready if item[0] <= now else later).append(item)
+            pending = later
+
+            for due_at, pid, region, score in ready:
+                evt = {
+                    "payment_id":  pid,
+                    "region":      region,
+                    "fraud_score": round(score, 3),
+                    "outcome":     score_outcome(score),
+                    "event_time":  now_iso(),
+                }
+                await nc.publish(SCORE_SUBJECT, json.dumps(evt).encode())
+                sent[0] += 1
+
+            if not ready:
+                await asyncio.sleep(0.02)
+    finally:
+        await nc.flush()
+        await nc.drain()
+
+
 async def main(rate: int, producers: int):
     per_producer = rate / producers if rate > 0 else 0
-    sent = [0] * producers
-    stop = asyncio.Event()
+    pay_sent   = [0] * producers
+    score_sent = [0]
+    stop       = asyncio.Event()
+    score_q: asyncio.Queue = asyncio.Queue(maxsize=200_000)
 
     print(
-        f"Publishing to {SUBJECT} — {producers} producers, "
-        f"target {rate:,}/s ({per_producer:,.0f}/s each)"
+        f"Publishing {PAYMENT_SUBJECT} + {SCORE_SUBJECT} — "
+        f"{producers} producers, target {rate:,} payments/s "
+        f"({per_producer:,.0f}/s each); 98% scored within 1s"
         if rate > 0
-        else f"Publishing to {SUBJECT} — {producers} producers, flat-out"
+        else f"Flat-out, {producers} producers, 98% scored within 1s"
     )
 
     tasks = [
-        asyncio.create_task(producer(i, per_producer, sent, stop))
+        asyncio.create_task(payment_producer(per_producer, pay_sent, i, score_q, stop))
         for i in range(producers)
     ]
+    tasks.append(asyncio.create_task(score_producer(score_sent, score_q, stop)))
 
     started = time.monotonic()
-    last_total = 0
-    last_t = started
+    last_p, last_s, last_t = 0, 0, started
     try:
         while True:
             await asyncio.sleep(1.0)
-            total = sum(sent)
-            now = time.monotonic()
-            inst = (total - last_total) / (now - last_t)
-            print(f"  sent={total:>10,d}  rate={inst:>10,.0f}/s")
-            last_total, last_t = total, now
+            p = sum(pay_sent); s = score_sent[0]; now = time.monotonic()
+            print(f"  payments={p:>10,d} ({(p-last_p)/(now-last_t):>9,.0f}/s)  "
+                  f"scores={s:>10,d} ({(s-last_s)/(now-last_t):>9,.0f}/s)  "
+                  f"queued={score_q.qsize():>6,d}")
+            last_p, last_s, last_t = p, s, now
     except (asyncio.CancelledError, KeyboardInterrupt):
         pass
     finally:
         stop.set()
+        await asyncio.sleep(0.2)
         for t in tasks:
             t.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         elapsed = time.monotonic() - started
-        total = sum(sent)
+        p, s = sum(pay_sent), score_sent[0]
         print(
-            f"\nstopped — sent {total:,d} in {elapsed:.1f}s "
-            f"(avg {total/elapsed:,.0f}/s)"
+            f"\nstopped — payments {p:,d} ({p/elapsed:,.0f}/s), "
+            f"scores {s:,d} ({s/elapsed:,.0f}/s) over {elapsed:.1f}s"
         )
 
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--rate", type=int, default=10_000, help="target msg/sec (0 = flat-out)")
+    ap.add_argument("--rate", type=int, default=10_000, help="payments/sec (0 = flat-out)")
     ap.add_argument("--producers", type=int, default=4)
     args = ap.parse_args()
     try:

--- a/examples/nats-payments/gen.py
+++ b/examples/nats-payments/gen.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Publishes fake payment events to NATS subject `payments.events` at ~50 msg/sec.
+
+    pip install nats-py
+    python gen.py
+
+Stop with Ctrl-C.
+"""
+
+import asyncio
+import json
+import random
+from datetime import datetime, timezone
+
+import nats
+
+
+NATS_URL = "nats://localhost:4222"
+SUBJECT = "payments.events"
+
+REGIONS = ["us-east", "us-west", "eu-west", "ap-south"]
+METHODS = ["card", "bank_transfer", "crypto", "wallet"]
+
+# Heavily weighted toward 'completed' so failed_count stays a minority signal.
+STATUSES = ["completed"] * 17 + ["failed"] * 2 + ["pending"] * 1
+
+
+async def main() -> None:
+    nc = await nats.connect(NATS_URL)
+    print(f"Connected to NATS — publishing to {SUBJECT}")
+    count = 0
+    try:
+        while True:
+            event = {
+                "payment_id": f"pay-{random.randint(1_000_000, 9_999_999)}",
+                "region":     random.choice(REGIONS),
+                "method":     random.choice(METHODS),
+                "amount_usd": round(random.uniform(5.0, 2000.0), 2),
+                "status":     random.choice(STATUSES),
+                "event_time": datetime.now(timezone.utc).isoformat(),
+            }
+            await nc.publish(SUBJECT, json.dumps(event).encode())
+            count += 1
+            if count % 100 == 0:
+                print(
+                    f"  {count} events  —  {event['region']:<8} "
+                    f"{event['method']:<14} ${event['amount_usd']:>8.2f}"
+                )
+            await asyncio.sleep(0.02)
+    finally:
+        await nc.drain()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/nats-payments/pipeline.sql
+++ b/examples/nats-payments/pipeline.sql
@@ -1,27 +1,35 @@
--- Reference copy of the pipeline SQL.
---
--- LaminarDB's [[pipeline]] section takes the SQL inline as a string, so
--- the authoritative copy lives in config.toml. This file is here for
--- readability and editor highlighting only — the server does not load it.
---
--- Source `payments` is declared in config.toml ([[source]]) with a flat
--- JSON schema. event_time arrives as RFC3339 and is parsed into a
--- TIMESTAMP column by the JSON decoder. Watermark is configured on
--- event_time with a 10s out-of-order tolerance.
---
--- The window rewriter auto-prepends window_start, window_end to the
--- SELECT list whenever it sees a windowed GROUP BY.
+-- Reference copies of the two pipelines.
+-- Live SQL lives in config.toml's [[pipeline]] sql fields.
 
+-- 1. Tumbling 1-minute rollup over the payments stream.
 SELECT
     region,
     method,
-    COUNT(*)                                            AS payment_count,
-    SUM(amount_usd)                                     AS total_usd,
-    AVG(amount_usd)                                     AS avg_usd,
-    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+    COUNT(*)          AS payment_count,
+    SUM(amount_usd)   AS total_usd,
+    AVG(amount_usd)   AS avg_usd
 FROM payments
 GROUP BY
     TUMBLE(event_time, INTERVAL '1' MINUTE),
     region,
     method
-EMIT ON WINDOW CLOSE
+EMIT ON WINDOW CLOSE;
+
+
+-- 2. Stream-to-stream interval join on payment_id with a 2-second window.
+--    Each row is one payment matched with its fraud score; score_latency_ms
+--    is the wall-clock between the two events.
+SELECT
+    p.payment_id,
+    p.region,
+    p.method,
+    p.amount_usd,
+    f.fraud_score,
+    f.outcome,
+    p.event_time                                              AS initiated_at,
+    f.event_time                                              AS scored_at,
+    CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms
+FROM payments p
+JOIN fraud_checks f
+    ON p.payment_id = f.payment_id
+    AND f.event_time BETWEEN p.event_time AND p.event_time + INTERVAL '2' SECOND;

--- a/examples/nats-payments/pipeline.sql
+++ b/examples/nats-payments/pipeline.sql
@@ -32,7 +32,7 @@ SELECT
     f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
-    CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms
+    (CAST(f.event_time AS BIGINT) - CAST(p.event_time AS BIGINT)) / 1000000 AS score_latency_ms
 FROM payments p
 JOIN fraud_checks f
     ON p.payment_id = f.payment_id

--- a/examples/nats-payments/pipeline.sql
+++ b/examples/nats-payments/pipeline.sql
@@ -19,13 +19,17 @@ EMIT ON WINDOW CLOSE;
 -- 2. Stream-to-stream interval join on payment_id with a 2-second window.
 --    Each row is one payment matched with its fraud score; score_latency_ms
 --    is the wall-clock between the two events.
+-- Right-side (fraud_checks) columns need explicit AS aliases — the
+-- interval-join operator rewrites table-qualified refs internally to
+-- `{col}_{right_table}`, so without an alias the emitted batch column
+-- is `fraud_score_fraud_checks`, not `fraud_score`.
 SELECT
-    p.payment_id,
-    p.region,
-    p.method,
-    p.amount_usd,
-    f.fraud_score,
-    f.outcome,
+    p.payment_id  AS payment_id,
+    p.region      AS region,
+    p.method      AS method,
+    p.amount_usd  AS amount_usd,
+    f.fraud_score AS fraud_score,
+    f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
     CAST(f.event_time - p.event_time AS BIGINT) / 1000000     AS score_latency_ms

--- a/examples/nats-payments/pipeline.sql
+++ b/examples/nats-payments/pipeline.sql
@@ -1,0 +1,27 @@
+-- Reference copy of the pipeline SQL.
+--
+-- LaminarDB's [[pipeline]] section takes the SQL inline as a string, so
+-- the authoritative copy lives in config.toml. This file is here for
+-- readability and editor highlighting only — the server does not load it.
+--
+-- Source `payments` is declared in config.toml ([[source]]) with a flat
+-- JSON schema. event_time arrives as RFC3339 and is parsed into a
+-- TIMESTAMP column by the JSON decoder. Watermark is configured on
+-- event_time with a 10s out-of-order tolerance.
+--
+-- The window rewriter auto-prepends window_start, window_end to the
+-- SELECT list whenever it sees a windowed GROUP BY.
+
+SELECT
+    region,
+    method,
+    COUNT(*)                                            AS payment_count,
+    SUM(amount_usd)                                     AS total_usd,
+    AVG(amount_usd)                                     AS avg_usd,
+    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)  AS failed_count
+FROM payments
+GROUP BY
+    TUMBLE(event_time, INTERVAL '1' MINUTE),
+    region,
+    method
+EMIT ON WINDOW CLOSE

--- a/examples/nats-payments/pipeline.sql
+++ b/examples/nats-payments/pipeline.sql
@@ -32,7 +32,10 @@ SELECT
     f.outcome     AS outcome,
     p.event_time                                              AS initiated_at,
     f.event_time                                              AS scored_at,
-    (CAST(f.event_time AS BIGINT) - CAST(p.event_time AS BIGINT)) / 1000000 AS score_latency_ms
+    CAST(
+        (date_part('epoch', f.event_time) - date_part('epoch', p.event_time)) * 1000
+        AS BIGINT
+    ) AS score_latency_ms
 FROM payments p
 JOIN fraud_checks f
     ON p.payment_id = f.payment_id

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Reads payment_summary committed by laminardb to MinIO and prints a
+window-by-window rollup.
+
+    pip install duckdb
+    python query.py
+
+Run after ~90 seconds of `gen.py` so at least one tumbling minute has
+closed and the sink has committed.
+
+We `parquet_scan` the data files directly instead of going through
+DuckDB's iceberg_scan(REST). Lakekeeper bakes its configured endpoint
+(`http://minio:9000`) into table metadata, and DuckDB's iceberg
+extension follows that endpoint as-is from the host where `minio`
+doesn't resolve. The Parquet files themselves live in MinIO and read
+fine over the host-published `localhost:9000` endpoint.
+"""
+
+import os
+import duckdb
+
+
+WAREHOUSE_GLOB = os.environ.get(
+    "PAYMENT_SUMMARY_GLOB",
+    "s3://warehouse/finance/*/*/data/*.parquet",
+)
+
+con = duckdb.connect()
+con.execute("INSTALL httpfs; LOAD httpfs;")
+con.execute("""
+    SET s3_endpoint          = 'localhost:9000';
+    SET s3_access_key_id     = 'minioadmin';
+    SET s3_secret_access_key = 'minioadmin';
+    SET s3_use_ssl           = false;
+    SET s3_url_style         = 'path';
+""")
+
+print("\n--- payment summary by region and method ---------------------")
+df = con.execute(f"""
+    SELECT
+        epoch_ms(window_start)::TIMESTAMP AS window_start,
+        epoch_ms(window_end)::TIMESTAMP   AS window_end,
+        region,
+        method,
+        payment_count,
+        ROUND(total_usd, 2) AS total_usd,
+        ROUND(avg_usd, 2)   AS avg_usd,
+        failed_count
+    FROM parquet_scan('{WAREHOUSE_GLOB}')
+    ORDER BY window_start DESC, total_usd DESC
+    LIMIT 40
+""").fetchdf()
+
+print(df.to_string(index=False))
+print(f"\n{len(df)} rows")

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
+Reads the demo's two Iceberg tables via Lakekeeper:
+
+* finance.payments_summary           — tumbling 1-min rollup
+* finance.payments_with_fraud_score  — payments ⨝ fraud-score (2s window)
 
     pip install duckdb
     python query.py
 
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
-closed and the sink has committed.
+closed and join rows have flowed.
 
 Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
-DuckDB can fetch the manifest paths Lakekeeper bakes into table
-metadata. See README.
-
-Throughput and commit cadence (real engine signals) come from
-bench.py scraping /metrics — this script is the readback.
+DuckDB can fetch manifest paths Lakekeeper bakes into table metadata.
+See README.
 """
 
 import duckdb
@@ -43,20 +43,50 @@ con.execute("""
     )
 """)
 
-print("\n--- payment summary by region and method (latest 40) ---------")
+
+def section(title: str) -> None:
+    print(f"\n--- {title} " + "-" * max(0, 60 - len(title) - 5))
+
+
+section("payments rollup by region and method (latest 16)")
 df = con.execute("""
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
-        region,
-        method,
+        region, method,
         payment_count,
         ROUND(total_usd, 2) AS total_usd,
-        ROUND(avg_usd, 2)   AS avg_usd,
-        failed_count
-    FROM catalog.finance.payment_summary
+        ROUND(avg_usd, 2)   AS avg_usd
+    FROM catalog.finance.payments_summary
     ORDER BY window_start DESC, total_usd DESC
-    LIMIT 40
+    LIMIT 16
 """).fetchdf()
 print(df.to_string(index=False))
-print(f"\n{len(df)} rows")
+
+section("payments matched with fraud score (latest 20)")
+df = con.execute("""
+    SELECT payment_id, region, method,
+           ROUND(amount_usd, 2) AS amount_usd,
+           fraud_score, outcome,
+           score_latency_ms
+    FROM catalog.finance.payments_with_fraud_score
+    ORDER BY scored_at DESC
+    LIMIT 20
+""").fetchdf()
+print(df.to_string(index=False))
+
+section("fraud-check latency by region")
+df = con.execute("""
+    SELECT
+        region,
+        COUNT(*)                                        AS scored,
+        CAST(quantile_cont(score_latency_ms, 0.50) AS BIGINT) AS p50_ms,
+        CAST(quantile_cont(score_latency_ms, 0.95) AS BIGINT) AS p95_ms,
+        CAST(quantile_cont(score_latency_ms, 0.99) AS BIGINT) AS p99_ms,
+        SUM(CASE WHEN outcome = 'blocked' THEN 1 ELSE 0 END)  AS blocked,
+        SUM(CASE WHEN outcome = 'review'  THEN 1 ELSE 0 END)  AS review
+    FROM catalog.finance.payments_with_fraud_score
+    GROUP BY region
+    ORDER BY region
+""").fetchdf()
+print(df.to_string(index=False))

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
+Reads payment_summary from Lakekeeper via DuckDB's iceberg extension
+and prints both the windowed rollup and engine latency percentiles.
 
     pip install duckdb
     python query.py
@@ -11,19 +12,23 @@ closed and the sink has committed.
 Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
 DuckDB can fetch the manifest paths Lakekeeper bakes into table
 metadata. See README.
+
+Latency definitions:
+* close_latency_ms — between window_end and emitted_at; measures how
+  long after a window logically closed the engine produced its row.
+  Real "engine commit cadence" indicator.
+* end_to_end_ms — between max event_time in the window and emitted_at;
+  measures publish→materialized lag for the freshest event in each row.
 """
 
 import duckdb
 
 
 con = duckdb.connect()
-
-# core_nightly: stable iceberg ext doesn't yet support AUTHORIZATION_TYPE 'none'.
 con.execute("FORCE INSTALL iceberg FROM core_nightly;")
 con.execute("LOAD iceberg;")
 con.execute("INSTALL httpfs; LOAD httpfs;")
 
-# Storage credentials for the Parquet/manifest fetches.
 con.execute("""
     CREATE SECRET rustfs (
         TYPE      S3,
@@ -35,8 +40,6 @@ con.execute("""
     )
 """)
 
-# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
-# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
 con.execute("""
     ATTACH 'demo' AS catalog (
         TYPE               ICEBERG,
@@ -45,8 +48,9 @@ con.execute("""
     )
 """)
 
-print("\n--- payment summary by region and method ---------------------")
-df = con.execute("""
+# Pull every row into a temp view we can query twice (rollup + percentiles).
+con.execute("""
+    CREATE OR REPLACE TEMP VIEW summary AS
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
@@ -55,11 +59,37 @@ df = con.execute("""
         payment_count,
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd,
-        failed_count
+        failed_count,
+        emitted_at,
+        max_event_time,
+        date_diff('millisecond', epoch_ms(window_end)::TIMESTAMP, emitted_at)
+            AS close_latency_ms,
+        date_diff('millisecond', max_event_time, emitted_at)
+            AS end_to_end_ms
     FROM catalog.finance.payment_summary
+""")
+
+print("\n--- payment summary by region and method (latest 40) ---------")
+df = con.execute("""
+    SELECT window_start, window_end, region, method,
+           payment_count, total_usd, avg_usd, failed_count
+    FROM summary
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 40
 """).fetchdf()
-
 print(df.to_string(index=False))
 print(f"\n{len(df)} rows")
+
+print("\n--- engine latency (over all committed window-rows) ----------")
+lat = con.execute("""
+    SELECT
+        COUNT(*)                                            AS n,
+        CAST(quantile_cont(close_latency_ms,  0.50) AS BIGINT) AS p50_close_ms,
+        CAST(quantile_cont(close_latency_ms,  0.95) AS BIGINT) AS p95_close_ms,
+        CAST(quantile_cont(close_latency_ms,  0.99) AS BIGINT) AS p99_close_ms,
+        CAST(quantile_cont(end_to_end_ms,     0.50) AS BIGINT) AS p50_e2e_ms,
+        CAST(quantile_cont(end_to_end_ms,     0.95) AS BIGINT) AS p95_e2e_ms,
+        CAST(quantile_cont(end_to_end_ms,     0.99) AS BIGINT) AS p99_e2e_ms
+    FROM summary
+""").fetchdf()
+print(lat.to_string(index=False))

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via DuckDB's iceberg extension
-and prints both the windowed rollup and engine latency percentiles.
+Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
 
     pip install duckdb
     python query.py
@@ -13,12 +12,8 @@ Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
 DuckDB can fetch the manifest paths Lakekeeper bakes into table
 metadata. See README.
 
-Latency definitions:
-* close_latency_ms — between window_end and emitted_at; measures how
-  long after a window logically closed the engine produced its row.
-  Real "engine commit cadence" indicator.
-* end_to_end_ms — between max event_time in the window and emitted_at;
-  measures publish→materialized lag for the freshest event in each row.
+Throughput and commit cadence (real engine signals) come from
+bench.py scraping /metrics — this script is the readback.
 """
 
 import duckdb
@@ -48,9 +43,8 @@ con.execute("""
     )
 """)
 
-# Pull every row into a temp view we can query twice (rollup + percentiles).
-con.execute("""
-    CREATE OR REPLACE TEMP VIEW summary AS
+print("\n--- payment summary by region and method (latest 40) ---------")
+df = con.execute("""
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
@@ -59,37 +53,10 @@ con.execute("""
         payment_count,
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd,
-        failed_count,
-        emitted_at,
-        max_event_time,
-        date_diff('millisecond', epoch_ms(window_end)::TIMESTAMP, emitted_at)
-            AS close_latency_ms,
-        date_diff('millisecond', max_event_time, emitted_at)
-            AS end_to_end_ms
+        failed_count
     FROM catalog.finance.payment_summary
-""")
-
-print("\n--- payment summary by region and method (latest 40) ---------")
-df = con.execute("""
-    SELECT window_start, window_end, region, method,
-           payment_count, total_usd, avg_usd, failed_count
-    FROM summary
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 40
 """).fetchdf()
 print(df.to_string(index=False))
 print(f"\n{len(df)} rows")
-
-print("\n--- engine latency (over all committed window-rows) ----------")
-lat = con.execute("""
-    SELECT
-        COUNT(*)                                            AS n,
-        CAST(quantile_cont(close_latency_ms,  0.50) AS BIGINT) AS p50_close_ms,
-        CAST(quantile_cont(close_latency_ms,  0.95) AS BIGINT) AS p95_close_ms,
-        CAST(quantile_cont(close_latency_ms,  0.99) AS BIGINT) AS p99_close_ms,
-        CAST(quantile_cont(end_to_end_ms,     0.50) AS BIGINT) AS p50_e2e_ms,
-        CAST(quantile_cont(end_to_end_ms,     0.95) AS BIGINT) AS p95_e2e_ms,
-        CAST(quantile_cont(end_to_end_ms,     0.99) AS BIGINT) AS p99_e2e_ms
-    FROM summary
-""").fetchdf()
-print(lat.to_string(index=False))

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -33,20 +33,13 @@ con.execute("""
     )
 """)
 
-# Catalog auth: Lakekeeper runs unauthenticated in this demo, but
-# DuckDB defaults to oauth2 — flip it to `none`.
-con.execute("""
-    CREATE SECRET catalog_auth (
-        TYPE               ICEBERG,
-        AUTHORIZATION_TYPE 'none'
-    )
-""")
-
-# Lakekeeper REST catalog.
+# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
+# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
 con.execute("""
     ATTACH 'demo' AS catalog (
-        TYPE     ICEBERG,
-        ENDPOINT 'http://localhost:8181/catalog'
+        TYPE               ICEBERG,
+        ENDPOINT           'http://localhost:8181/catalog',
+        AUTHORIZATION_TYPE 'none'
     )
 """)
 

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -8,21 +8,29 @@ Reads the demo's two Iceberg tables via Lakekeeper:
     pip install duckdb
     python query.py
 
-Run after ~90 seconds of `gen.py` so at least one tumbling minute has
-closed and join rows have flowed.
+Run AFTER stopping gen.py — the tables accumulate parquet files fast
+at 10K/s, and DuckDB's concurrent httpfs reads contend with
+laminardb's ongoing writes against RustFS. Stopping the publisher
+gives DuckDB an idle store to scan.
 
 Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
 DuckDB can fetch manifest paths Lakekeeper bakes into table metadata.
 See README.
 """
 
+import time
+
 import duckdb
 
 
 con = duckdb.connect()
-con.execute("FORCE INSTALL iceberg FROM core_nightly;")
+con.execute("INSTALL iceberg FROM core_nightly;")
 con.execute("LOAD iceberg;")
 con.execute("INSTALL httpfs; LOAD httpfs;")
+# Throttle parallel httpfs GETs — at 10K/s ingest the table accumulates
+# many small parquet files and RustFS occasionally drops connections
+# under DuckDB's default concurrency.
+con.execute("SET threads=2;")
 
 con.execute("""
     CREATE SECRET rustfs (
@@ -44,6 +52,26 @@ con.execute("""
 """)
 
 
+def materialise(local_name: str, source: str, attempts: int = 3) -> None:
+    """Materialise an Iceberg table into a local DuckDB table; retry on
+    transient httpfs connect errors."""
+    for i in range(attempts):
+        try:
+            con.execute(f"CREATE OR REPLACE TABLE {local_name} AS SELECT * FROM {source}")
+            return
+        except duckdb.IOException as e:
+            if i == attempts - 1:
+                raise
+            print(f"  retry {local_name} ({i+1}/{attempts}) after: {e}", flush=True)
+            time.sleep(1.0)
+
+
+print("loading payments_summary ...", flush=True)
+materialise("summary", "catalog.finance.payments_summary")
+print("loading payments_with_fraud_score ...", flush=True)
+materialise("joined", "catalog.finance.payments_with_fraud_score")
+
+
 def section(title: str) -> None:
     print(f"\n--- {title} " + "-" * max(0, 60 - len(title) - 5))
 
@@ -57,7 +85,7 @@ df = con.execute("""
         payment_count,
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd
-    FROM catalog.finance.payments_summary
+    FROM summary
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 16
 """).fetchdf()
@@ -69,7 +97,7 @@ df = con.execute("""
            ROUND(amount_usd, 2) AS amount_usd,
            fraud_score, outcome,
            score_latency_ms
-    FROM catalog.finance.payments_with_fraud_score
+    FROM joined
     ORDER BY scored_at DESC
     LIMIT 20
 """).fetchdf()
@@ -85,7 +113,7 @@ df = con.execute("""
         CAST(quantile_cont(score_latency_ms, 0.99) AS BIGINT)          AS p99_ms,
         CAST(SUM(CASE WHEN outcome = 'blocked' THEN 1 ELSE 0 END) AS BIGINT) AS blocked,
         CAST(SUM(CASE WHEN outcome = 'review'  THEN 1 ELSE 0 END) AS BIGINT) AS review
-    FROM catalog.finance.payments_with_fraud_score
+    FROM joined
     GROUP BY region
     ORDER BY region
 """).fetchdf()

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,63 +1,56 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
+Reads payment_summary from Lakekeeper via PyIceberg.
 
-    pip install duckdb
+    pip install "pyiceberg[s3fs,pyarrow]"
     python query.py
 
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
 closed and the sink has committed.
 
 Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
-that DuckDB can fetch the Iceberg manifest paths Lakekeeper bakes into
-table metadata. See README.
+PyIceberg can fetch the manifest paths Lakekeeper bakes into table
+metadata. See README.
 """
 
-import duckdb
+from datetime import datetime, timezone
+
+from pyiceberg.catalog.rest import RestCatalog
 
 
-con = duckdb.connect()
+catalog = RestCatalog(
+    name="demo",
+    **{
+        "uri":       "http://localhost:8181/catalog",
+        "warehouse": "demo",
+        # Lakekeeper runs unauthenticated in this demo profile.
+        "auth":      {"type": "noop"},
+        # Storage credentials for the data files. Lakekeeper points at
+        # http://rustfs:9000 (in-cluster); on the host `rustfs` resolves
+        # to 127.0.0.1 via the README hosts entry.
+        "s3.endpoint":          "http://rustfs:9000",
+        "s3.access-key-id":     "rustfsadmin",
+        "s3.secret-access-key": "rustfsadmin",
+        "s3.region":            "us-east-1",
+    },
+)
 
-con.execute("INSTALL httpfs;  LOAD httpfs;")
-con.execute("INSTALL iceberg; LOAD iceberg;")
+table = catalog.load_table("finance.payment_summary")
 
-# Storage credentials for the Parquet/manifest fetches.
-con.execute("""
-    CREATE SECRET rustfs (
-        TYPE      S3,
-        KEY_ID    'rustfsadmin',
-        SECRET    'rustfsadmin',
-        ENDPOINT  'rustfs:9000',
-        URL_STYLE 'path',
-        USE_SSL   false
+# scan().to_pandas() applies snapshot resolution and schema evolution.
+df = table.scan().to_pandas()
+
+# window_start / window_end are Int64 epoch ms; render as timestamps.
+for col in ("window_start", "window_end"):
+    df[col] = df[col].apply(
+        lambda ms: datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        .strftime("%Y-%m-%d %H:%M:%S")
     )
-""")
+df["total_usd"] = df["total_usd"].round(2)
+df["avg_usd"]   = df["avg_usd"].round(2)
 
-# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
-# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
-con.execute("""
-    ATTACH 'demo' AS catalog (
-        TYPE               ICEBERG,
-        ENDPOINT           'http://localhost:8181/catalog',
-        AUTHORIZATION_TYPE 'none'
-    )
-""")
+df = df.sort_values(["window_start", "total_usd"], ascending=[False, False]).head(40)
 
 print("\n--- payment summary by region and method ---------------------")
-df = con.execute("""
-    SELECT
-        epoch_ms(window_start)::TIMESTAMP AS window_start,
-        epoch_ms(window_end)::TIMESTAMP   AS window_end,
-        region,
-        method,
-        payment_count,
-        ROUND(total_usd, 2) AS total_usd,
-        ROUND(avg_usd, 2)   AS avg_usd,
-        failed_count
-    FROM catalog.finance.payment_summary
-    ORDER BY window_start DESC, total_usd DESC
-    LIMIT 40
-""").fetchdf()
-
 print(df.to_string(index=False))
 print(f"\n{len(df)} rows")

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,56 +1,67 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via PyIceberg.
+Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
 
-    pip install "pyiceberg[s3fs,pyarrow]"
+    pip install duckdb
     python query.py
 
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
 closed and the sink has committed.
 
 Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
-PyIceberg can fetch the manifest paths Lakekeeper bakes into table
+DuckDB can fetch the manifest paths Lakekeeper bakes into table
 metadata. See README.
 """
 
-from datetime import datetime, timezone
-
-from pyiceberg.catalog.rest import RestCatalog
+import duckdb
 
 
-catalog = RestCatalog(
-    name="demo",
-    **{
-        "uri":       "http://localhost:8181/catalog",
-        "warehouse": "demo",
-        # Lakekeeper runs unauthenticated in this demo profile.
-        "auth":      {"type": "noop"},
-        # Storage credentials for the data files. Lakekeeper points at
-        # http://rustfs:9000 (in-cluster); on the host `rustfs` resolves
-        # to 127.0.0.1 via the README hosts entry.
-        "s3.endpoint":          "http://rustfs:9000",
-        "s3.access-key-id":     "rustfsadmin",
-        "s3.secret-access-key": "rustfsadmin",
-        "s3.region":            "us-east-1",
-    },
-)
+con = duckdb.connect()
 
-table = catalog.load_table("finance.payment_summary")
+# Pull the iceberg extension from core_nightly: AUTHORIZATION_TYPE 'none'
+# is required for unauthenticated REST catalogs and was added after the
+# stable extension cut.
+con.execute("FORCE INSTALL iceberg FROM core_nightly;")
+con.execute("LOAD iceberg;")
+con.execute("INSTALL httpfs; LOAD httpfs;")
 
-# scan().to_pandas() applies snapshot resolution and schema evolution.
-df = table.scan().to_pandas()
-
-# window_start / window_end are Int64 epoch ms; render as timestamps.
-for col in ("window_start", "window_end"):
-    df[col] = df[col].apply(
-        lambda ms: datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
-        .strftime("%Y-%m-%d %H:%M:%S")
+# Storage credentials for the Parquet/manifest fetches.
+con.execute("""
+    CREATE SECRET rustfs (
+        TYPE      S3,
+        KEY_ID    'rustfsadmin',
+        SECRET    'rustfsadmin',
+        ENDPOINT  'rustfs:9000',
+        URL_STYLE 'path',
+        USE_SSL   false
     )
-df["total_usd"] = df["total_usd"].round(2)
-df["avg_usd"]   = df["avg_usd"].round(2)
+""")
 
-df = df.sort_values(["window_start", "total_usd"], ascending=[False, False]).head(40)
+# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
+# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
+con.execute("""
+    ATTACH 'demo' AS catalog (
+        TYPE               ICEBERG,
+        ENDPOINT           'http://localhost:8181/catalog',
+        AUTHORIZATION_TYPE 'none'
+    )
+""")
 
 print("\n--- payment summary by region and method ---------------------")
+df = con.execute("""
+    SELECT
+        epoch_ms(window_start)::TIMESTAMP AS window_start,
+        epoch_ms(window_end)::TIMESTAMP   AS window_end,
+        region,
+        method,
+        payment_count,
+        ROUND(total_usd, 2) AS total_usd,
+        ROUND(avg_usd, 2)   AS avg_usd,
+        failed_count
+    FROM catalog.finance.payment_summary
+    ORDER BY window_start DESC, total_usd DESC
+    LIMIT 40
+""").fetchdf()
+
 print(df.to_string(index=False))
 print(f"\n{len(df)} rows")

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
+Reads payment_summary committed by laminardb to RustFS and prints a
+window-by-window rollup.
 
     pip install duckdb
     python query.py
@@ -8,47 +9,36 @@ Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
 closed and the sink has committed.
 
-Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
-DuckDB can fetch the manifest paths Lakekeeper bakes into table
-metadata. See README.
+We `parquet_scan` the data files directly. The Iceberg metadata in
+Lakekeeper bakes its in-cluster `http://rustfs:9000` endpoint into
+manifest paths, which the host can't resolve. The Parquet files
+themselves live in RustFS and read fine over the host-published
+`localhost:9000` endpoint.
+
+Path layout: <warehouse-uuid>/<table-uuid>/data/<file>.parquet.
 """
 
+import os
 import duckdb
 
 
+WAREHOUSE_GLOB = os.environ.get(
+    "PAYMENT_SUMMARY_GLOB",
+    "s3://warehouse/finance/*/*/data/*.parquet",
+)
+
 con = duckdb.connect()
-
-# Pull the iceberg extension from core_nightly: AUTHORIZATION_TYPE 'none'
-# is required for unauthenticated REST catalogs and was added after the
-# stable extension cut.
-con.execute("FORCE INSTALL iceberg FROM core_nightly;")
-con.execute("LOAD iceberg;")
 con.execute("INSTALL httpfs; LOAD httpfs;")
-
-# Storage credentials for the Parquet/manifest fetches.
 con.execute("""
-    CREATE SECRET rustfs (
-        TYPE      S3,
-        KEY_ID    'rustfsadmin',
-        SECRET    'rustfsadmin',
-        ENDPOINT  'rustfs:9000',
-        URL_STYLE 'path',
-        USE_SSL   false
-    )
-""")
-
-# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
-# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
-con.execute("""
-    ATTACH 'demo' AS catalog (
-        TYPE               ICEBERG,
-        ENDPOINT           'http://localhost:8181/catalog',
-        AUTHORIZATION_TYPE 'none'
-    )
+    SET s3_endpoint          = 'localhost:9000';
+    SET s3_access_key_id     = 'rustfsadmin';
+    SET s3_secret_access_key = 'rustfsadmin';
+    SET s3_use_ssl           = false;
+    SET s3_url_style         = 'path';
 """)
 
 print("\n--- payment summary by region and method ---------------------")
-df = con.execute("""
+df = con.execute(f"""
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
@@ -58,7 +48,7 @@ df = con.execute("""
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd,
         failed_count
-    FROM catalog.finance.payment_summary
+    FROM parquet_scan('{WAREHOUSE_GLOB}')
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 40
 """).fetchdf()

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary committed by laminardb to MinIO and prints a
+Reads payment_summary committed by laminardb to RustFS and prints a
 window-by-window rollup.
 
     pip install duckdb
@@ -11,9 +11,9 @@ closed and the sink has committed.
 
 We `parquet_scan` the data files directly instead of going through
 DuckDB's iceberg_scan(REST). Lakekeeper bakes its configured endpoint
-(`http://minio:9000`) into table metadata, and DuckDB's iceberg
-extension follows that endpoint as-is from the host where `minio`
-doesn't resolve. The Parquet files themselves live in MinIO and read
+(`http://rustfs:9000`) into table metadata, and DuckDB's iceberg
+extension follows that endpoint as-is from the host where `rustfs`
+doesn't resolve. The Parquet files themselves live in RustFS and read
 fine over the host-published `localhost:9000` endpoint.
 """
 
@@ -30,8 +30,8 @@ con = duckdb.connect()
 con.execute("INSTALL httpfs; LOAD httpfs;")
 con.execute("""
     SET s3_endpoint          = 'localhost:9000';
-    SET s3_access_key_id     = 'minioadmin';
-    SET s3_secret_access_key = 'minioadmin';
+    SET s3_access_key_id     = 'rustfsadmin';
+    SET s3_secret_access_key = 'rustfsadmin';
     SET s3_use_ssl           = false;
     SET s3_url_style         = 'path';
 """)

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary committed by laminardb to RustFS and prints a
-window-by-window rollup.
+Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
 
     pip install duckdb
     python query.py
@@ -9,35 +8,41 @@ window-by-window rollup.
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
 closed and the sink has committed.
 
-We `parquet_scan` the data files directly instead of going through
-DuckDB's iceberg_scan(REST). Lakekeeper bakes its configured endpoint
-(`http://rustfs:9000`) into table metadata, and DuckDB's iceberg
-extension follows that endpoint as-is from the host where `rustfs`
-doesn't resolve. The Parquet files themselves live in RustFS and read
-fine over the host-published `localhost:9000` endpoint.
+Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
+that DuckDB can fetch the Iceberg manifest paths Lakekeeper bakes into
+table metadata. See README.
 """
 
-import os
 import duckdb
 
 
-WAREHOUSE_GLOB = os.environ.get(
-    "PAYMENT_SUMMARY_GLOB",
-    "s3://warehouse/finance/*/*/data/*.parquet",
-)
-
 con = duckdb.connect()
-con.execute("INSTALL httpfs; LOAD httpfs;")
+
+con.execute("INSTALL httpfs;  LOAD httpfs;")
+con.execute("INSTALL iceberg; LOAD iceberg;")
+
+# Storage credentials for the Parquet/manifest fetches.
 con.execute("""
-    SET s3_endpoint          = 'localhost:9000';
-    SET s3_access_key_id     = 'rustfsadmin';
-    SET s3_secret_access_key = 'rustfsadmin';
-    SET s3_use_ssl           = false;
-    SET s3_url_style         = 'path';
+    CREATE SECRET rustfs (
+        TYPE      S3,
+        KEY_ID    'rustfsadmin',
+        SECRET    'rustfsadmin',
+        ENDPOINT  'rustfs:9000',
+        URL_STYLE 'path',
+        USE_SSL   false
+    )
+""")
+
+# Lakekeeper REST catalog.
+con.execute("""
+    ATTACH 'demo' AS catalog (
+        TYPE     ICEBERG,
+        ENDPOINT 'http://localhost:8181/catalog'
+    )
 """)
 
 print("\n--- payment summary by region and method ---------------------")
-df = con.execute(f"""
+df = con.execute("""
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
@@ -47,7 +52,7 @@ df = con.execute(f"""
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd,
         failed_count
-    FROM parquet_scan('{WAREHOUSE_GLOB}')
+    FROM catalog.finance.payment_summary
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 40
 """).fetchdf()

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -79,12 +79,12 @@ section("fraud-check latency by region")
 df = con.execute("""
     SELECT
         region,
-        COUNT(*)                                        AS scored,
-        CAST(quantile_cont(score_latency_ms, 0.50) AS BIGINT) AS p50_ms,
-        CAST(quantile_cont(score_latency_ms, 0.95) AS BIGINT) AS p95_ms,
-        CAST(quantile_cont(score_latency_ms, 0.99) AS BIGINT) AS p99_ms,
-        SUM(CASE WHEN outcome = 'blocked' THEN 1 ELSE 0 END)  AS blocked,
-        SUM(CASE WHEN outcome = 'review'  THEN 1 ELSE 0 END)  AS review
+        COUNT(*)                                                       AS scored,
+        CAST(quantile_cont(score_latency_ms, 0.50) AS BIGINT)          AS p50_ms,
+        CAST(quantile_cont(score_latency_ms, 0.95) AS BIGINT)          AS p95_ms,
+        CAST(quantile_cont(score_latency_ms, 0.99) AS BIGINT)          AS p99_ms,
+        CAST(SUM(CASE WHEN outcome = 'blocked' THEN 1 ELSE 0 END) AS BIGINT) AS blocked,
+        CAST(SUM(CASE WHEN outcome = 'review'  THEN 1 ELSE 0 END) AS BIGINT) AS review
     FROM catalog.finance.payments_with_fraud_score
     GROUP BY region
     ORDER BY region

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Reads payment_summary committed by laminardb to RustFS and prints a
-window-by-window rollup.
+Reads payment_summary from Lakekeeper via DuckDB's iceberg extension.
 
     pip install duckdb
     python query.py
@@ -9,36 +8,45 @@ window-by-window rollup.
 Run after ~90 seconds of `gen.py` so at least one tumbling minute has
 closed and the sink has committed.
 
-We `parquet_scan` the data files directly. The Iceberg metadata in
-Lakekeeper bakes its in-cluster `http://rustfs:9000` endpoint into
-manifest paths, which the host can't resolve. The Parquet files
-themselves live in RustFS and read fine over the host-published
-`localhost:9000` endpoint.
-
-Path layout: <warehouse-uuid>/<table-uuid>/data/<file>.parquet.
+Prerequisite: `rustfs` must resolve to `127.0.0.1` from the host so
+DuckDB can fetch the manifest paths Lakekeeper bakes into table
+metadata. See README.
 """
 
-import os
 import duckdb
 
 
-WAREHOUSE_GLOB = os.environ.get(
-    "PAYMENT_SUMMARY_GLOB",
-    "s3://warehouse/finance/*/*/data/*.parquet",
-)
-
 con = duckdb.connect()
+
+# core_nightly: stable iceberg ext doesn't yet support AUTHORIZATION_TYPE 'none'.
+con.execute("FORCE INSTALL iceberg FROM core_nightly;")
+con.execute("LOAD iceberg;")
 con.execute("INSTALL httpfs; LOAD httpfs;")
+
+# Storage credentials for the Parquet/manifest fetches.
 con.execute("""
-    SET s3_endpoint          = 'localhost:9000';
-    SET s3_access_key_id     = 'rustfsadmin';
-    SET s3_secret_access_key = 'rustfsadmin';
-    SET s3_use_ssl           = false;
-    SET s3_url_style         = 'path';
+    CREATE SECRET rustfs (
+        TYPE      S3,
+        KEY_ID    'rustfsadmin',
+        SECRET    'rustfsadmin',
+        ENDPOINT  'rustfs:9000',
+        URL_STYLE 'path',
+        USE_SSL   false
+    )
+""")
+
+# Lakekeeper REST catalog. Lakekeeper runs unauthenticated in this demo;
+# DuckDB defaults to oauth2 on the ATTACH so flip it to 'none'.
+con.execute("""
+    ATTACH 'demo' AS catalog (
+        TYPE               ICEBERG,
+        ENDPOINT           'http://localhost:8181/catalog',
+        AUTHORIZATION_TYPE 'none'
+    )
 """)
 
 print("\n--- payment summary by region and method ---------------------")
-df = con.execute(f"""
+df = con.execute("""
     SELECT
         epoch_ms(window_start)::TIMESTAMP AS window_start,
         epoch_ms(window_end)::TIMESTAMP   AS window_end,
@@ -48,7 +56,7 @@ df = con.execute(f"""
         ROUND(total_usd, 2) AS total_usd,
         ROUND(avg_usd, 2)   AS avg_usd,
         failed_count
-    FROM parquet_scan('{WAREHOUSE_GLOB}')
+    FROM catalog.finance.payment_summary
     ORDER BY window_start DESC, total_usd DESC
     LIMIT 40
 """).fetchdf()

--- a/examples/nats-payments/query.py
+++ b/examples/nats-payments/query.py
@@ -33,6 +33,15 @@ con.execute("""
     )
 """)
 
+# Catalog auth: Lakekeeper runs unauthenticated in this demo, but
+# DuckDB defaults to oauth2 — flip it to `none`.
+con.execute("""
+    CREATE SECRET catalog_auth (
+        TYPE               ICEBERG,
+        AUTHORIZATION_TYPE 'none'
+    )
+""")
+
 # Lakekeeper REST catalog.
 con.execute("""
     ATTACH 'demo' AS catalog (


### PR DESCRIPTION
## Summary

Closes the `auto.create=true` gap on the Iceberg sink and ships a self-contained NATS → Iceberg demo that exercises the full path.

The Iceberg sink was gated on `config.arrow_schema()` returning Some, but `pipeline_lifecycle` only plumbed `_arrow_schema` into source configs — never sinks. Result: `load_table` ran unconditionally at sink-open and failed against a fresh REST catalog with `Tried to load a table that does not exist`.

## Changes

### Framework
- **`pipeline_lifecycle::resolve_stream_output_schemas`** — plans each `CREATE STREAM` with DataFusion at start time, mirrors the runtime `window_start, window_end` prefix for windowed streams, stashes the resolved Arrow schema on every downstream sink config via `_arrow_schema`. Iterative planning loop handles stream-on-stream dependencies (an `EmptyTable` placeholder makes each resolved stream visible to later passes); stalls surface the planner's actual error.
- **`WindowOperatorConfig::output_prefix_fields()`** is now the single source of truth for `[window_start: Int64, window_end: Int64]`. `core_window_state.rs`, `eowc_state.rs`, and the resolver all consume it instead of hand-rolling the same two-field literal.
- **NATS source `open()`** now reads `config.arrow_schema()` like the Kafka source does, instead of holding the registry's placeholder `Schema::empty()`.
- **Iceberg sink**:
  - Replaced hand-rolled `PARQUET:field_id` stamping with `iceberg::arrow::arrow_schema_to_schema_auto_assign_ids` (upstream primitive in iceberg-rust 0.9).
  - New `storage_factory(warehouse, storage_type)` selects the OpenDAL backend for the URLs the catalog will return: explicit `storage.type` (`s3 | s3a | fs`) wins, otherwise inferred from `s3://` / `s3a://` / `file://` warehouse URLs. REST catalogs use a logical warehouse name and now require the explicit setting — no more silent default to `Fs`. New error codes LDB-5100 / LDB-5101.
- **`laminar-server`** exposes the `nats` feature and includes it in `default`.

### Demo (`examples/nats-payments/`)
- `nats-server` publishes JSON payment events
- `laminardb` reads the NATS subject, tumbles into 1-minute windows by region+method, writes to Iceberg via Lakekeeper REST
- MinIO holds the Iceberg warehouse; Postgres backs Lakekeeper
- DuckDB reads the resulting Parquet files (Lakekeeper bakes its in-cluster `http://minio:9000` endpoint into Iceberg metadata which the host can't resolve, so `query.py` uses `parquet_scan` directly — documented inline)

## Tests

- 4 new resolver tests: windowed prefix, non-windowed, chained-via-iteration, unresolvable cycle reports planner error.
- 7 storage_factory tests: inference for s3/s3a/file URLs, explicit override wins, bare path requires explicit setting, both error codes.
- All 26 existing `core_window_state` tests still pass after the prefix lift.

## Test plan

- [x] `cargo test -p laminar-db --no-default-features --features iceberg --lib resolver_tests::` — 4 pass
- [x] `cargo test -p laminar-connectors --no-default-features --features iceberg --lib storage_factory` — 7 pass
- [x] `cargo test -p laminar-db --no-default-features --features iceberg --lib core_window` — 26 pass
- [x] `cargo clippy -p laminar-db -p laminar-connectors -p laminar-sql --no-default-features --features laminar-db/iceberg --tests` — clean
- [x] End-to-end demo run: 3 tumbling-minute windows → 48 rows (3 × 16 region/method combos) committed to Iceberg, queried via DuckDB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NATS sources can use SQL DDL-provided schemas at runtime.
  * Iceberg connector supports optional storage.type with smarter inference and clearer warehouse semantics.
  * Startup automatic schema resolution for streams to derive sink input schemas.
  * Windowed outputs now use translator-provided window-prefix fields for consistent window_start/window_end.

* **Bug Fixes**
  * Improved errors for missing/invalid Iceberg storage config and deterministic field ID assignment for Iceberg tables.

* **Documentation**
  * Added end-to-end NATS→Iceberg payments demo, configs, scripts, and Docker setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->