### PR TITLE
perf(db): move sink sync barrier from per-cycle to per-checkpoint

### DIFF
--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -143,6 +143,8 @@ impl ConnectorPipelineCallback {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
+        self.sync_sinks_and_drain_events().await;
+
         let operator_states = self
             .capture_and_serialize_operator_state()
             .await
@@ -308,6 +310,43 @@ impl ConnectorPipelineCallback {
         operator_states.extend(mv_states);
 
         Ok(operator_states)
+    }
+
+    /// Wait for every sink to finish processing previously-enqueued
+    /// `WriteBatch` commands, then drain any `SinkEvent`s they produced.
+    /// Callers rely on `sink_timed_out` being current after this returns.
+    async fn sync_sinks_and_drain_events(&mut self) {
+        let sync_futures = self.sinks.iter().map(|(name, handle, _, _, _)| {
+            let name = name.clone();
+            let handle = handle.clone();
+            async move {
+                if let Err(e) = handle.sync().await {
+                    tracing::warn!(sink = %name, error = %e, "sink sync barrier failed");
+                }
+            }
+        });
+        futures::future::join_all(sync_futures).await;
+        self.drain_sink_events();
+    }
+
+    /// Non-blocking drain of `sink_event_rx` into Prometheus counters and
+    /// `sink_timed_out`.
+    fn drain_sink_events(&mut self) {
+        while let Ok(event) = self.sink_event_rx.try_recv() {
+            tracing::debug!(?event, "sink event");
+            match &event {
+                crate::sink_task::SinkEvent::WriteError { .. } => {
+                    self.prom.sink_write_failures.inc();
+                }
+                crate::sink_task::SinkEvent::WriteTimeout { .. } => {
+                    self.sink_timed_out = true;
+                    self.prom.sink_write_timeouts.inc();
+                }
+                crate::sink_task::SinkEvent::ChannelClosed { .. } => {
+                    self.prom.sink_task_channel_closed.inc();
+                }
+            }
+        }
     }
 
     async fn compile_pending_sink_filters(
@@ -518,36 +557,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             .collect();
         futures::future::join_all(sink_futures).await;
 
-        // Barrier: wait for every sink task to finish processing the
-        // commands we just enqueued, so the drain below catches any
-        // failures before maybe_checkpoint can advance source offsets.
-        let sync_futures = self.sinks.iter().map(|(name, handle, _, _, _)| {
-            let name = name.clone();
-            let handle = handle.clone();
-            async move {
-                if let Err(e) = handle.sync().await {
-                    tracing::warn!(sink = %name, error = %e, "sink sync barrier failed");
-                }
-            }
-        });
-        futures::future::join_all(sync_futures).await;
-
-        // Drain SinkEvents emitted by sink tasks during this cycle.
-        while let Ok(event) = self.sink_event_rx.try_recv() {
-            tracing::debug!(?event, "sink event");
-            match &event {
-                crate::sink_task::SinkEvent::WriteError { .. } => {
-                    self.prom.sink_write_failures.inc();
-                }
-                crate::sink_task::SinkEvent::WriteTimeout { .. } => {
-                    self.sink_timed_out = true;
-                    self.prom.sink_write_timeouts.inc();
-                }
-                crate::sink_task::SinkEvent::ChannelClosed { .. } => {
-                    self.prom.sink_task_channel_closed.inc();
-                }
-            }
-        }
+        // Opportunistic; the strict "all prior writes settled" barrier
+        // runs in the checkpoint paths, not on every cycle.
+        self.drain_sink_events();
     }
 
     fn extract_watermark(&mut self, source_name: &str, batch: &RecordBatch) {
@@ -685,6 +697,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             return None;
         }
 
+        self.sync_sinks_and_drain_events().await;
+
         // After a sink timeout, skip one checkpoint cycle so that source
         // offsets don't advance past the dropped batch. The NEXT cycle will
         // clear this flag and checkpoint normally. This preserves at-least-once:
@@ -814,6 +828,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if self.prom.cycles.get() == 0 {
             return None;
         }
+
+        self.sync_sinks_and_drain_events().await;
 
         // Clear after one suppression — the timer-based path that also
         // clears this flag is unreachable when barrier checkpointing is active.


### PR DESCRIPTION
## Summary

`write_to_sinks` currently round-trips through every sink's command queue (`handle.sync()`) at the end of every cycle so the next `maybe_checkpoint` can read an up-to-date `sink_timed_out` flag and suppress checkpoints for poisoned epochs. The barrier is correct but pays the round-trip cost on every cycle, even though the invariant only needs to hold at checkpoint time.

For at-least-once pipelines with a mix of fast (Kafka) and slow (Iceberg/Delta on S3) sinks, the per-cycle barrier ties cycle latency to the slowest sink's queue-drain time. With a 30s default checkpoint interval this is ~3000x more synchronization than the invariant requires.

## What changed

- New private helper `sync_sinks_and_drain_events()` does exactly what the old per-cycle block did: `join_all` over each sink's `handle.sync()` plus a `try_recv` drain of `sink_event_rx` into Prometheus counters / `sink_timed_out`.
- `write_to_sinks` keeps a non-blocking `drain_sink_events()` after `join_all(sink_futures)` so metrics still update opportunistically between checkpoints — only the `sync()` round-trip moves.
- The helper runs at the top of `maybe_checkpoint`, `checkpoint_with_barrier`, and `force_capture_and_checkpoint`, before any code reads `sink_timed_out` or captures operator state.

## Correctness

The invariant — *"every WriteBatch enqueued before this checkpoint has been processed and any failures are reflected in `sink_timed_out` before offsets advance"* — is preserved:

- `sync_sinks_and_drain_events()` runs immediately before `sink_timed_out` is read on every checkpoint path.
- For exactly-once pipelines, the `delivery_guarantee == ExactlyOnce` early-return in `maybe_checkpoint` short-circuits before the sync call, and `pre_commit_sinks` in 2PC is itself the barrier — no behavior change.
- A `WriteError` or `WriteTimeout` that arrives mid-cycle but after `drain_sink_events()` is picked up by the next cycle's drain or by the pre-checkpoint sync, whichever comes first. Either way `sink_timed_out` is correct at the point of decision.

## Test plan

- [x] `cargo test --all --no-default-features --lib` — 2311/2311 passing.
- [x] `cargo clippy -p laminar-db --no-default-features -- -D warnings` — clean.
- [x] Sink-timeout, exactly-once, rollback, and checkpoint roundtrip tests all green.

## Performance

For at-least-once with mixed delivery latency:
- Cycle latency drops from ~max(sink_latency) to ~max(local CPU step).
- Checkpoint latency is unchanged — same round-trip, just paid on the checkpoint cadence (default 30s) instead of every cycle.

For exactly-once: zero change (the timer-based path was already short-circuited).