### PR TITLE
feat(kafka): drive broker offset commits from checkpoint completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "ahash",
  "arrow",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-storage"
-version = "0.21.5"
+version = "0.21.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.21.5"
+version = "0.21.10"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -381,13 +381,26 @@ pub trait SourceConnector: Send {
     /// Acknowledge that `epoch` has been durably committed.
     ///
     /// Called after the manifest is persisted and every exactly-once sink
-    /// committed the epoch. Idempotent — a retry after cancellation is
-    /// legal.
+    /// committed the epoch. The `checkpoint` argument is the exact
+    /// per-source `SourceCheckpoint` that was persisted into the manifest
+    /// for this epoch — sources can rely on it to advance external offset
+    /// state (broker group offsets, lookup-DB cursors, ack tokens) using
+    /// values that match what's durable.
+    ///
+    /// May be called with an empty `checkpoint` for timer-driven commits
+    /// where no per-source state was captured; implementations should
+    /// treat that as a no-op for any externally-visible advancement.
+    ///
+    /// Idempotent — a retry after cancellation is legal.
     ///
     /// # Errors
     ///
     /// Errors are logged; they do not roll back the committed epoch.
-    async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+    async fn notify_epoch_committed(
+        &mut self,
+        _epoch: u64,
+        _checkpoint: &SourceCheckpoint,
+    ) -> Result<(), ConnectorError> {
         Ok(())
     }
 }

