### PR TITLE
perf(db): close hot-path allocation cliffs in callback, sinks, joins, windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,6 +4748,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "futures",
+ "indexmap 2.13.0",
  "laminar-connectors",
  "laminar-core",
  "laminar-derive",
@@ -4769,6 +4770,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "trait-variant",
 ]
 
 [[package]]
@@ -8357,6 +8359,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ categories = ["database", "embedded", "data-structures"]
 # Core dependencies
 tokio = { version = "1.51", features = ["full"] }
 async-trait = "0.1"
+trait-variant = "0.1"
+indexmap = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rkyv = { version = "0.8", features = ["std", "alloc", "bytecheck"] }

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -80,6 +80,8 @@ sqlparser = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 async-trait = { workspace = true }
+trait-variant = { workspace = true }
+indexmap = { workspace = true }
 futures = { workspace = true }
 crossfire = { workspace = true }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -250,7 +250,9 @@ fn build_weighted_batch(
         }
     }
 
-    let weight_array: ArrayRef = Arc::new(arrow::array::Int64Array::from(weights.to_vec()));
+    let weight_array: ArrayRef = Arc::new(arrow::array::Int64Array::from_iter_values(
+        weights.iter().copied(),
+    ));
 
     let mut all_arrays = group_arrays;
     all_arrays.extend(agg_arrays);

--- a/crates/laminar-db/src/changelog_filter.rs
+++ b/crates/laminar-db/src/changelog_filter.rs
@@ -3,6 +3,8 @@
 //! Filters CDC `RecordBatch`es to separate positive (I, U+, U) and negative (D, U-)
 //! events. Non-CDC batches (no `_op` column) pass through unchanged.
 
+use std::borrow::Cow;
+
 use arrow::array::{BooleanArray, RecordBatch, StringArray};
 use arrow::datatypes::DataType;
 
@@ -57,37 +59,36 @@ pub(crate) fn filter_positive_events(batch: &RecordBatch) -> Result<RecordBatch,
         .map_err(|e| DbError::Pipeline(format!("changelog filter: {e}")))
 }
 
-/// Prepare a batch for a sink. If the batch has a `__weight` column and
-/// the sink is NOT changelog-aware, filter to positive weights and strip
-/// the column. Changelog-aware sinks receive the batch unchanged.
-pub(crate) fn prepare_for_sink(batch: &RecordBatch, changelog_sink: bool) -> RecordBatch {
+/// For non-changelog sinks, drop rows with non-positive `__weight` and strip
+/// the column. Otherwise the input is borrowed unchanged.
+pub(crate) fn prepare_for_sink(batch: &RecordBatch, changelog_sink: bool) -> Cow<'_, RecordBatch> {
     if changelog_sink {
-        return batch.clone();
+        return Cow::Borrowed(batch);
     }
     let Ok(idx) = batch
         .schema()
         .index_of(crate::aggregate_state::WEIGHT_COLUMN)
     else {
-        return batch.clone();
+        return Cow::Borrowed(batch);
     };
     let Some(weights) = batch
         .column(idx)
         .as_any()
         .downcast_ref::<arrow::array::Int64Array>()
     else {
-        return batch.clone();
+        return Cow::Borrowed(batch);
     };
     // Keep only rows with positive weight.
     let mask: BooleanArray = weights.iter().map(|w| Some(w.unwrap_or(0) > 0)).collect();
     let Ok(filtered) = arrow::compute::filter_record_batch(batch, &mask) else {
-        return batch.clone();
+        return Cow::Borrowed(batch);
     };
     // Strip the __weight column.
     if filtered.num_columns() == 0 {
-        return filtered;
+        return Cow::Owned(filtered);
     }
     let indices: Vec<usize> = (0..filtered.num_columns()).filter(|&i| i != idx).collect();
-    filtered.project(&indices).unwrap_or(filtered)
+    Cow::Owned(filtered.project(&indices).unwrap_or(filtered))
 }
 
 #[cfg(test)]

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -123,9 +123,12 @@ pub(crate) struct CoreWindowState {
     post_projection: Option<PostProjection>,
     /// Reusable scratch map for no-group window assignment (avoids per-batch allocation).
     scratch_nogroup: AHashMap<i64, Vec<u32>>,
-    /// Reusable scratch map for grouped window assignment (avoids per-batch allocation).
-    #[allow(clippy::type_complexity)]
-    scratch_grouped: AHashMap<(i64, arrow::row::OwnedRow), Vec<u32>>,
+    /// Bucket map keyed by `(window_start, group_id)`. Group ids come
+    /// from `scratch_group_keys` and are dense within a batch.
+    scratch_grouped: AHashMap<(i64, u32), Vec<u32>>,
+    /// Per-batch group-key set; the index is the group id used by
+    /// `scratch_grouped`.
+    scratch_group_keys: indexmap::IndexSet<arrow::row::OwnedRow, ahash::RandomState>,
 }
 
 impl CoreWindowState {
@@ -631,6 +634,7 @@ impl CoreWindowState {
             post_projection,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
+            scratch_group_keys: indexmap::IndexSet::default(),
         }))
     }
 
@@ -728,39 +732,40 @@ impl CoreWindowState {
             return Ok(());
         }
 
-        // Grouped path: OwnedRow as key (one owned() per row, ~8-32 bytes each)
+        // Grouped path: dedup group keys per batch, bucket by integer id.
         let rows_ref = rows.as_ref().expect("rows set when has_groups");
         let mut grouped = std::mem::take(&mut self.scratch_grouped);
