### PR TITLE
fix(db): N-way join correctness — chain past the first specialised step, reject unbounded multi-way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - name: Set swap space
         uses: pierotofy/set-swap-space@v1.0
         with:
@@ -83,10 +88,15 @@ jobs:
       - uses: actions/checkout@v6
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - name: Set swap space (Linux)
         if: runner.os == 'Linux'
         uses: pierotofy/set-swap-space@v1.0
@@ -136,10 +146,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - name: Set swap space
         uses: pierotofy/set-swap-space@v1.0
         with:
@@ -164,10 +179,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
@@ -235,10 +255,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_BUILD_JOBS: 2
 
 jobs:
   build:
@@ -20,6 +24,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: false
+    - name: Set swap space
+      uses: pierotofy/set-swap-space@v1.0
+      with:
+        swap-size-gb: 10
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev libcurl4-openssl-dev cmake pkg-config libsasl2-dev libudev-dev protobuf-compiler
     - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,7 @@ dependencies = [
  "object_store 0.13.2",
  "parking_lot 0.12.5",
  "prometheus",
+ "proptest",
  "rdkafka",
  "rkyv",
  "rustc-hash",

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -114,6 +114,7 @@ laminar-connectors = { path = "../laminar-connectors", version = "0.21.5", featu
 criterion = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }
+proptest = { workspace = true }
 # Kafka producer/admin client used by `kafka_docker_scenarios.rs` integration tests.
 # Tests skip gracefully when the Redpanda broker started by
 # `tests/docker/compose.yml` is not reachable on `localhost:19092`.

--- a/crates/laminar-db/src/connector_manager.rs
+++ b/crates/laminar-db/src/connector_manager.rs
@@ -40,6 +40,10 @@ pub(crate) struct StreamRegistration {
     pub emit_clause: Option<laminar_sql::parser::EmitClause>,
     pub window_config: Option<laminar_sql::translator::WindowOperatorConfig>,
     pub order_config: Option<laminar_sql::translator::OrderOperatorConfig>,
+    /// Per-step join configs from the planner (one entry per binary step,
+    /// left-deep). Lets the executor skip SQL re-parses when the query
+    /// has no streaming-specific join step.
+    pub join_config: Option<Vec<laminar_sql::translator::JoinOperatorConfig>>,
 }
 
 #[derive(Debug, Clone)]
@@ -354,6 +358,7 @@ mod tests {
             emit_clause: None,
             window_config: None,
             order_config: None,
+            join_config: None,
         });
         assert_eq!(mgr.stream_names(), vec!["agg_stream"]);
     }
@@ -511,6 +516,7 @@ mod tests {
             emit_clause: None,
             window_config: None,
             order_config: None,
+            join_config: None,
         });
         assert!(mgr.unregister_sink("s1"));
         assert!(!mgr.unregister_sink("s1"));

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -645,8 +645,12 @@ impl LaminarDB {
 
         let query_sql = query_sql.to_string();
 
-        // Plan the statement to extract emit_clause, window_config, and order_config
-        let (plan_emit, plan_window, plan_order) = {
+        // Plan the statement to extract emit_clause, window_config, order_config,
+        // and the multi-step join_config (one entry per binary join step).
+        // Planning errors (e.g. unbounded multi-way stream-stream rejection)
+        // surface to the caller — DDL must not silently fall back when the
+        // planner has rejected the query.
+        let (plan_emit, plan_window, plan_order, plan_joins) = {
             let mut planner = self.planner.lock();
             let stmt = StreamingStatement::CreateStream {
                 name: name.clone(),
@@ -661,8 +665,10 @@ impl LaminarDB {
                     qp.emit_clause.clone(),
                     qp.window_config.clone(),
                     qp.order_config.clone(),
+                    qp.join_config.clone(),
                 ),
-                _ => (emit_clause.cloned(), None, None),
+                Ok(_) => (emit_clause.cloned(), None, None, None),
+                Err(e) => return Err(laminar_sql::Error::from(e).into()),
             }
         };
 
@@ -675,6 +681,7 @@ impl LaminarDB {
                 emit_clause: plan_emit.clone(),
                 window_config: plan_window.clone(),
                 order_config: plan_order.clone(),
+                join_config: plan_joins.clone(),
             });
         }
 
@@ -687,6 +694,7 @@ impl LaminarDB {
                 emit_clause: plan_emit,
                 window_config: plan_window,
                 order_config: plan_order,
+                join_config: plan_joins,
             });
         }
 
@@ -932,8 +940,9 @@ impl LaminarDB {
                 .map_err(|e| DbError::MaterializedView(e.to_string()))?;
         }
 
-        // Plan the MV's backing query to extract emit_clause, window_config, and order_config
-        let (plan_emit, plan_window, plan_order) = {
+        // Plan the MV's backing query to extract emit_clause, window_config,
+        // order_config, and the multi-step join_config.
+        let (plan_emit, plan_window, plan_order, plan_joins) = {
             let mut planner = self.planner.lock();
             // Wrap the inner query as a CreateStream to reuse the planner
             let stmt = StreamingStatement::CreateStream {
@@ -949,8 +958,9 @@ impl LaminarDB {
                     qp.emit_clause.clone(),
                     qp.window_config.clone(),
                     qp.order_config.clone(),
+                    qp.join_config.clone(),
                 ),
-                _ => (None, None, None),
+                _ => (None, None, None, None),
             }
         };
 
@@ -963,6 +973,7 @@ impl LaminarDB {
                 emit_clause: plan_emit.clone(),
                 window_config: plan_window.clone(),
                 order_config: plan_order.clone(),
+                join_config: plan_joins.clone(),
             });
         }
 
@@ -1008,6 +1019,7 @@ impl LaminarDB {
                 emit_clause: plan_emit,
                 window_config: plan_window,
                 order_config: plan_order,
+                join_config: plan_joins,
             });
         }
 

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -26,6 +26,10 @@ use crate::key_column::{extract_column_as_timestamps, extract_key_column, KeyCol
 /// Compact when accumulated batch count exceeds this threshold.
 const COMPACTION_THRESHOLD: usize = 32;
 
+/// Flush partial output once the match buffer reaches this many pairs.
+/// Bounds memory on cross-product shapes.
+const EMIT_THRESHOLD: usize = 65_536;
+
 /// Index type: `key_hash` → sorted `timestamp` → list of `(batch_idx, row_idx)`.
 type SideIndex = FxHashMap<u64, BTreeMap<i64, Vec<(usize, usize)>>>;
 
@@ -88,20 +92,24 @@ impl SideState {
         delete_key: &KeyColumn<'_>,
         delete_row: usize,
         key_col_name: &str,
-    ) {
+    ) -> Result<(), DbError> {
         let Some(btree) = self.index.get_mut(&key_hash) else {
-            return;
+            return Ok(());
         };
         let Some(entries) = btree.get_mut(&ts) else {
-            return;
+            return Ok(());
         };
-        let before = entries.len();
-        entries.retain(|&(batch_idx, row_idx)| {
-            extract_key_column(&self.batches[batch_idx], key_col_name).map_or(true, |stored_key| {
-                !delete_key.keys_equal(delete_row, &stored_key, row_idx)
-            })
-        });
-        let removed = before - entries.len();
+
+        // `Vec::retain` can't surface errors, so do it by hand.
+        let mut kept: Vec<(usize, usize)> = Vec::with_capacity(entries.len());
+        for &(batch_idx, row_idx) in entries.iter() {
+            let stored_key = extract_key_column(&self.batches[batch_idx], key_col_name)?;
+            if !delete_key.keys_equal(delete_row, &stored_key, row_idx) {
+                kept.push((batch_idx, row_idx));
+            }
+        }
+        let removed = entries.len() - kept.len();
+        *entries = kept;
         self.row_count = self.row_count.saturating_sub(removed);
         if entries.is_empty() {
             btree.remove(&ts);
@@ -109,6 +117,7 @@ impl SideState {
         if btree.is_empty() {
             self.index.remove(&key_hash);
         }
+        Ok(())
     }
 
     /// Evict all rows with `ts < cutoff`, then compact if batch count exceeds threshold.
@@ -396,6 +405,67 @@ fn probe_index(
     results
 }
 
+/// Drain `match_pairs` into one output batch via `arrow::compute::interleave` —
+/// one call per column, no per-row slice + concat.
+fn flush_match_pairs(
+    match_pairs: &mut Vec<(usize, usize, usize, usize)>,
+    output_schema: &SchemaRef,
+    left_batches: &[RecordBatch],
+    right_batches: &[RecordBatch],
+    left_only: bool,
+    out: &mut Vec<RecordBatch>,
+) -> Result<(), DbError> {
+    if match_pairs.is_empty() {
+        return Ok(());
+    }
+
+    let left_indices: Vec<(usize, usize)> =
+        match_pairs.iter().map(|&(b, r, _, _)| (b, r)).collect();
+    let right_indices: Vec<(usize, usize)> = if left_only {
+        Vec::new()
+    } else {
+        match_pairs.iter().map(|&(_, _, b, r)| (b, r)).collect()
+    };
+
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
+
+    if let Some(first) = left_batches.first() {
+        for col_idx in 0..first.num_columns() {
+            let arrays: Vec<&dyn Array> = left_batches
+                .iter()
+                .map(|b| b.column(col_idx).as_ref())
+                .collect();
+            let arr = arrow::compute::interleave(&arrays, &left_indices).map_err(|e| {
+                DbError::query_pipeline_arrow("interval join (interleave left)", &e)
+            })?;
+            columns.push(arr);
+        }
+    }
+
+    if !left_only {
+        if let Some(first) = right_batches.first() {
+            for col_idx in 0..first.num_columns() {
+                let arrays: Vec<&dyn Array> = right_batches
+                    .iter()
+                    .map(|b| b.column(col_idx).as_ref())
+                    .collect();
+                let arr = arrow::compute::interleave(&arrays, &right_indices).map_err(|e| {
+                    DbError::query_pipeline_arrow("interval join (interleave right)", &e)
+                })?;
+                columns.push(arr);
+            }
+        }
+    }
+
+    let batch = RecordBatch::try_new(output_schema.clone(), columns)
+        .map_err(|e| DbError::query_pipeline_arrow("interval join (result)", &e))?;
+    if batch.num_rows() > 0 {
+        out.push(batch);
+    }
+    match_pairs.clear();
+    Ok(())
+}
+
 /// Execute one cycle of an interval join.
 ///
 /// Bounds are inclusive: `|left_ts - right_ts| <= bound_ms`. NULL keys are
@@ -430,7 +500,7 @@ pub(crate) fn execute_interval_join_cycle(
                 if let Some(kh) = keys.hash_at(i) {
                     state
                         .left
-                        .remove_by_key_ts(kh, ts, &keys, i, &config.left_key);
+                        .remove_by_key_ts(kh, ts, &keys, i, &config.left_key)?;
                 }
             }
         }
@@ -443,135 +513,59 @@ pub(crate) fn execute_interval_join_cycle(
                 if let Some(kh) = keys.hash_at(i) {
                     state
                         .right
-                        .remove_by_key_ts(kh, ts, &keys, i, &config.right_key);
+                        .remove_by_key_ts(kh, ts, &keys, i, &config.right_key)?;
                 }
             }
         }
     }
 
-    let left_batches = &left_pos[..];
-    let right_batches = &right_pos[..];
+    // A pure-delete CDC batch yields zero positive rows; treat it as None
+    // so new_*_batch_idx never points past the end of state.
+    let concat_nonempty =
+        |slices: &[RecordBatch], side: &str| -> Result<Option<RecordBatch>, DbError> {
+            if slices.is_empty() {
+                return Ok(None);
+            }
+            let schema = slices[0].schema();
+            let b = concat_batches(&schema, slices)
+                .map_err(|e| DbError::query_pipeline_arrow(side, &e))?;
+            Ok((b.num_rows() > 0).then_some(b))
+        };
+    let new_left = concat_nonempty(&left_pos, "interval join (left concat)")?;
+    let new_right = concat_nonempty(&right_pos, "interval join (right concat)")?;
 
-    // Concat incoming batches for each side
-    let new_left = if left_batches.is_empty() {
-        None
-    } else {
-        let schema = left_batches[0].schema();
-        Some(
-            concat_batches(&schema, left_batches)
-                .map_err(|e| DbError::query_pipeline_arrow("interval join (left concat)", &e))?,
-        )
-    };
-
-    let new_right = if right_batches.is_empty() {
-        None
-    } else {
-        let schema = right_batches[0].schema();
-        Some(
-            concat_batches(&schema, right_batches)
-                .map_err(|e| DbError::query_pipeline_arrow("interval join (right concat)", &e))?,
-        )
-    };
-
-    // Record the boundary between old and new batches on each side
+    // Buffer before probing so every (batch_idx, row_idx) we produce already
+    // points into state.batches — lets flush_match_pairs run mid-probe
+    // without juggling in-flight batch references.
     let left_old_count = state.left.batches.len();
     let right_old_count = state.right.batches.len();
-
-    // Step 1: Buffer new right into state first (so new left can probe it)
     if let Some(ref rb) = new_right {
         state
             .right
             .add_batch(rb, &config.right_key, &config.right_time_column)?;
     }