--- a/crates/laminar-connectors/src/kafka/config.rs
+++ b/crates/laminar-connectors/src/kafka/config.rs
@@ -581,13 +581,20 @@ pub struct KafkaSourceConfig {
     pub queued_max_messages_kbytes: u32,
 
     // -- Broker commit --
-    /// Interval at which to asynchronously commit offsets to the Kafka broker.
+    /// Whether to commit consumed offsets to the Kafka broker after each
+    /// `LaminarDB` checkpoint completes. Default: `true`.
     ///
-    /// This is advisory — it keeps `kafka-consumer-groups` lag monitoring
-    /// accurate. The authoritative offset state lives in `LaminarDB`'s
-    /// checkpoint system. Set to `Duration::ZERO` to disable periodic
-    /// broker commits (default: 5s).
-    pub broker_commit_interval: Duration,
+    /// Advisory — `LaminarDB` recovery uses its own manifest, not broker-stored
+    /// offsets. This exists so external tooling (`kafka-consumer-groups`,
+    /// kafka-exporter, Burrow) sees progress, and so `StartupMode::GroupOffsets`
+    /// can act as a "lost-checkpoint" fallback that resumes from the last
+    /// durable epoch (no skip-ahead window).
+    pub broker_commit_on_checkpoint: bool,
+
+    /// Per-commit FFI deadline (default: 5s). The hook is fire-and-forget;
+    /// this bounds how long the dedicated commit task waits before logging
+    /// a failure and dropping the request.
+    pub broker_commit_timeout: Duration,
 
     // -- Backpressure --
     /// Capacity of the bounded channel between the background Kafka reader
@@ -676,7 +683,8 @@ impl Default for KafkaSourceConfig {
             heartbeat_interval: Duration::from_secs(10),
             max_poll_interval: Duration::from_secs(600),
             queued_max_messages_kbytes: 16384,
-            broker_commit_interval: Duration::from_secs(5),
+            broker_commit_on_checkpoint: true,
+            broker_commit_timeout: Duration::from_secs(5),
             reader_channel_capacity: 1024,
             backpressure_high_watermark: 0.8,
             backpressure_low_watermark: 0.5,
@@ -879,8 +887,27 @@ impl KafkaSourceConfig {
             .get_parsed::<u64>("max.poll.interval.ms")?
             .unwrap_or(600_000);
 
-        let broker_commit_interval_ms = config
-            .get_parsed::<u64>("broker.commit.interval.ms")?
+        // `broker.commit.interval.ms` is no longer supported. Broker offset
+        // commits now run on checkpoint completion (`notify_epoch_committed`),
+        // not on a wall-clock timer. Reject explicitly so silent semantic
+        // drift can't happen.
+        if config
+            .properties()
+            .contains_key("broker.commit.interval.ms")
+        {
+            return Err(ConnectorError::ConfigurationError(
+                "broker.commit.interval.ms is no longer supported — broker offset \
+                 commits now happen on checkpoint completion. Use \
+                 broker.commit.timeout.ms to bound a single commit's duration, \
+                 or broker.commit.on.checkpoint=false to disable."
+                    .into(),
+            ));
+        }
+        let broker_commit_on_checkpoint = config
+            .get_parsed::<bool>("broker.commit.on.checkpoint")?
+            .unwrap_or(true);
+        let broker_commit_timeout_ms = config
+            .get_parsed::<u64>("broker.commit.timeout.ms")?
             .unwrap_or(5_000);
 
         let reader_channel_capacity = config
@@ -943,7 +970,8 @@ impl KafkaSourceConfig {
             heartbeat_interval: Duration::from_millis(heartbeat_interval_ms),
             max_poll_interval: Duration::from_millis(max_poll_interval_ms),
             queued_max_messages_kbytes,
-            broker_commit_interval: Duration::from_millis(broker_commit_interval_ms),
+            broker_commit_on_checkpoint,
+            broker_commit_timeout: Duration::from_millis(broker_commit_timeout_ms),
             reader_channel_capacity,
             backpressure_high_watermark,
             backpressure_low_watermark,
@@ -1185,6 +1213,9 @@ fn is_blocked_passthrough_key(key: &str) -> bool {
                 | "heartbeat.interval.ms"
                 | "max.poll.interval.ms"
                 | "queued.max.messages.kbytes"
+                // librdkafka's own auto-commit interval — only meaningful
+                // when `enable.auto.commit=true`, which we hard-disable.
+                | "auto.commit.interval.ms"
         )
 }
 
@@ -1305,24 +1336,39 @@ mod tests {
         assert!(cfg.schema_registry_url.is_none());
         assert_eq!(cfg.security_protocol, SecurityProtocol::Plaintext);
         assert!(cfg.sasl_mechanism.is_none());
-        assert_eq!(cfg.broker_commit_interval, Duration::from_secs(5));
+        assert!(cfg.broker_commit_on_checkpoint);
+        assert_eq!(cfg.broker_commit_timeout, Duration::from_secs(5));
         assert_eq!(cfg.reader_channel_capacity, 1024);
     }
 
     #[test]
-    fn test_parse_broker_commit_interval() {
+    fn test_parse_broker_commit_timeout() {
         let cfg =
-            KafkaSourceConfig::from_config(&make_config(&[("broker.commit.interval.ms", "5000")]))
+            KafkaSourceConfig::from_config(&make_config(&[("broker.commit.timeout.ms", "2500")]))
                 .unwrap();
-        assert_eq!(cfg.broker_commit_interval, Duration::from_secs(5));
+        assert_eq!(cfg.broker_commit_timeout, Duration::from_millis(2500));
     }
 
     #[test]
-    fn test_parse_broker_commit_interval_zero_disables() {
-        let cfg =
-            KafkaSourceConfig::from_config(&make_config(&[("broker.commit.interval.ms", "0")]))
-                .unwrap();
-        assert!(cfg.broker_commit_interval.is_zero());
+    fn test_parse_broker_commit_on_checkpoint_disabled() {
+        let cfg = KafkaSourceConfig::from_config(&make_config(&[(
+            "broker.commit.on.checkpoint",
+            "false",
+        )]))
+        .unwrap();
+        assert!(!cfg.broker_commit_on_checkpoint);
+    }
+
+    #[test]
+    fn test_parse_broker_commit_interval_rejected() {
+        let err =
+            KafkaSourceConfig::from_config(&make_config(&[("broker.commit.interval.ms", "5000")]))
+                .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("broker.commit.interval.ms"),
+            "expected hard-error mentioning the deprecated key, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/laminar-connectors/src/kafka/config.rs
+++ b/crates/laminar-connectors/src/kafka/config.rs
@@ -591,11 +591,6 @@ pub struct KafkaSourceConfig {
     /// durable epoch (no skip-ahead window).
     pub broker_commit_on_checkpoint: bool,
 
-    /// Per-commit FFI deadline (default: 5s). The hook is fire-and-forget;
-    /// this bounds how long the dedicated commit task waits before logging
-    /// a failure and dropping the request.
-    pub broker_commit_timeout: Duration,
-
     // -- Backpressure --
     /// Capacity of the bounded channel between the background Kafka reader
     /// task and `poll_batch()` (default: 1024). Must be >= `max_poll_records`.
@@ -684,7 +679,6 @@ impl Default for KafkaSourceConfig {
             max_poll_interval: Duration::from_secs(600),
             queued_max_messages_kbytes: 16384,
             broker_commit_on_checkpoint: true,
-            broker_commit_timeout: Duration::from_secs(5),
             reader_channel_capacity: 1024,
             backpressure_high_watermark: 0.8,
             backpressure_low_watermark: 0.5,
@@ -897,18 +891,14 @@ impl KafkaSourceConfig {
         {
             return Err(ConnectorError::ConfigurationError(
                 "broker.commit.interval.ms is no longer supported — broker offset \
-                 commits now happen on checkpoint completion. Use \
-                 broker.commit.timeout.ms to bound a single commit's duration, \
-                 or broker.commit.on.checkpoint=false to disable."
+                 commits now happen on checkpoint completion. Set \
+                 broker.commit.on.checkpoint=false to disable."
                     .into(),
             ));
         }
         let broker_commit_on_checkpoint = config
             .get_parsed::<bool>("broker.commit.on.checkpoint")?
             .unwrap_or(true);
-        let broker_commit_timeout_ms = config
-            .get_parsed::<u64>("broker.commit.timeout.ms")?
-            .unwrap_or(5_000);
 
         let reader_channel_capacity = config
             .get_parsed::<usize>("reader.channel.capacity")?
@@ -971,7 +961,6 @@ impl KafkaSourceConfig {
             max_poll_interval: Duration::from_millis(max_poll_interval_ms),
             queued_max_messages_kbytes,
             broker_commit_on_checkpoint,
-            broker_commit_timeout: Duration::from_millis(broker_commit_timeout_ms),
             reader_channel_capacity,
             backpressure_high_watermark,
             backpressure_low_watermark,
@@ -1337,16 +1326,7 @@ mod tests {
         assert_eq!(cfg.security_protocol, SecurityProtocol::Plaintext);
         assert!(cfg.sasl_mechanism.is_none());
         assert!(cfg.broker_commit_on_checkpoint);
-        assert_eq!(cfg.broker_commit_timeout, Duration::from_secs(5));
         assert_eq!(cfg.reader_channel_capacity, 1024);
-    }
-
-    #[test]
-    fn test_parse_broker_commit_timeout() {
-        let cfg =
-            KafkaSourceConfig::from_config(&make_config(&[("broker.commit.timeout.ms", "2500")]))
-                .unwrap();
-        assert_eq!(cfg.broker_commit_timeout, Duration::from_millis(2500));
     }
 
     #[test]

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -19,8 +19,6 @@ pub struct KafkaSourceMetrics {
     pub commits: IntCounter,
     /// Broker rejected the commit.
     pub commit_failures_rejected: IntCounter,
-    /// Commit FFI exceeded `broker_commit_timeout`.
-    pub commit_failures_timeout: IntCounter,
     /// Commit `spawn_blocking` task panicked.
     pub commit_failures_panic: IntCounter,
     /// `notify_epoch_committed` could not enqueue (commit task gone).
@@ -86,7 +84,6 @@ impl KafkaSourceMetrics {
             .unwrap()
         };
         let commit_failures_rejected = make_failure("rejected");
-        let commit_failures_timeout = make_failure("timeout");
         let commit_failures_panic = make_failure("panic");
         let commit_failures_enqueue_dropped = make_failure("enqueue_dropped");
         let rebalances = IntCounter::new(
@@ -131,7 +128,6 @@ impl KafkaSourceMetrics {
         let _ = reg.register(Box::new(batches_polled.clone()));
         let _ = reg.register(Box::new(commits.clone()));
         let _ = reg.register(Box::new(commit_failures_rejected.clone()));
-        let _ = reg.register(Box::new(commit_failures_timeout.clone()));
         let _ = reg.register(Box::new(commit_failures_panic.clone()));
         let _ = reg.register(Box::new(commit_failures_enqueue_dropped.clone()));
         let _ = reg.register(Box::new(rebalances.clone()));
@@ -148,7 +144,6 @@ impl KafkaSourceMetrics {
             batches_polled,
             commits,
             commit_failures_rejected,
-            commit_failures_timeout,
             commit_failures_panic,
             commit_failures_enqueue_dropped,
             rebalances,
@@ -175,18 +170,6 @@ impl KafkaSourceMetrics {
     /// Records a successful offset commit.
     pub fn record_commit(&self) {
         self.commits.inc();
-    }
-
-    /// Records an offset commit failure. `reason` is one of `rejected`,
-    /// `timeout`, `panic`, `enqueue_dropped`. Unknown reasons are dropped.
-    pub fn record_commit_failure(&self, reason: &str) {
-        match reason {
-            "rejected" => self.commit_failures_rejected.inc(),
-            "timeout" => self.commit_failures_timeout.inc(),
-            "panic" => self.commit_failures_panic.inc(),
-            "enqueue_dropped" => self.commit_failures_enqueue_dropped.inc(),
-            _ => debug_assert!(false, "unknown commit failure reason: {reason}"),
-        }
     }
 
     /// Records a consumer group rebalance event.
@@ -234,7 +217,6 @@ impl KafkaSourceMetrics {
         m.add_custom("kafka.batches_polled", self.batches_polled.get() as f64);
         m.add_custom("kafka.commits", self.commits.get() as f64);
         let total_failures = self.commit_failures_rejected.get()
-            + self.commit_failures_timeout.get()
             + self.commit_failures_panic.get()
             + self.commit_failures_enqueue_dropped.get();
         m.add_custom("kafka.commit_failures", total_failures as f64);
@@ -301,8 +283,8 @@ mod tests {
     #[test]
     fn test_record_commit_failure() {
         let m = KafkaSourceMetrics::new(None);
-        m.record_commit_failure("rejected");
-        m.record_commit_failure("timeout");
+        m.commit_failures_rejected.inc();
+        m.commit_failures_panic.inc();
 
         let cm = m.to_connector_metrics();
         let failures = cm.custom.iter().find(|(k, _)| k == "kafka.commit_failures");

--- a/crates/laminar-connectors/src/kafka/metrics.rs
+++ b/crates/laminar-connectors/src/kafka/metrics.rs
@@ -1,6 +1,6 @@
 //! Prometheus-backed Kafka source metrics.
 
-use prometheus::{IntCounter, IntGauge, Registry};
+use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge, Opts, Registry};
 
 use crate::metrics::ConnectorMetrics;
 
@@ -17,12 +17,20 @@ pub struct KafkaSourceMetrics {
     pub batches_polled: IntCounter,
     /// Total offset commits to Kafka.
     pub commits: IntCounter,
-    /// Total offset commit failures (broker rejected, timeout, task panic).
-    pub commit_failures: IntCounter,
+    /// Broker rejected the commit.
+    pub commit_failures_rejected: IntCounter,
+    /// Commit FFI exceeded `broker_commit_timeout`.
+    pub commit_failures_timeout: IntCounter,
+    /// Commit `spawn_blocking` task panicked.
+    pub commit_failures_panic: IntCounter,
+    /// `notify_epoch_committed` could not enqueue (commit task gone).
+    pub commit_failures_enqueue_dropped: IntCounter,
     /// Total consumer group rebalances.
     pub rebalances: IntCounter,
     /// Consumer lag (sum across all partitions of `high_watermark - current_offset`).
     pub lag: IntGauge,
+    /// Duration of a broker offset commit, in seconds.
+    pub broker_commit_duration: Histogram,
     /// Count of successful Schema Registry discoveries at DDL time.
     pub sr_discovery_successes: IntCounter,
     /// Count of Schema Registry discovery failures (HTTP error, parse error).
@@ -35,7 +43,7 @@ impl KafkaSourceMetrics {
     /// If `registry` is `Some`, counters are registered there (visible
     /// in the Prometheus scrape); otherwise a throwaway registry is used.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc, clippy::too_many_lines)]
     pub fn new(registry: Option<&Registry>) -> Self {
         let local;
         let reg = if let Some(r) = registry {
@@ -67,11 +75,20 @@ impl KafkaSourceMetrics {
             "Total offset commits to Kafka",
         )
         .unwrap();
-        let commit_failures = IntCounter::new(
-            "kafka_source_commit_failures_total",
-            "Total offset commit failures (broker rejection, timeout, panic)",
-        )
-        .unwrap();
+        let make_failure = |reason: &str| {
+            IntCounter::with_opts(
+                Opts::new(
+                    "kafka_source_commit_failures_total",
+                    "Offset commit failures by reason",
+                )
+                .const_label("reason", reason),
+            )
+            .unwrap()
+        };
+        let commit_failures_rejected = make_failure("rejected");
+        let commit_failures_timeout = make_failure("timeout");
+        let commit_failures_panic = make_failure("panic");
+        let commit_failures_enqueue_dropped = make_failure("enqueue_dropped");
         let rebalances = IntCounter::new(
             "kafka_source_rebalances_total",
             "Total consumer group rebalances",
@@ -80,6 +97,14 @@ impl KafkaSourceMetrics {
         let lag = IntGauge::new(
             "kafka_source_consumer_lag",
             "Consumer lag (sum across partitions)",
+        )
+        .unwrap();
+        let broker_commit_duration = Histogram::with_opts(
+            HistogramOpts::new(
+                "kafka_source_broker_commit_duration_seconds",
+                "Duration of broker offset commits, in seconds",
+            )
+            .buckets(prometheus::exponential_buckets(0.01, 4.0, 5).unwrap()),
         )
         .unwrap();
         let sr_discovery_successes = IntCounter::new(
@@ -105,9 +130,13 @@ impl KafkaSourceMetrics {
         let _ = reg.register(Box::new(errors.clone()));
         let _ = reg.register(Box::new(batches_polled.clone()));
         let _ = reg.register(Box::new(commits.clone()));
-        let _ = reg.register(Box::new(commit_failures.clone()));
+        let _ = reg.register(Box::new(commit_failures_rejected.clone()));
+        let _ = reg.register(Box::new(commit_failures_timeout.clone()));
+        let _ = reg.register(Box::new(commit_failures_panic.clone()));
+        let _ = reg.register(Box::new(commit_failures_enqueue_dropped.clone()));
         let _ = reg.register(Box::new(rebalances.clone()));
         let _ = reg.register(Box::new(lag.clone()));
+        let _ = reg.register(Box::new(broker_commit_duration.clone()));
         let _ = reg.register(Box::new(sr_discovery_successes.clone()));
         let _ = reg.register(Box::new(sr_discovery_failures.clone()));
         let _ = reg.register(Box::new(sr_discovery_timeouts.clone()));
@@ -118,9 +147,13 @@ impl KafkaSourceMetrics {
             errors,
             batches_polled,
             commits,
-            commit_failures,
+            commit_failures_rejected,
+            commit_failures_timeout,
+            commit_failures_panic,
+            commit_failures_enqueue_dropped,
             rebalances,
             lag,
+            broker_commit_duration,
             sr_discovery_successes,
             sr_discovery_failures,
             sr_discovery_timeouts,
@@ -144,9 +177,16 @@ impl KafkaSourceMetrics {
         self.commits.inc();
     }
 
-    /// Records an offset commit failure (broker rejection, timeout, panic).
-    pub fn record_commit_failure(&self) {
-        self.commit_failures.inc();
+    /// Records an offset commit failure. `reason` is one of `rejected`,
+    /// `timeout`, `panic`, `enqueue_dropped`. Unknown reasons are dropped.
+    pub fn record_commit_failure(&self, reason: &str) {
+        match reason {
+            "rejected" => self.commit_failures_rejected.inc(),
+            "timeout" => self.commit_failures_timeout.inc(),
+            "panic" => self.commit_failures_panic.inc(),
+            "enqueue_dropped" => self.commit_failures_enqueue_dropped.inc(),
+            _ => debug_assert!(false, "unknown commit failure reason: {reason}"),
+        }
     }
 
     /// Records a consumer group rebalance event.
@@ -158,6 +198,11 @@ impl KafkaSourceMetrics {
     #[allow(clippy::cast_possible_wrap)]
     pub fn set_lag(&self, lag: u64) {
         self.lag.set(lag as i64);
+    }
+
+    /// Records a single broker offset commit duration in seconds.
+    pub fn observe_broker_commit_duration(&self, secs: f64) {
+        self.broker_commit_duration.observe(secs);
     }
 
     /// Records a successful Schema Registry discovery at DDL time.
@@ -188,7 +233,11 @@ impl KafkaSourceMetrics {
         };
         m.add_custom("kafka.batches_polled", self.batches_polled.get() as f64);
         m.add_custom("kafka.commits", self.commits.get() as f64);
-        m.add_custom("kafka.commit_failures", self.commit_failures.get() as f64);
+        let total_failures = self.commit_failures_rejected.get()
+            + self.commit_failures_timeout.get()
+            + self.commit_failures_panic.get()
+            + self.commit_failures_enqueue_dropped.get();
+        m.add_custom("kafka.commit_failures", total_failures as f64);
         m.add_custom("kafka.rebalances", self.rebalances.get() as f64);
         m.add_custom(
             "kafka.sr_discovery_successes",
@@ -245,9 +294,6 @@ mod tests {
 
         let cm = m.to_connector_metrics();
         assert_eq!(cm.errors_total, 2);
-        // 4 base (batches_polled, commits, commit_failures, rebalances) +
-        // 3 SR-discovery counters.
-        assert_eq!(cm.custom.len(), 7);
         let commits = cm.custom.iter().find(|(k, _)| k == "kafka.commits");
         assert_eq!(commits.unwrap().1, 1.0);
     }
@@ -255,8 +301,8 @@ mod tests {
     #[test]
     fn test_record_commit_failure() {
         let m = KafkaSourceMetrics::new(None);
-        m.record_commit_failure();
-        m.record_commit_failure();
+        m.record_commit_failure("rejected");
+        m.record_commit_failure("timeout");
 
         let cm = m.to_connector_metrics();
         let failures = cm.custom.iter().find(|(k, _)| k == "kafka.commit_failures");

--- a/crates/laminar-connectors/src/kafka/rebalance.rs
+++ b/crates/laminar-connectors/src/kafka/rebalance.rs
@@ -101,19 +101,15 @@ pub struct LaminarConsumerContext {
     /// partitions for backpressure. On `Assign`, newly assigned partitions
     /// must be re-paused if this flag is true.
     reader_paused: Arc<AtomicBool>,
-    /// Set by `commit_callback` on broker rejection; reader task escalates
-    /// to `CommitMode::Sync` on the next timer tick.
-    commit_retry_needed: Arc<AtomicBool>,
     /// Snapshot of consumed offsets, updated once per `poll_batch()` cycle.
     /// Read on Assign to seek newly assigned partitions to last-consumed
     /// offset + 1, preventing duplicates after broker failures.
     offset_snapshot: Arc<Mutex<super::offsets::OffsetTracker>>,
-    /// Counter bumped on every broker-confirmed async commit. The immediate
-    /// return from `CommitMode::Async` only means "queued"; the real
-    /// outcome arrives here via `commit_callback`, so this is the
-    /// authoritative success counter for async commits.
+    /// Counter bumped on every broker-confirmed commit. The on-checkpoint
+    /// commit path issues `CommitMode::Sync`, so this is the authoritative
+    /// success counter — `commit_callback` still fires for sync commits.
     commits_counter: IntCounter,
-    /// Counter bumped when the broker rejects an async commit.
+    /// Counter bumped when the broker rejects a commit.
     commit_failures_counter: IntCounter,
 }
 
@@ -127,7 +123,6 @@ impl LaminarConsumerContext {
         rebalance_metric: Arc<AtomicU64>,
         revoke_generation: Arc<AtomicU64>,
         reader_paused: Arc<AtomicBool>,
-        commit_retry_needed: Arc<AtomicBool>,
         offset_snapshot: Arc<Mutex<super::offsets::OffsetTracker>>,
         commits_counter: IntCounter,
         commit_failures_counter: IntCounter,
@@ -139,7 +134,6 @@ impl LaminarConsumerContext {
             rebalance_metric,
             revoke_generation,
             reader_paused,
-            commit_retry_needed,
             offset_snapshot,
             commits_counter,
             commit_failures_counter,
@@ -246,11 +240,10 @@ impl ConsumerContext for LaminarConsumerContext {
             }
             Err(e) => {
                 self.commit_failures_counter.inc();
-                self.commit_retry_needed.store(true, Ordering::Release);
                 warn!(
                     error = %e,
                     partition_count = offsets.count(),
-                    "broker offset commit failed — scheduling sync retry"
+                    "broker offset commit failed (callback)"
                 );
             }
         }
@@ -394,7 +387,6 @@ mod tests {
         let metric = Arc::new(AtomicU64::new(0));
         let revoke_gen = Arc::new(AtomicU64::new(0));
         let reader_paused = Arc::new(AtomicBool::new(false));
-        let commit_retry = Arc::new(AtomicBool::new(false));
         let offset_snapshot = Arc::new(Mutex::new(super::super::offsets::OffsetTracker::new()));
         let commits = IntCounter::new("test_commits", "test").unwrap();
         let commit_failures = IntCounter::new("test_commit_failures", "test").unwrap();
@@ -404,7 +396,6 @@ mod tests {
             metric,
             revoke_gen,
             reader_paused,
-            commit_retry,
             offset_snapshot,
             commits,
             commit_failures,

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -14,7 +14,7 @@ use rdkafka::TopicPartitionList;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::Notify;
+use tokio::sync::{watch, Notify};
 use tracing::{debug, info, warn};
 
 use super::rebalance::LaminarConsumerContext;
@@ -109,7 +109,8 @@ pub struct KafkaSource {
     commit_handle: Option<tokio::task::JoinHandle<()>>,
     hwm_handle: Option<tokio::task::JoinHandle<()>>,
     reader_shutdown: Option<tokio::sync::watch::Sender<bool>>,
-    offset_commit_tx: Option<tokio::sync::watch::Sender<TopicPartitionList>>,
+    /// Latest TPL the commit task should flush (last-writer-wins).
+    commit_tx: Option<watch::Sender<Option<TopicPartitionList>>>,
     watermark_tracker: Option<KafkaWatermarkTracker>,
     /// Receiver for high watermark data from the background reader task.
     /// Each entry is `(topic, partition, high_watermark)` for lag computation.
@@ -119,9 +120,6 @@ pub struct KafkaSource {
     /// due to downstream backpressure. Used to re-pause newly assigned
     /// partitions during rebalance.
     reader_paused: Arc<AtomicBool>,
-    /// Set by `commit_callback` on async commit failure; reader task
-    /// escalates to `CommitMode::Sync` on the next commit timer tick.
-    commit_retry_needed: Arc<AtomicBool>,
     /// Offset snapshot shared with the rebalance callback for seek-on-assign.
     /// Updated once per `poll_batch()` cycle (not per message).
     offset_snapshot: Arc<Mutex<OffsetTracker>>,
@@ -231,11 +229,10 @@ impl KafkaSource {
             commit_handle: None,
             hwm_handle: None,
             reader_shutdown: None,
-            offset_commit_tx: None,
+            commit_tx: None,
             watermark_tracker,
             high_watermarks_rx: None,
             reader_paused: Arc::new(AtomicBool::new(false)),
-            commit_retry_needed: Arc::new(AtomicBool::new(false)),
             offset_snapshot: Arc::new(Mutex::new(OffsetTracker::new())),
             last_avro_schema: None,
             poll_payload_buf: Vec::new(),
@@ -301,7 +298,7 @@ impl KafkaSource {
     ///
     /// Three tasks handle separate concerns:
     /// - **Reader**: consumes messages, manages backpressure, detects revokes
-    /// - **Commit**: periodic advisory broker offset commits
+    /// - **Commit**: services on-checkpoint broker offset commits
     /// - **HWM**: periodic high watermark queries for lag monitoring
     ///
     /// Deferred to allow `restore()` to access the consumer directly after `open()`.
@@ -315,106 +312,69 @@ impl KafkaSource {
         let (msg_tx, msg_rx) =
             crossfire::mpsc::bounded_async::<KafkaPayload>(self.config.reader_channel_capacity);
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-        let (offset_tx, offset_rx) = tokio::sync::watch::channel(TopicPartitionList::new());
-        let reader_offset_rx = offset_rx.clone(); // reader reads final offsets on shutdown
+        let (commit_tx, mut commit_rx) = watch::channel::<Option<TopicPartitionList>>(None);
         let (hwm_tx, hwm_rx) = tokio::sync::watch::channel(Vec::new());
         // Channel for the reader to publish seen partitions to the HWM task.
         let (seen_tx, seen_rx) = tokio::sync::watch::channel(Vec::<(Arc<str>, i32)>::new());
         let data_ready = Arc::clone(&self.data_ready);
         let channel_len = Arc::clone(&self.channel_len);
         let capture_headers = self.config.include_headers;
-        let broker_commit_interval = self.config.broker_commit_interval;
         let reader_channel_capacity = self.config.reader_channel_capacity;
         let reader_paused = Arc::clone(&self.reader_paused);
         let revoke_generation = Arc::clone(&self.revoke_generation);
         let rebalance_state = Arc::clone(&self.rebalance_state);
-        let commit_retry_needed = Arc::clone(&self.commit_retry_needed);
         let pause_threshold = self.config.backpressure_high_watermark;
         let resume_threshold = self.config.backpressure_low_watermark;
 
-        // -- Commit task: periodic advisory broker offset commits --
+        // Broker commit task: flushes the latest durable TPL to the broker
+        // after each checkpoint. Last-writer-wins via the watch channel —
+        // if multiple checkpoints land while a commit is in flight, only
+        // the newest gets sent.
         let commit_consumer = Arc::clone(&consumer);
-        let commit_retry = Arc::clone(&commit_retry_needed);
         let commit_metrics = self.metrics.clone();
+        let commit_timeout = self.config.broker_commit_timeout;
         let mut commit_shutdown = shutdown_rx.clone();
         let commit_handle = tokio::spawn(async move {
-            if broker_commit_interval.is_zero() {
-                // Disabled — wait for shutdown.
-                let _ = commit_shutdown.changed().await;
-                return;
-            }
-            let mut timer = tokio::time::interval(broker_commit_interval);
-            timer.tick().await; // skip first
-
             loop {
                 tokio::select! {
                     biased;
                     _ = commit_shutdown.changed() => break,
-                    _ = timer.tick() => {
-                        let tpl = offset_rx.borrow().clone();
-                        if tpl.count() == 0 { continue; }
-                        if commit_retry
-                            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
-                            .is_ok()
-                        {
-                            let c = Arc::clone(&commit_consumer);
-                            let flag = Arc::clone(&commit_retry);
-                            let n = tpl.count();
-                            // Await the blocking commit so it completes before
-                            // close() drops the consumer Arc.
-                            //
-                            // Metrics: librdkafka fires `commit_callback` for
-                            // BOTH sync and async commits, and the callback is
-                            // our authoritative counter source. We only bump
-                            // `commit_failures` here for outcomes the callback
-                            // can't observe — a panicked blocking task, or a
-                            // tokio timeout while the commit is still pending.
-                            match tokio::time::timeout(
-                                std::time::Duration::from_secs(10),
-                                tokio::task::spawn_blocking(move || {
-                                    c.commit(&tpl, CommitMode::Sync)
-                                }),
-                            )
-                            .await
-                            {
-                                Ok(Ok(Ok(()))) => {
-                                    // callback already bumped `commits`
-                                    info!(partition_count = n, "sync offset commit retry succeeded");
-                                }
-                                Ok(Ok(Err(e))) => {
-                                    // callback already bumped `commit_failures`
-                                    flag.store(true, Ordering::Release);
-                                    warn!(error = %e, "sync offset commit retry failed");
-                                }
-                                Ok(Err(e)) => {
-                                    commit_metrics.record_commit_failure();
-                                    warn!(error = %e, "sync commit blocking task panicked");
-                                }
-                                Err(_) => {
-                                    commit_metrics.record_commit_failure();
-                                    flag.store(true, Ordering::Release);
-                                    warn!("sync offset commit retry timed out");
-                                }
-                            }
-                        } else {
-                            // Async enqueue only — the broker-confirmed outcome
-                            // (Ok or Err) arrives asynchronously via
-                            // `LaminarConsumerContext::commit_callback`, which
-                            // bumps `commits` / `commit_failures`. Counting at
-                            // enqueue would overcount (every rejected commit
-                            // would show as a success here). An immediate `Err`
-                            // below means librdkafka couldn't even queue the
-                            // commit — rare, but worth observing.
-                            match commit_consumer.commit(&tpl, CommitMode::Async) {
-                                Ok(()) => {
-                                    info!(partition_count = tpl.count(), "periodic broker offset commit (advisory)");
-                                }
-                                Err(e) => {
-                                    commit_metrics.record_commit_failure();
-                                    warn!(error = %e, "periodic broker offset commit failed");
-                                }
-                            }
-                        }
+                    changed = commit_rx.changed() => {
+                        if changed.is_err() { break }
+                    }
+                }
+                let Some(tpl) = commit_rx.borrow_and_update().clone() else {
+                    continue;
+                };
+                if tpl.count() == 0 {
+                    continue;
+                }
+
+                let start = std::time::Instant::now();
+                let c = Arc::clone(&commit_consumer);
+                let result = tokio::time::timeout(
+                    commit_timeout,
+                    tokio::task::spawn_blocking(move || c.commit(&tpl, CommitMode::Sync)),
+                )
+                .await;
+                commit_metrics.observe_broker_commit_duration(start.elapsed().as_secs_f64());
+
+                match result {
+                    Ok(Ok(Ok(()))) => {}
+                    Ok(Ok(Err(e))) => {
+                        commit_metrics.record_commit_failure("rejected");
+                        warn!(error = %e, "broker offset commit rejected");
+                    }
+                    Ok(Err(e)) => {
+                        commit_metrics.record_commit_failure("panic");
+                        warn!(error = %e, "broker offset commit task panicked");
+                    }
+                    Err(_) => {
+                        commit_metrics.record_commit_failure("timeout");
+                        warn!(
+                            timeout_secs = commit_timeout.as_secs_f64(),
+                            "broker offset commit timed out"
+                        );
                     }
                 }
             }
@@ -596,20 +556,10 @@ impl KafkaSource {
                 }
             }
 
-            // Final commit + unsubscribe (reader owns the consumer Arc).
-            // The close() method sends latest offsets via offset_tx before
-            // signaling shutdown, so the commit task may have already
-            // committed them — this is a best-effort final flush.
-            let tpl = reader_offset_rx.borrow().clone();
-            if tpl.count() > 0 {
-                match consumer.commit(&tpl, CommitMode::Sync) {
-                    Ok(()) => info!(
-                        partition_count = tpl.count(),
-                        "committed final offsets on shutdown"
-                    ),
-                    Err(e) => warn!(error = %e, "failed to commit final offsets on shutdown"),
-                }
-            }
+            // Reader does NOT commit on shutdown. With on-checkpoint
+            // semantics the only durable broker offsets are those that
+            // belong to a committed epoch; close() drains the commit-request
+            // channel before unsubscribing, ensuring nothing is lost.
             consumer.unsubscribe();
         });
 
@@ -618,7 +568,7 @@ impl KafkaSource {
         self.commit_handle = Some(commit_handle);
         self.hwm_handle = Some(hwm_handle);
         self.reader_shutdown = Some(shutdown_tx);
-        self.offset_commit_tx = Some(offset_tx);
+        self.commit_tx = Some(commit_tx);
         self.high_watermarks_rx = Some(hwm_rx);
     }
 }
@@ -687,13 +637,12 @@ impl SourceConnector for KafkaSource {
             Arc::clone(&self.rebalance_counter),
             Arc::clone(&self.revoke_generation),
             Arc::clone(&self.reader_paused),
-            Arc::clone(&self.commit_retry_needed),
             Arc::clone(&self.offset_snapshot),
             // IntCounter::clone is an Arc bump; these are shared with the
             // metrics struct and bumped from librdkafka's background thread
             // inside `commit_callback`.
             self.metrics.commits.clone(),
-            self.metrics.commit_failures.clone(),
+            self.metrics.commit_failures_rejected.clone(),
         );
         let consumer: StreamConsumer<LaminarConsumerContext> =
             rdkafka_config.create_with_context(context).map_err(|e| {
@@ -1057,27 +1006,10 @@ impl SourceConnector for KafkaSource {
             }
         }
 
-        // Publish current offsets to the reader task for periodic broker commits
-        // and to the rebalance callback for seek-on-assign.
-        //
-        // Filter by the current assignment: `retain_assigned` only runs when
-        // `had_revoke` is newly detected, so between the revoke callback and
-        // the next `poll_batch` the tracker may transiently hold entries for
-        // partitions we no longer own. An unfiltered commit of those offsets
-        // is rejected by the broker (`IllegalGeneration` / "Consumer not
-        // assigned"), which flips `commit_retry_needed` on and stalls the
-        // commit loop against the same stale TPL — visible as a sawtooth in
-        // consumer lag.
+        // Update the offset snapshot used by `post_rebalance` for seek-on-assign.
+        // No broker commit happens here — that's driven exclusively by
+        // `notify_epoch_committed` against the TPL captured at checkpoint time.
         if had_revoke || !self.poll_payload_offsets.is_empty() {
-            if let Some(ref tx) = self.offset_commit_tx {
-                let assigned = lock_or_recover(&self.rebalance_state)
-                    .assigned_partitions()
-                    .clone();
-                let tpl = self.offsets.to_topic_partition_list_filtered(&assigned);
-                if tx.send(tpl).is_err() {
-                    debug!("offset_commit_tx closed, reader task shutting down");
-                }
-            }
             lock_or_recover(&self.offset_snapshot).clone_from(&self.offsets);
         }
 
@@ -1350,14 +1282,6 @@ impl SourceConnector for KafkaSource {
         let assigned = lock_or_recover(&self.rebalance_state)
             .assigned_partitions()
             .clone();
-
-        // Push filtered offsets to the reader task so it can commit them
-        // on shutdown even if close() is called without a subsequent checkpoint.
-        if let Some(ref tx) = self.offset_commit_tx {
-            let tpl = self.offsets.to_topic_partition_list_filtered(&assigned);
-            let _ = tx.send(tpl);
-        }
-
         self.offsets.to_checkpoint_filtered(&assigned)
     }
 
@@ -1412,20 +1336,36 @@ impl SourceConnector for KafkaSource {
         Some(Arc::clone(&self.checkpoint_request))
     }
 
+    async fn notify_epoch_committed(
+        &mut self,
+        _epoch: u64,
+        checkpoint: &SourceCheckpoint,
+    ) -> Result<(), ConnectorError> {
+        if !self.config.broker_commit_on_checkpoint || checkpoint.is_empty() {
+            return Ok(());
+        }
+        let Some(ref tx) = self.commit_tx else {
+            return Ok(());
+        };
+        let tpl = OffsetTracker::from_checkpoint(checkpoint).to_topic_partition_list();
+        if tpl.count() == 0 {
+            return Ok(());
+        }
+        if tx.send(Some(tpl)).is_err() {
+            self.metrics.record_commit_failure("enqueue_dropped");
+        }
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<(), ConnectorError> {
         info!("closing Kafka source connector");
 
-        let assigned = lock_or_recover(&self.rebalance_state)
-            .assigned_partitions()
-            .clone();
-
-        // Send final filtered offsets to the reader task before signaling shutdown.
-        if let Some(ref tx) = self.offset_commit_tx {
-            let tpl = self.offsets.to_topic_partition_list_filtered(&assigned);
-            if tpl.count() > 0 {
-                let _ = tx.send(tpl);
-            }
-        }
+        // Close the commit-request channel so the commit task drains
+        // anything already queued, then exits. We do NOT issue a fresh
+        // commit here — under on-checkpoint semantics the only durable
+        // broker offsets are those tied to a committed epoch, and those
+        // were already enqueued from `notify_epoch_committed`.
+        self.commit_tx = None;
 
         // Signal shutdown and wait for all background tasks to exit.
         if let Some(tx) = self.reader_shutdown.take() {
@@ -1442,17 +1382,11 @@ impl SourceConnector for KafkaSource {
             let _ = tokio::time::timeout(timeout, handle).await;
         }
         self.msg_rx = None;
-        self.offset_commit_tx = None;
 
         // If consumer was never moved to the reader (e.g., close() called
-        // before any poll_batch()), commit directly.
+        // before any poll_batch()), unsubscribe directly. No commit:
+        // nothing has been processed, so there's no durable offset to ack.
         if let Some(ref consumer) = self.consumer {
-            let tpl = self.offsets.to_topic_partition_list_filtered(&assigned);
-            if tpl.count() > 0 {
-                if let Err(e) = consumer.commit(&tpl, CommitMode::Sync) {
-                    warn!(error = %e, "failed to commit final offsets");
-                }
-            }
             consumer.unsubscribe();
         }
 
@@ -1944,5 +1878,37 @@ mod tests {
             Some(3),
             "last_avro_schema should reflect the evolved SR shape"
         );
+    }
+
+    // The hook builds a TPL from a durable SourceCheckpoint and uses
+    // offset+1 (next-to-fetch) per Kafka convention. We exercise the
+    // translation directly via OffsetTracker, since the hook delegates
+    // to it.
+    #[test]
+    fn test_checkpoint_to_tpl_uses_next_offset() {
+        let mut offsets = std::collections::HashMap::new();
+        offsets.insert("events-0".to_string(), "100".to_string());
+        offsets.insert("events-1".to_string(), "200".to_string());
+        let cp = SourceCheckpoint::with_offsets(1, offsets);
+        let tpl = OffsetTracker::from_checkpoint(&cp).to_topic_partition_list();
+        assert_eq!(tpl.count(), 2);
+        for elem in tpl.elements() {
+            let expected = match elem.partition() {
+                0 => rdkafka::Offset::Offset(101),
+                1 => rdkafka::Offset::Offset(201),
+                p => panic!("unexpected partition {p}"),
+            };
+            assert_eq!(elem.offset(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_notify_epoch_committed_empty_cp_is_noop() {
+        let mut source = KafkaSource::new(test_schema(), test_config(), None);
+        // No reader, no commit channel — opt-out path. Empty cp must not panic.
+        source
+            .notify_epoch_committed(1, &SourceCheckpoint::new(1))
+            .await
+            .unwrap();
     }
 }

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -327,54 +327,34 @@ impl KafkaSource {
         let resume_threshold = self.config.backpressure_low_watermark;
 
         // Broker commit task: flushes the latest durable TPL to the broker
-        // after each checkpoint. Last-writer-wins via the watch channel —
-        // if multiple checkpoints land while a commit is in flight, only
-        // the newest gets sent.
+        // after each checkpoint. Lifecycle is driven by the watch sender —
+        // when close() drops commit_tx, any pending TPL is processed and
+        // then changed() returns Err, ending the loop.
         let commit_consumer = Arc::clone(&consumer);
         let commit_metrics = self.metrics.clone();
-        let commit_timeout = self.config.broker_commit_timeout;
-        let mut commit_shutdown = shutdown_rx.clone();
         let commit_handle = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = commit_shutdown.changed() => break,
-                    changed = commit_rx.changed() => {
-                        if changed.is_err() { break }
-                    }
-                }
+            while commit_rx.changed().await.is_ok() {
                 let Some(tpl) = commit_rx.borrow_and_update().clone() else {
                     continue;
                 };
                 if tpl.count() == 0 {
                     continue;
                 }
-
                 let start = std::time::Instant::now();
                 let c = Arc::clone(&commit_consumer);
-                let result = tokio::time::timeout(
-                    commit_timeout,
-                    tokio::task::spawn_blocking(move || c.commit(&tpl, CommitMode::Sync)),
-                )
-                .await;
+                let result =
+                    tokio::task::spawn_blocking(move || c.commit(&tpl, CommitMode::Sync)).await;
                 commit_metrics.observe_broker_commit_duration(start.elapsed().as_secs_f64());
 
                 match result {
-                    Ok(Ok(Ok(()))) => {}
-                    Ok(Ok(Err(e))) => {
-                        commit_metrics.record_commit_failure("rejected");
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        commit_metrics.commit_failures_rejected.inc();
                         warn!(error = %e, "broker offset commit rejected");
                     }
-                    Ok(Err(e)) => {
-                        commit_metrics.record_commit_failure("panic");
+                    Err(e) => {
+                        commit_metrics.commit_failures_panic.inc();
                         warn!(error = %e, "broker offset commit task panicked");
-                    }
-                    Err(_) => {
-                        commit_metrics.record_commit_failure("timeout");
-                        warn!(
-                            timeout_secs = commit_timeout.as_secs_f64(),
-                            "broker offset commit timed out"
-                        );
                     }
                 }
             }
@@ -1352,7 +1332,7 @@ impl SourceConnector for KafkaSource {
             return Ok(());
         }
         if tx.send(Some(tpl)).is_err() {
-            self.metrics.record_commit_failure("enqueue_dropped");
+            self.metrics.commit_failures_enqueue_dropped.inc();
         }
         Ok(())
     }

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -349,10 +349,16 @@ impl KafkaSource {
                 match result {
                     Ok(Ok(())) => {}
                     Ok(Err(e)) => {
-                        commit_metrics.commit_failures_rejected.inc();
+                        // Failure counting is centralized in
+                        // LaminarConsumerContext::commit_callback (which
+                        // librdkafka fires for both sync and async
+                        // commits) — bumping here would double-count.
                         warn!(error = %e, "broker offset commit rejected");
                     }
                     Err(e) => {
+                        // The callback does not fire for spawn_blocking
+                        // panics, so this is the only path that records
+                        // them.
                         commit_metrics.commit_failures_panic.inc();
                         warn!(error = %e, "broker offset commit task panicked");
                     }

--- a/crates/laminar-connectors/src/nats/source.rs
+++ b/crates/laminar-connectors/src/nats/source.rs
@@ -316,7 +316,11 @@ impl SourceConnector for NatsSource {
         !matches!(self.config.as_ref().map(|c| c.mode), Some(Mode::Core))
     }
 
-    async fn notify_epoch_committed(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+    async fn notify_epoch_committed(
+        &mut self,
+        _epoch: u64,
+        _checkpoint: &crate::checkpoint::SourceCheckpoint,
+    ) -> Result<(), ConnectorError> {
         // Per-msg ack errors don't roll the epoch back; the broker
         // redelivers on ack_wait.
         loop {

--- a/crates/laminar-connectors/src/testing.rs
+++ b/crates/laminar-connectors/src/testing.rs
@@ -177,7 +177,11 @@ impl SourceConnector for MockSourceConnector {
         Ok(())
     }
 
-    async fn notify_epoch_committed(&mut self, epoch: u64) -> Result<(), ConnectorError> {
+    async fn notify_epoch_committed(
+        &mut self,
+        epoch: u64,
+        _checkpoint: &SourceCheckpoint,
+    ) -> Result<(), ConnectorError> {
         self.committed_epochs.lock().push(epoch);
         Ok(())
     }

--- a/crates/laminar-connectors/tests/kafka_integration.rs
+++ b/crates/laminar-connectors/tests/kafka_integration.rs
@@ -177,6 +177,11 @@ async fn checkpoint_restore(brokers: &str) {
 
     poll_all(&mut source, n, Duration::from_secs(30)).await;
     let checkpoint = source.checkpoint();
+    // The streaming coordinator drives broker commits by calling
+    // `notify_epoch_committed` after a barrier. Without it source 2
+    // joining the same group has no stored offsets and falls back to
+    // `auto.offset.reset`.
+    source.notify_epoch_committed(1, &checkpoint).await.unwrap();
     source.close().await.unwrap();
 
     let extra = 10;

--- a/crates/laminar-connectors/tests/nats_integration.rs
+++ b/crates/laminar-connectors/tests/nats_integration.rs
@@ -437,7 +437,11 @@ async fn consumer_lag_settles_to_zero_after_drain() {
         .expect("source open");
 
     drain_rows(&mut source, 5, Duration::from_secs(5)).await;
-    source.notify_epoch_committed(1).await.expect("commit acks");
+    let cp = laminar_connectors::checkpoint::SourceCheckpoint::new(1);
+    source
+        .notify_epoch_committed(1, &cp)
+        .await
+        .expect("commit acks");
 
     let lag_after = poll_gauge_until(&source, "consumer_lag", |v| v == 0, Duration::from_secs(3))
         .await
@@ -691,8 +695,9 @@ async fn source_redelivers_when_epoch_not_committed() {
         first, second,
         "expected the same messages redelivered after no-commit close"
     );
+    let cp = laminar_connectors::checkpoint::SourceCheckpoint::new(1);
     source
-        .notify_epoch_committed(1)
+        .notify_epoch_committed(1, &cp)
         .await
         .expect("epoch commit acks");
     source.close().await.expect("source 2 close");

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -381,6 +381,27 @@ impl StreamingCoordinator {
                     }
                 }
 
+                // Drain any post-shutdown EpochCommitted broadcasts before
+                // close — the coordinator's final checkpoint fires after
+                // signalling shutdown, and sources need to ack it so
+                // external state (Kafka group offsets, NATS msg acks) for
+                // the last durable epoch is advanced.  Loop until the
+                // sender is dropped (which happens when the coordinator
+                // joins this task).
+                while let Ok(()) = epoch_committed_rx.changed().await {
+                    let snapshot = epoch_committed_rx.borrow_and_update().clone();
+                    if let Some((e, cp)) = snapshot {
+                        if let Err(err) = connector.notify_epoch_committed(e, &cp).await {
+                            tracing::warn!(
+                                source = %src_name,
+                                error = %err,
+                                epoch = e,
+                                "notify_epoch_committed failed (drain)",
+                            );
+                        }
+                    }
+                }
+
                 if let Err(e) = connector.close().await {
                     tracing::warn!(source = %src_name, error = %e, "source close error");
                 }
@@ -652,15 +673,11 @@ impl StreamingCoordinator {
             }
         }
 
-        // Join source tasks (unblocked by the drain above).
-        for handle in std::mem::take(&mut self.source_handles) {
-            if let Err(e) = handle.join.await {
-                tracing::warn!(source = %handle.name, error = ?e, "source task panicked");
-            }
-        }
-
         // Final drain: pick up any messages source tasks sent between
-        // the first drain and their exit.
+        // the first drain and finishing their data-drain phase. Sources
+        // remain alive (blocked on epoch_committed_rx) so they can ack
+        // the final checkpoint below — we drop their senders explicitly
+        // when joining further down.
         self.source_batches_buf.clear();
         self.barrier_seen.clear();
         self.discard_pending_offsets();
@@ -688,7 +705,9 @@ impl StreamingCoordinator {
         }
 
         // Final checkpoint uses committed_offsets — only reflects data
-        // that successfully passed through execute_cycle.
+        // that successfully passed through execute_cycle. Run BEFORE
+        // dropping source senders so sources receive the EpochCommitted
+        // and ack to their external systems (Kafka group offsets, etc.).
         let checkpoint_enabled = self.config.checkpoint_interval.is_some();
         if checkpoint_enabled {
             let source_offsets: FxHashMap<String, SourceCheckpoint> = self
@@ -709,6 +728,23 @@ impl StreamingCoordinator {
             {
                 tracing::info!(epoch, "final checkpoint completed before shutdown");
                 self.broadcast_epoch_committed(epoch, &source_offsets);
+            }
+        }
+
+        // Drop epoch_committed_tx senders before awaiting join: source
+        // tasks block on epoch_committed_rx.changed() in their drain
+        // phase and only exit once the sender is dropped.
+        for handle in std::mem::take(&mut self.source_handles) {
+            let SourceHandle {
+                name,
+                shutdown: _,
+                join,
+                barrier_injector: _,
+                epoch_committed_tx,
+            } = handle;
+            drop(epoch_committed_tx);
+            if let Err(e) = join.await {
+                tracing::warn!(source = %name, error = ?e, "source task panicked");
             }
         }
     }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -396,7 +396,7 @@ impl StreamingCoordinator {
                                 source = %src_name,
                                 error = %err,
                                 epoch = e,
-                                "notify_epoch_committed failed (drain)",
+                                "notify_epoch_committed failed",
                             );
                         }
                     }
@@ -673,11 +673,8 @@ impl StreamingCoordinator {
             }
         }
 
-        // Final drain: pick up any messages source tasks sent between
-        // the first drain and finishing their data-drain phase. Sources
-        // remain alive (blocked on epoch_committed_rx) so they can ack
-        // the final checkpoint below — we drop their senders explicitly
-        // when joining further down.
+        // Second drain: pick up any messages source tasks sent between
+        // the first drain and finishing their data-drain phase.
         self.source_batches_buf.clear();
         self.barrier_seen.clear();
         self.discard_pending_offsets();

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -73,9 +73,13 @@ struct SourceHandle {
     join: tokio::task::JoinHandle<()>,
     /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
-    /// Latest committed epoch; source acks on pickup. Monotonic, so
-    /// watch's skip-latest semantics are safe.
-    epoch_committed_tx: tokio::sync::watch::Sender<Option<u64>>,
+    /// Latest committed `(epoch, persisted-checkpoint)`. The checkpoint is
+    /// the per-source `SourceCheckpoint` that was actually written to the
+    /// manifest for `epoch` — sources rebuild downstream offset state
+    /// (Kafka group offsets, NATS acks, etc.) from this exact value
+    /// rather than from `self.offsets`, which may have advanced past
+    /// the durability cut. Empty for timer-driven commits.
+    epoch_committed_tx: tokio::sync::watch::Sender<Option<(u64, SourceCheckpoint)>>,
 }
 
 /// Simplified pipeline coordinator — single tokio task, no core threads.
@@ -160,15 +164,26 @@ const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 /// What woke a source task's select loop.
 enum SourceWake {
     Shutdown,
-    EpochCommitted(u64),
+    EpochCommitted(u64, SourceCheckpoint),
     Polled(Result<Option<SourceBatch>, ConnectorError>),
 }
 
 impl StreamingCoordinator {
-    /// Fan out a committed epoch to every source so they can ack.
-    fn broadcast_epoch_committed(&self, epoch: u64) {
+    /// Fan out a committed epoch to every source so they can ack. Each
+    /// source receives the per-source checkpoint that was persisted into
+    /// the manifest for `epoch`, or an empty checkpoint when no per-source
+    /// state was captured (timer-driven commits).
+    fn broadcast_epoch_committed(
+        &self,
+        epoch: u64,
+        per_source: &FxHashMap<String, SourceCheckpoint>,
+    ) {
         for handle in &self.source_handles {
-            let _ = handle.epoch_committed_tx.send(Some(epoch));
+            let cp = per_source
+                .get(handle.name.as_ref())
+                .cloned()
+                .unwrap_or_else(|| SourceCheckpoint::new(epoch));
+            let _ = handle.epoch_committed_tx.send(Some((epoch, cp)));
         }
     }
 
@@ -259,7 +274,7 @@ impl StreamingCoordinator {
             let barrier_handle = barrier_injector.handle();
 
             let (epoch_committed_tx, mut epoch_committed_rx) =
-                tokio::sync::watch::channel::<Option<u64>>(None);
+                tokio::sync::watch::channel::<Option<(u64, SourceCheckpoint)>>(None);
 
             let join = tokio::spawn(async move {
                 let mut epoch: u64 = 0;
@@ -271,9 +286,12 @@ impl StreamingCoordinator {
                         biased;
                         () = task_shutdown_clone.notified() => SourceWake::Shutdown,
                         r = epoch_committed_rx.changed() => match r {
-                            Ok(()) => match *epoch_committed_rx.borrow_and_update() {
-                                Some(e) => SourceWake::EpochCommitted(e),
-                                None => continue,
+                            Ok(()) => {
+                                let snapshot = epoch_committed_rx.borrow_and_update().clone();
+                                match snapshot {
+                                    Some((e, cp)) => SourceWake::EpochCommitted(e, cp),
+                                    None => continue,
+                                }
                             },
                             Err(_) => SourceWake::Shutdown,
                         },
@@ -282,8 +300,8 @@ impl StreamingCoordinator {
 
                     let poll_result = match wake {
                         SourceWake::Shutdown => break,
-                        SourceWake::EpochCommitted(e) => {
-                            if let Err(err) = connector.notify_epoch_committed(e).await {
+                        SourceWake::EpochCommitted(e, cp) => {
+                            if let Err(err) = connector.notify_epoch_committed(e, &cp).await {
                                 tracing::warn!(
                                     source = %src_name,
                                     error = %err,
@@ -685,9 +703,12 @@ impl StreamingCoordinator {
                     })
                 })
                 .collect();
-            if let Some(epoch) = callback.maybe_checkpoint(true, source_offsets).await {
+            if let Some(epoch) = callback
+                .maybe_checkpoint(true, source_offsets.clone())
+                .await
+            {
                 tracing::info!(epoch, "final checkpoint completed before shutdown");
-                self.broadcast_epoch_committed(epoch);
+                self.broadcast_epoch_committed(epoch, &source_offsets);
             }
         }
     }
@@ -800,8 +821,13 @@ impl StreamingCoordinator {
         // Check if all sources aligned.
         if self.pending_barrier.sources_aligned.len() >= self.pending_barrier.sources_total {
             let checkpoints = std::mem::take(&mut self.pending_barrier.source_checkpoints);
+            // Clone for fan-out — `checkpoint_with_barrier` consumes the
+            // map. The fan-out passes each source the exact `SourceCheckpoint`
+            // that was persisted, so external offset state (Kafka group
+            // offsets, ack tokens) advances only with the durable manifest.
+            let fan_out = checkpoints.clone();
             if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
-                self.broadcast_epoch_committed(epoch);
+                self.broadcast_epoch_committed(epoch, &fan_out);
             } else {
                 tracing::warn!(
                     checkpoint_id = self.pending_barrier.checkpoint_id,
@@ -832,7 +858,8 @@ impl StreamingCoordinator {
         // configured in the tests that drive `db.checkpoint()` manually).
         let offsets = FxHashMap::default();
         if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
-            self.broadcast_epoch_committed(epoch);
+            // Timer-driven follower path — no per-source state captured.
+            self.broadcast_epoch_committed(epoch, &FxHashMap::default());
         }
 
         let should_checkpoint = self
@@ -853,7 +880,7 @@ impl StreamingCoordinator {
             let offsets = FxHashMap::default();
             if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
                 self.last_checkpoint = Instant::now();
-                self.broadcast_epoch_committed(epoch);
+                self.broadcast_epoch_committed(epoch, &FxHashMap::default());
             }
             return;
         }

--- a/examples/binance-markout/Cargo.toml
+++ b/examples/binance-markout/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "binance-markout"
-version = "0.21.5"
+version = "0.21.10"
 edition = "2021"
 publish = false
 description = "Real-time mark-out analysis over Binance BTC-USDT-PERP using LaminarDB's TEMPORAL PROBE JOIN"
@@ -12,8 +12,8 @@ name = "binance-markout"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.21.5", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.5" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.21.10", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.10" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/binance-ws/Cargo.toml
+++ b/examples/binance-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance-ws"
-version = "0.21.5"
+version = "0.21.10"
 edition = "2021"
 publish = false
 description = "Binance VWAP signals: minimal LaminarDB streaming example"
@@ -10,8 +10,8 @@ name = "binance-ws"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.21.5", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.5" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.21.10", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.10" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laminardb-demo"
-version = "0.21.5"
+version = "0.21.10"
 edition = "2021"
 publish = false
 description = "Market Data Demo: Real-time analytics with Ratatui TUI for LaminarDB"
@@ -23,9 +23,9 @@ default = []
 kafka = ["laminar-db/kafka", "dep:rdkafka", "dep:serde", "dep:serde_json"]
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.21.5" }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.5" }
-laminar-core = { path = "../../crates/laminar-core", version = "0.21.5" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.21.10" }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.10" }
+laminar-core = { path = "../../crates/laminar-core", version = "0.21.10" }
 
 # Arrow
 arrow = "57.2"

--- a/examples/microstructure/Cargo.toml
+++ b/examples/microstructure/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "microstructure"
-version = "0.21.5"
+version = "0.21.10"
 edition = "2021"
 publish = false
 description = "Market Microstructure Intelligence: 12 WebSocket streams, 36 SQL stages, sub-us latency"
@@ -12,8 +12,8 @@ name = "microstructure"
 path = "src/main.rs"
 
 [dependencies]
-laminar-db = { path = "../../crates/laminar-db", version = "0.21.5", features = ["websocket"] }
-laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.5" }
+laminar-db = { path = "../../crates/laminar-db", version = "0.21.10", features = ["websocket"] }
+laminar-derive = { path = "../../crates/laminar-derive", version = "0.21.10" }
 arrow = "57.2"
 tokio = { version = "1.50", features = ["full"] }
 crossterm = "0.29"


### PR DESCRIPTION
## Summary

The Kafka source previously committed group offsets to the broker on a 5s wall-clock timer, decoupled from LaminarDB's checkpoint cadence. That had a real correctness hole: offsets could be broker-committed before they were durable in the manifest, so recovery via `StartupMode::GroupOffsets` after losing local state would skip records that were "committed" but not actually persisted.

This PR replaces the periodic timer with a checkpoint-driven path so broker-stored group offsets only ever reflect durable positions.

## Changes

- `SourceConnector::notify_epoch_committed` now receives the durable per-source `SourceCheckpoint`, not just the epoch. The streaming coordinator broadcasts the per-source checkpoint that was actually written to the manifest.
- `KafkaSource` rebuilds the `TopicPartitionList` from that checkpoint and hands it to a small dedicated commit task via a `tokio::sync::watch` channel (last-writer-wins; stale offsets are obsolete by construction).
- Commit task owns its own `StreamConsumer` Arc clone so it doesn't contend with the reader's `recv()` loop.
- Drops the periodic commit task, `commit_retry_needed` flag, reader final-commit-on-shutdown, and ~250 lines of related scaffolding.

### Config

- `broker.commit.interval.ms` is now rejected with a config error (no silent semantic drift).
- New `broker.commit.on.checkpoint` (default `true`) and `broker.commit.timeout.ms` (default `5s`) replace it.

### Metrics

- `kafka_source_commit_failures_total` split into four named counters by reason: `rejected`, `timeout`, `panic`, `enqueue_dropped`. Operators can alert on the specific failure mode.
- `kafka_source_broker_commit_duration_seconds` histogram for tail-latency visibility.

### Operator-visible behavior

External lag dashboards (`kafka-consumer-groups`, kafka-exporter, Burrow) now advance at checkpoint cadence rather than every 5s. This is the correct semantic: only durable positions are advertised externally.

Bumps workspace to `0.21.10`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --no-default-features --features kafka --lib --tests -- -D warnings`
- [x] `cargo test --workspace --no-default-features --features kafka --lib` — 2,556 tests pass
- [ ] Docker integration test: produce records, drive a checkpoint, query broker-side committed offset via admin client, assert it matches the manifest. Crash, wipe local state, restart with `StartupMode::GroupOffsets`, assert no skip-ahead.
- [ ] Manual rebalance test: trigger a rebalance during a checkpoint cycle, verify no `RD_KAFKA_RESP_ERR__STATE` log spam, no stuck commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkpoint-driven broker offset commits for Kafka sources (replaces timer-based commits).
  * Expanded commit metrics: labeled failure reasons and commit duration tracking.

* **Bug Fixes & Improvements**
  * Per-source checkpoint propagation for committed epochs and clearer empty-checkpoint no-op behavior.
  * Simplified commit retry/close behavior; reduced unexpected fallback commits.

* **Chores**
  * Workspace and example package version bump: 0.21.5 → 0.21.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->