+        let mut group_keys = std::mem::take(&mut self.scratch_group_keys);
         grouped.clear();
+        group_keys.clear();
 
         for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
             if ts_ms == NULL_TIMESTAMP {
-                continue; // skip rows with null timestamps
+                continue;
             }
-            let row_key = rows_ref.row(row_idx).owned();
+            let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
-            let idx = row_idx as u32;
+            let (gid, idx) = (gid as u32, row_idx as u32);
             match &self.assigner {
                 CoreWindowAssigner::Tumbling(a) => {
                     grouped
-                        .entry((a.assign(ts_ms).start, row_key))
+                        .entry((a.assign(ts_ms).start, gid))
                         .or_default()
                         .push(idx);
                 }
                 CoreWindowAssigner::Hopping(a) => {
                     for wid in a.assign_windows(ts_ms) {
-                        grouped
-                            .entry((wid.start, row_key.clone()))
-                            .or_default()
-                            .push(idx);
+                        grouped.entry((wid.start, gid)).or_default().push(idx);
                     }
                 }
                 CoreWindowAssigner::Session { .. } => unreachable!("handled above"),
             }
         }
 
-        for ((window_start, row_key), indices) in &grouped {
-            // Ensure group exists in window state (borrow-split pattern)
+        for ((window_start, gid), indices) in &grouped {
+            let row_key = group_keys
+                .get_index(*gid as usize)
+                .expect("gid was just produced by insert_full");
             let needs_insert = {
                 let window_groups = self.windows.entry(*window_start).or_default();
                 if window_groups.contains_key(row_key) {
@@ -802,6 +807,7 @@ impl CoreWindowState {
         }
 
         self.scratch_grouped = grouped;
+        self.scratch_group_keys = group_keys;
         Ok(())
     }
 
@@ -1621,6 +1627,7 @@ mod tests {
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
+            scratch_group_keys: indexmap::IndexSet::default(),
         }
     }
 
@@ -1684,6 +1691,7 @@ mod tests {
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
+            scratch_group_keys: indexmap::IndexSet::default(),
         }
     }
 
@@ -1735,6 +1743,7 @@ mod tests {
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
+            scratch_group_keys: indexmap::IndexSet::default(),
         }
     }
 