-
-    // Collect match pairs: (left_batch_idx, left_row_idx, right_batch_idx, right_row_idx)
-    let mut match_pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
-    let is_semi = config.join_type == StreamJoinType::LeftSemi;
-    // For Semi: track which new left rows already matched (at most one per left row)
-    let mut semi_matched: FxHashSet<usize> = FxHashSet::default();
-
-    // Step 2: Probe new left rows against all right (old + new)
-    if let Some(ref lb) = new_left {
-        let left_keys = extract_key_column(lb, &config.left_key)?;
-        let left_timestamps = extract_column_as_timestamps(lb, &config.left_time_column)?;
-
-        // The new left batch will be added at batch_idx = left_old_count
-        let new_left_batch_idx = left_old_count;
-
-        for (row_idx, &left_ts) in left_timestamps.iter().enumerate() {
-            if is_semi && semi_matched.contains(&row_idx) {
-                continue;
-            }
-            let Some(key_hash) = left_keys.hash_at(row_idx) else {
-                continue; // Skip null keys
-            };
-            let candidates = probe_index(&state.right.index, key_hash, left_ts, bound_ms);
-
-            for (r_batch, r_row) in candidates {
-                if is_semi && semi_matched.contains(&row_idx) {
-                    break;
-                }
-                let r_key_col =
-                    extract_key_column(&state.right.batches[r_batch], &config.right_key)?;
-                if left_keys.keys_equal(row_idx, &r_key_col, r_row) {
-                    match_pairs.push((new_left_batch_idx, row_idx, r_batch, r_row));
-                    if is_semi {
-                        semi_matched.insert(row_idx);
-                    }
-                }
-            }
-        }
-    }
-
-    // Step 3: Probe new right rows against OLD left rows only (avoid double-emit)
-    if let Some(ref rb) = new_right {
-        let right_keys = extract_key_column(rb, &config.right_key)?;
-        let right_timestamps = extract_column_as_timestamps(rb, &config.right_time_column)?;
-
-        let new_right_batch_idx = right_old_count;
-
-        for (row_idx, &right_ts) in right_timestamps.iter().enumerate() {
-            let Some(key_hash) = right_keys.hash_at(row_idx) else {
-                continue; // Skip null keys
-            };
-            let candidates = probe_index(&state.left.index, key_hash, right_ts, bound_ms);
-
-            for (l_batch, l_row) in candidates {
-                if l_batch < left_old_count {
-                    let l_key_col =
-                        extract_key_column(&state.left.batches[l_batch], &config.left_key)?;
-                    if right_keys.keys_equal(row_idx, &l_key_col, l_row) {
-                        match_pairs.push((l_batch, l_row, new_right_batch_idx, row_idx));
-                    }
-                }
-            }
-        }
-    }
-
-    // Step 4: Buffer new left rows into state (after probing to get correct indices)
     if let Some(ref lb) = new_left {
         state
             .left
             .add_batch(lb, &config.left_key, &config.left_time_column)?;
     }
+    let new_left_batch_idx = left_old_count;
+    let new_right_batch_idx = right_old_count;
 
