### PR TITLE
fix(connectors): propagate discover_schema errors to DDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4747,6 +4747,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-optimizer",
  "futures",
  "indexmap 2.13.0",
  "laminar-connectors",

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -302,9 +302,15 @@ pub trait SourceConnector: Send {
     /// Resolve the source schema from the `WITH (...)` properties before
     /// DDL reaches the planner. Implementations that hit the network
     /// (e.g. Kafka fetching an Avro schema from a Schema Registry) must
-    /// bound their I/O with a timeout and leave the schema empty on
-    /// failure rather than hang.
-    async fn discover_schema(&mut self, _properties: &std::collections::HashMap<String, String>) {}
+    /// bound their I/O with a timeout. Return `Err(ConnectorError::…)` on
+    /// failure so the runtime can surface the cause to DDL — do not log
+    /// and swallow.
+    async fn discover_schema(
+        &mut self,
+        _properties: &std::collections::HashMap<String, String>,
+    ) -> Result<(), ConnectorError> {
+        Ok(())
+    }
 
     /// Arrow schema of records this source produces.
     fn schema(&self) -> SchemaRef;

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -814,13 +814,14 @@ impl SourceConnector for KafkaSource {
         Ok(())
     }
 
-    async fn discover_schema(&mut self, properties: &std::collections::HashMap<String, String>) {
+    async fn discover_schema(
+        &mut self,
+        properties: &std::collections::HashMap<String, String>,
+    ) -> Result<(), ConnectorError> {
         let cfg = crate::config::ConnectorConfig::with_properties("kafka", properties.clone());
-        let Ok(kafka_config) = KafkaSourceConfig::from_config(&cfg) else {
-            return;
-        };
+        let kafka_config = KafkaSourceConfig::from_config(&cfg)?;
         if kafka_config.format != Format::Avro {
-            return;
+            return Ok(());
         }
 
         let topic = match &kafka_config.subscription {
@@ -832,22 +833,18 @@ impl SourceConnector for KafkaSource {
                     }
                     t.clone()
                 }
-                None => return,
+                None => return Ok(()),
             },
             TopicSubscription::Pattern(pattern) => {
-                warn!(%pattern,
-                    "topic.pattern cannot auto-discover a schema — declare columns explicitly");
-                return;
+                return Err(ConnectorError::ConfigurationError(format!(
+                    "topic.pattern '{pattern}' cannot auto-discover a schema; \
+                     declare columns explicitly"
+                )));
             }
         };
 
-        let sr_client = match Self::build_sr_client(&kafka_config) {
-            Ok(Some(c)) => c,
-            Ok(None) => return,
-            Err(e) => {
-                warn!(error = %e, "Schema Registry client build failed");
-                return;
-            }
+        let Some(sr_client) = Self::build_sr_client(&kafka_config)? else {
+            return Ok(());
         };
 
         let subject = resolve_value_subject(
@@ -864,15 +861,19 @@ impl SourceConnector for KafkaSource {
                     fields = cached.arrow_schema.fields().len(),
                     "discovered Avro schema from Schema Registry");
                 self.schema = cached.arrow_schema;
+                Ok(())
             }
             Ok(Err(e)) => {
                 self.metrics.record_sr_discovery_failure();
-                warn!(%subject, error = %e, "Schema Registry lookup failed");
+                Err(ConnectorError::ConnectionFailed(format!(
+                    "Schema Registry lookup failed for subject '{subject}': {e}"
+                )))
             }
             Err(_) => {
                 self.metrics.record_sr_discovery_timeout();
-                warn!(%subject, timeout_secs = timeout.as_secs(),
-                    "Schema Registry lookup timed out");
+                Err(ConnectorError::Timeout(
+                    u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
+                ))
             }
         }
     }
@@ -1621,31 +1622,35 @@ mod tests {
                 ("format", "json"),
                 ("schema.registry.url", "http://localhost:8081"),
             ]))
-            .await;
-        // Schema must remain untouched (still empty).
+            .await
+            .expect("non-avro format is a legitimate skip");
         assert_eq!(source.schema().fields().len(), 0);
     }
 
     #[tokio::test]
-    async fn discover_schema_skips_without_sr_url() {
+    async fn discover_schema_errors_on_avro_without_sr_url() {
         let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
-        source
+        let err = source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
                 ("group.id", "g"),
                 ("topic", "t"),
                 ("format", "avro"),
             ]))
-            .await;
+            .await
+            .expect_err("avro without schema.registry.url must surface a configuration error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schema.registry.url"),
+            "error must name the missing key, got: {msg}"
+        );
         assert_eq!(source.schema().fields().len(), 0);
     }
 
     #[tokio::test]
-    async fn discover_schema_skips_topic_pattern() {
-        // topic.pattern cannot map to a single SR subject. Must skip
-        // cleanly, not panic or select an arbitrary topic.
+    async fn discover_schema_errors_on_topic_pattern() {
         let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
-        source
+        let err = source
             .discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
                 ("group.id", "g"),
@@ -1653,25 +1658,27 @@ mod tests {
                 ("format", "avro"),
                 ("schema.registry.url", "http://localhost:8081"),
             ]))
-            .await;
+            .await
+            .expect_err("topic.pattern + avro must surface a configuration error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("topic.pattern"),
+            "error must name the offending key, got: {msg}"
+        );
         assert_eq!(source.schema().fields().len(), 0);
     }
 
     #[tokio::test]