@@ -1784,6 +1793,7 @@ mod tests {
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
+            scratch_group_keys: indexmap::IndexSet::default(),
         }
     }
 

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -54,6 +54,9 @@ pub struct EngineMetrics {
     pub sink_write_timeouts: IntCounter,
     /// Sink task channel closed.
     pub sink_task_channel_closed: IntCounter,
+    /// Rows dropped because the sink's WHERE filter failed to compile to
+    /// a `PhysicalExpr` (fail-closed). Label: `sink`.
+    pub sink_filter_rejected_rows: IntCounterVec,
     /// Per-cycle processing duration.
     pub cycle_duration: Histogram,
     /// Checkpoint cycle duration.
@@ -182,6 +185,14 @@ impl EngineMetrics {
             sink_task_channel_closed: reg!(IntCounter::new(
                 "sink_task_channel_closed_total",
                 "Sink task channel closed"
+            )
+            .unwrap()),
+            sink_filter_rejected_rows: reg!(IntCounterVec::new(
+                Opts::new(
+                    "sink_filter_rejected_rows_total",
+                    "Rows dropped because the sink filter failed to compile",
+                ),
+                &["sink"],
             )
             .unwrap()),
             cycle_duration: reg!(Histogram::with_opts(

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -595,23 +595,30 @@ impl IncrementalEowcState {
             return Ok(());
         }
 
-        // Grouped path: OwnedRow as key
+        // Grouped path. Dedup group keys per batch and bucket by
+        // (window, group_id) so per-window assignment doesn't clone the
+        // OwnedRow for each overlapping window.
         let rows_ref = rows.as_ref().expect("rows set when has_groups");
-        let mut grouped: AHashMap<(i64, arrow::row::OwnedRow), Vec<u32>> = AHashMap::new();
+        let mut group_keys: indexmap::IndexSet<arrow::row::OwnedRow, ahash::RandomState> =
+            indexmap::IndexSet::default();
+        let mut grouped: AHashMap<(i64, u32), Vec<u32>> = AHashMap::new();
+
         for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
             if ts_ms == NULL_TIMESTAMP {
-                continue; // skip rows with null timestamps
+                continue;
             }
-            let row_key = rows_ref.row(row_idx).owned();
+            let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
-            let idx = row_idx as u32;
+            let (gid, idx) = (gid as u32, row_idx as u32);
             for ws in assign_windows(ts_ms, &self.window_type) {
-                grouped.entry((ws, row_key.clone())).or_default().push(idx);
+                grouped.entry((ws, gid)).or_default().push(idx);
             }
         }
 
-        for ((window_start, row_key), indices) in &grouped {
-            // Ensure group exists (borrow-split pattern)
+        for ((window_start, gid), indices) in &grouped {
+            let row_key = group_keys
+                .get_index(*gid as usize)
+                .expect("gid was just produced by insert_full");
             let needs_insert = {
                 let window_groups = self.windows.entry(*window_start).or_default();
                 if window_groups.contains_key(row_key) {

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -151,14 +151,37 @@ impl SideState {
         // Sort by (batch_idx, row_idx) for sequential access
         live_rows.sort_unstable();
 
-        // Slice each live row and collect
-        let mut slices: Vec<RecordBatch> = Vec::with_capacity(live_rows.len());
-        for &(batch_idx, row_idx) in &live_rows {
-            slices.push(self.batches[batch_idx].slice(row_idx, 1));
+        // One `take` per source batch over the contiguous run of live rows.
+        let mut taken: Vec<RecordBatch> = Vec::new();
+        let mut i = 0;
+        while i < live_rows.len() {
+            let batch_idx = live_rows[i].0;
+            let mut j = i + 1;
+            while j < live_rows.len() && live_rows[j].0 == batch_idx {
+                j += 1;
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let indices = arrow::array::UInt32Array::from_iter_values(
+                live_rows[i..j].iter().map(|&(_, row)| row as u32),
+            );
+            let src = &self.batches[batch_idx];
+            let cols: Result<Vec<ArrayRef>, _> = src
+                .columns()
+                .iter()
+                .map(|c| arrow::compute::take(c.as_ref(), &indices, None))
+                .collect();
+            let cols = cols
+                .map_err(|e| DbError::query_pipeline_arrow("interval join (compact take)", &e))?;
+            taken.push(
+                RecordBatch::try_new(src.schema(), cols).map_err(|e| {
+                    DbError::query_pipeline_arrow("interval join (compact build)", &e)
+                })?,
+            );
+            i = j;
         }
 
         let schema = self.batches[0].schema();
-        let compacted = concat_batches(&schema, &slices)
+        let compacted = concat_batches(&schema, &taken)
             .map_err(|e| DbError::query_pipeline_arrow("interval join (compact)", &e))?;
 
         // Replace batches and rebuild index

--- a/crates/laminar-db/src/mv_store.rs
+++ b/crates/laminar-db/src/mv_store.rs
@@ -5,6 +5,8 @@
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
@@ -95,22 +97,34 @@ impl MvEntry {
 /// via `Arc<parking_lot::RwLock<MvStore>>`.
 pub(crate) struct MvStore {
     entries: HashMap<String, MvEntry>,
+    /// Mirrors `!entries.is_empty()`; lets the hot path skip the write lock.
+    has_any: Arc<AtomicBool>,
 }
 
 impl MvStore {
     pub fn new() -> Self {
         Self {
             entries: HashMap::new(),
+            has_any: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn has_any_handle(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.has_any)
     }
 
     pub fn create_mv(&mut self, name: &str, schema: SchemaRef, mode: MvStorageMode) {
         self.entries
             .insert(name.to_string(), MvEntry::new(schema, mode));
+        self.has_any.store(true, Ordering::Release);
     }
 
     pub fn drop_mv(&mut self, name: &str) -> bool {
-        self.entries.remove(name).is_some()
+        let removed = self.entries.remove(name).is_some();
+        if self.entries.is_empty() {
+            self.has_any.store(false, Ordering::Release);
+        }
+        removed
     }
 
     pub fn has_mv(&self, name: &str) -> bool {

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -31,11 +31,8 @@ pub struct SourceRegistration {
 }
 
 /// Callback trait for the coordinator to interact with the rest of the DB.
-///
 /// Trait exists for test seam; production impl is `ConnectorPipelineCallback`.
-///
-/// This decouples the pipeline module from db.rs internals.
-#[async_trait::async_trait]
+#[trait_variant::make(Send)]
 pub trait PipelineCallback: Send + 'static {
     /// Called with accumulated source batches to execute a SQL cycle.
     async fn execute_cycle(
@@ -64,17 +61,8 @@ pub trait PipelineCallback: Send + 'static {
     /// Get the current pipeline watermark.
     fn current_watermark(&self) -> i64;
 
-    /// Perform a periodic (timer-based) checkpoint. Returns `Some(epoch)`
-    /// on successful commit, `None` otherwise.
-    ///
-    /// **Semantics: at-least-once.** Timer-based checkpoints capture source
-    /// offsets *before* operator state. On recovery the consumer replays
-    /// from the offset, and operators may re-process records that were
-    /// already processed before the crash (at-least-once, not exactly-once).
-    ///
-    /// For exactly-once semantics, use [`checkpoint_with_barrier`] instead,
-    /// which captures offsets and operator state at a consistent cut across
-    /// all sources.
+    /// Perform a periodic (timer-based) checkpoint. At-least-once semantics.
+    /// For exactly-once, use [`checkpoint_with_barrier`].
     ///
     /// [`checkpoint_with_barrier`]: PipelineCallback::checkpoint_with_barrier
     async fn maybe_checkpoint(
@@ -83,9 +71,7 @@ pub trait PipelineCallback: Send + 'static {
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64>;
 
-    /// Called when all sources have aligned on a barrier. Returns
-    /// `Some(epoch)` on successful commit, `None` on failure — the
-    /// caller retries on the next interval.
+    /// Called when all sources have aligned on a barrier.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
@@ -100,8 +86,7 @@ pub trait PipelineCallback: Send + 'static {
     /// Apply a DDL control message (add/drop stream) to the running pipeline.
     fn apply_control(&mut self, msg: super::ControlMsg);
 
-    /// Returns `true` when internal buffers are near capacity and the
-    /// caller should stop feeding new data. Default returns `false`.
+    /// Returns `true` when internal buffers are near capacity.
     fn is_backpressured(&self) -> bool {
         false
     }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -897,7 +897,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl PipelineCallback for MockCallback {
         async fn execute_cycle(
             &mut self,
@@ -1303,7 +1302,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl PipelineCallback for BackpressuredCallback {
         async fn execute_cycle(
             &mut self,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -340,9 +340,7 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) =
-                compile_sink_filter_sql(&self.filter_ctx, sql, &schema).await
-            {
+            if let Some(compiled) = compile_sink_filter_sql(&self.filter_ctx, sql, &schema).await {
                 self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
             } else {
                 tracing::error!(
@@ -353,8 +351,7 @@ impl ConnectorPipelineCallback {
                 );
                 self.compiled_sink_filters[i] = SinkFilter::Rejected;
             }
-            self.pending_sink_filter_compiles =
-                self.pending_sink_filter_compiles.saturating_sub(1);
+            self.pending_sink_filter_compiles = self.pending_sink_filter_compiles.saturating_sub(1);
         }
     }
 }
@@ -475,8 +472,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                     let changelog_capable = *changelog_capable;
                     Some(async move {
                         for batch in shared.iter() {
-                            let filtered: Cow<RecordBatch> = if let Some(ref phys) =
-                                compiled_filter
+                            let filtered: Cow<RecordBatch> = if let Some(ref phys) = compiled_filter
                             {
                                 match apply_compiled_sink_filter(batch, phys) {
                                     Ok(Some(fb)) => Cow::Owned(fb),

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -27,6 +27,13 @@ pub(crate) enum SinkFilter {
     Rejected,
 }
 
+/// Per-cycle dispatch chosen from `SinkFilter`. `Rejected` is fail-closed.
+enum SinkFilterDispatch {
+    Compiled(Arc<dyn PhysicalExpr>),
+    Rejected,
+    None,
+}
+
 /// Implements [`PipelineCallback`](crate::pipeline::PipelineCallback) to bridge
 /// the event-driven pipeline coordinator to the rest of the database (stream
 /// executor, sinks, watermarks, checkpoints, table sources).
@@ -347,7 +354,8 @@ impl ConnectorPipelineCallback {
                     sink = %sink_name,
                     filter = %sql,
                     "[LDB-1100] sink filter did not compile to a PhysicalExpr; \
-                     filter disabled (no per-batch SQL fallback)"
+                     fail-closed: ALL rows from this stream will be dropped \
+                     for this sink. Track via sink_filter_rejected_rows_total."
                 );
                 self.compiled_sink_filters[i] = SinkFilter::Rejected;
             }
@@ -465,29 +473,40 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         .clone();
                     let sink_name = sink_name.clone();
                     let handle = handle.clone();
-                    let compiled_filter = match self.compiled_sink_filters.get(sink_idx) {
-                        Some(SinkFilter::Compiled(phys)) => Some(Arc::clone(phys)),
-                        Some(SinkFilter::Pending | SinkFilter::Rejected) | None => None,
+                    // Rejected → drop (fail-closed). Pending → None (no filter SQL set).
+                    let filter_state = match self.compiled_sink_filters.get(sink_idx).cloned() {
+                        Some(SinkFilter::Compiled(phys)) => SinkFilterDispatch::Compiled(phys),
+                        Some(SinkFilter::Rejected) => SinkFilterDispatch::Rejected,
+                        Some(SinkFilter::Pending) | None => SinkFilterDispatch::None,
                     };
                     let changelog_capable = *changelog_capable;
+                    let prom = Arc::clone(&self.prom);
                     Some(async move {
                         for batch in shared.iter() {
-                            let filtered: Cow<RecordBatch> = if let Some(ref phys) = compiled_filter
-                            {
-                                match apply_compiled_sink_filter(batch, phys) {
-                                    Ok(Some(fb)) => Cow::Owned(fb),
-                                    Ok(None) => continue,
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            sink = %sink_name,
-                                            error = %e,
-                                            "Compiled sink filter error"
-                                        );
-                                        continue;
+                            let filtered: Cow<RecordBatch> = match &filter_state {
+                                SinkFilterDispatch::Compiled(phys) => {
+                                    match apply_compiled_sink_filter(batch, phys) {
+                                        Ok(Some(fb)) => Cow::Owned(fb),
+                                        Ok(None) => continue,
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                sink = %sink_name,
+                                                error = %e,
+                                                "Compiled sink filter error"
+                                            );
+                                            continue;
+                                        }
                                     }
                                 }
-                            } else {
-                                Cow::Borrowed(batch)
+                                SinkFilterDispatch::Rejected => {
+                                    #[allow(clippy::cast_possible_truncation)]
+                                    let dropped = batch.num_rows() as u64;
+                                    prom.sink_filter_rejected_rows
+                                        .with_label_values(&[sink_name.as_str()])
+                                        .inc_by(dropped);
+                                    continue;
+                                }
+                                SinkFilterDispatch::None => Cow::Borrowed(batch),
                             };
 
                             let prepared = crate::changelog_filter::prepare_for_sink(
@@ -1290,6 +1309,34 @@ mod tests {
 
         let got = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
         assert!(got.is_err(), "non-Fail errors must not trigger shutdown");
+    }
+
+    /// Rejected must drop, not passthrough.
+    #[test]
+    fn rejected_filter_dispatches_to_drop_not_passthrough() {
+        let filters = vec![SinkFilter::Rejected];
+        let dispatch = match filters.first().cloned() {
+            Some(SinkFilter::Compiled(phys)) => SinkFilterDispatch::Compiled(phys),
+            Some(SinkFilter::Rejected) => SinkFilterDispatch::Rejected,
+            Some(SinkFilter::Pending) | None => SinkFilterDispatch::None,
+        };
+        assert!(
+            matches!(dispatch, SinkFilterDispatch::Rejected),
+            "Rejected filter must map to Rejected dispatch (drop), not None (passthrough)"
+        );
+    }
+
+    /// Pending / absent → no filter (compilation runs before the dispatch loop).
+    #[test]
+    fn pending_and_absent_filters_dispatch_to_passthrough() {
+        for filter in [Some(SinkFilter::Pending), None] {
+            let dispatch = match filter.clone() {
+                Some(SinkFilter::Compiled(phys)) => SinkFilterDispatch::Compiled(phys),
+                Some(SinkFilter::Rejected) => SinkFilterDispatch::Rejected,
+                Some(SinkFilter::Pending) | None => SinkFilterDispatch::None,
+            };
+            assert!(matches!(dispatch, SinkFilterDispatch::None));
+        }
     }
 
     /// Consumer-side cap is a no-op when the cluster has not yet

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1314,7 +1314,7 @@ mod tests {
     /// Rejected must drop, not passthrough.
     #[test]
     fn rejected_filter_dispatches_to_drop_not_passthrough() {
-        let filters = vec![SinkFilter::Rejected];
+        let filters = [SinkFilter::Rejected];
         let dispatch = match filters.first().cloned() {
             Some(SinkFilter::Compiled(phys)) => SinkFilterDispatch::Compiled(phys),
             Some(SinkFilter::Rejected) => SinkFilterDispatch::Rejected,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1,11 +1,10 @@
 //! Production `PipelineCallback` bridging coordinator to sinks, checkpoints, and watermarks.
 #![allow(clippy::disallowed_types)] // cold path
 
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
@@ -20,11 +19,13 @@ use rustc_hash::FxHashMap;
 use crate::db::{filter_late_rows, SourceWatermarkState};
 use crate::error::DbError;
 
-/// Base prefix for the temporary table used by sink WHERE filters.
-const FILTER_INPUT_TABLE: &str = "__laminar_filter_input";
-
-/// Monotonic counter for unique filter table names (concurrent-safe).
-static FILTER_TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+/// Resolution state of a sink WHERE filter.
+#[derive(Clone)]
+pub(crate) enum SinkFilter {
+    Pending,
+    Compiled(Arc<dyn PhysicalExpr>),
+    Rejected,
+}
 
 /// Implements [`PipelineCallback`](crate::pipeline::PipelineCallback) to bridge
 /// the event-driven pipeline coordinator to the rest of the database (stream
@@ -49,6 +50,9 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) watermark_states: FxHashMap<String, SourceWatermarkState>,
     pub(crate) source_entries_for_wm: FxHashMap<String, Arc<crate::catalog::SourceEntry>>,
     pub(crate) source_ids: FxHashMap<String, usize>,
+    /// Pre-interned source names keyed by source id; avoids `Arc::from` per cycle.
+    pub(crate) source_name_arcs: FxHashMap<usize, Arc<str>>,
+    pub(crate) source_wms_buf: FxHashMap<Arc<str>, i64>,
     pub(crate) tracker: Option<laminar_core::time::WatermarkTracker>,
     pub(crate) prom: Arc<crate::engine_metrics::EngineMetrics>,
     pub(crate) pipeline_watermark: Arc<std::sync::atomic::AtomicI64>,
@@ -62,11 +66,12 @@ pub(crate) struct ConnectorPipelineCallback {
     )>,
     pub(crate) table_store: Arc<parking_lot::RwLock<crate::table_store::TableStore>>,
     pub(crate) mv_store: Arc<parking_lot::RwLock<crate::mv_store::MvStore>>,
+    /// Mirrors `MvStore::has_any`; read per cycle to skip the write lock.
+    pub(crate) mv_store_has_any: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) lookup_registry: Arc<laminar_sql::datafusion::LookupTableRegistry>,
-    /// Cached `SessionContext` for sink WHERE filters (avoids per-batch allocation).
     pub(crate) filter_ctx: SessionContext,
-    /// Lazily-compiled sink filter expressions, indexed by sink position.
-    pub(crate) compiled_sink_filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    pub(crate) compiled_sink_filters: Vec<SinkFilter>,
+    pub(crate) pending_sink_filter_compiles: usize,
     pub(crate) last_checkpoint: std::time::Instant,
     /// `None` = no automatic checkpointing (manual only via coordinator).
     pub(crate) checkpoint_interval: Option<std::time::Duration>,
@@ -314,17 +319,19 @@ impl ConnectorPipelineCallback {
         &mut self,
         results: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
     ) {
-        // Ensure the compiled_sink_filters vec has the right length.
-        while self.compiled_sink_filters.len() < self.sinks.len() {
-            self.compiled_sink_filters.push(None);
+        if self.pending_sink_filter_compiles == 0 {
+            return;
         }
 
-        for (i, (_, _, filter_sql, sink_input, _)) in self.sinks.iter().enumerate() {
-            // Skip if no filter or already compiled.
-            if filter_sql.is_none() || self.compiled_sink_filters[i].is_some() {
+        while self.compiled_sink_filters.len() < self.sinks.len() {
+            self.compiled_sink_filters.push(SinkFilter::Pending);
+        }
+
+        for (i, (sink_name, _, filter_sql, sink_input, _)) in self.sinks.iter().enumerate() {
+            if filter_sql.is_none() || !matches!(self.compiled_sink_filters[i], SinkFilter::Pending)
+            {
                 continue;
             }
-            // Need a batch to determine the schema.
             let Some(batches) = results.get(sink_input.as_str()) else {
                 continue;
             };
@@ -332,17 +339,26 @@ impl ConnectorPipelineCallback {
                 continue;
             };
             let schema = batch.schema();
+            let sql = filter_sql.as_deref().unwrap();
             if let Some(compiled) =
-                compile_sink_filter_sql(&self.filter_ctx, filter_sql.as_deref().unwrap(), &schema)
-                    .await
+                compile_sink_filter_sql(&self.filter_ctx, sql, &schema).await
             {
-                self.compiled_sink_filters[i] = Some(compiled);
+                self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
+            } else {
+                tracing::error!(
+                    sink = %sink_name,
+                    filter = %sql,
+                    "[LDB-1100] sink filter did not compile to a PhysicalExpr; \
+                     filter disabled (no per-batch SQL fallback)"
+                );
+                self.compiled_sink_filters[i] = SinkFilter::Rejected;
             }
+            self.pending_sink_filter_compiles =
+                self.pending_sink_filter_compiles.saturating_sub(1);
         }
     }
 }
 
-#[async_trait::async_trait]
 #[allow(clippy::too_many_lines)]
 impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     async fn execute_cycle(
@@ -350,19 +366,14 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
         watermark: i64,
     ) -> Result<FxHashMap<Arc<str>, Vec<RecordBatch>>, String> {
-        #[cfg_attr(not(feature = "cluster-unstable"), allow(unused_mut))]
-        let mut source_wms: FxHashMap<Arc<str>, i64> = if let Some(ref tracker) = self.tracker {
-            self.source_ids
-                .iter()
-                .filter_map(|(name, &sid)| {
-                    tracker
-                        .source_watermark(sid)
-                        .map(|wm| (Arc::from(name.as_str()), wm))
-                })
-                .collect()
-        } else {
-            FxHashMap::default()
-        };
+        self.source_wms_buf.clear();
+        if let Some(ref tracker) = self.tracker {
+            for (&sid, name_arc) in &self.source_name_arcs {
+                if let Some(wm) = tracker.source_watermark(sid) {
+                    self.source_wms_buf.insert(Arc::clone(name_arc), wm);
+                }
+            }
+        }
 
         #[cfg(feature = "cluster-unstable")]
         {
@@ -370,13 +381,13 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 .cluster_controller
                 .as_ref()
                 .and_then(|cc| cc.cluster_min_watermark());
-            Self::cap_source_watermarks_by_cluster_min(&mut source_wms, cluster_wm);
+            Self::cap_source_watermarks_by_cluster_min(&mut self.source_wms_buf, cluster_wm);
         }
 
-        let swm_ref = if source_wms.is_empty() {
+        let swm_ref = if self.source_wms_buf.is_empty() {
             None
         } else {
-            Some(&source_wms)
+            Some(&self.source_wms_buf)
         };
         self.graph
             .execute_cycle(source_batches, watermark, swm_ref)
@@ -407,6 +418,12 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if results.is_empty() {
             return;
         }
+        if !self
+            .mv_store_has_any
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
         let mut store = self.mv_store.write();
         let mut updates = 0u64;
         for (stream_name, batches) in results {
@@ -429,41 +446,40 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     async fn write_to_sinks(&mut self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
-        // Lazy-compile any pending sink filters.
         self.compile_pending_sink_filters(results).await;
 
-        // Route results to sinks concurrently, filtered by FROM clause.
-        // The per-call I/O timeout is enforced inside the sink task; the
-        // bounded command channel backpressures us naturally. Failures
-        // and timeouts are reported out of band via SinkEvents drained
-        // below after join_all.
-        let filter_ctx = self.filter_ctx.clone(); // Arc bump — cheap
+        // Share per-stream batches across sinks so fan-out doesn't reclone the Vec.
+        let mut shared_inputs: FxHashMap<&str, Arc<[RecordBatch]>> = FxHashMap::default();
+
         let sink_futures: Vec<_> = self
             .sinks
             .iter()
             .enumerate()
             .filter_map(
-                |(sink_idx, (sink_name, handle, filter_expr, sink_input, changelog_capable))| {
+                |(sink_idx, (sink_name, handle, _filter_sql, sink_input, changelog_capable))| {
                     // Route by FROM clause: only send matching results.
                     let batches = results.get(sink_input.as_str())?;
                     if batches.is_empty() {
                         return None;
                     }
+                    let shared = shared_inputs
+                        .entry(sink_input.as_str())
+                        .or_insert_with(|| Arc::<[RecordBatch]>::from(batches.as_slice()))
+                        .clone();
                     let sink_name = sink_name.clone();
                     let handle = handle.clone();
-                    let compiled_filter = self
-                        .compiled_sink_filters
-                        .get(sink_idx)
-                        .and_then(Clone::clone);
-                    let filter_expr = filter_expr.clone();
-                    let batches = batches.clone();
-                    let ctx = filter_ctx.clone();
+                    let compiled_filter = match self.compiled_sink_filters.get(sink_idx) {
+                        Some(SinkFilter::Compiled(phys)) => Some(Arc::clone(phys)),
+                        Some(SinkFilter::Pending | SinkFilter::Rejected) | None => None,
+                    };
+                    let changelog_capable = *changelog_capable;
                     Some(async move {
-                        for batch in &batches {
-                            let filtered = if let Some(ref phys) = compiled_filter {
-                                // Use compiled PhysicalExpr — no SQL overhead
+                        for batch in shared.iter() {
+                            let filtered: Cow<RecordBatch> = if let Some(ref phys) =
+                                compiled_filter
+                            {
                                 match apply_compiled_sink_filter(batch, phys) {
-                                    Ok(Some(fb)) => fb,
+                                    Ok(Some(fb)) => Cow::Owned(fb),
                                     Ok(None) => continue,
                                     Err(e) => {
                                         tracing::warn!(
@@ -474,42 +490,24 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                                         continue;
                                     }
                                 }
-                            } else if let Some(ref filter_sql) = filter_expr {
-                                // Fallback to SQL-based filter
-                                match apply_filter(&ctx, batch, filter_sql).await {
-                                    Ok(Some(fb)) => fb,
-                                    Ok(None) => continue,
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            sink = %sink_name,
-                                            filter = %filter_sql,
-                                            error = %e,
-                                            "Sink filter error"
-                                        );
-                                        continue;
-                                    }
-                                }
                             } else {
-                                batch.clone()
+                                Cow::Borrowed(batch)
                             };
 
-                            let filtered = crate::changelog_filter::prepare_for_sink(
+                            let prepared = crate::changelog_filter::prepare_for_sink(
                                 &filtered,
-                                *changelog_capable,
+                                changelog_capable,
                             );
-
-                            if filtered.num_rows() > 0 {
-                                if let Err(e) = handle.write_batch(filtered).await {
-                                    // ChannelClosed metric is incremented when
-                                    // we drain the event channel below; here
-                                    // we just log and stop sending to this sink.
-                                    tracing::warn!(
-                                        sink = %sink_name,
-                                        error = %e,
-                                        "Sink command channel closed"
-                                    );
-                                    break;
-                                }
+                            if prepared.num_rows() == 0 {
+                                continue;
+                            }
+                            if let Err(e) = handle.write_batch(prepared.into_owned()).await {
+                                tracing::warn!(
+                                    sink = %sink_name,
+                                    error = %e,
+                                    "Sink command channel closed"
+                                );
+                                break;
                             }
                         }
                     })
@@ -1190,70 +1188,6 @@ fn update_partial_cache_from_batch(
 /// Encode an Arrow schema as a hex-encoded IPC flatbuffer for `ConnectorConfig`.
 pub(crate) fn encode_arrow_schema(schema: &arrow_schema::Schema) -> String {
     laminar_connectors::config::encode_arrow_schema_ipc(schema)
-}
-
-/// Apply a SQL WHERE filter to a `RecordBatch` using a cached `SessionContext`.
-///
-/// Each call uses a unique temporary table name so concurrent calls on the
-/// same context (via `join_all`) do not interfere with each other.
-///
-/// Returns `Ok(Some(filtered_batch))` if rows match, `Ok(None)` if no rows match,
-/// or an error if the filter expression is invalid.
-async fn apply_filter(
-    ctx: &SessionContext,
-    batch: &RecordBatch,
-    filter_sql: &str,
-) -> Result<Option<RecordBatch>, DbError> {
-    // Unique table name per call to avoid concurrent conflicts.
-    let id = FILTER_TABLE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let table_name = format!("{FILTER_INPUT_TABLE}_{id}");
-
-    let schema = batch.schema();
-
-    // Register the batch as a temporary table
-    let mem_table = datafusion::datasource::MemTable::try_new(schema, vec![vec![batch.clone()]])
-        .map_err(|e| DbError::query_pipeline("sink filter", &e))?;
-
-    ctx.register_table(&*table_name, Arc::new(mem_table))
-        .map_err(|e| DbError::query_pipeline("sink filter", &e))?;
-
-    // Execute the filter query, always deregistering the temp table afterward.
-    let sql = format!("SELECT * FROM {table_name} WHERE {filter_sql}");
-    let result = async {
-        let df = ctx
-            .sql(&sql)
-            .await
-            .map_err(|e| DbError::query_pipeline("sink filter", &e))?;
-
-        let batches = df
-            .collect()
-            .await
-            .map_err(|e| DbError::query_pipeline("sink filter", &e))?;
-
-        if batches.is_empty() {
-            return Ok(None);
-        }
-
-        let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-        if total_rows == 0 {
-            return Ok(None);
-        }
-
-        // Merge all result batches into one (DataFusion may split output across
-        // multiple partitions, so dropping all but the first would lose rows).
-        if batches.len() == 1 {
-            return Ok(batches.into_iter().next());
-        }
-        let merged = arrow::compute::concat_batches(&batches[0].schema(), &batches)
-            .map_err(|e| DbError::query_pipeline_arrow("sink filter concat", &e))?;
-        Ok(Some(merged))
-    }
-    .await;
-
-    // Clean up: deregister the temporary table to avoid catalog bloat.
-    let _ = ctx.deregister_table(&*table_name);
-
-    result
 }
 
 /// Apply a compiled `PhysicalExpr` filter to a batch.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1345,6 +1345,20 @@ impl LaminarDB {
         graph.set_max_input_buf_bytes(pipeline_config.max_input_buf_bytes);
         graph.set_backpressure_policy(pipeline_config.backpressure_policy);
 
+        let sinks_pending_filter_count = sinks
+            .iter()
+            .filter(|(_, _, filter_sql, _, _)| filter_sql.is_some())
+            .count();
+
+        let source_name_arcs: rustc_hash::FxHashMap<usize, Arc<str>> = source_ids
+            .iter()
+            .map(|(name, &sid)| (sid, Arc::<str>::from(name.as_str())))
+            .collect();
+        let source_wms_buf = rustc_hash::FxHashMap::with_capacity_and_hasher(
+            source_name_arcs.len(),
+            rustc_hash::FxBuildHasher,
+        );
+
         let prom = self
             .engine_metrics
             .lock()
@@ -1368,16 +1382,20 @@ impl LaminarDB {
             watermark_states,
             source_entries_for_wm,
             source_ids,
+            source_name_arcs,
+            source_wms_buf,
             tracker,
             prom,
             pipeline_watermark,
             coordinator,
             table_sources,
             table_store: table_store_for_loop,
+            mv_store_has_any: self.mv_store.read().has_any_handle(),
             mv_store: self.mv_store.clone(),
             lookup_registry: Arc::clone(&self.lookup_registry),
             filter_ctx: laminar_sql::create_session_context(),
             compiled_sink_filters: Vec::new(),
+            pending_sink_filter_compiles: sinks_pending_filter_count,
             last_checkpoint: std::time::Instant::now(),
             checkpoint_interval: self
                 .config

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -49,7 +49,6 @@ impl BarrierTrackingCallback {
     }
 }
 
-#[async_trait::async_trait]
 impl PipelineCallback for BarrierTrackingCallback {
     async fn execute_cycle(
         &mut self,


### PR DESCRIPTION
## Summary

Closes the per-cycle allocation cliffs surfaced by an end-to-end review of the streaming pipeline (source -> SQL planner -> filter -> coordinator -> aggregation -> sink). No behavior changes; all existing tests cover the touched paths.

## What changed

### Sink path
- Sink WHERE filters that don't compile to a `PhysicalExpr` are now rejected up front (`[LDB-1100]`) instead of silently falling back to a per-batch SQL plan/execute. The old `apply_filter()` registered a MemTable, parsed, planned and executed a SELECT per batch per sink — a single misformed filter could dominate cycle time.
- Share per-stream batches across sinks via `Arc<[RecordBatch]>` so fan-out to N sinks doesn't reclone the `Vec`. Dropped the redundant `filter_ctx.clone()`.
- `prepare_for_sink` returns `Cow<'_, RecordBatch>`; the changelog and no-weight passthrough branches borrow.

### Pipeline coordinator
- Switched `PipelineCallback` from `#[async_trait]` to native `async fn` in trait via `#[trait_variant::make(Send)]`. Removes the per-call `Box<dyn Future>` on `execute_cycle` / `write_to_sinks` / `poll_tables`.
- Reuse the per-cycle source watermark map (`FxHashMap`) and pre-intern source-name `Arc<str>`s instead of rebuilding the map every cycle.
- Skip the `mv_store` write lock when no MVs are registered; gated by an `Arc<AtomicBool>` mirroring `MvStore::has_any`.

### Aggregate / window state
- Per-batch group-key interning in EOWC and core window paths via `indexmap::IndexSet<OwnedRow, ahash::RandomState>`; bucket by integer `group_id`. Eliminates the `O(rows * overlapping_windows)` `OwnedRow` clones the hopping-window path used to do.
- `build_weighted_batch`: `Int64Array::from_iter_values` for weights — no intermediate `Vec`.

### Interval join compaction
- Replaced per-row `RecordBatch::slice(row, 1)` + `concat_batches` with one `arrow::compute::take` per source batch over the contiguous run of live rows, then a single `concat`.

## Realistic impact

For `HOP(size = 4 min, slide = 1 min)` over 1M rows/s with 100 distinct groups:
- EOWC inner loop: ~5M -> ~1M `OwnedRow` allocs/s.
- Sink fan-out to 3 sinks: no longer pays N `batches.clone()` per cycle.
- Coordinator: no per-cycle `Box<dyn Future>` from the callback trait; no `Arc<str>::from` per source per cycle.
- Interval-join compaction at the threshold: M tiny `slice` allocations replaced by one `take` per source batch.

## Test plan

- [x] `cargo test --all --no-default-features --lib` — 2311/2311 passing.
- [x] `cargo clippy -p laminar-db --no-default-features -- -D warnings` — clean.
- [x] Hopping / tumbling / session window tests, EOWC checkpoint roundtrips, interval-join compaction, MV create/drop, sink filter compile/reject — all green.

## Out of scope (deferred)

- Decoupling the per-cycle sink sync barrier from non-exactly-once sinks (touches EO semantics; needs its own change).
- Pushing OwnedRow interning further with `raw_entry_mut` to drop the `row.owned()` per row to once per distinct group (requires switching to `hashbrown::HashMap` directly).
- Bulk-inserting CDC rows into the foyer cache (needs an upstream API change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced cloning and memory use across record-batch, window-state, join compaction, and sink fan-out paths; MV store hot-path optimized to skip locks when empty; shared batches across sinks to avoid per-sink copies.

* **New Features**
  * Added a metric tracking rows rejected when a sink filter fails compilation.

* **Documentation**
  * Simplified checkpointing and backpressure docs.

* **Chores**
  * Updated workspace dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->