-    // Determine or update output schema. Rebuild when both sides become available
-    // to ensure right-column suffixing is correct.
+    let left_only = matches!(
+        config.join_type,
+        StreamJoinType::LeftSemi | StreamJoinType::LeftAnti
+    );
+
+    // Refresh the output schema once both sides have been seen.
     {
         let left_schema = state.left.batches.first().map(RecordBatch::schema);
         let right_schema = state.right.batches.first().map(RecordBatch::schema);
         match (left_schema, right_schema) {
             (Some(ls), Some(rs)) => {
-                // Always set when both sides available (may upgrade a partial schema)
                 state.output_schema = Some(build_output_schema(&ls, &rs, config));
             }
-            (Some(ls), None)
-                if state.output_schema.is_none()
-                    && matches!(
-                        config.join_type,
-                        StreamJoinType::LeftSemi | StreamJoinType::LeftAnti
-                    ) =>
-            {
+            (Some(ls), None) if state.output_schema.is_none() && left_only => {
                 state.output_schema =
                     Some(build_output_schema(&ls, &Arc::new(Schema::empty()), config));
             }
@@ -585,101 +579,157 @@ pub(crate) fn execute_interval_join_cycle(
         }
     }
 
-    let left_only = matches!(
-        config.join_type,
-        StreamJoinType::LeftSemi | StreamJoinType::LeftAnti
-    );
+    let is_semi = config.join_type == StreamJoinType::LeftSemi;
+    let is_anti = config.join_type == StreamJoinType::LeftAnti;
+    let mut result: Vec<RecordBatch> = Vec::new();
 
-    // Step 5: Build output from match_pairs (Anti emits nothing here — only at eviction)
-    let mut result = if match_pairs.is_empty() || config.join_type == StreamJoinType::LeftAnti {
-        Vec::new()
-    } else {
-        let output_schema = state.output_schema.as_ref().ok_or_else(|| {
-            DbError::Pipeline("interval join: output schema not available".to_string())
-        })?;
-        let left_schema = state
+    // Borrow batches immutably for the probe; eviction below needs &mut so
+    // the cached key columns must drop first.
+    {
+        // One KeyColumn per buffered batch — saves a schema lookup +
+        // downcast per candidate inside the inner probe loops.
+        let left_key_cols: Vec<KeyColumn<'_>> = state
             .left
             .batches
-            .first()
-            .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
+            .iter()
+            .map(|b| extract_key_column(b, &config.left_key))
+            .collect::<Result<_, _>>()?;
+        let right_key_cols: Vec<KeyColumn<'_>> = state
+            .right
+            .batches
+            .iter()
+            .map(|b| extract_key_column(b, &config.right_key))
+            .collect::<Result<_, _>>()?;
 
-        let num_rows = match_pairs.len();
-        let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
+        // Anti emits only at eviction; don't bother accumulating pairs we'll discard.
+        let collect_pairs = !is_anti;
+        let mut match_pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
+        let mut semi_matched: FxHashSet<usize> = FxHashSet::default();
 
-        for col_idx in 0..left_schema.fields().len() {
-            let mut builder = Vec::with_capacity(num_rows);
-            for &(l_batch, l_row, _, _) in &match_pairs {
-                let array = state.left.batches[l_batch].column(col_idx);
-                let sliced = array.slice(l_row, 1);
-                builder.push(sliced);
+        let flush = |pairs: &mut Vec<_>, result: &mut Vec<RecordBatch>| {
+            if pairs.is_empty() {
+                return Ok(());
             }
-            let refs: Vec<&dyn Array> = builder.iter().map(AsRef::as_ref).collect();
-            let concatenated = arrow::compute::concat(&refs)
-                .map_err(|e| DbError::query_pipeline_arrow("interval join (left concat)", &e))?;
-            columns.push(concatenated);
-        }
+            let schema = state.output_schema.as_ref().ok_or_else(|| {
+                DbError::Pipeline("interval join: output schema not available".to_string())
+            })?;
+            flush_match_pairs(
+                pairs,
+                schema,
+                &state.left.batches,
+                &state.right.batches,
+                left_only,
+                result,
+            )
+        };
 
-        if !left_only {
-            let right_schema = state
-                .right
-                .batches
-                .first()
-                .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
-            for col_idx in 0..right_schema.fields().len() {
-                let mut builder = Vec::with_capacity(num_rows);
-                for &(_, _, r_batch, r_row) in &match_pairs {
-                    let array = state.right.batches[r_batch].column(col_idx);
-                    let sliced = array.slice(r_row, 1);
-                    builder.push(sliced);
+        // Step 1: probe new left rows against all right (old + new).
+        if new_left.is_some() {
+            let lb_kc = &left_key_cols[new_left_batch_idx];
+            let lb_ts = extract_column_as_timestamps(
+                &state.left.batches[new_left_batch_idx],
+                &config.left_time_column,
+            )?;
+            for (row_idx, &left_ts) in lb_ts.iter().enumerate() {
+                if is_semi && semi_matched.contains(&row_idx) {
+                    continue;
                 }
-                let refs: Vec<&dyn Array> = builder.iter().map(AsRef::as_ref).collect();
-                let concatenated = arrow::compute::concat(&refs).map_err(|e| {
-                    DbError::query_pipeline_arrow("interval join (right concat)", &e)
-                })?;
-                columns.push(concatenated);
+                let Some(key_hash) = lb_kc.hash_at(row_idx) else {
+                    continue;
+                };
+                for (r_batch, r_row) in probe_index(&state.right.index, key_hash, left_ts, bound_ms)
+                {
+                    if is_semi && semi_matched.contains(&row_idx) {
+                        break;
+                    }
+                    if !lb_kc.keys_equal(row_idx, &right_key_cols[r_batch], r_row) {
+                        continue;
+                    }
+                    if collect_pairs {
+                        match_pairs.push((new_left_batch_idx, row_idx, r_batch, r_row));
+                        if match_pairs.len() >= EMIT_THRESHOLD {
+                            flush(&mut match_pairs, &mut result)?;
+                        }
+                    }
+                    if is_semi {
+                        semi_matched.insert(row_idx);
+                    }
+                }
             }
         }
 
-        let batch = RecordBatch::try_new(output_schema.clone(), columns)
-            .map_err(|e| DbError::query_pipeline_arrow("interval join (result)", &e))?;
-        if batch.num_rows() > 0 {
-            vec![batch]
-        } else {
-            Vec::new()
+        // Step 2: probe new right rows against OLD left rows only — new_left ×
+        // new_right pairs were already produced in step 1.
+        if new_right.is_some() {
+            let rb_kc = &right_key_cols[new_right_batch_idx];
+            let rb_ts = extract_column_as_timestamps(
+                &state.right.batches[new_right_batch_idx],
+                &config.right_time_column,
+            )?;
+            for (row_idx, &right_ts) in rb_ts.iter().enumerate() {
+                let Some(key_hash) = rb_kc.hash_at(row_idx) else {
+                    continue;
+                };
+                for (l_batch, l_row) in probe_index(&state.left.index, key_hash, right_ts, bound_ms)
+                {
+                    if l_batch >= left_old_count {
+                        continue;
+                    }
+                    if !rb_kc.keys_equal(row_idx, &left_key_cols[l_batch], l_row) {
+                        continue;
+                    }
+                    if collect_pairs {
+                        match_pairs.push((l_batch, l_row, new_right_batch_idx, row_idx));
+                        if match_pairs.len() >= EMIT_THRESHOLD {
+                            flush(&mut match_pairs, &mut result)?;
+                        }
+                    }
+                }
+            }
         }
-    };
 
-    // Step 5.5: For LEFT/RIGHT/FULL/ANTI, emit unmatched rows about to be evicted.
-    // Probe the opposite side's state — runs BEFORE eviction so all matches are available.
-    if matches!(
-        config.join_type,
-        StreamJoinType::Left | StreamJoinType::Full | StreamJoinType::LeftAnti
-    ) {
-        let left_cutoff = right_watermark.saturating_sub(bound_ms);
-        if left_cutoff > state.left_evicted_cutoff && !state.left.batches.is_empty() {
-            let unmatched = emit_unmatched_left_rows(state, config, left_cutoff, bound_ms)?;
-            if let Some(batch) = unmatched {
-                result.push(batch);
+        flush(&mut match_pairs, &mut result)?;
+
+        // Step 3: emit unmatched rows about to be evicted (LEFT/RIGHT/FULL/ANTI).
+        // Runs before eviction so the opposite side's state is still complete.
+        if matches!(
+            config.join_type,
+            StreamJoinType::Left | StreamJoinType::Full | StreamJoinType::LeftAnti
+        ) {
+            let left_cutoff = right_watermark.saturating_sub(bound_ms);
+            if left_cutoff > state.left_evicted_cutoff && !state.left.batches.is_empty() {
+                emit_unmatched_left_rows(
+                    state,
+                    &left_key_cols,
+                    &right_key_cols,
+                    config,
+                    left_cutoff,
+                    bound_ms,
+                    &mut result,
+                )?;
+            }
+        }
+        if matches!(
+            config.join_type,
+            StreamJoinType::Right | StreamJoinType::Full
+        ) {
+            let right_cutoff = left_watermark.saturating_sub(bound_ms);
+            if right_cutoff > state.right_evicted_cutoff && !state.right.batches.is_empty() {
+                emit_unmatched_right_rows(
+                    state,
+                    &left_key_cols,
+                    &right_key_cols,
+                    right_cutoff,
+                    bound_ms,
+                    &mut result,
+                )?;
             }
         }
     }
-    if matches!(
-        config.join_type,
-        StreamJoinType::Right | StreamJoinType::Full
-    ) {
-        let right_cutoff = left_watermark.saturating_sub(bound_ms);
-        if right_cutoff > state.right_evicted_cutoff && !state.right.batches.is_empty() {
-            let unmatched = emit_unmatched_right_rows(state, config, right_cutoff, bound_ms)?;
-            if let Some(batch) = unmatched {
-                result.push(batch);
-            }
-        }
-    }
 
-    // Step 6: Evict expired rows independently per side.
-    // A left row at ts can match right rows with ts in [left_ts - bound, left_ts + bound].
-    // Once the right watermark passes left_ts + bound, no future right row can match.
-    // So: evict left rows where ts < right_watermark - bound (and vice versa).
+    // Step 4: evict. A left row at ts can only still match right rows with
+    // ts in [left_ts - bound, left_ts + bound], so once the right watermark
+    // passes left_ts + bound it's safe to drop. Symmetric for right.
     let left_cutoff = right_watermark.saturating_sub(bound_ms);
     if left_cutoff > state.left_evicted_cutoff {
         state
@@ -698,16 +748,19 @@ pub(crate) fn execute_interval_join_cycle(
     Ok(result)
 }
 
-/// For LEFT/ANTI joins: emit left rows about to be evicted that have no match
-/// in the current right state. Called BEFORE right-side eviction.
+/// LEFT/ANTI: emit pre-eviction left rows with no match in current right state.
+/// Output is chunked at `EMIT_THRESHOLD` rows.
 fn emit_unmatched_left_rows(
     state: &IntervalJoinState,
+    left_key_cols: &[KeyColumn<'_>],
+    right_key_cols: &[KeyColumn<'_>],
     config: &StreamJoinConfig,
     left_cutoff: i64,
     bound_ms: i64,
-) -> Result<Option<RecordBatch>, DbError> {
+    out: &mut Vec<RecordBatch>,
+) -> Result<(), DbError> {
     let Some(output_schema) = state.output_schema.as_ref() else {
-        return Ok(None);
+        return Ok(());
     };
 
     let left_only = matches!(
@@ -721,11 +774,10 @@ fn emit_unmatched_left_rows(
         for (&ts, entries) in btree.range(..left_cutoff) {
             for &(batch_idx, row_idx) in entries {
                 let candidates = probe_index(&state.right.index, key_hash, ts, bound_ms);
-                let left_key =
-                    extract_key_column(&state.left.batches[batch_idx], &config.left_key)?;
+                let left_key = &left_key_cols[batch_idx];
                 let has_match = candidates.iter().any(|&(rb, rr)| {
-                    extract_key_column(&state.right.batches[rb], &config.right_key)
-                        .is_ok_and(|rk| left_key.keys_equal(row_idx, &rk, rr))
+                    let rk = &right_key_cols[rb];
+                    left_key.keys_equal(row_idx, rk, rr)
                 });
                 if !has_match {
                     unmatched_left.push((batch_idx, row_idx));
@@ -735,59 +787,67 @@ fn emit_unmatched_left_rows(
     }
 
     if unmatched_left.is_empty() {
-        return Ok(None);
+        return Ok(());
     }
 
-    let left_schema = state
+    let left_field_count = state
         .left
         .batches
         .first()
-        .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
-
-    let num_rows = unmatched_left.len();
-    let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
-
-    for col_idx in 0..left_schema.fields().len() {
-        let mut builder = Vec::with_capacity(num_rows);
-        for &(batch_idx, row_idx) in &unmatched_left {
-            let array = state.left.batches[batch_idx].column(col_idx);
-            builder.push(array.slice(row_idx, 1));
-        }
-        let refs: Vec<&dyn Array> = builder.iter().map(AsRef::as_ref).collect();
-        let concatenated = arrow::compute::concat(&refs)
-            .map_err(|e| DbError::query_pipeline_arrow("interval join (unmatched left)", &e))?;
-        columns.push(concatenated);
-    }
-
-    if !left_only {
-        let right_schema = state
+        .map_or(0, RecordBatch::num_columns);
+    let right_field_count = if left_only {
+        0
+    } else {
+        state
             .right
             .batches
             .first()
-            .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
-        for col_idx in 0..right_schema.fields().len() {
-            let dt = output_schema
-                .field(left_schema.fields().len() + col_idx)
-                .data_type();
+            .map_or(0, RecordBatch::num_columns)
+    };
+
+    for chunk in unmatched_left.chunks(EMIT_THRESHOLD) {
+        let num_rows = chunk.len();
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
+
+        for col_idx in 0..left_field_count {
+            let arrays: Vec<&dyn Array> = state
+                .left
+                .batches
+                .iter()
+                .map(|b| b.column(col_idx).as_ref())
+                .collect();
+            let arr = arrow::compute::interleave(&arrays, chunk).map_err(|e| {
+                DbError::query_pipeline_arrow("interval join (unmatched left interleave)", &e)
+            })?;
+            columns.push(arr);
+        }
+
+        for col_idx in 0..right_field_count {
+            let dt = output_schema.field(left_field_count + col_idx).data_type();
             columns.push(arrow::array::new_null_array(dt, num_rows));
         }
-    }
 
-    RecordBatch::try_new(output_schema.clone(), columns)
-        .map(|b| if b.num_rows() > 0 { Some(b) } else { None })
-        .map_err(|e| DbError::query_pipeline_arrow("interval join (unmatched result)", &e))
+        let batch = RecordBatch::try_new(output_schema.clone(), columns).map_err(|e| {
+            DbError::query_pipeline_arrow("interval join (unmatched left result)", &e)
+        })?;
+        if batch.num_rows() > 0 {
+            out.push(batch);
+        }
+    }
+    Ok(())
 }
 
-/// For RIGHT/FULL joins: emit right rows about to be evicted that have no match
-/// in the current left state. Symmetric to `emit_unmatched_left_rows`.
+/// RIGHT/FULL: symmetric to `emit_unmatched_left_rows`.
 fn emit_unmatched_right_rows(
     state: &IntervalJoinState,
-    config: &StreamJoinConfig,
+    left_key_cols: &[KeyColumn<'_>],
+    right_key_cols: &[KeyColumn<'_>],
     right_cutoff: i64,
     bound_ms: i64,
-) -> Result<Option<RecordBatch>, DbError> {
+    out: &mut Vec<RecordBatch>,
+) -> Result<(), DbError> {
     let Some(output_schema) = state.output_schema.as_ref() else {
-        return Ok(None);
+        return Ok(());
     };
 
     let mut unmatched_right: Vec<(usize, usize)> = Vec::new();
@@ -796,11 +856,10 @@ fn emit_unmatched_right_rows(
         for (&ts, entries) in btree.range(..right_cutoff) {
             for &(batch_idx, row_idx) in entries {
                 let candidates = probe_index(&state.left.index, key_hash, ts, bound_ms);
-                let right_key =
-                    extract_key_column(&state.right.batches[batch_idx], &config.right_key)?;
+                let right_key = &right_key_cols[batch_idx];
                 let has_match = candidates.iter().any(|&(lb, lr)| {
-                    extract_key_column(&state.left.batches[lb], &config.left_key)
-                        .is_ok_and(|lk| right_key.keys_equal(row_idx, &lk, lr))
+                    let lk = &left_key_cols[lb];
+                    right_key.keys_equal(row_idx, lk, lr)
                 });
                 if !has_match {
                     unmatched_right.push((batch_idx, row_idx));
@@ -810,43 +869,50 @@ fn emit_unmatched_right_rows(
     }
 
     if unmatched_right.is_empty() {
-        return Ok(None);
+        return Ok(());
     }
 
-    let left_schema = state
+    let left_field_count = state
         .left
         .batches
         .first()
-        .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
-    let right_schema = state
+        .map_or(0, RecordBatch::num_columns);
+    let right_field_count = state
         .right
         .batches
         .first()
-        .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
+        .map_or(0, RecordBatch::num_columns);
 
-    let num_rows = unmatched_right.len();
-    let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
+    for chunk in unmatched_right.chunks(EMIT_THRESHOLD) {
+        let num_rows = chunk.len();
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(output_schema.fields().len());
 
-    for col_idx in 0..left_schema.fields().len() {
-        let dt = output_schema.field(col_idx).data_type();
-        columns.push(arrow::array::new_null_array(dt, num_rows));
-    }
-
-    for col_idx in 0..right_schema.fields().len() {
-        let mut builder = Vec::with_capacity(num_rows);
-        for &(batch_idx, row_idx) in &unmatched_right {
-            let array = state.right.batches[batch_idx].column(col_idx);
-            builder.push(array.slice(row_idx, 1));
+        for col_idx in 0..left_field_count {
+            let dt = output_schema.field(col_idx).data_type();
+            columns.push(arrow::array::new_null_array(dt, num_rows));
         }
-        let refs: Vec<&dyn Array> = builder.iter().map(AsRef::as_ref).collect();
-        let concatenated = arrow::compute::concat(&refs)
-            .map_err(|e| DbError::query_pipeline_arrow("interval join (unmatched right)", &e))?;
-        columns.push(concatenated);
-    }
 
-    RecordBatch::try_new(output_schema.clone(), columns)
-        .map(|b| if b.num_rows() > 0 { Some(b) } else { None })
-        .map_err(|e| DbError::query_pipeline_arrow("interval join (unmatched right result)", &e))
+        for col_idx in 0..right_field_count {
+            let arrays: Vec<&dyn Array> = state
+                .right
+                .batches
+                .iter()
+                .map(|b| b.column(col_idx).as_ref())
+                .collect();
+            let arr = arrow::compute::interleave(&arrays, chunk).map_err(|e| {
+                DbError::query_pipeline_arrow("interval join (unmatched right interleave)", &e)
+            })?;
+            columns.push(arr);
+        }
+
+        let batch = RecordBatch::try_new(output_schema.clone(), columns).map_err(|e| {
+            DbError::query_pipeline_arrow("interval join (unmatched right result)", &e)
+        })?;
+        if batch.num_rows() > 0 {
+            out.push(batch);
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1269,6 +1335,75 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].num_rows(), 1);
         assert_eq!(result[0].num_columns(), 3); // Left columns only
+    }
+
+    #[test]
+    fn test_remove_by_key_ts_propagates_extraction_error() {
+        // Buffer one row, then call remove_by_key_ts with a key column name
+        // that does not exist on the buffered batch. Pre-fix this returned
+        // Ok(()) silently because `map_or(true, ...)` retained the row on
+        // extraction failure, leaving phantom state.
+        let mut side = SideState::new();
+        let batch = left_batch(&["A"], &[100], &[1.0]);
+        side.add_batch(&batch, "id", "ts").unwrap();
+
+        // Probe key extracted from a "delete" batch that happens to have an `id` column.
+        let del = left_batch(&["A"], &[100], &[1.0]);
+        let del_keys = extract_key_column(&del, "id").unwrap();
+        let kh = del_keys.hash_at(0).unwrap();
+
+        // Buffered batch has no column called "missing" — extraction must fail.
+        let err = side.remove_by_key_ts(kh, 100, &del_keys, 0, "missing");
+        assert!(err.is_err(), "extraction failure must propagate");
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_wrap, clippy::cast_precision_loss)]
+    fn test_match_pairs_bounded_partial_emit_on_cross_product() {
+        // Adversarial shape: every left × every right matches (single key,
+        // wide bound, all timestamps within tolerance). Must emit multiple
+        // batches each ≤ EMIT_THRESHOLD rows, never accumulate all M·N pairs.
+        let config = StreamJoinConfig {
+            left_key: "id".to_string(),
+            right_key: "id".to_string(),
+            left_time_column: "ts".to_string(),
+            right_time_column: "ts".to_string(),
+            left_table: "left_stream".to_string(),
+            right_table: "right_stream".to_string(),
+            time_bound: Duration::from_millis(1_000_000),
+            join_type: StreamJoinType::Inner,
+        };
+        let mut state = IntervalJoinState::new();
+
+        // 300 × 300 = 90,000 pairs > 65,536 threshold → at least 2 output batches.
+        let m = 300usize;
+        let ids_l: Vec<&str> = (0..m).map(|_| "K").collect();
+        let ts_l: Vec<i64> = (0..m).map(|i| i as i64).collect();
+        let v_l: Vec<f64> = (0..m).map(|i| i as f64).collect();
+        let left = left_batch(&ids_l, &ts_l, &v_l);
+
+        let ids_r: Vec<&str> = (0..m).map(|_| "K").collect();
+        let ts_r: Vec<i64> = (0..m).map(|i| i as i64).collect();
+        let v_r: Vec<f64> = (0..m).map(|i| i as f64).collect();
+        let right = right_batch(&ids_r, &ts_r, &v_r);
+
+        let result =
+            execute_interval_join_cycle(&mut state, &[left], &[right], &config, 0, 0).unwrap();
+
+        let total: usize = result.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(total, m * m, "every pair must appear exactly once");
+        assert!(
+            result.len() >= 2,
+            "expected partial emits across multiple batches, got {}",
+            result.len()
+        );
+        for b in &result {
+            assert!(
+                b.num_rows() <= EMIT_THRESHOLD,
+                "partial batch exceeded EMIT_THRESHOLD: {}",
+                b.num_rows()
+            );
+        }
     }
 
     #[test]

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -665,7 +665,11 @@ impl OperatorGraph {
         }
     }
 
-    #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+    #[allow(
+        clippy::too_many_lines,
+        clippy::too_many_arguments,
+        clippy::needless_pass_by_value
+    )]
     pub fn add_query(
         &mut self,
         name: String,
@@ -674,25 +678,45 @@ impl OperatorGraph {
         window_config: Option<WindowOperatorConfig>,
         order_config: Option<OrderOperatorConfig>,
         idle_ttl_ms: Option<u64>,
+        join_config: Option<Vec<laminar_sql::translator::JoinOperatorConfig>>,
     ) {
-        // Detection (same as StreamExecutor::add_query)
+        // The planner's vec lets us short-circuit re-parsing for queries
+        // that have no specialized join step (or no joins at all).
+        // TemporalProbe is parsed off the token stream rather than the
+        // sqlparser AST, so it is never present in `join_config` and
+        // always needs its own detector pass.
+        use laminar_sql::translator::JoinOperatorConfig;
+        let needs_specialized_detection = join_config.as_ref().is_none_or(|jcs| {
+            jcs.iter().any(|c| {
+                matches!(
+                    c,
+                    JoinOperatorConfig::StreamStream(_)
+                        | JoinOperatorConfig::Asof(_)
+                        | JoinOperatorConfig::Temporal(_)
+                )
+            })
+        });
+
         let (temporal_probe_config, temporal_probe_projection_sql) =
             detect_temporal_probe_query(&sql);
-        let (asof_config, projection_sql) = if temporal_probe_config.is_none() {
-            detect_asof_query(&sql)
-        } else {
-            (None, None)
-        };
-        let (temporal_config, temporal_projection_sql) = if temporal_probe_config.is_none() {
-            detect_temporal_query(&sql)
-        } else {
-            (None, None)
-        };
-        let stream_join_detection = if temporal_probe_config.is_none() {
-            detect_stream_join_query(&sql)
-        } else {
-            None
-        };
+        let (asof_config, projection_sql) =
+            if temporal_probe_config.is_none() && needs_specialized_detection {
+                detect_asof_query(&sql)
+            } else {
+                (None, None)
+            };
+        let (temporal_config, temporal_projection_sql) =
+            if temporal_probe_config.is_none() && needs_specialized_detection {
+                detect_temporal_query(&sql)
+            } else {
+                (None, None)
+            };
+        let stream_join_detection =
+            if temporal_probe_config.is_none() && needs_specialized_detection {
+                detect_stream_join_query(&sql)
+            } else {
+                None
+            };
         let stream_join_config = stream_join_detection.as_ref().map(|d| d.config.clone());
         let stream_join_projection_sql = stream_join_detection
             .as_ref()
@@ -1477,6 +1501,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(graph.nodes.len(), 2); // source "trades" + query "q1"
@@ -1497,10 +1522,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "q2".to_string(),
             "SELECT symbol FROM q1 WHERE price > 100".to_string(),
+            None,
             None,
             None,
             None,
@@ -1527,10 +1554,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "q1".to_string(),
             "SELECT * FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -1568,6 +1597,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(graph.output_map.contains_key("q1"));
 
@@ -1585,6 +1615,7 @@ mod tests {
         graph.add_query(
             "filtered".to_string(),
             "SELECT symbol, price FROM trades WHERE price > 200".to_string(),
+            None,
             None,
             None,
             None,
@@ -1622,6 +1653,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let source_batches = FxHashMap::default();
@@ -1649,10 +1681,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "q2".to_string(),
             "SELECT symbol FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -1678,6 +1712,7 @@ mod tests {
         graph.add_query(
             "q1".to_string(),
             "SELECT * FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -1716,6 +1751,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let mut source = FxHashMap::default();
@@ -1743,6 +1779,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let mut source = FxHashMap::default();
@@ -1759,6 +1796,7 @@ mod tests {
         graph.add_query(
             "agg".to_string(),
             "SELECT symbol, SUM(price) AS total FROM trades GROUP BY symbol".to_string(),
+            None,
             None,
             None,
             None,
@@ -1810,10 +1848,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "step2".to_string(),
             "SELECT symbol, doubled FROM step1 WHERE doubled > 400".to_string(),
+            None,
             None,
             None,
             None,
@@ -1841,10 +1881,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "low".to_string(),
             "SELECT symbol, price FROM trades WHERE price <= 200".to_string(),
+            None,
             None,
             None,
             None,
@@ -1855,6 +1897,7 @@ mod tests {
             "combined".to_string(),
             "SELECT h.symbol, h.price FROM high h INNER JOIN low l ON h.symbol = l.symbol"
                 .to_string(),
+            None,
             None,
             None,
             None,
@@ -1884,10 +1927,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "q2".to_string(),
             "SELECT * FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -1920,6 +1965,7 @@ mod tests {
             graph.add_query(
                 format!("q{i}"),
                 "SELECT * FROM trades".to_string(),
+                None,
                 None,
                 None,
                 None,
@@ -1960,6 +2006,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let mut source = FxHashMap::default();
@@ -1981,6 +2028,7 @@ mod tests {
         graph.add_query(
             "agg".to_string(),
             "SELECT symbol, SUM(price) AS total FROM trades GROUP BY symbol".to_string(),
+            None,
             None,
             None,
             None,
@@ -2009,6 +2057,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // Need one cycle to lazy-init state before restore will take effect
@@ -2030,6 +2079,7 @@ mod tests {
         graph.add_query(
             "agg".to_string(),
             "SELECT symbol, SUM(price) AS total FROM trades GROUP BY symbol".to_string(),
+            None,
             None,
             None,
             None,
@@ -2066,10 +2116,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "q1".to_string(),
             "SELECT symbol, price FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -2119,6 +2171,7 @@ mod tests {
              TEMPORAL PROBE JOIN market_data m ON (symbol) \
              TIMESTAMPS (ts, mts) LIST (0s, 5s) AS p"
                 .to_string(),
+            None,
             None,
             None,
             None,
@@ -2175,6 +2228,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         // Push some data into the source buffer
         if let Some(&node_id) = graph.source_map.get("trades") {
@@ -2194,6 +2248,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         // Fill source buffer to 50% of cap
         if let Some(&node_id) = graph.source_map.get("trades") {
@@ -2209,6 +2264,7 @@ mod tests {
         graph.add_query(
             "q1".to_string(),
             "SELECT * FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -2242,10 +2298,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "downstream".to_string(),
             "SELECT symbol FROM proj".to_string(),
+            None,
             None,
             None,
             None,
@@ -2294,12 +2352,14 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         // Now register `derived` — this replaces the placeholder.
         graph.add_query(
             "derived".to_string(),
             "SELECT symbol, price FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -2321,6 +2381,7 @@ mod tests {
         graph.add_query(
             "sink".to_string(),
             "SELECT symbol FROM trades".to_string(),
+            None,
             None,
             None,
             None,
@@ -2410,6 +2471,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let batch = test_batch(); // AAPL + GOOG
@@ -2460,6 +2522,7 @@ mod tests {
              AND a.ts BETWEEN p.ts AND p.ts + INTERVAL '10' SECOND \
              WHERE p.type = 'A' AND a.type = 'B'"
                 .to_string(),
+            None,
             None,
             None,
             None,
@@ -2528,10 +2591,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "consumer".to_string(),
             "SELECT symbol FROM producer".to_string(),
+            None,
             None,
             None,
             None,
@@ -2608,10 +2673,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         graph.add_query(
             "consumer".to_string(),
             "SELECT symbol FROM producer".to_string(),
+            None,
             None,
             None,
             None,

--- a/crates/laminar-db/src/pipeline/mod.rs
+++ b/crates/laminar-db/src/pipeline/mod.rs
@@ -14,7 +14,7 @@ pub use streaming_coordinator::StreamingCoordinator;
 
 use arrow::datatypes::SchemaRef;
 use laminar_sql::parser::EmitClause;
-use laminar_sql::translator::{OrderOperatorConfig, WindowOperatorConfig};
+use laminar_sql::translator::{JoinOperatorConfig, OrderOperatorConfig, WindowOperatorConfig};
 
 /// Control message sent from `LaminarDB` DDL handlers to the running
 /// `StreamingCoordinator` for live schema changes (add/drop streams).
@@ -33,6 +33,8 @@ pub enum ControlMsg {
         window_config: Option<WindowOperatorConfig>,
         /// ORDER BY configuration.
         order_config: Option<OrderOperatorConfig>,
+        /// Per-step join configs from the planner (left-deep).
+        join_config: Option<Vec<JoinOperatorConfig>>,
     },
     /// Remove a streaming query from the running pipeline.
     DropStream {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -948,6 +948,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 emit_clause,
                 window_config,
                 order_config,
+                join_config,
             } => {
                 self.graph.add_query(
                     name.clone(),
@@ -956,6 +957,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                     window_config,
                     order_config,
                     None,
+                    join_config,
                 );
                 tracing::info!(stream = %name, "Stream added via control channel");
             }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -488,6 +488,7 @@ impl LaminarDB {
                 reg.window_config.clone(),
                 reg.order_config.clone(),
                 None,
+                reg.join_config.clone(),
             );
         }
 
@@ -1597,6 +1598,7 @@ mod resolver_tests {
                 )
             }),
             order_config: None,
+            join_config: None,
         }
     }
 

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
@@ -1486,6 +1486,24 @@ fn build_stream_join_projection_sql(
     let has_residual = select.from.len() == 1 && select.from[0].joins.len() > 1;
     let tmp_qual: Option<&str> = has_residual.then_some("__interval_tmp");
 
+    // Count natural-name occurrences so colliding projections (`p.type`,
+    // `a.type`) can be aliased as `{qual}_{col}` instead of duplicate `type`.
+    let mut natural_counts: FxHashMap<String, usize> = FxHashMap::default();
+    if has_residual {
+        for item in &select.projection {
+            if let SelectItem::UnnamedExpr(expr) = item {
+                let n = match expr {
+                    Expr::CompoundIdentifier(parts) => parts.last().map(|p| p.value.clone()),
+                    Expr::Identifier(ident) => Some(ident.value.clone()),
+                    _ => None,
+                };
+                if let Some(n) = n {
+                    *natural_counts.entry(n).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
     let items: Vec<String> = select
         .projection
         .iter()
@@ -1493,20 +1511,25 @@ fn build_stream_join_projection_sql(
             SelectItem::UnnamedExpr(expr) => {
                 let rewritten =
                     rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
-                // With residual joins we prefix step-0 cols with
-                // `__interval_tmp.`; alias back to the natural column name
-                // so DataFusion's projection labels stay user-visible.
-                // TODO: self-joins on a residual chain (`SELECT p.type, a.type
-                // FROM p JOIN a ... JOIN c ...`) still collide on the natural
-                // name. The fix is collision-aware aliasing — only emit `AS n`
-                // when no other rewritten projection produces the same `n`.
+                // Alias back to the natural column name so projection labels
+                // stay user-visible. On self-join collisions, fall back to
+                // `{qual}_{col}` so output names stay unique.
                 if has_residual {
-                    let natural = match expr {
-                        Expr::CompoundIdentifier(parts) => parts.last().map(|p| p.value.clone()),
-                        Expr::Identifier(ident) => Some(ident.value.clone()),
-                        _ => None,
+                    let (qual, natural) = match expr {
+                        Expr::CompoundIdentifier(parts) if parts.len() == 2 => (
+                            Some(parts[0].value.clone()),
+                            Some(parts[1].value.clone()),
+                        ),
+                        Expr::Identifier(ident) => (None, Some(ident.value.clone())),
+                        _ => (None, None),
                     };
                     if let Some(n) = natural {
+                        let collides = natural_counts.get(&n).copied().unwrap_or(0) > 1;
+                        if collides {
+                            if let Some(q) = qual {
+                                return format!("{rewritten} AS {q}_{n}");
+                            }
+                        }
                         if rewritten != n {
                             return format!("{rewritten} AS {n}");
                         }
@@ -1541,11 +1564,10 @@ fn build_stream_join_projection_sql(
         String::new()
     };
 
-    // IntervalJoin matches symmetrically; BETWEEN is directional. The
-    // upper bound is already enforced by the time bound; only `right_ts >=
-    // left_ts` needs to be added here.
-    // TODO(interval-rewriter): remove once `INTERVAL +` against BIGINT is
-    // normalised in the analyzer rule (memory/interval-rewriter-timestamp-plan.md).
+    // IntervalJoin matches symmetrically (`|left_ts - right_ts| <= N`) but
+    // BETWEEN is directional (`right_ts >= left_ts AND right_ts <= left_ts +
+    // N`). The upper bound is already covered by the symmetric tolerance; we
+    // add `right_ts >= left_ts` here to enforce the lower bound.
     let directional_filter = if !config.left_time_column.is_empty()
         && !config.right_time_column.is_empty()
     {
@@ -2152,6 +2174,37 @@ mod self_join_filter_tests {
         assert!(
             d.projection_sql.contains("WHERE"),
             "LEFT JOIN must keep right predicate in WHERE: {}",
+            d.projection_sql
+        );
+    }
+
+    #[test]
+    fn test_residual_self_join_aliases_collisions() {
+        // `p.type` and `a.type` both rewrite to step-0 columns and would
+        // otherwise alias to `AS type` twice. Collision-aware aliasing
+        // must emit `AS p_type` / `AS a_type` so output names stay unique.
+        let d = detect_stream_join_query(
+            "SELECT p.type, a.type, p.key FROM events p \
+             JOIN events a ON p.key = a.key \
+             AND a.ts BETWEEN p.ts AND p.ts + INTERVAL '10' SECOND \
+             JOIN dim d ON d.key = p.key",
+        )
+        .expect("should detect self-join");
+
+        assert!(
+            d.projection_sql.contains("AS p_type"),
+            "expected `AS p_type`, got: {}",
+            d.projection_sql
+        );
+        assert!(
+            d.projection_sql.contains("AS a_type"),
+            "expected `AS a_type`, got: {}",
+            d.projection_sql
+        );
+        // Non-colliding `p.key` keeps the natural-name alias.
+        assert!(
+            d.projection_sql.contains("AS key"),
+            "non-colliding `p.key` should still alias to `key`: {}",
             d.projection_sql
         );
     }

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -779,6 +779,7 @@ fn extract_self_join_pre_filters(
             analysis.left_alias.as_deref(),
             analysis.right_alias.as_deref(),
             config,
+            None,
         )
     });
 
@@ -864,6 +865,7 @@ pub(crate) fn detect_stream_join_query(sql: &str) -> Option<StreamJoinDetection>
                     stream_analysis.left_alias.as_deref(),
                     stream_analysis.right_alias.as_deref(),
                     &config,
+                    None,
                 );
                 format!(" WHERE {rewritten}")
             })
@@ -1476,15 +1478,45 @@ fn build_stream_join_projection_sql(
     let left_alias = analysis.left_alias.as_deref();
     let right_alias = analysis.right_alias.as_deref();
 
+    // When the original SELECT chains more joins past the stream-stream step
+    // (`A JOIN B ... JOIN C ...`), they run as residual joins in the post-
+    // projection over `__interval_tmp` plus the live source catalog. Step-0
+    // column refs are then prefixed with `__interval_tmp.` so shared names
+    // (e.g. `ka` present in both `__interval_tmp` and `c`) don't collide.
+    let has_residual = select.from.len() == 1 && select.from[0].joins.len() > 1;
+    let tmp_qual: Option<&str> = has_residual.then_some("__interval_tmp");
+
     let items: Vec<String> = select
         .projection
         .iter()
         .map(|item| match item {
             SelectItem::UnnamedExpr(expr) => {
-                rewrite_stream_join_expr(expr, left_alias, right_alias, config)
+                let rewritten =
+                    rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
+                // With residual joins we prefix step-0 cols with
+                // `__interval_tmp.`; alias back to the natural column name
+                // so DataFusion's projection labels stay user-visible.
+                // TODO: self-joins on a residual chain (`SELECT p.type, a.type
+                // FROM p JOIN a ... JOIN c ...`) still collide on the natural
+                // name. The fix is collision-aware aliasing — only emit `AS n`
+                // when no other rewritten projection produces the same `n`.
+                if has_residual {
+                    let natural = match expr {
+                        Expr::CompoundIdentifier(parts) => parts.last().map(|p| p.value.clone()),
+                        Expr::Identifier(ident) => Some(ident.value.clone()),
+                        _ => None,
+                    };
+                    if let Some(n) = natural {
+                        if rewritten != n {
+                            return format!("{rewritten} AS {n}");
+                        }
+                    }
+                }
+                rewritten
             }
             SelectItem::ExprWithAlias { expr, alias } => {
-                let rewritten = rewrite_stream_join_expr(expr, left_alias, right_alias, config);
+                let rewritten =
+                    rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
                 format!("{rewritten} AS {alias}")
             }
             SelectItem::Wildcard(_) => "*".to_string(),
@@ -1503,18 +1535,96 @@ fn build_stream_join_projection_sql(
         })
         .collect();
 
+    let residual = if has_residual {
+        render_residual_joins(&select.from[0].joins[1..], config, left_alias, right_alias, tmp_qual)
+    } else {
+        String::new()
+    };
+
+    // IntervalJoin matches symmetrically; BETWEEN is directional. The
+    // upper bound is already enforced by the time bound; only `right_ts >=
+    // left_ts` needs to be added here.
+    // TODO(interval-rewriter): remove once `INTERVAL +` against BIGINT is
+    // normalised in the analyzer rule (memory/interval-rewriter-timestamp-plan.md).
+    let directional_filter = if !config.left_time_column.is_empty()
+        && !config.right_time_column.is_empty()
+    {
+        let left_ref = match tmp_qual {
+            Some(q) => format!("{q}.{}", config.left_time_column),
+            None => config.left_time_column.clone(),
+        };
+        let right_ref = match tmp_qual {
+            Some(q) => format!("{q}.{}_{}", config.right_time_column, config.right_table),
+            None => format!("{}_{}", config.right_time_column, config.right_table),
+        };
+        format!("{right_ref} >= {left_ref}")
+    } else {
+        String::new()
+    };
+
+    let combined_where = match (where_clause.is_empty(), directional_filter.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => where_clause.to_string(),
+        (true, false) => format!(" WHERE {directional_filter}"),
+        (false, false) => format!("{where_clause} AND ({directional_filter})"),
+    };
+
     format!(
-        "SELECT {} FROM __interval_tmp{where_clause}",
+        "SELECT {} FROM __interval_tmp{residual}{combined_where}",
         items.join(", ")
     )
 }
 
-/// Rewrite table-qualified column refs for the `__interval_tmp` schema.
+/// Append residual joins (steps 1..N) onto a projection that selects
+/// from `__interval_tmp`. Unsupported join shapes (CROSS, USING, etc.)
+/// pass through via sqlparser's Display — we only rewrite ON exprs.
+fn render_residual_joins(
+    joins: &[sqlparser::ast::Join],
+    config: &StreamJoinConfig,
+    left_alias: Option<&str>,
+    right_alias: Option<&str>,
+    tmp_qual: Option<&str>,
+) -> String {
+    use sqlparser::ast::{JoinConstraint, JoinOperator};
+    let mut out = String::new();
+    for join in joins {
+        let (kw, on) = match &join.join_operator {
+            JoinOperator::Inner(JoinConstraint::On(e))
+            | JoinOperator::Join(JoinConstraint::On(e))
+            | JoinOperator::StraightJoin(JoinConstraint::On(e)) => ("JOIN", e),
+            JoinOperator::Left(JoinConstraint::On(e))
+            | JoinOperator::LeftOuter(JoinConstraint::On(e)) => ("LEFT JOIN", e),
+            JoinOperator::Right(JoinConstraint::On(e))
+            | JoinOperator::RightOuter(JoinConstraint::On(e)) => ("RIGHT JOIN", e),
+            JoinOperator::FullOuter(JoinConstraint::On(e)) => ("FULL JOIN", e),
+            // No ON expr to rewrite — let sqlparser format the whole join.
+            _ => {
+                out.push(' ');
+                let _ = std::fmt::Write::write_fmt(&mut out, format_args!("{join}"));
+                continue;
+            }
+        };
+        let on_sql = rewrite_stream_join_expr(on, left_alias, right_alias, config, tmp_qual);
+        let _ = std::fmt::Write::write_fmt(
+            &mut out,
+            format_args!(" {kw} {} ON {on_sql}", join.relation),
+        );
+    }
+    out
+}
+
+/// Rewrite `t.col` references against the `__interval_tmp` schema:
+/// step-0 left columns become bare names, right columns get the
+/// `_<right_table>` suffix that `IntervalJoinState` adds. With
+/// `tmp_qual = Some("__interval_tmp")` the rewritten names are also
+/// prefixed to disambiguate from downstream tables in residual joins.
+#[allow(clippy::too_many_lines)]
 fn rewrite_stream_join_expr(
     expr: &sqlparser::ast::Expr,
     left_alias: Option<&str>,
     right_alias: Option<&str>,
     config: &StreamJoinConfig,
+    tmp_qual: Option<&str>,
 ) -> String {
     match expr {
         Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
@@ -1523,26 +1633,38 @@ fn rewrite_stream_join_expr(
             let is_left = table == &config.left_table || left_alias.is_some_and(|a| a == table);
             let is_right = table == &config.right_table || right_alias.is_some_and(|a| a == table);
             if is_left || is_right {
-                if is_right {
+                let bare = if is_right {
                     format!("{col}_{}", config.right_table)
                 } else {
                     col.clone()
+                };
+                if let Some(q) = tmp_qual {
+                    format!("{q}.{bare}")
+                } else {
+                    bare
                 }
             } else {
                 expr.to_string()
             }
         }
         Expr::BinaryOp { left, op, right } => {
-            let l = rewrite_stream_join_expr(left, left_alias, right_alias, config);
-            let r = rewrite_stream_join_expr(right, left_alias, right_alias, config);
+            let l =
+                rewrite_stream_join_expr(left, left_alias, right_alias, config, tmp_qual);
+            let r = rewrite_stream_join_expr(
+                right, left_alias, right_alias, config, tmp_qual,
+            );
             format!("{l} {op} {r}")
         }
         Expr::UnaryOp { op, expr: inner } => {
-            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
+            let r = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
             format!("{op} {r}")
         }
         Expr::Nested(inner) => {
-            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
+            let r = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
             format!("({r})")
         }
         Expr::Cast {
@@ -1550,15 +1672,21 @@ fn rewrite_stream_join_expr(
             data_type,
             ..
         } => {
-            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
+            let r = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
             format!("CAST({r} AS {data_type})")
         }
         Expr::IsNull(inner) => {
-            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
+            let r = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
             format!("{r} IS NULL")
         }
         Expr::IsNotNull(inner) => {
-            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
+            let r = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
             format!("{r} IS NOT NULL")
         }
         Expr::Between {
@@ -1567,9 +1695,15 @@ fn rewrite_stream_join_expr(
             low,
             high,
         } => {
-            let e = rewrite_stream_join_expr(inner, left_alias, right_alias, config);
-            let l = rewrite_stream_join_expr(low, left_alias, right_alias, config);
-            let h = rewrite_stream_join_expr(high, left_alias, right_alias, config);
+            let e = rewrite_stream_join_expr(
+                inner, left_alias, right_alias, config, tmp_qual,
+            );
+            let l = rewrite_stream_join_expr(
+                low, left_alias, right_alias, config, tmp_qual,
+            );
+            let h = rewrite_stream_join_expr(
+                high, left_alias, right_alias, config, tmp_qual,
+            );
             if *negated {
                 format!("{e} NOT BETWEEN {l} AND {h}")
             } else {
@@ -1586,7 +1720,9 @@ fn rewrite_stream_join_expr(
                         .map(|arg| match arg {
                             sqlparser::ast::FunctionArg::Unnamed(
                                 sqlparser::ast::FunctionArgExpr::Expr(e),
-                            ) => rewrite_stream_join_expr(e, left_alias, right_alias, config),
+                            ) => rewrite_stream_join_expr(
+                                e, left_alias, right_alias, config, tmp_qual,
+                            ),
                             other => other.to_string(),
                         })
                         .collect();
@@ -1939,9 +2075,11 @@ mod self_join_filter_tests {
 
         assert_eq!(d.left_pre_filter.as_deref(), Some("type = 'A'"));
         assert_eq!(d.right_pre_filter.as_deref(), Some("type = 'B'"));
+        // Only the directional filter remains (user's WHERE pushed to
+        // pre-filters); no user-derived predicate stays post-join.
         assert!(
-            !d.projection_sql.contains("WHERE"),
-            "inner join should have no post-join WHERE, got: {}",
+            !d.projection_sql.contains("type"),
+            "user predicates should be pushed to pre-filters, got: {}",
             d.projection_sql
         );
     }

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -1516,10 +1516,9 @@ fn build_stream_join_projection_sql(
                 // `{qual}_{col}` so output names stay unique.
                 if has_residual {
                     let (qual, natural) = match expr {
-                        Expr::CompoundIdentifier(parts) if parts.len() == 2 => (
-                            Some(parts[0].value.clone()),
-                            Some(parts[1].value.clone()),
-                        ),
+                        Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
+                            (Some(parts[0].value.clone()), Some(parts[1].value.clone()))
+                        }
                         Expr::Identifier(ident) => (None, Some(ident.value.clone())),
                         _ => (None, None),
                     };
@@ -1559,7 +1558,13 @@ fn build_stream_join_projection_sql(
         .collect();
 
     let residual = if has_residual {
-        render_residual_joins(&select.from[0].joins[1..], config, left_alias, right_alias, tmp_qual)
+        render_residual_joins(
+            &select.from[0].joins[1..],
+            config,
+            left_alias,
+            right_alias,
+            tmp_qual,
+        )
     } else {
         String::new()
     };
@@ -1568,21 +1573,20 @@ fn build_stream_join_projection_sql(
     // BETWEEN is directional (`right_ts >= left_ts AND right_ts <= left_ts +
     // N`). The upper bound is already covered by the symmetric tolerance; we
     // add `right_ts >= left_ts` here to enforce the lower bound.
-    let directional_filter = if !config.left_time_column.is_empty()
-        && !config.right_time_column.is_empty()
-    {
-        let left_ref = match tmp_qual {
-            Some(q) => format!("{q}.{}", config.left_time_column),
-            None => config.left_time_column.clone(),
+    let directional_filter =
+        if !config.left_time_column.is_empty() && !config.right_time_column.is_empty() {
+            let left_ref = match tmp_qual {
+                Some(q) => format!("{q}.{}", config.left_time_column),
+                None => config.left_time_column.clone(),
+            };
+            let right_ref = match tmp_qual {
+                Some(q) => format!("{q}.{}_{}", config.right_time_column, config.right_table),
+                None => format!("{}_{}", config.right_time_column, config.right_table),
+            };
+            format!("{right_ref} >= {left_ref}")
+        } else {
+            String::new()
         };
-        let right_ref = match tmp_qual {
-            Some(q) => format!("{q}.{}_{}", config.right_time_column, config.right_table),
-            None => format!("{}_{}", config.right_time_column, config.right_table),
-        };
-        format!("{right_ref} >= {left_ref}")
-    } else {
-        String::new()
-    };
 
     let combined_where = match (where_clause.is_empty(), directional_filter.is_empty()) {
         (true, true) => String::new(),
@@ -1670,23 +1674,16 @@ fn rewrite_stream_join_expr(
             }
         }
         Expr::BinaryOp { left, op, right } => {
-            let l =
-                rewrite_stream_join_expr(left, left_alias, right_alias, config, tmp_qual);
-            let r = rewrite_stream_join_expr(
-                right, left_alias, right_alias, config, tmp_qual,
-            );
+            let l = rewrite_stream_join_expr(left, left_alias, right_alias, config, tmp_qual);
+            let r = rewrite_stream_join_expr(right, left_alias, right_alias, config, tmp_qual);
             format!("{l} {op} {r}")
         }
         Expr::UnaryOp { op, expr: inner } => {
-            let r = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
+            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
             format!("{op} {r}")
         }
         Expr::Nested(inner) => {
-            let r = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
+            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
             format!("({r})")
         }
         Expr::Cast {
@@ -1694,21 +1691,15 @@ fn rewrite_stream_join_expr(
             data_type,
             ..
         } => {
-            let r = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
+            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
             format!("CAST({r} AS {data_type})")
         }
         Expr::IsNull(inner) => {
-            let r = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
+            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
             format!("{r} IS NULL")
         }
         Expr::IsNotNull(inner) => {
-            let r = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
+            let r = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
             format!("{r} IS NOT NULL")
         }
         Expr::Between {
@@ -1717,15 +1708,9 @@ fn rewrite_stream_join_expr(
             low,
             high,
         } => {
-            let e = rewrite_stream_join_expr(
-                inner, left_alias, right_alias, config, tmp_qual,
-            );
-            let l = rewrite_stream_join_expr(
-                low, left_alias, right_alias, config, tmp_qual,
-            );
-            let h = rewrite_stream_join_expr(
-                high, left_alias, right_alias, config, tmp_qual,
-            );
+            let e = rewrite_stream_join_expr(inner, left_alias, right_alias, config, tmp_qual);
+            let l = rewrite_stream_join_expr(low, left_alias, right_alias, config, tmp_qual);
+            let h = rewrite_stream_join_expr(high, left_alias, right_alias, config, tmp_qual);
             if *negated {
                 format!("{e} NOT BETWEEN {l} AND {h}")
             } else {
@@ -1743,7 +1728,11 @@ fn rewrite_stream_join_expr(
                             sqlparser::ast::FunctionArg::Unnamed(
                                 sqlparser::ast::FunctionArgExpr::Expr(e),
                             ) => rewrite_stream_join_expr(
-                                e, left_alias, right_alias, config, tmp_qual,
+                                e,
+                                left_alias,
+                                right_alias,
+                                config,
+                                tmp_qual,
                             ),
                             other => other.to_string(),
                         })

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -1469,6 +1469,7 @@ fn rewrite_temporal_expr(
 // Private: Stream-stream join projection rewriting
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_lines)]
 fn build_stream_join_projection_sql(
     select: &sqlparser::ast::Select,
     analysis: &laminar_sql::parser::join_parser::JoinAnalysis,

--- a/crates/laminar-db/tests/n_way_join_differential.rs
+++ b/crates/laminar-db/tests/n_way_join_differential.rs
@@ -1,0 +1,580 @@
+//! Differential harness for N-way joins.
+//!
+//! Oracle: DataFusion batch execution over `MemTable`s. SUT: LaminarDB
+//! driving the same SQL through `CREATE STREAM`. Equality: multiset over
+//! Arrow row encoding.
+
+#![allow(clippy::disallowed_types)] // tests use std HashMap freely
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::row::{RowConverter, SortField};
+use datafusion::datasource::MemTable;
+use datafusion::prelude::SessionContext;
+use laminar_db::{FromBatch, LaminarDB};
+use proptest::prelude::*;
+use proptest::test_runner::{Config as PropConfig, TestRng, TestRunner};
+
+// ---------------------------------------------------------------------------
+// Drain helpers — wait for sources to clear and the coordinator to advance.
+// ---------------------------------------------------------------------------
+
+/// Wait until every source has drained and the coordinator has advanced a
+/// couple of cycles past that point — enough for an IntervalJoinOperator
+/// (cycle N) to feed its post-projection sink (N+1) and reach the
+/// subscription's output queue (N+2).
+async fn await_quiescence(
+    db: &LaminarDB,
+    sources: &[&laminar_db::UntypedSourceHandle],
+) {
+    const POLL: Duration = Duration::from_millis(20);
+    const STAGE_BUDGET: Duration = Duration::from_secs(2);
+
+    let deadline = std::time::Instant::now() + STAGE_BUDGET;
+    while std::time::Instant::now() < deadline {
+        if sources.iter().all(|h| h.pending() == 0) {
+            break;
+        }
+        tokio::time::sleep(POLL).await;
+    }
+
+    let baseline = db.metrics().total_cycles;
+    let deadline = std::time::Instant::now() + STAGE_BUDGET;
+    while std::time::Instant::now() < deadline
+        && db.metrics().total_cycles < baseline + 2
+    {
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+fn drain_subscription(sub: &mut laminar_db::TypedSubscription<CapturedBatch>) -> Vec<RecordBatch> {
+    let mut out = Vec::new();
+    while let Some(batches) = sub.poll() {
+        for cb in batches {
+            if cb.0.num_rows() > 0 {
+                out.push(cb.0);
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Subscription wrapper — we want raw batches, not deserialised rows.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct CapturedBatch(RecordBatch);
+
+impl FromBatch for CapturedBatch {
+    fn from_batch(batch: &RecordBatch, row: usize) -> Self {
+        Self(batch.slice(row, 1))
+    }
+    // Return one entry per row so `from_batch` is consistent with
+    // `from_batch_all`. Callers in this harness only use the latter.
+    fn from_batch_all(batch: &RecordBatch) -> Vec<Self> {
+        (0..batch.num_rows())
+            .map(|i| Self(batch.slice(i, 1)))
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schemas — three sources for both chain and star shapes.
+// ---------------------------------------------------------------------------
+
+fn schema_c() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("kc", DataType::Int64, false),
+        Field::new("ka", DataType::Int64, false),
+        Field::new("xc", DataType::Utf8, false),
+    ]))
+}
+
+fn make_batch_c(rows: &[(i64, i64, &str)]) -> RecordBatch {
+    let kc: Vec<i64> = rows.iter().map(|r| r.0).collect();
+    let ka: Vec<i64> = rows.iter().map(|r| r.1).collect();
+    let xc: Vec<&str> = rows.iter().map(|r| r.2).collect();
+    RecordBatch::try_new(
+        schema_c(),
+        vec![
+            Arc::new(Int64Array::from(kc)),
+            Arc::new(Int64Array::from(ka)),
+            Arc::new(StringArray::from(xc)),
+        ],
+    )
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Multiset equality over a vector of batches.
+// ---------------------------------------------------------------------------
+
+fn batches_to_sorted_rows(
+    batches: &[RecordBatch],
+    schema: &SchemaRef,
+) -> Result<Vec<Vec<u8>>, arrow::error::ArrowError> {
+    let fields: Vec<SortField> = schema
+        .fields()
+        .iter()
+        .map(|f| SortField::new(f.data_type().clone()))
+        .collect();
+    let converter = RowConverter::new(fields)?;
+
+    let mut all_rows: Vec<Vec<u8>> = Vec::new();
+    for b in batches {
+        if b.num_rows() == 0 {
+            continue;
+        }
+        // Re-project to the canonical column order if the SUT batch ordered
+        // columns differently. (If schemas already match, this is a no-op.)
+        let projected = if b.schema().fields() == schema.fields() {
+            b.clone()
+        } else {
+            let indices: Result<Vec<usize>, _> = schema
+                .fields()
+                .iter()
+                .map(|f| {
+                    b.schema().index_of(f.name()).map_err(|_| {
+                        arrow::error::ArrowError::SchemaError(format!(
+                            "missing column '{}' in SUT output",
+                            f.name()
+                        ))
+                    })
+                })
+                .collect();
+            b.project(&indices?)?
+        };
+        let cols = projected.columns().to_vec();
+        let rows = converter.convert_columns(&cols)?;
+        for i in 0..rows.num_rows() {
+            all_rows.push(rows.row(i).as_ref().to_vec());
+        }
+    }
+    all_rows.sort();
+    Ok(all_rows)
+}
+
+/// Format a multiset as a histogram for failure messages.
+fn histogram(rows: &[Vec<u8>]) -> BTreeMap<Vec<u8>, usize> {
+    let mut h = BTreeMap::new();
+    for r in rows {
+        *h.entry(r.clone()).or_insert(0) += 1;
+    }
+    h
+}
+
+fn diff_counts(
+    oracle: &[Vec<u8>],
+    sut: &[Vec<u8>],
+) -> (Vec<(Vec<u8>, isize)>, usize, usize) {
+    let h_o = histogram(oracle);
+    let h_s = histogram(sut);
+    let mut diffs: Vec<(Vec<u8>, isize)> = Vec::new();
+    for (k, vo) in &h_o {
+        let vs = h_s.get(k).copied().unwrap_or(0);
+        if *vo != vs {
+            diffs.push((k.clone(), *vo as isize - vs as isize));
+        }
+    }
+    for (k, vs) in &h_s {
+        if !h_o.contains_key(k) {
+            diffs.push((k.clone(), -(*vs as isize)));
+        }
+    }
+    (diffs, oracle.len(), sut.len())
+}
+
+// ---------------------------------------------------------------------------
+// Output schema for the BETWEEN positive tests.
+// ---------------------------------------------------------------------------
+
+fn output_schema_chain_star() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("ka", DataType::Int64, false),
+        Field::new("xa", DataType::Utf8, false),
+        Field::new("xb", DataType::Utf8, false),
+        Field::new("xc", DataType::Utf8, false),
+    ]))
+}
+
+// ---------------------------------------------------------------------------
+// Rejection assertions — H1 forbids unbounded multi-way stream-stream joins.
+// Equi-equi chain, equi-equi star, and the cross-cycle shape all fall under
+// this rule; CREATE STREAM should fail at plan time with a clear message.
+// ---------------------------------------------------------------------------
+
+async fn expect_planning_rejection(create_stream_sql: &str) -> String {
+    let db = LaminarDB::open().expect("open");
+    db.execute("CREATE SOURCE a (ka BIGINT, kb BIGINT, xa VARCHAR)")
+        .await
+        .expect("ddl a");
+    db.execute("CREATE SOURCE b (kb BIGINT, kc BIGINT, xb VARCHAR)")
+        .await
+        .expect("ddl b");
+    db.execute("CREATE SOURCE c (kc BIGINT, ka BIGINT, xc VARCHAR)")
+        .await
+        .expect("ddl c");
+
+    let err = db.execute(create_stream_sql).await.expect_err(
+        "expected planning rejection for unbounded multi-way streaming join",
+    );
+    format!("{err}")
+}
+
+#[tokio::test]
+async fn rejects_unbounded_chain() {
+    let msg = expect_planning_rejection(
+        "CREATE STREAM out AS SELECT a.ka, a.xa, b.xb, c.xc FROM a \
+         JOIN b ON a.kb = b.kb JOIN c ON b.kc = c.kc",
+    )
+    .await;
+    assert!(msg.contains("unbounded join"), "got: {msg}");
+    assert!(msg.contains("lookup table"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn rejects_unbounded_star() {
+    let msg = expect_planning_rejection(
+        "CREATE STREAM out AS SELECT a.ka, a.xa, b.xb, c.xc FROM a \
+         JOIN b ON a.kb = b.kb JOIN c ON a.ka = c.ka",
+    )
+    .await;
+    assert!(msg.contains("unbounded join"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn rejects_unbounded_two_way() {
+    let msg = expect_planning_rejection(
+        "CREATE STREAM out AS SELECT a.ka, b.xb FROM a JOIN b ON a.kb = b.kb",
+    )
+    .await;
+    assert!(msg.contains("unbounded join"), "got: {msg}");
+}
+
+// ===========================================================================
+// v2 #1 — BETWEEN-bounded chain. Surfaces audit C1/C2:
+// `detect_stream_join_query` matches the first step (a↔b), so
+// `IntervalJoinOperator` is built for those two only — c is dropped from the
+// operator graph. SUT either errors at projection compile or silently drops
+// rows joining through c.
+// ===========================================================================
+
+const BETWEEN_CHAIN_SUT_SQL: &str = "SELECT a.ka, a.xa, b.xb, c.xc FROM a \
+    JOIN b ON a.kb = b.kb AND b.ts BETWEEN a.ts AND a.ts + INTERVAL '5' SECOND \
+    JOIN c ON b.kc = c.kc";
+
+// Oracle: SUT's INTERVAL '5' SECOND lowers to 5000ms in the operator's
+// time_bound. Express the same predicate against BIGINT ms columns so
+// DataFusion can plan it without TIMESTAMP arithmetic.
+const BETWEEN_CHAIN_ORACLE_SQL: &str = "SELECT a.ka, a.xa, b.xb, c.xc FROM a \
+    JOIN b ON a.kb = b.kb AND b.ts BETWEEN a.ts AND a.ts + 5000 \
+    JOIN c ON b.kc = c.kc";
+
+fn schema_a_ts() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("ka", DataType::Int64, false),
+        Field::new("kb", DataType::Int64, false),
+        Field::new("ts", DataType::Int64, false),
+        Field::new("xa", DataType::Utf8, false),
+    ]))
+}
+
+fn schema_b_ts() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("kb", DataType::Int64, false),
+        Field::new("kc", DataType::Int64, false),
+        Field::new("ts", DataType::Int64, false),
+        Field::new("xb", DataType::Utf8, false),
+    ]))
+}
+
+fn make_a_ts(rows: &[(i64, i64, i64, &str)]) -> RecordBatch {
+    let ka: Vec<i64> = rows.iter().map(|r| r.0).collect();
+    let kb: Vec<i64> = rows.iter().map(|r| r.1).collect();
+    let ts: Vec<i64> = rows.iter().map(|r| r.2).collect();
+    let xa: Vec<&str> = rows.iter().map(|r| r.3).collect();
+    RecordBatch::try_new(
+        schema_a_ts(),
+        vec![
+            Arc::new(Int64Array::from(ka)),
+            Arc::new(Int64Array::from(kb)),
+            Arc::new(Int64Array::from(ts)),
+            Arc::new(StringArray::from(xa)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_b_ts(rows: &[(i64, i64, i64, &str)]) -> RecordBatch {
+    let kb: Vec<i64> = rows.iter().map(|r| r.0).collect();
+    let kc: Vec<i64> = rows.iter().map(|r| r.1).collect();
+    let ts: Vec<i64> = rows.iter().map(|r| r.2).collect();
+    let xb: Vec<&str> = rows.iter().map(|r| r.3).collect();
+    RecordBatch::try_new(
+        schema_b_ts(),
+        vec![
+            Arc::new(Int64Array::from(kb)),
+            Arc::new(Int64Array::from(kc)),
+            Arc::new(Int64Array::from(ts)),
+            Arc::new(StringArray::from(xb)),
+        ],
+    )
+    .unwrap()
+}
+
+async fn run_oracle_ts(
+    sql: &str,
+    a: Vec<RecordBatch>,
+    b: Vec<RecordBatch>,
+    c: Vec<RecordBatch>,
+) -> Result<Vec<RecordBatch>, datafusion::error::DataFusionError> {
+    let ctx = SessionContext::new();
+    ctx.register_table("a", Arc::new(MemTable::try_new(schema_a_ts(), vec![a])?))?;
+    ctx.register_table("b", Arc::new(MemTable::try_new(schema_b_ts(), vec![b])?))?;
+    ctx.register_table("c", Arc::new(MemTable::try_new(schema_c(), vec![c])?))?;
+    let df = ctx.sql(sql).await?;
+    df.collect().await
+}
+
+async fn run_sut_ts(
+    sql: &str,
+    a_batches: Vec<RecordBatch>,
+    b_batches: Vec<RecordBatch>,
+    c_rows: &[(i64, i64, &str)],
+) -> Result<Vec<RecordBatch>, String> {
+    let db = LaminarDB::open().map_err(|e| format!("open: {e}"))?;
+
+    db.execute(
+        "CREATE SOURCE a (ka BIGINT, kb BIGINT, ts BIGINT, xa VARCHAR, \
+         WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+    )
+    .await
+    .map_err(|e| format!("ddl a: {e}"))?;
+    db.execute(
+        "CREATE SOURCE b (kb BIGINT, kc BIGINT, ts BIGINT, xb VARCHAR, \
+         WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+    )
+    .await
+    .map_err(|e| format!("ddl b: {e}"))?;
+    // c is a lookup table (the natural production shape for an enrichment
+    // join on the residual side of an interval-bounded chain).
+    db.execute(
+        "CREATE LOOKUP TABLE c (kc BIGINT NOT NULL, ka BIGINT, xc VARCHAR, \
+         PRIMARY KEY (kc)) WITH ('connector' = 'static')",
+    )
+    .await
+    .map_err(|e| format!("ddl c: {e}"))?;
+
+    // Seed the lookup table. Single multi-row INSERT keeps the planner
+    // round-trip count down for proptest cases. String-formatted values
+    // are safe here because `xc` comes from the proptest alphabet
+    // `[a-z]{1,3}` — do NOT copy this idiom into production seeding code.
+    if !c_rows.is_empty() {
+        let values: Vec<String> = c_rows
+            .iter()
+            .map(|(kc, ka, xc)| format!("({kc}, {ka}, '{xc}')"))
+            .collect();
+        let insert_sql = format!("INSERT INTO c VALUES {}", values.join(", "));
+        db.execute(&insert_sql)
+            .await
+            .map_err(|e| format!("insert c: {e}"))?;
+    }
+
+    let stream_sql = format!("CREATE STREAM out AS {sql}");
+    db.execute(&stream_sql)
+        .await
+        .map_err(|e| format!("ddl stream: {e}"))?;
+
+    db.start().await.map_err(|e| format!("start: {e}"))?;
+
+    let mut sub = db
+        .subscribe::<CapturedBatch>("out")
+        .map_err(|e| format!("subscribe: {e}"))?;
+
+    let h_a = db.source_untyped("a").map_err(|e| format!("h_a: {e}"))?;
+    let h_b = db.source_untyped("b").map_err(|e| format!("h_b: {e}"))?;
+
+    for batch in a_batches {
+        h_a.push_arrow(batch)
+            .map_err(|e| format!("push a: {e}"))?;
+    }
+    for batch in b_batches {
+        h_b.push_arrow(batch)
+            .map_err(|e| format!("push b: {e}"))?;
+    }
+
+    await_quiescence(&db, &[&h_a, &h_b]).await;
+    let collected = drain_subscription(&mut sub);
+
+    db.shutdown().await.map_err(|e| format!("shutdown: {e}"))?;
+    Ok(collected)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smoke_n3_between_chain() {
+    // a.ts and b.ts within 5s; b.kc = c.kc to chain.
+    let a = [(1_i64, 10_i64, 1_000_i64, "a1"), (2, 20, 2_000, "a2")];
+    let b = [
+        (10_i64, 100_i64, 1_500_i64, "b1"), // matches a1: 1500-1000=500 <= 5000
+        (20, 200, 2_300, "b2"),             // matches a2: 2300-2000=300 <= 5000
+    ];
+    let c = [(100_i64, 1_i64, "c1"), (200, 2, "c2")];
+
+    let oracle = run_oracle_ts(
+        BETWEEN_CHAIN_ORACLE_SQL,
+        vec![make_a_ts(&a)],
+        vec![make_b_ts(&b)],
+        vec![make_batch_c(&c)],
+    )
+    .await
+    .expect("oracle exec");
+
+    let sut_result = run_sut_ts(
+        BETWEEN_CHAIN_SUT_SQL,
+        vec![make_a_ts(&a)],
+        vec![make_b_ts(&b)],
+        &c,
+    )
+    .await;
+
+    let schema = output_schema_chain_star();
+    let oracle_rows = batches_to_sorted_rows(&oracle, &schema).expect("oracle rows");
+
+    match sut_result {
+        Err(e) => {
+            // Capture the SUT failure as the counter-example.
+            panic!(
+                "[BETWEEN CHAIN N=3 SMOKE] oracle={} rows; SUT failed: {e}",
+                oracle_rows.len()
+            );
+        }
+        Ok(sut) => {
+            let sut_rows = batches_to_sorted_rows(&sut, &schema).expect("sut rows");
+            if oracle_rows != sut_rows {
+                let (diffs, no, ns) = diff_counts(&oracle_rows, &sut_rows);
+                panic!(
+                    "[BETWEEN CHAIN N=3 SMOKE] oracle={no} sut={ns} diffs={} \
+                     (positive = oracle has more, negative = sut has more)",
+                    diffs.len()
+                );
+            }
+        }
+    }
+}
+
+fn between_row_strategy() -> impl Strategy<Value = (i64, i64, i64, String)> {
+    (0_i64..6, 0_i64..6, 0_i64..10_000, "[a-z]{1,3}")
+}
+
+fn between_rows_strategy() -> impl Strategy<Value = Vec<(i64, i64, i64, String)>> {
+    proptest::collection::vec(between_row_strategy(), 0..12)
+}
+
+#[derive(Debug, Clone)]
+struct BetweenCase {
+    a: Vec<(i64, i64, i64, String)>,
+    b: Vec<(i64, i64, i64, String)>,
+    c: Vec<(i64, i64, String)>,
+}
+
+fn between_case_strategy() -> impl Strategy<Value = BetweenCase> {
+    let c_row = (0_i64..6, 0_i64..6, "[a-z]{1,3}").prop_map(|(k1, k2, s)| (k1, k2, s));
+    let c_rows = proptest::collection::vec(c_row, 0..12).prop_map(|rows| {
+        // c is materialised as a LOOKUP TABLE keyed on kc; dedupe in the
+        // generator so the oracle (plain MemTable, no PK) sees the same
+        // multiset the SUT does.
+        let mut by_key: BTreeMap<i64, (i64, i64, String)> = BTreeMap::new();
+        for row in rows {
+            by_key.insert(row.0, row);
+        }
+        by_key.into_values().collect()
+    });
+    (between_rows_strategy(), between_rows_strategy(), c_rows)
+        .prop_map(|(a, b, c)| BetweenCase { a, b, c })
+}
+
+fn block_on_check_between(case: &BetweenCase) -> Result<(), String> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .map_err(|e| format!("rt build: {e}"))?;
+    rt.block_on(async {
+        let a: Vec<_> = case
+            .a
+            .iter()
+            .map(|(k1, k2, t, s)| (*k1, *k2, *t, s.as_str()))
+            .collect();
+        let b: Vec<_> = case
+            .b
+            .iter()
+            .map(|(k1, k2, t, s)| (*k1, *k2, *t, s.as_str()))
+            .collect();
+        let c: Vec<_> = case
+            .c
+            .iter()
+            .map(|(k1, k2, s)| (*k1, *k2, s.as_str()))
+            .collect();
+        let oracle = run_oracle_ts(
+            BETWEEN_CHAIN_ORACLE_SQL,
+            vec![make_a_ts(&a)],
+            vec![make_b_ts(&b)],
+            vec![make_batch_c(&c)],
+        )
+        .await
+        .map_err(|e| format!("oracle: {e}"))?;
+
+        let sut = run_sut_ts(
+            BETWEEN_CHAIN_SUT_SQL,
+            vec![make_a_ts(&a)],
+            vec![make_b_ts(&b)],
+            &c,
+        )
+        .await
+        .map_err(|e| format!("sut: {e}"))?;
+
+        let schema = output_schema_chain_star();
+        let oracle_rows =
+            batches_to_sorted_rows(&oracle, &schema).map_err(|e| format!("o rows: {e}"))?;
+        let sut_rows =
+            batches_to_sorted_rows(&sut, &schema).map_err(|e| format!("s rows: {e}"))?;
+
+        if oracle_rows == sut_rows {
+            return Ok(());
+        }
+        let (diffs, no, ns) = diff_counts(&oracle_rows, &sut_rows);
+        Err(format!(
+            "oracle={no} sut={ns} diffs={} a={:?} b={:?} c={:?}",
+            diffs.len(),
+            case.a,
+            case.b,
+            case.c
+        ))
+    })
+}
+
+/// Deterministic seed shared by every property test in this file.
+const PROPTEST_SEED: [u8; 32] = [42; 32];
+
+#[test]
+fn property_n3_between_chain() {
+    let config = PropConfig {
+        cases: 16,
+        failure_persistence: None,
+        ..PropConfig::default()
+    };
+    let rng = TestRng::from_seed(proptest::test_runner::RngAlgorithm::ChaCha, &PROPTEST_SEED);
+    let mut runner = TestRunner::new_with_rng(config, rng);
+    let result = runner.run(&between_case_strategy(), |case| {
+        block_on_check_between(&case).map_err(|m| TestCaseError::Fail(m.into()))
+    });
+    if let Err(e) = result {
+        panic!("[BETWEEN CHAIN N=3] property failed: {e}");
+    }
+}
+

--- a/crates/laminar-db/tests/n_way_join_differential.rs
+++ b/crates/laminar-db/tests/n_way_join_differential.rs
@@ -27,10 +27,7 @@ use proptest::test_runner::{Config as PropConfig, TestRng, TestRunner};
 /// couple of cycles past that point — enough for an IntervalJoinOperator
 /// (cycle N) to feed its post-projection sink (N+1) and reach the
 /// subscription's output queue (N+2).
-async fn await_quiescence(
-    db: &LaminarDB,
-    sources: &[&laminar_db::UntypedSourceHandle],
-) {
+async fn await_quiescence(db: &LaminarDB, sources: &[&laminar_db::UntypedSourceHandle]) {
     const POLL: Duration = Duration::from_millis(20);
     const STAGE_BUDGET: Duration = Duration::from_secs(2);
 
@@ -44,9 +41,7 @@ async fn await_quiescence(
 
     let baseline = db.metrics().total_cycles;
     let deadline = std::time::Instant::now() + STAGE_BUDGET;
-    while std::time::Instant::now() < deadline
-        && db.metrics().total_cycles < baseline + 2
-    {
+    while std::time::Instant::now() < deadline && db.metrics().total_cycles < baseline + 2 {
         tokio::time::sleep(POLL).await;
     }
 }
@@ -168,10 +163,7 @@ fn histogram(rows: &[Vec<u8>]) -> BTreeMap<Vec<u8>, usize> {
     h
 }
 
-fn diff_counts(
-    oracle: &[Vec<u8>],
-    sut: &[Vec<u8>],
-) -> (Vec<(Vec<u8>, isize)>, usize, usize) {
+fn diff_counts(oracle: &[Vec<u8>], sut: &[Vec<u8>]) -> (Vec<(Vec<u8>, isize)>, usize, usize) {
     let h_o = histogram(oracle);
     let h_s = histogram(sut);
     let mut diffs: Vec<(Vec<u8>, isize)> = Vec::new();
@@ -220,9 +212,10 @@ async fn expect_planning_rejection(create_stream_sql: &str) -> String {
         .await
         .expect("ddl c");
 
-    let err = db.execute(create_stream_sql).await.expect_err(
-        "expected planning rejection for unbounded multi-way streaming join",
-    );
+    let err = db
+        .execute(create_stream_sql)
+        .await
+        .expect_err("expected planning rejection for unbounded multi-way streaming join");
     format!("{err}")
 }
 
@@ -400,12 +393,10 @@ async fn run_sut_ts(
     let h_b = db.source_untyped("b").map_err(|e| format!("h_b: {e}"))?;
 
     for batch in a_batches {
-        h_a.push_arrow(batch)
-            .map_err(|e| format!("push a: {e}"))?;
+        h_a.push_arrow(batch).map_err(|e| format!("push a: {e}"))?;
     }
     for batch in b_batches {
-        h_b.push_arrow(batch)
-            .map_err(|e| format!("push b: {e}"))?;
+        h_b.push_arrow(batch).map_err(|e| format!("push b: {e}"))?;
     }
 
     await_quiescence(&db, &[&h_a, &h_b]).await;
@@ -494,8 +485,11 @@ fn between_case_strategy() -> impl Strategy<Value = BetweenCase> {
         }
         by_key.into_values().collect()
     });
-    (between_rows_strategy(), between_rows_strategy(), c_rows)
-        .prop_map(|(a, b, c)| BetweenCase { a, b, c })
+    (between_rows_strategy(), between_rows_strategy(), c_rows).prop_map(|(a, b, c)| BetweenCase {
+        a,
+        b,
+        c,
+    })
 }
 
 fn block_on_check_between(case: &BetweenCase) -> Result<(), String> {
@@ -541,8 +535,7 @@ fn block_on_check_between(case: &BetweenCase) -> Result<(), String> {
         let schema = output_schema_chain_star();
         let oracle_rows =
             batches_to_sorted_rows(&oracle, &schema).map_err(|e| format!("o rows: {e}"))?;
-        let sut_rows =
-            batches_to_sorted_rows(&sut, &schema).map_err(|e| format!("s rows: {e}"))?;
+        let sut_rows = batches_to_sorted_rows(&sut, &schema).map_err(|e| format!("s rows: {e}"))?;
 
         if oracle_rows == sut_rows {
             return Ok(());
@@ -577,4 +570,3 @@ fn property_n3_between_chain() {
         panic!("[BETWEEN CHAIN N=3] property failed: {e}");
     }
 }
-

--- a/crates/laminar-sql/src/parser/join_parser.rs
+++ b/crates/laminar-sql/src/parser/join_parser.rs
@@ -261,6 +261,13 @@ impl JoinAnalysis {
             additional_key_columns: vec![],
         }
     }
+
+    /// True if this step has any kind of temporal bound — a `BETWEEN`-derived
+    /// time bound, ASOF match condition, or `FOR SYSTEM_TIME AS OF`.
+    #[must_use]
+    pub fn is_bounded(&self) -> bool {
+        self.time_bound.is_some() || self.is_asof_join || self.is_temporal_join
+    }
 }
 
 /// Analyze a SELECT statement for join information.

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -25,7 +25,7 @@ use crate::parser::aggregation_parser::analyze_aggregates;
 use crate::parser::analytic_parser::{
     analyze_analytic_functions, analyze_window_frames, FrameBound,
 };
-use crate::parser::join_parser::analyze_joins;
+use crate::parser::join_parser::{analyze_joins, MultiJoinAnalysis};
 use crate::parser::lookup_table::{validate_properties, LookupTableProperties};
 use crate::parser::order_analyzer::analyze_order_by;
 use crate::parser::{
@@ -258,7 +258,6 @@ impl StreamingPlanner {
     }
 
     /// Plans a CREATE CONTINUOUS QUERY statement.
-    #[allow(clippy::unused_self)] // Will use planner state for query registration
     fn plan_continuous_query(
         &mut self,
         name: &ObjectName,
@@ -276,7 +275,7 @@ impl StreamingPlanner {
         };
 
         // Analyze the query for streaming features
-        let query_plan = Self::analyze_query(&stmt, emit_clause)?;
+        let query_plan = self.analyze_query(&stmt, emit_clause)?;
 
         Ok(StreamingPlan::Query(QueryPlan {
             name: Some(object_name_to_string(name)),
@@ -304,6 +303,10 @@ impl StreamingPlanner {
                 let join_analysis = analyze_joins(select).map_err(|e| {
                     PlanningError::InvalidQuery(format!("Join analysis failed: {e}"))
                 })?;
+
+                if let Some(ref multi) = join_analysis {
+                    reject_unbounded_streaming_join(multi, &self.lookup_tables)?;
+                }
 
                 // Check for ORDER BY
                 let order_analysis = analyze_order_by(stmt);
@@ -377,6 +380,7 @@ impl StreamingPlanner {
 
     /// Analyzes a query for streaming features.
     fn analyze_query(
+        &self,
         stmt: &Statement,
         emit_clause: Option<&EmitClause>,
     ) -> Result<QueryAnalysis, PlanningError> {
@@ -403,6 +407,7 @@ impl StreamingPlanner {
                 if let Some(multi) = analyze_joins(select).map_err(|e| {
                     PlanningError::InvalidQuery(format!("Join analysis failed: {e}"))
                 })? {
+                    reject_unbounded_streaming_join(&multi, &self.lookup_tables)?;
                     analysis.join_config = Some(JoinOperatorConfig::from_multi_analysis(&multi));
                 }
             }
@@ -622,6 +627,28 @@ fn object_name_to_string(name: &ObjectName) -> String {
     name.to_string()
 }
 
+/// Reject unbounded joins between two streaming sources.
+fn reject_unbounded_streaming_join(
+    multi: &MultiJoinAnalysis,
+    lookup_tables: &HashMap<String, LookupTableInfo>,
+) -> Result<(), PlanningError> {
+    for step in &multi.joins {
+        if step.is_bounded() {
+            continue;
+        }
+        let left_lookup = lookup_tables.contains_key(&step.left_table);
+        let right_lookup = lookup_tables.contains_key(&step.right_table);
+        if !left_lookup && !right_lookup {
+            return Err(PlanningError::InvalidQuery(format!(
+                "unbounded join between streaming sources '{}' and '{}'; \
+                 add a temporal predicate or use a lookup table",
+                step.left_table, step.right_table,
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Planning errors
 #[derive(Debug, thiserror::Error)]
 pub enum PlanningError {
@@ -817,7 +844,8 @@ mod tests {
     fn test_plan_query_with_join() {
         let mut planner = StreamingPlanner::new();
         let statements = StreamingParser::parse_sql(
-            "SELECT * FROM orders o JOIN payments p ON o.order_id = p.order_id",
+            "SELECT * FROM orders o JOIN payments p ON o.order_id = p.order_id \
+             AND p.ts BETWEEN o.ts AND o.ts + INTERVAL '1' HOUR",
         )
         .unwrap();
 
@@ -832,6 +860,19 @@ mod tests {
             }
             _ => panic!("Expected Query plan"),
         }
+    }
+
+    #[test]
+    fn test_plan_rejects_unbounded_streaming_join() {
+        let mut planner = StreamingPlanner::new();
+        let statements = StreamingParser::parse_sql(
+            "SELECT * FROM orders o JOIN payments p ON o.order_id = p.order_id",
+        )
+        .unwrap();
+        let err = planner.plan(&statements[0]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unbounded join"), "got: {msg}");
+        assert!(msg.contains("lookup table"), "got: {msg}");
     }
 
     #[test]
@@ -962,8 +1003,11 @@ mod tests {
     #[test]
     fn test_plan_single_join_produces_vec_of_one() {
         let mut planner = StreamingPlanner::new();
-        let statements =
-            StreamingParser::parse_sql("SELECT * FROM a JOIN b ON a.id = b.a_id").unwrap();
+        let statements = StreamingParser::parse_sql(
+            "SELECT * FROM a JOIN b ON a.id = b.a_id \
+             AND b.ts BETWEEN a.ts AND a.ts + INTERVAL '1' HOUR",
+        )
+        .unwrap();
 
         let plan = planner.plan(&statements[0]).unwrap();
         match plan {
@@ -979,7 +1023,10 @@ mod tests {
     fn test_plan_two_way_join() {
         let mut planner = StreamingPlanner::new();
         let statements = StreamingParser::parse_sql(
-            "SELECT * FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id",
+            "SELECT * FROM a JOIN b ON a.id = b.a_id \
+                 AND b.ts BETWEEN a.ts AND a.ts + INTERVAL '1' HOUR \
+             JOIN c ON b.id = c.b_id \
+                 AND c.ts BETWEEN b.ts AND b.ts + INTERVAL '1' HOUR",
         )
         .unwrap();
 
@@ -1000,6 +1047,16 @@ mod tests {
     #[test]
     fn test_plan_mixed_join_types() {
         let mut planner = StreamingPlanner::new();
+        // The second JOIN here would be unbounded if `customers` were a
+        // streaming source. Register it as a lookup table so the rejection
+        // rule passes.
+        let _ = planner.plan(
+            &StreamingParser::parse_sql(
+                "CREATE LOOKUP TABLE customers (id BIGINT NOT NULL, name VARCHAR, \
+                 PRIMARY KEY (id)) WITH (connector = 'parquet', path = '/tmp/x.parquet')",
+            )
+            .unwrap()[0],
+        );
         let statements = StreamingParser::parse_sql(
             "SELECT * FROM orders o \
              JOIN payments p ON o.id = p.order_id \


### PR DESCRIPTION
## Summary

- **Planner**: reject unbounded joins between two streaming sources at plan time, matching the Arroyo / RisingWave rule. A query that joins ≥ 2 streaming sources without a temporal bound (`BETWEEN`, `ASOF`, `FOR SYSTEM_TIME AS OF`) and no `LOOKUP TABLE` on either side is rejected with an actionable message.
- **Executor**: `IntervalJoinOperator`'s post-projection now appends residual `JOIN` clauses (steps 1..N) instead of dropping them. Step-0 column refs are qualified with `__interval_tmp.<col>` to disambiguate against downstream tables; aliasing recovers the user-visible names.
- **Plumbing**: `ddl.rs::handle_create_stream` propagates planner errors instead of swallowing them, which is needed for the new rejection to reach the user. The planner's `Vec<JoinOperatorConfig>` is now load-bearing — `OperatorGraph::add_query` uses it to skip three of the four `detect_*_query` SQL re-parses when no specialised step exists.
- **Tests**: differential harness at `crates/laminar-db/tests/n_way_join_differential.rs` compares LaminarDB streaming output against a DataFusion batch oracle. Covers bounded chain + lookup tail (smoke + property) and the three rejection shapes (chain, star, 2-way).

## Why

`SELECT a.x, b.y, c.z FROM a JOIN b ON a.k=b.k AND b.ts BETWEEN a.ts AND a.ts + INTERVAL '5' SECOND JOIN c ON b.k2 = c.k2` previously emitted zero rows: the `IntervalJoinOperator` materialised the a⋈b step but the post-projection only knew about `__interval_tmp` and could not resolve `c.*`. Unbounded multi-way streaming joins (no `BETWEEN` anywhere) silently produced per-cycle batch joins with no cross-cycle matching — a memory-correctness footgun.

## Changes

| Area | File | Change |
|------|------|--------|
| Planner | `laminar-sql/src/planner/mod.rs` | `reject_unbounded_streaming_join` |
| Planner | `laminar-sql/src/parser/join_parser.rs` | `JoinAnalysis::is_bounded()` |
| Executor | `laminar-db/src/sql_analysis.rs` | residual joins + qualification + directional filter |
| Executor | `laminar-db/src/operator_graph.rs` | consume planner's `join_config` to skip re-parses |
| Plumbing | `laminar-db/src/ddl.rs` | propagate planning errors |
| Plumbing | `laminar-db/src/{connector_manager,pipeline/*,pipeline_lifecycle,pipeline_callback}.rs` | thread `join_config` end-to-end |
| Tests | `laminar-db/tests/n_way_join_differential.rs` | new file — proptest differential harness |

## Test plan

- [x] `cargo clippy -p laminar-sql -p laminar-db --tests --no-default-features -- -D warnings` — clean
- [x] `cargo test -p laminar-sql --no-default-features --lib` — 827 passing
- [x] `cargo test -p laminar-db --no-default-features --lib` — 620 passing
- [x] `cargo test -p laminar-db --test n_way_join_differential --no-default-features` — 5/5 passing under default and `--test-threads=1`

## Follow-ups (filed inline as TODOs at the call sites)

- `TODO(interval-rewriter)` in `sql_analysis.rs::build_stream_join_projection_sql` — replace the directional residual filter (`right_ts >= left_ts`) with the original `BETWEEN` predicate once `INTERVAL` arithmetic against `BIGINT` is normalised in a DataFusion analyzer rule.
- TODO at the same site for collision-aware aliasing in the residual self-join case (`SELECT p.type, a.type FROM p JOIN a ... JOIN c ...`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming queries now support residual joins that continue after an initial stream-to-stream join.

* **Improvements**
  * Stricter validation for multi-way streaming joins—unbounded joins now require temporal predicates or lookup tables, with clearer errors.
  * More efficient interval-join processing with chunked output emission and better error propagation.

* **Tests**
  * Added comprehensive differential and property-based tests for multi-way and bounded-join scenarios.

* **Chores**
  * Added dev-time testing tooling and updated CI workflow maintenance steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->