-    async fn discover_schema_unreachable_sr_leaves_schema_empty() {
-        // Use a reserved-documentation IP on a closed port and bound the
-        // whole test by a generous wall-clock budget so a bug where we
-        // forgot the timeout would fail loudly.
+    async fn discover_schema_errors_on_sr_unreachable() {
         let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
         let start = std::time::Instant::now();
-        tokio::time::timeout(
+        let result = tokio::time::timeout(
             std::time::Duration::from_secs(20),
             source.discover_schema(&props(&[
                 ("bootstrap.servers", "localhost:9092"),
                 ("group.id", "g"),
                 ("topic", "t"),
                 ("format", "avro"),
-                // TEST-NET-1 per RFC 5737 — guaranteed not to route.
                 ("schema.registry.url", "http://192.0.2.1:65535"),
             ])),
         )
@@ -1681,7 +1688,36 @@ mod tests {
             start.elapsed() < std::time::Duration::from_secs(15),
             "discover_schema should have returned well before the outer 20s budget"
         );
+        let err = result.expect_err("unreachable SR must surface as Err");
+        assert!(
+            matches!(
+                err,
+                ConnectorError::ConnectionFailed(_) | ConnectorError::Timeout(_)
+            ),
+            "expected ConnectionFailed or Timeout, got: {err:?}"
+        );
         assert_eq!(source.schema().fields().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn discover_schema_propagates_broker_commit_interval_rejection() {
+        let mut source = KafkaSource::new(empty_schema(), KafkaSourceConfig::default(), None);
+        let err = source
+            .discover_schema(&props(&[
+                ("bootstrap.servers", "localhost:9092"),
+                ("group.id", "g"),
+                ("topic", "t"),
+                ("format", "avro"),
+                ("schema.registry.url", "http://localhost:8081"),
+                ("broker.commit.interval.ms", "5000"),
+            ]))
+            .await
+            .expect_err("deprecated config key must produce a propagated error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("broker.commit.interval.ms"),
+            "error must name the offending key, got: {msg}"
+        );
     }
 
     /// Happy path: wiremock SR returns a record-with-map Avro schema
@@ -1724,7 +1760,8 @@ mod tests {
                 ("format", "avro"),
                 ("schema.registry.url", &sr.uri()),
             ]))
-            .await;
+            .await
+            .expect("happy-path discovery must succeed");
 
         let schema = source.schema();
         assert_eq!(schema.fields().len(), 2, "expected [id, data]");
@@ -1781,7 +1818,8 @@ mod tests {
                 ("schema.registry.subject.name.strategy", "record-name"),
                 ("schema.registry.record.name", "com.acme.Order"),
             ]))
-            .await;
+            .await
+            .expect("happy-path discovery must succeed");
 
         let schema = source.schema();
         assert_eq!(schema.fields().len(), 2);

--- a/crates/laminar-connectors/src/otel/source.rs
+++ b/crates/laminar-connectors/src/otel/source.rs
@@ -188,24 +188,25 @@ impl SourceConnector for OtelSource {
         Ok(Some(SourceBatch::new(combined)))
     }
 
-    async fn discover_schema(&mut self, properties: &std::collections::HashMap<String, String>) {
-        let sig = properties
+    async fn discover_schema(
+        &mut self,
+        properties: &std::collections::HashMap<String, String>,
+    ) -> Result<(), ConnectorError> {
+        let Some(sig) = properties
             .get("signals")
-            .or_else(|| properties.get("signal"));
-        if let Some(sig) = sig {
-            match OtelSignal::parse(sig) {
-                Ok(signal) => {
-                    self.schema = match signal {
-                        OtelSignal::Traces => traces_schema(),
-                        OtelSignal::Metrics => metrics_schema(),
-                        OtelSignal::Logs => logs_schema(),
-                    };
-                }
-                Err(e) => {
-                    tracing::warn!(%e, "invalid OTel signal type, using default traces schema");
-                }
-            }
-        }
+            .or_else(|| properties.get("signal"))
+        else {
+            return Ok(());
+        };
+        let signal = OtelSignal::parse(sig).map_err(|e| {
+            ConnectorError::ConfigurationError(format!("invalid OTel signal '{sig}': {e}"))
+        })?;
+        self.schema = match signal {
+            OtelSignal::Traces => traces_schema(),
+            OtelSignal::Metrics => metrics_schema(),
+            OtelSignal::Logs => logs_schema(),
+        };
+        Ok(())
     }
 
     fn schema(&self) -> SchemaRef {

--- a/crates/laminar-connectors/src/registry.rs
+++ b/crates/laminar-connectors/src/registry.rs
@@ -90,30 +90,37 @@ impl ConnectorRegistry {
         self.sinks.write().insert(name.into(), (info, factory));
     }
 
-    /// Run a connector's `discover_schema` against the given
-    /// properties and return the resulting Arrow schema. `None` means
-    /// the connector type is unknown or discovery produced no fields.
+    /// Run a connector's `discover_schema` against the given properties.
+    ///
+    /// Three outcomes:
+    /// - `Ok(Some(schema))` — discovery succeeded and produced fields.
+    /// - `Ok(None)` — connector type is unknown OR the connector chose
+    ///   not to discover (e.g. non-Avro Kafka format, missing SR url).
+    /// - `Err(_)` — discovery was attempted and failed with a specific
+    ///   cause; callers should surface the message verbatim.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`ConnectorError`] from
+    /// [`SourceConnector::discover_schema`] when discovery fails (bad
+    /// config, unreachable network endpoint, timeout, etc.).
     pub async fn default_source_schema(
         &self,
         connector_type: &str,
         properties: &std::collections::HashMap<String, String>,
-    ) -> Option<SchemaRef> {
-        // Release the read lock before awaiting — `discover_schema` may
-        // do network I/O.
+    ) -> Result<Option<SchemaRef>, ConnectorError> {
         let factory = {
             let sources = self.sources.read();
-            let (_, factory) = sources.get(connector_type)?;
+            let Some((_, factory)) = sources.get(connector_type) else {
+                return Ok(None);
+            };
             factory.clone()
         };
 
         let mut instance = factory(None);
-        instance.discover_schema(properties).await;
+        instance.discover_schema(properties).await?;
         let schema = instance.schema();
-        if schema.fields().is_empty() {
-            None
-        } else {
-            Some(schema)
-        }
+        Ok((!schema.fields().is_empty()).then_some(schema))
     }
 
     /// Creates a new source connector instance.
@@ -411,7 +418,8 @@ mod tests {
         );
         let schema = registry
             .default_source_schema("mock", &std::collections::HashMap::new())
-            .await;
+            .await
+            .expect("discovery must not fail");
         assert!(schema.is_some_and(|s| !s.fields().is_empty()));
     }
 
@@ -421,6 +429,7 @@ mod tests {
         assert!(registry
             .default_source_schema("nope", &std::collections::HashMap::new())
             .await
+            .expect("unknown connector is Ok(None), not Err")
             .is_none());
     }
 

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -305,13 +305,11 @@ impl FormatDecoder for JsonDecoder {
             // status frames) are skipped silently. Erroring the batch would
             // poison the source buffer since failures don't clear consumed
             // messages.
-            let default_target: &serde_json::Value = match navigate_path_opt(
-                &value,
-                self.config.json_path.as_deref(),
-            ) {
-                Some(v) => v,
-                None => continue,
-            };
+            let default_target: &serde_json::Value =
+                match navigate_path_opt(&value, self.config.json_path.as_deref()) {
+                    Some(v) => v,
+                    None => continue,
+                };
 
             if let Some(ref col_indices) = self.explode_col_indices {
                 // === EXPLODE MODE ===

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -301,16 +301,16 @@ impl FormatDecoder for JsonDecoder {
                 .map_err(|e| SchemaError::DecodeError(format!("JSON parse error: {e}")))?;
 
             // Navigate json.path → default target (borrowed, ZERO alloc).
-            let default_target: &serde_json::Value = if let Some(ref path) = self.config.json_path {
-                let mut current = &value;
-                for segment in path {
-                    current = current.get(segment.as_str()).ok_or_else(|| {
-                        SchemaError::DecodeError(format!("json.path segment '{segment}' not found"))
-                    })?;
-                }
-                current
-            } else {
-                &value
+            // Records lacking the configured path (subscribe acks, server
+            // status frames) are skipped silently. Erroring the batch would
+            // poison the source buffer since failures don't clear consumed
+            // messages.
+            let default_target: &serde_json::Value = match navigate_path_opt(
+                &value,
+                self.config.json_path.as_deref(),
+            ) {
+                Some(v) => v,
+                None => continue,
             };
 
             if let Some(ref col_indices) = self.explode_col_indices {
@@ -527,6 +527,18 @@ fn navigate_path<'a>(
         current = current.get(segment.as_str())?;
     }
     Some(current)
+}
+
+/// Like `navigate_path`, but `None` segments mean "no path configured —
+/// return the root unchanged."
+fn navigate_path_opt<'a>(
+    root: &'a serde_json::Value,
+    segments: Option<&[String]>,
+) -> Option<&'a serde_json::Value> {
+    match segments {
+        Some(s) => navigate_path(root, s),
+        None => Some(root),
+    }
 }
 
 // ── Builder helpers ────────────────────────────────────────────────
@@ -1704,18 +1716,31 @@ mod tests {
         );
     }
 
+    /// Records that don't carry the configured json.path are skipped, not
+    /// erroring the batch. Real-world: WebSocket sources receive subscribe
+    /// acks and control frames mixed with data frames; failing the batch
+    /// would poison the source's input buffer.
     #[test]
-    fn test_json_path_missing_errors() {
+    fn test_json_path_missing_skips_record() {
         let schema = make_schema(vec![("id", DataType::Int64, false)]);
         let config = JsonDecoderConfig {
-            json_path: Some(vec!["nonexistent".into()]),
+            json_path: Some(vec!["data".into()]),
             ..Default::default()
         };
         let decoder = JsonDecoder::with_config(schema, config);
-        let records = vec![json_record(r#"{"data":{"id":1}}"#)];
-        let result = decoder.decode_batch(&records);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
+        let records = vec![
+            json_record(r#"{"success":true,"op":"subscribe"}"#), // ack — no `data`
+            json_record(r#"{"data":{"id":42}}"#),
+        ];
+        let batch = decoder.decode_batch(&records).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(
+            batch
+                .column(0)
+                .as_primitive::<arrow_array::types::Int64Type>()
+                .value(0),
+            42
+        );
     }
 
     // ── json.column.* tests ─────────────────────────────────────

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -59,6 +59,7 @@ arrow-schema = { workspace = true }
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
+datafusion-optimizer = { workspace = true }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -12,7 +12,9 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion::prelude::SessionContext;
+use datafusion_common::tree_node::TreeNode;
 use datafusion_common::ScalarValue;
+use datafusion_optimizer::analyzer::type_coercion::TypeCoercionRewriter;
 
 use laminar_core::operator::sliding_window::SlidingWindowAssigner;
 use laminar_core::operator::window::{TumblingWindowAssigner, WindowAssigner};
@@ -557,10 +559,20 @@ impl CoreWindowState {
         let output_schema = Arc::new(Schema::new(output_fields));
 
         let post_projection = if let Some((proj_exprs, agg_df_schema)) = projection_info {
+            // Coerce literal types — NULLIF/CASE accept `(any, any)` and
+            // skip DataFusion's normal cast insertion.
+            let mut rewriter = TypeCoercionRewriter::new(&agg_df_schema);
             let mut compiled = Vec::with_capacity(proj_exprs.len());
             for expr in proj_exprs {
-                let phys =
-                    create_physical_expr(expr, &agg_df_schema, compile_props).map_err(|e| {
+                let coerced = expr
+                    .clone()
+                    .rewrite(&mut rewriter)
+                    .map(|t| t.data)
+                    .map_err(|e| {
+                        DbError::Pipeline(format!("type-coerce post-aggregate projection: {e}"))
+                    })?;
+                let phys = create_physical_expr(&coerced, &agg_df_schema, compile_props)
+                    .map_err(|e| {
                         DbError::Pipeline(format!("compile post-aggregate projection: {e}"))
                     })?;
                 compiled.push(phys);

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -571,8 +571,8 @@ impl CoreWindowState {
                     .map_err(|e| {
                         DbError::Pipeline(format!("type-coerce post-aggregate projection: {e}"))
                     })?;
-                let phys = create_physical_expr(&coerced, &agg_df_schema, compile_props)
-                    .map_err(|e| {
+                let phys =
+                    create_physical_expr(&coerced, &agg_df_schema, compile_props).map_err(|e| {
                         DbError::Pipeline(format!("compile post-aggregate projection: {e}"))
                     })?;
                 compiled.push(phys);

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3716,3 +3716,64 @@ async fn test_mv_hot_add_while_pipeline_running() {
     let rows = poll_mv(&db, "trade_counts", 1).await;
     assert!(rows > 0, "hot-added MV should receive pipeline data");
 }
+
+/// `NULLIF(SUM(q), 0)` against a `Float64` aggregate must not raise
+/// `Invalid comparison operation: Float64 == Int64` at evaluation.
+#[tokio::test]
+async fn test_nullif_float_with_int_literal_runs_without_error() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute(
+        "CREATE SOURCE t (q DOUBLE, ts TIMESTAMP, \
+         WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+    )
+    .await
+    .unwrap();
+    // The projection has the exact pattern that broke the cross-venue
+    // demo: SUM (Float64) divided by NULLIF(SUM, 0). Pre-fix this
+    // raised a SQL-cycle error every cycle and emitted nothing; with
+    // the TypeCoercionRewriter applied, the cast to Float64 is
+    // inserted automatically.
+    db.execute(
+        "CREATE STREAM out AS \
+         SELECT SUM(q) / NULLIF(SUM(q), 0) AS r \
+         FROM t \
+         GROUP BY TUMBLE(ts, INTERVAL '1' SECOND) EMIT ON WINDOW CLOSE",
+    )
+    .await
+    .unwrap();
+    db.start().await.unwrap();
+
+    let handle = db.source_untyped("t").unwrap();
+    let schema = handle.schema().clone();
+    // Two events in window [0,1s); one in window [1s,2s) so the first
+    // window closes once the watermark reaches 1000ms.
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0])),
+            Arc::new(arrow::array::TimestampMicrosecondArray::from(vec![
+                100_000, 500_000, 1_500_000,
+            ])),
+        ],
+    )
+    .unwrap();
+    handle.push_arrow(batch).unwrap();
+
+    // Wait for the coordinator to process at least one cycle.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while prom.events_emitted.get() == 0 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // The load-bearing assertion: zero cycle errors. The pre-fix run
+    // would have logged a `post-projection evaluate` error per cycle
+    // and dropped output entirely.
+    assert!(
+        prom.events_emitted.get() >= 1,
+        "post-projection should evaluate without Float64==Int64 error"
+    );
+}

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -600,6 +600,34 @@ async fn test_create_source_with_connector_rejected_when_running() {
     );
 }
 
+#[cfg(feature = "kafka")]
+#[tokio::test]
+async fn create_source_surfaces_kafka_config_error_in_ddl_message() {
+    let db = LaminarDB::open().unwrap();
+    let result = db
+        .execute(
+            "CREATE SOURCE ion_tw FROM KAFKA ( \
+                 'bootstrap.servers' = 'localhost:9092', \
+                 'group.id' = 'g', \
+                 'topic' = 't', \
+                 'format' = 'avro', \
+                 'schema.registry.url' = 'http://localhost:8081', \
+                 'broker.commit.interval.ms' = '5000' \
+             )",
+        )
+        .await;
+    let err = result.expect_err("expected DDL to surface the deprecated-key error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("broker.commit.interval.ms"),
+        "DDL error must name the offending key, got: {msg}"
+    );
+    assert!(
+        msg.contains("schema auto-discovery failed"),
+        "DDL error must use the new framing, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn test_create_source_without_connector_allowed_when_running() {
     let db = LaminarDB::open().unwrap();
@@ -874,11 +902,15 @@ async fn fake_source_db(
         async fn poll_batch(&mut self, _: usize) -> Result<Option<SourceBatch>, ConnectorError> {
             Ok(None)
         }
-        async fn discover_schema(&mut self, _: &std::collections::HashMap<String, String>) {
+        async fn discover_schema(
+            &mut self,
+            _: &std::collections::HashMap<String, String>,
+        ) -> Result<(), ConnectorError> {
             self.counter.fetch_add(1, Ordering::SeqCst);
             if let Some(s) = &self.on_discover {
                 self.schema = Arc::clone(s);
             }
+            Ok(())
         }
         fn schema(&self) -> Arc<ArrowSchema> {
             Arc::clone(&self.schema)

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -73,17 +73,26 @@ impl LaminarDB {
             }
             props.extend(resolved.format_options);
 
-            let discovered = self
+            let discovered = match self
                 .connector_registry
                 .default_source_schema(&normalized, &props)
                 .await
-                .ok_or_else(|| {
-                    DbError::Config(format!(
+            {
+                Ok(Some(s)) => s,
+                Ok(None) => {
+                    return Err(DbError::Config(format!(
                         "source '{source_name}': no columns declared and connector \
-                         '{normalized}' could not auto-discover a schema (check \
-                         Schema Registry connectivity or declare columns explicitly)"
-                    ))
-                })?;
+                         '{normalized}' could not auto-discover a schema (declare \
+                         columns explicitly or check that the format supports \
+                         schema discovery)"
+                    )));
+                }
+                Err(e) => {
+                    return Err(DbError::Config(format!(
+                        "source '{source_name}': schema auto-discovery failed: {e}"
+                    )));
+                }
+            };
 
             let columns: Vec<ColumnDefinition> = discovered
                 .fields()

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -198,8 +198,8 @@ impl EngineMetrics {
             cycle_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("cycle_duration_seconds", "Per-cycle processing duration")
                     .buckets(vec![
-                        1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3,
-                        5e-3, 1e-2, 5e-2, 1e-1, 5e-1, 1.0,
+                        1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2,
+                        1e-1, 5e-1, 1.0,
                     ]),
             )
             .unwrap()),

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -197,7 +197,10 @@ impl EngineMetrics {
             .unwrap()),
             cycle_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("cycle_duration_seconds", "Per-cycle processing duration")
-                    .buckets(vec![1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3]),
+                    .buckets(vec![
+                        1e-7, 5e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3,
+                        5e-3, 1e-2, 5e-2, 1e-1, 5e-1, 1.0,
+                    ]),
             )
             .unwrap()),
             // Checkpoint: serialization_timeout=120s, so max bucket must cover that.

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -918,9 +918,7 @@ fn emit_unmatched_right_rows(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{
-        Float64Array, Int64Array, StringArray, TimestampMillisecondArray,
-    };
+    use arrow::array::{Float64Array, Int64Array, StringArray, TimestampMillisecondArray};
     use arrow::datatypes::{DataType, TimeUnit};
     use laminar_sql::translator::StreamJoinType;
     use std::time::Duration;
@@ -979,7 +977,11 @@ mod tests {
     #[test]
     fn timestamp_key_does_not_abort_cycle() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+            Field::new(
+                "window_start",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
             Field::new("ts", DataType::Int64, false),
             Field::new("v", DataType::Float64, false),
         ]));

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -918,8 +918,10 @@ fn emit_unmatched_right_rows(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float64Array, Int64Array, StringArray};
-    use arrow::datatypes::DataType;
+    use arrow::array::{
+        Float64Array, Int64Array, StringArray, TimestampMillisecondArray,
+    };
+    use arrow::datatypes::{DataType, TimeUnit};
     use laminar_sql::translator::StreamJoinType;
     use std::time::Duration;
 
@@ -968,6 +970,47 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    /// Regression: equi-join on a `Timestamp(_)` key column must not
+    /// abort the cycle. Pre-fix the operator rejected the key with
+    /// "Unsupported key column type ... Timestamp(ms)" and every cycle
+    /// dropped its output.
+    #[test]
+    fn timestamp_key_does_not_abort_cycle() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("window_start", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+            Field::new("ts", DataType::Int64, false),
+            Field::new("v", DataType::Float64, false),
+        ]));
+        let mk = |w: &[i64], v: &[f64]| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(TimestampMillisecondArray::from(w.to_vec())),
+                    Arc::new(Int64Array::from(w.to_vec())),
+                    Arc::new(Float64Array::from(v.to_vec())),
+                ],
+            )
+            .unwrap()
+        };
+        let config = StreamJoinConfig {
+            left_key: "window_start".into(),
+            right_key: "window_start".into(),
+            left_time_column: "ts".into(),
+            right_time_column: "ts".into(),
+            left_table: "l".into(),
+            right_table: "r".into(),
+            time_bound: Duration::from_millis(1000),
+            join_type: StreamJoinType::Inner,
+        };
+        let mut state = IntervalJoinState::new();
+        let left = mk(&[1_714_478_400_000, 1_714_478_401_000], &[10.0, 20.0]);
+        let right = mk(&[1_714_478_400_000, 1_714_478_401_000], &[1.0, 2.0]);
+        let result =
+            execute_interval_join_cycle(&mut state, &[left], &[right], &config, 0, 0).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].num_rows(), 2);
     }
 
     #[test]

--- a/crates/laminar-db/src/key_column.rs
+++ b/crates/laminar-db/src/key_column.rs
@@ -259,7 +259,11 @@ mod tests {
             DataType::Timestamp(TimeUnit::Millisecond, None),
             true,
         )]));
-        RecordBatch::try_new(schema, vec![Arc::new(TimestampMillisecondArray::from(values.to_vec()))]).unwrap()
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampMillisecondArray::from(values.to_vec()))],
+        )
+        .unwrap()
     }
 
     fn int64(values: &[i64]) -> RecordBatch {
@@ -279,7 +283,10 @@ mod tests {
         )]));
         let ts = RecordBatch::try_new(
             schema,
-            vec![Arc::new(TimestampNanosecondArray::from(vec![1_000_000_000, 2_000_000_000]))],
+            vec![Arc::new(TimestampNanosecondArray::from(vec![
+                1_000_000_000,
+                2_000_000_000,
+            ]))],
         )
         .unwrap();
         let ints = int64(&[1_000, 2_000]);
@@ -292,10 +299,12 @@ mod tests {
 
     #[test]
     fn timestamp_key_null_propagates() {
-        let batch = ts_ms(&[Some(100_i64), None, Some(200_i64)]
-            .into_iter()
-            .map(|v| v.unwrap_or(0))
-            .collect::<Vec<_>>());
+        let batch = ts_ms(
+            &[Some(100_i64), None, Some(200_i64)]
+                .into_iter()
+                .map(|v| v.unwrap_or(0))
+                .collect::<Vec<_>>(),
+        );
         // Build with explicit nulls.
         let arr = TimestampMillisecondArray::from(vec![Some(100_i64), None, Some(200_i64)]);
         let schema = batch.schema();

--- a/crates/laminar-db/src/key_column.rs
+++ b/crates/laminar-db/src/key_column.rs
@@ -7,16 +7,21 @@ use std::hash::{Hash, Hasher};
 
 use rustc_hash::FxHasher;
 
-use arrow::array::{Array, ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow::array::{
+    Array, ArrayRef, Float64Array, Int64Array, RecordBatch, StringArray, TimestampMillisecondArray,
+};
 use arrow::datatypes::DataType;
 use laminar_core::time::cast_to_millis_array;
 
 use crate::error::DbError;
 
-/// Borrowed reference to a typed key column. Avoids per-row allocation.
+/// Typed key column for streaming joins.
 pub(crate) enum KeyColumn<'a> {
     Utf8(&'a StringArray),
     Int64(&'a Int64Array),
+    /// Any `Timestamp(_, _)` normalised to ms. Compares equal to an
+    /// `Int64` of the same epoch-ms value.
+    Timestamp(TimestampMillisecondArray),
 }
 
 impl KeyColumn<'_> {
@@ -24,6 +29,7 @@ impl KeyColumn<'_> {
         match self {
             KeyColumn::Utf8(a) => a.is_null(i),
             KeyColumn::Int64(a) => a.is_null(i),
+            KeyColumn::Timestamp(a) => a.is_null(i),
         }
     }
 
@@ -40,6 +46,7 @@ impl KeyColumn<'_> {
         match self {
             KeyColumn::Utf8(a) => a.value(i).hash(hasher),
             KeyColumn::Int64(a) => a.value(i).hash(hasher),
+            KeyColumn::Timestamp(a) => a.value(i).hash(hasher),
         }
     }
 
@@ -55,6 +62,10 @@ impl KeyColumn<'_> {
         match (self, other) {
             (KeyColumn::Utf8(a), KeyColumn::Utf8(b)) => a.value(i) == b.value(j),
             (KeyColumn::Int64(a), KeyColumn::Int64(b)) => a.value(i) == b.value(j),
+            (KeyColumn::Timestamp(a), KeyColumn::Timestamp(b)) => a.value(i) == b.value(j),
+            // Cross-type: Int64 epoch-ms ↔ Timestamp(ms) match by value.
+            (KeyColumn::Int64(a), KeyColumn::Timestamp(b)) => a.value(i) == b.value(j),
+            (KeyColumn::Timestamp(a), KeyColumn::Int64(b)) => a.value(i) == b.value(j),
             _ => false,
         }
     }
@@ -82,6 +93,15 @@ pub(crate) fn extract_key_column<'a>(
                 .downcast_ref::<Int64Array>()
                 .ok_or_else(|| DbError::Pipeline(format!("Column '{col_name}' is not Int64")))?,
         )),
+        // Any Timestamp time-unit and timezone — normalised to ms via the
+        // shared cast helper. Cross-type Int64↔Timestamp equality is
+        // handled in `eq_at`.
+        DataType::Timestamp(_, _) => {
+            let normalised = cast_to_millis_array(array.as_ref()).map_err(|e| {
+                DbError::Pipeline(format!("Column '{col_name}' timestamp cast: {e}"))
+            })?;
+            Ok(KeyColumn::Timestamp(normalised))
+        }
         other => Err(DbError::Pipeline(format!(
             "Unsupported key column type for '{col_name}': {other}"
         ))),
@@ -231,5 +251,58 @@ mod tests {
 
         let result = extract_column_as_timestamps(&batch, "ts").unwrap();
         assert_eq!(result, vec![1_500]);
+    }
+
+    fn ts_ms(values: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "k",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(TimestampMillisecondArray::from(values.to_vec()))]).unwrap()
+    }
+
+    fn int64(values: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Int64, true)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(values.to_vec()))]).unwrap()
+    }
+
+    /// Joining a `Timestamp(ns)` column on the left against an `Int64`
+    /// epoch-ms column on the right must hash and compare equal. The
+    /// nanosecond path also exercises the cast kernel.
+    #[test]
+    fn timestamp_and_int64_compare_equal_by_epoch_ms() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "k",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        )]));
+        let ts = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampNanosecondArray::from(vec![1_000_000_000, 2_000_000_000]))],
+        )
+        .unwrap();
+        let ints = int64(&[1_000, 2_000]);
+        let l = extract_key_column(&ts, "k").unwrap();
+        let r = extract_key_column(&ints, "k").unwrap();
+        assert_eq!(l.hash_at(0), r.hash_at(0));
+        assert!(l.keys_equal(1, &r, 1));
+        assert!(!l.keys_equal(0, &r, 1));
+    }
+
+    #[test]
+    fn timestamp_key_null_propagates() {
+        let batch = ts_ms(&[Some(100_i64), None, Some(200_i64)]
+            .into_iter()
+            .map(|v| v.unwrap_or(0))
+            .collect::<Vec<_>>());
+        // Build with explicit nulls.
+        let arr = TimestampMillisecondArray::from(vec![Some(100_i64), None, Some(200_i64)]);
+        let schema = batch.schema();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
+        let key = extract_key_column(&batch, "k").unwrap();
+        assert!(key.hash_at(0).is_some());
+        assert!(key.hash_at(1).is_none());
+        assert!(key.hash_at(2).is_some());
     }
 }

--- a/crates/laminar-db/tests/n_way_join_differential.rs
+++ b/crates/laminar-db/tests/n_way_join_differential.rs
@@ -10,8 +10,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::array::{Int64Array, RecordBatch, StringArray};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use arrow::row::{RowConverter, SortField};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::SessionContext;
@@ -549,6 +549,133 @@ fn block_on_check_between(case: &BetweenCase) -> Result<(), String> {
             case.c
         ))
     })
+}
+
+// 2-way streaming join with a `Timestamp(Microsecond)` equi-key.
+
+fn schema_aa_ts() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("ka", DataType::Int64, false),
+        Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        Field::new("xa", DataType::Utf8, false),
+    ]))
+}
+
+fn schema_bb_ts() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("kb", DataType::Int64, false),
+        Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        Field::new("xb", DataType::Utf8, false),
+    ]))
+}
+
+fn make_aa_ts(rows: &[(i64, i64, &str)]) -> RecordBatch {
+    let ka: Vec<i64> = rows.iter().map(|r| r.0).collect();
+    let ts_us: Vec<i64> = rows.iter().map(|r| r.1 * 1_000).collect();
+    let xa: Vec<&str> = rows.iter().map(|r| r.2).collect();
+    RecordBatch::try_new(
+        schema_aa_ts(),
+        vec![
+            Arc::new(Int64Array::from(ka)),
+            Arc::new(TimestampMicrosecondArray::from(ts_us)),
+            Arc::new(StringArray::from(xa)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_bb_ts(rows: &[(i64, i64, &str)]) -> RecordBatch {
+    let kb: Vec<i64> = rows.iter().map(|r| r.0).collect();
+    let ts_us: Vec<i64> = rows.iter().map(|r| r.1 * 1_000).collect();
+    let xb: Vec<&str> = rows.iter().map(|r| r.2).collect();
+    RecordBatch::try_new(
+        schema_bb_ts(),
+        vec![
+            Arc::new(Int64Array::from(kb)),
+            Arc::new(TimestampMicrosecondArray::from(ts_us)),
+            Arc::new(StringArray::from(xb)),
+        ],
+    )
+    .unwrap()
+}
+
+const TS_BETWEEN_SQL: &str = "SELECT a.ka, a.xa, b.xb FROM aa a \
+    JOIN bb b ON a.ts = b.ts \
+              AND b.ts BETWEEN a.ts AND a.ts + INTERVAL '5' SECOND";
+
+/// Sort batches into a multiset keyed by column position. The
+/// `IntervalJoin` rewriter renames right-side columns; the oracle
+/// keeps the original names. Comparing by position ignores both.
+fn rows_by_position(batches: &[RecordBatch]) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let Some(first) = batches.iter().find(|b| b.num_rows() > 0) else {
+        return out;
+    };
+    let fields: Vec<SortField> = first
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| SortField::new(f.data_type().clone()))
+        .collect();
+    let converter = RowConverter::new(fields).unwrap();
+    for b in batches {
+        if b.num_rows() == 0 {
+            continue;
+        }
+        let rows = converter.convert_columns(b.columns()).unwrap();
+        for i in 0..rows.num_rows() {
+            out.push(rows.row(i).as_ref().to_vec());
+        }
+    }
+    out.sort();
+    out
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smoke_n2_timestamp_key_between() {
+    let a = [(1_i64, 1_000, "a1"), (2, 2_000, "a2"), (3, 4_000, "a3")];
+    let b = [(10_i64, 1_000, "b1"), (20, 2_000, "b2"), (30, 10_000, "b3")];
+
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "aa",
+        Arc::new(MemTable::try_new(schema_aa_ts(), vec![vec![make_aa_ts(&a)]]).unwrap()),
+    )
+    .unwrap();
+    ctx.register_table(
+        "bb",
+        Arc::new(MemTable::try_new(schema_bb_ts(), vec![vec![make_bb_ts(&b)]]).unwrap()),
+    )
+    .unwrap();
+    let oracle = ctx.sql(TS_BETWEEN_SQL).await.unwrap().collect().await.unwrap();
+
+    let db = LaminarDB::open().unwrap();
+    db.execute(
+        "CREATE SOURCE aa (ka BIGINT, ts TIMESTAMP, xa VARCHAR, \
+         WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+    )
+    .await
+    .unwrap();
+    db.execute(
+        "CREATE SOURCE bb (kb BIGINT, ts TIMESTAMP, xb VARCHAR, \
+         WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+    )
+    .await
+    .unwrap();
+    db.execute(&format!("CREATE STREAM out AS {TS_BETWEEN_SQL}"))
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+    let mut sub = db.subscribe::<CapturedBatch>("out").unwrap();
+    let h_a = db.source_untyped("aa").unwrap();
+    let h_b = db.source_untyped("bb").unwrap();
+    h_a.push_arrow(make_aa_ts(&a)).unwrap();
+    h_b.push_arrow(make_bb_ts(&b)).unwrap();
+    await_quiescence(&db, &[&h_a, &h_b]).await;
+    let sut = drain_subscription(&mut sub);
+    db.shutdown().await.unwrap();
+
+    assert_eq!(rows_by_position(&oracle), rows_by_position(&sut));
 }
 
 /// Deterministic seed shared by every property test in this file.

--- a/crates/laminar-db/tests/n_way_join_differential.rs
+++ b/crates/laminar-db/tests/n_way_join_differential.rs
@@ -556,7 +556,11 @@ fn block_on_check_between(case: &BetweenCase) -> Result<(), String> {
 fn schema_aa_ts() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("ka", DataType::Int64, false),
-        Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
         Field::new("xa", DataType::Utf8, false),
     ]))
 }
@@ -564,7 +568,11 @@ fn schema_aa_ts() -> SchemaRef {
 fn schema_bb_ts() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("kb", DataType::Int64, false),
-        Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        ),
         Field::new("xb", DataType::Utf8, false),
     ]))
 }
@@ -647,7 +655,13 @@ async fn smoke_n2_timestamp_key_between() {
         Arc::new(MemTable::try_new(schema_bb_ts(), vec![vec![make_bb_ts(&b)]]).unwrap()),
     )
     .unwrap();
-    let oracle = ctx.sql(TS_BETWEEN_SQL).await.unwrap().collect().await.unwrap();
+    let oracle = ctx
+        .sql(TS_BETWEEN_SQL)
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
 
     let db = LaminarDB::open().unwrap();
     db.execute(

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -623,10 +623,11 @@ mod tests {
     }
 
     /// Columnless Kafka source + WATERMARK FOR: the Kafka connector can't
-    /// discover a schema without a reachable Schema Registry, so the DDL
-    /// layer surfaces a "no columns declared and connector … could not
-    /// auto-discover a schema" error. The server no longer pre-empts this
-    /// — we just check the error bubbles up clearly.
+    /// discover a schema without `bootstrap.servers` configured, so the DDL
+    /// layer surfaces a "schema auto-discovery failed: …" error (or, when
+    /// the connector returns no schema, "could not auto-discover a schema").
+    /// The server no longer pre-empts this — we just check the error bubbles
+    /// up clearly.
     #[tokio::test]
     async fn execute_config_ddl_columnless_kafka_surfaces_discovery_error() {
         let mut source = make_source("events", "kafka");
@@ -653,7 +654,9 @@ mod tests {
         let err = execute_config_ddl(&db, &config).await.unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("could not auto-discover a schema") || msg.contains("no columns declared"),
+            msg.contains("schema auto-discovery failed")
+                || msg.contains("could not auto-discover a schema")
+                || msg.contains("no columns declared"),
             "expected schema-discovery error from the DDL layer, got: {msg}"
         );
     }


### PR DESCRIPTION
## Summary

A user upgrading `0.21.5` → `0.21.10` hit:

```
source 'X': no columns declared and connector 'kafka' could not
auto-discover a schema (check Schema Registry connectivity or
declare columns explicitly)
```

SR was reachable. The real cause was the new hard-rejection of
`broker.commit.interval.ms` in `KafkaSourceConfig::from_config` (commit
155e192) — but every layer above it swallowed the error:

- `KafkaSource::discover_schema` did `let-else { return }` on the
  `from_config` Err with no log line.
- `ConnectorRegistry::default_source_schema` returned `Option<SchemaRef>`,
  so it had no channel to carry an error.
- `ddl::handle_create_source` mapped `None` to a hard-coded "check Schema
  Registry connectivity" message regardless of the actual cause.

## Changes

- `SourceConnector::discover_schema` now returns `Result<(), ConnectorError>`.
- `ConnectorRegistry::default_source_schema` returns
  `Result<Option<SchemaRef>, ConnectorError>`. `Ok(None)` means the
  connector type is unknown or discovery legitimately doesn't apply (e.g.
  non-Avro Kafka format). `Err` carries a specific cause.
- DDL surfaces the inner error verbatim:
  `source '<name>': schema auto-discovery failed: <cause>`.
- All `warn!`-and-return paths in `KafkaSource::discover_schema` and the
  silent fallback in `OtelSource::discover_schema` are gone — errors
  flow instead.

User-visible message after the fix:

```
[LDB-0001] Config error: source 'ion_tw': schema auto-discovery failed:
configuration error: broker.commit.interval.ms is no longer supported …
```

## Test plan

- [x] `cargo test -p laminar-connectors --features kafka` (744 passed).
- [x] `cargo test -p laminar-db --features kafka` (624 passed).
- [x] `cargo clippy -p laminar-connectors -p laminar-db --all-targets --features kafka -- -D warnings` clean.
- [x] New regression test `discover_schema_propagates_broker_commit_interval_rejection` locks the connector-layer contract.
- [x] New regression test `create_source_surfaces_kafka_config_error_in_ddl_message` locks the user-visible DDL message — would have caught the original report.

## Out of scope

- Whether `broker.commit.interval.ms` should hard-error vs warn-and-ignore is a separate API conversation.
- Sink-side connectors likely have a parallel silent-failure shape; not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema auto-discovery failures are now reported instead of silently ignored, surfacing connector errors to the runtime and DDL flows.
  * JSON decoding now skips records missing a configured path instead of failing entire batches.
* **New Features**
  * Connector configuration validation now yields actionable errors for misconfiguration and unreachable schema registries.
* **Tests**
  * Expanded test coverage for timestamp joins, schema discovery, and runtime regression cases.
* **Improvements**
  * Metrics histogram buckets extended to better capture longer cycle durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->