### PR TITLE
feat(server): SUBSCRIBE over the Postgres wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3042,17 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4787,24 +4808,31 @@ version = "0.21.10"
 dependencies = [
  "anyhow",
  "arrow-array",
+ "arrow-cast",
  "arrow-json",
+ "arrow-schema",
+ "async-trait",
  "axum",
  "chrono",
  "clap",
  "crossfire",
+ "futures",
  "gethostname",
  "humantime-serde",
  "laminar-core",
  "laminar-db",
+ "laminar-sql",
  "laminar-storage",
  "mimalloc",
  "notify",
  "openssl",
  "parking_lot 0.12.5",
+ "pgwire",
  "prometheus",
  "regex",
  "serde",
  "serde_json",
+ "sqlparser",
  "tempfile",
  "thiserror 2.0.18",
  "tikv-jemallocator",
@@ -4859,6 +4887,29 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
@@ -5164,6 +5215,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "mea"
@@ -6066,6 +6123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_interval_2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a055f44628dcf9c4e68f931535dabd3544a239655fdde25a3b0e95d4b36e9260"
+dependencies = [
+ "bytes",
+ "chrono",
+ "postgres-types",
+]
+
+[[package]]
 name = "pgpq"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6077,6 +6145,30 @@ dependencies = [
  "bytes",
  "enum_dispatch",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pgwire"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3cee243b682091188b90f22b07585ad6b43e699b52bc29422bd9ca6ce2c2deb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "derive-new",
+ "futures",
+ "hex",
+ "lazy-regex",
+ "md5",
+ "pg_interval_2",
+ "postgres-types",
+ "rand 0.10.0",
+ "ryu",
+ "serde_json",
+ "smol_str",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6253,6 +6345,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
+ "array-init",
  "bytes",
  "chrono",
  "fallible-iterator",
@@ -7585,6 +7678,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "snap"

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -1135,16 +1135,15 @@ impl LaminarDB {
             )));
         }
 
-        let (schema, filterable) =
-            if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
-                (mv.schema, true)
-            } else if let Some(src) = self.catalog.get_source(name) {
-                (Arc::clone(&src.schema), true)
-            } else if let Some(entry) = self.catalog.get_stream_entry(name) {
-                (entry.sink.schema(), false)
-            } else {
-                return Err(DbError::StreamNotFound(name.to_string()));
-            };
+        let (schema, filterable) = if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
+            (mv.schema, true)
+        } else if let Some(src) = self.catalog.get_source(name) {
+            (Arc::clone(&src.schema), true)
+        } else if let Some(entry) = self.catalog.get_stream_entry(name) {
+            (entry.sink.schema(), false)
+        } else {
+            return Err(DbError::StreamNotFound(name.to_string()));
+        };
 
         let filter = match filter_sql {
             None => None,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -163,6 +163,8 @@ pub struct LaminarDB {
     /// `None`, `db.checkpoint()` falls back to the direct coordinator
     /// path (only valid when the engine has no stateful operators).
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
+    /// SUBSCRIBE fan-out registry, shared with the pipeline callback.
+    pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
 }
 
 /// Oneshot reply carrying the full `CheckpointResult` back to the
@@ -342,6 +344,7 @@ impl LaminarDB {
             #[cfg(feature = "cluster-unstable")]
             assignment_snapshot_store: parking_lot::Mutex::new(None),
             force_ckpt_tx: parking_lot::Mutex::new(None),
+            subscription_registry: Arc::new(crate::subscription::SubscriptionRegistry::new()),
         })
     }
 
@@ -975,6 +978,9 @@ impl LaminarDB {
             StreamingStatement::AlterSource { name, operation } => {
                 self.handle_alter_source(name, operation)
             }
+            StreamingStatement::Subscribe(_) => Err(DbError::InvalidOperation(
+                "SUBSCRIBE requires the pgwire endpoint, not HTTP /api/v1/sql".into(),
+            )),
         }
     }
 
@@ -1072,6 +1078,13 @@ impl LaminarDB {
         self.session_properties.lock().clone()
     }
 
+    /// Set a session property. Keys are lowercased.
+    pub fn set_session_property(&self, key: &str, value: &str) {
+        self.session_properties
+            .lock()
+            .insert(key.to_lowercase(), value.to_string());
+    }
+
     /// Subscribe to a named stream or materialized view.
     ///
     /// # Errors
@@ -1101,6 +1114,62 @@ impl LaminarDB {
         self.catalog
             .get_stream_subscription(name)
             .ok_or_else(|| DbError::StreamNotFound(name.to_string()))
+    }
+
+    /// Open a SUBSCRIBE portal against a named MV, source, or stream.
+    /// `filter_sql` is rejected on streams (their schema is opaque).
+    ///
+    /// # Errors
+    /// Returns `StreamNotFound` if `name` is unknown, or `Pipeline` if the
+    /// subscriber cap is reached or the filter fails to compile.
+    pub async fn open_subscription(
+        &self,
+        name: &str,
+        filter_sql: Option<&str>,
+    ) -> Result<crate::subscription::SubscriptionPortal, DbError> {
+        let attached = self.subscription_registry.subscriber_count(name);
+        if attached >= crate::subscription::MAX_SUBSCRIBERS_PER_MV {
+            return Err(DbError::Pipeline(format!(
+                "subscriber cap reached for '{name}' ({attached}/{})",
+                crate::subscription::MAX_SUBSCRIBERS_PER_MV
+            )));
+        }
+
+        let (schema, filterable) =
+            if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
+                (mv.schema, true)
+            } else if let Some(src) = self.catalog.get_source(name) {
+                (Arc::clone(&src.schema), true)
+            } else if let Some(entry) = self.catalog.get_stream_entry(name) {
+                (entry.sink.schema(), false)
+            } else {
+                return Err(DbError::StreamNotFound(name.to_string()));
+            };
+
+        let filter = match filter_sql {
+            None => None,
+            Some(_) if !filterable => {
+                return Err(DbError::Pipeline(format!(
+                    "WHERE on stream '{name}' is not supported (opaque schema); \
+                     subscribe to a materialized view"
+                )));
+            }
+            Some(sql) => Some(
+                crate::filter_compile::compile(&self.ctx, sql, &schema)
+                    .await
+                    .ok_or_else(|| {
+                        DbError::Pipeline(format!("subscribe filter '{sql}' did not compile"))
+                    })?,
+            ),
+        };
+
+        let rx = self.subscription_registry.subscribe(name);
+        Ok(match filter {
+            Some(phys) => {
+                crate::subscription::SubscriptionPortal::open_with_filter(name, schema, rx, phys)
+            }
+            None => crate::subscription::SubscriptionPortal::open(name, schema, rx),
+        })
     }
 
     /// Handle EXPLAIN statement — show the streaming query plan.

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3800,7 +3800,10 @@ async fn open_subscription_resolves_named_stream() {
         .unwrap();
     db.start().await.unwrap();
 
-    let mut portal = db.open_subscription("all_trades", None).await.expect("portal opens");
+    let mut portal = db
+        .open_subscription("all_trades", None)
+        .await
+        .expect("portal opens");
 
     let handle = db.source_untyped("trades").unwrap();
     let schema = handle.schema().clone();
@@ -3816,13 +3819,10 @@ async fn open_subscription_resolves_named_stream() {
 
     // Wait up to 2s for the cycle to emit. The portal pump runs on the
     // main runtime; the engine's `push_to_streams` fires the broadcast.
-    let frame = tokio::time::timeout(
-        std::time::Duration::from_secs(2),
-        portal.next_frame(),
-    )
-    .await
-    .expect("portal must produce a frame within 2s")
-    .expect("frame");
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), portal.next_frame())
+        .await
+        .expect("portal must produce a frame within 2s")
+        .expect("frame");
     let crate::subscription::PortalFrame::Batch(b) = frame else {
         panic!("expected Batch, got {frame:?}");
     };

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3777,3 +3777,116 @@ async fn test_nullif_float_with_int_literal_runs_without_error() {
         "post-projection should evaluate without Float64==Int64 error"
     );
 }
+
+#[tokio::test]
+async fn open_subscription_resolves_unknown_name_to_error() {
+    let db = LaminarDB::open().unwrap();
+    let err = db.open_subscription("nope", None).await.unwrap_err();
+    assert!(matches!(err, DbError::StreamNotFound(_)));
+}
+
+#[tokio::test]
+async fn open_subscription_resolves_named_stream() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+
+    let mut portal = db.open_subscription("all_trades", None).await.expect("portal opens");
+
+    let handle = db.source_untyped("trades").unwrap();
+    let schema = handle.schema().clone();
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["AAPL"])),
+            Arc::new(arrow::array::Float64Array::from(vec![150.0])),
+        ],
+    )
+    .unwrap();
+    handle.push_arrow(batch).unwrap();
+
+    // Wait up to 2s for the cycle to emit. The portal pump runs on the
+    // main runtime; the engine's `push_to_streams` fires the broadcast.
+    let frame = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        portal.next_frame(),
+    )
+    .await
+    .expect("portal must produce a frame within 2s")
+    .expect("frame");
+    let crate::subscription::PortalFrame::Batch(b) = frame else {
+        panic!("expected Batch, got {frame:?}");
+    };
+    assert!(b.num_rows() >= 1);
+}
+
+#[tokio::test]
+async fn open_subscription_with_invalid_filter_errors_at_open() {
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+
+    let err = db
+        .open_subscription("trades", Some("nonexistent_col > 1"))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("subscribe filter") || msg.contains("nonexistent_col"),
+        "expected filter compile error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn open_subscription_with_filter_on_stream_is_rejected() {
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+
+    let err = db
+        .open_subscription("all_trades", Some("symbol = 'AAPL'"))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("opaque"), "got: {err}");
+}
+
+#[tokio::test]
+async fn drop_stream_closes_subscription() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM s AS SELECT * FROM trades")
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+
+    let mut portal = db.open_subscription("s", None).await.unwrap();
+
+    db.execute("DROP STREAM s").await.unwrap();
+
+    // Pump exits, mpsc closes, next_frame eventually returns None.
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while portal.next_frame().await.is_some() {}
+    })
+    .await
+    .expect("portal must close");
+}

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3817,16 +3817,20 @@ async fn open_subscription_resolves_named_stream() {
     .unwrap();
     handle.push_arrow(batch).unwrap();
 
-    // Wait up to 2s for the cycle to emit. The portal pump runs on the
-    // main runtime; the engine's `push_to_streams` fires the broadcast.
-    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), portal.next_frame())
-        .await
-        .expect("portal must produce a frame within 2s")
-        .expect("frame");
-    let crate::subscription::PortalFrame::Batch(b) = frame else {
-        panic!("expected Batch, got {frame:?}");
-    };
-    assert!(b.num_rows() >= 1);
+    // Wait up to 2s for a Batch frame, ignoring barrier markers.
+    let batch = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match portal.next_frame().await {
+                Some(crate::subscription::PortalFrame::Batch(b)) => break Some(b),
+                Some(crate::subscription::PortalFrame::Barrier { .. }) => {}
+                None => break None,
+            }
+        }
+    })
+    .await
+    .expect("portal must produce a Batch within 2s")
+    .expect("batch frame");
+    assert!(batch.num_rows() >= 1);
 }
 
 #[tokio::test]

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -751,6 +751,8 @@ impl LaminarDB {
         }
         self.connector_manager.lock().unregister_stream(&name_str);
 
+        self.subscription_registry.drop_name(&name_str);
+
         // Notify the running coordinator to remove the query. If the
         // channel is saturated, surface a transient error so the caller
         // can retry rather than seeing a successful DROP that leaves the
@@ -869,6 +871,7 @@ impl LaminarDB {
             // Try dropping as stream first
             if self.catalog.drop_stream(dep) {
                 self.connector_manager.lock().unregister_stream(dep);
+                self.subscription_registry.drop_name(dep);
             }
             // Try dropping as MV (cascade further)
             {
@@ -878,6 +881,7 @@ impl LaminarDB {
                     let mut mgr = self.connector_manager.lock();
                     for v in &views {
                         mgr.unregister_stream(&v.name);
+                        self.subscription_registry.drop_name(&v.name);
                     }
                 }
             }
@@ -1130,6 +1134,10 @@ impl LaminarDB {
                 mv_store.drop_mv(dropped);
                 let _ = self.ctx.deregister_table(dropped);
             }
+        }
+        // Drop subscription channels outside the locks (registry never nests in mv_store).
+        for dropped in &dropped_names {
+            self.subscription_registry.drop_name(dropped);
         }
 
         Ok(ExecuteResult::Ddl(DdlInfo {

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -1,5 +1,6 @@
 //! Shared SQL filter compile + apply for sinks and SUBSCRIBE.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
@@ -11,20 +12,44 @@ use datafusion_expr::{Expr, LogicalPlan};
 
 use crate::error::DbError;
 
+static COMPILE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Registers a temporary table on construction and deregisters on drop, so a
+/// concurrent compile or an early return can never leak the registration onto
+/// the shared `SessionContext`.
+struct ScopedTable<'a> {
+    ctx: &'a SessionContext,
+    name: String,
+}
+
+impl<'a> ScopedTable<'a> {
+    fn new(ctx: &'a SessionContext, schema: &SchemaRef) -> Option<Self> {
+        let name = format!(
+            "__filter_compile_{}",
+            COMPILE_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
+        ctx.register_table(&name, Arc::new(empty)).ok()?;
+        Some(Self { ctx, name })
+    }
+}
+
+impl Drop for ScopedTable<'_> {
+    fn drop(&mut self) {
+        let _ = self.ctx.deregister_table(&self.name);
+    }
+}
+
 /// Compile `filter_sql` against `schema`. Returns `None` on any failure.
 pub(crate) async fn compile(
     ctx: &SessionContext,
     filter_sql: &str,
     schema: &SchemaRef,
 ) -> Option<Arc<dyn PhysicalExpr>> {
-    let table = "__filter_compile";
-    let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
-    let _ = ctx.deregister_table(table);
-    ctx.register_table(table, Arc::new(empty)).ok()?;
-
-    let sql = format!("SELECT * FROM {table} WHERE {filter_sql}");
+    let scoped = ScopedTable::new(ctx, schema)?;
+    let sql = format!("SELECT * FROM {} WHERE {filter_sql}", scoped.name);
     let plan = ctx.sql(&sql).await.ok()?.logical_plan().clone();
-    let _ = ctx.deregister_table(table);
+    drop(scoped);
 
     let expr = find_predicate(&plan)?;
     let df_schema = DFSchema::try_from(schema.as_ref().clone()).ok()?;

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -1,0 +1,65 @@
+//! Shared SQL filter compile + apply for sinks and SUBSCRIBE.
+
+use std::sync::Arc;
+
+use arrow_array::{BooleanArray, RecordBatch};
+use arrow::datatypes::SchemaRef;
+use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion::prelude::SessionContext;
+use datafusion_common::DFSchema;
+use datafusion_expr::{Expr, LogicalPlan};
+
+use crate::error::DbError;
+
+/// Compile `filter_sql` against `schema`. Returns `None` on any failure.
+pub(crate) async fn compile(
+    ctx: &SessionContext,
+    filter_sql: &str,
+    schema: &SchemaRef,
+) -> Option<Arc<dyn PhysicalExpr>> {
+    let table = "__filter_compile";
+    let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
+    let _ = ctx.deregister_table(table);
+    ctx.register_table(table, Arc::new(empty)).ok()?;
+
+    let sql = format!("SELECT * FROM {table} WHERE {filter_sql}");
+    let plan = ctx.sql(&sql).await.ok()?.logical_plan().clone();
+    let _ = ctx.deregister_table(table);
+
+    let expr = find_predicate(&plan)?;
+    let df_schema = DFSchema::try_from(schema.as_ref().clone()).ok()?;
+    create_physical_expr(&expr, &df_schema, ctx.state().execution_props()).ok()
+}
+
+fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {
+    match plan {
+        LogicalPlan::Filter(f) => Some(f.predicate.clone()),
+        LogicalPlan::Projection(p) => find_predicate(&p.input),
+        LogicalPlan::Sort(s) => find_predicate(&s.input),
+        LogicalPlan::Limit(l) => find_predicate(&l.input),
+        _ => plan.inputs().iter().find_map(|i| find_predicate(i)),
+    }
+}
+
+/// Apply a compiled boolean predicate. `Ok(None)` if every row is filtered out.
+pub(crate) fn apply(
+    batch: &RecordBatch,
+    expr: &dyn PhysicalExpr,
+) -> Result<Option<RecordBatch>, DbError> {
+    if batch.num_rows() == 0 {
+        return Ok(None);
+    }
+    let result = expr
+        .evaluate(batch)
+        .map_err(|e| DbError::Pipeline(format!("filter eval: {e}")))?;
+    let array = result
+        .into_array(batch.num_rows())
+        .map_err(|e| DbError::Pipeline(format!("filter to_array: {e}")))?;
+    let mask = array
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| DbError::Pipeline("filter must return BooleanArray".into()))?;
+    let filtered = arrow::compute::filter_record_batch(batch, mask)
+        .map_err(|e| DbError::Pipeline(format!("filter: {e}")))?;
+    if filtered.num_rows() == 0 { Ok(None) } else { Ok(Some(filtered)) }
+}

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use arrow_array::{BooleanArray, RecordBatch};
 use arrow::datatypes::SchemaRef;
+use arrow_array::{BooleanArray, RecordBatch};
 use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion::prelude::SessionContext;
 use datafusion_common::DFSchema;
@@ -61,5 +61,9 @@ pub(crate) fn apply(
         .ok_or_else(|| DbError::Pipeline("filter must return BooleanArray".into()))?;
     let filtered = arrow::compute::filter_record_batch(batch, mask)
         .map_err(|e| DbError::Pipeline(format!("filter: {e}")))?;
-    if filtered.num_rows() == 0 { Ok(None) } else { Ok(Some(filtered)) }
+    if filtered.num_rows() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(filtered))
+    }
 }

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -54,6 +54,7 @@ mod eowc_state;
 pub mod api;
 mod ddl;
 mod error;
+mod filter_compile;
 mod handle;
 mod interval_join;
 mod key_column;
@@ -78,6 +79,9 @@ mod show_commands;
 mod sink_task;
 mod sql_analysis;
 mod sql_utils;
+/// External `SUBSCRIBE` substrate: per-name broadcast channel and the
+/// per-portal pump task.
+pub mod subscription;
 mod table_backend;
 mod table_cache_mode;
 mod table_provider;

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -95,4 +95,9 @@ pub trait PipelineCallback: Send + 'static {
     fn has_deferred_input(&self) -> bool {
         false
     }
+
+    /// Forward a durable checkpoint epoch to external SUBSCRIBE consumers.
+    fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        let _ = (epoch, checkpoint_id);
+    }
 }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -859,8 +859,11 @@ impl StreamingCoordinator {
             // that was persisted, so external offset state (Kafka group
             // offsets, ack tokens) advances only with the durable manifest.
             let fan_out = checkpoints.clone();
+            let checkpoint_id = self.pending_barrier.checkpoint_id;
             if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
                 self.broadcast_epoch_committed(epoch, &fan_out);
+                // Wire barrier = durable epoch.
+                callback.publish_barrier(epoch, checkpoint_id);
             } else {
                 tracing::warn!(
                     checkpoint_id = self.pending_barrier.checkpoint_id,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -385,7 +385,9 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) = crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await {
+            if let Some(compiled) =
+                crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await
+            {
                 self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
             } else {
                 tracing::error!(
@@ -983,7 +985,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
-        self.subscription_registry.broadcast_barrier(epoch, checkpoint_id);
+        self.subscription_registry
+            .broadcast_barrier(epoch, checkpoint_id);
     }
 
     fn has_deferred_input(&self) -> bool {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -7,10 +7,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::SchemaRef;
-use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion::physical_expr::PhysicalExpr;
 use datafusion::prelude::SessionContext;
-use datafusion_common::DFSchema;
 use laminar_connectors::checkpoint::SourceCheckpoint;
 use laminar_core::alloc::{PriorityClass, PriorityGuard};
 use laminar_core::streaming;
@@ -109,6 +107,7 @@ pub(crate) struct ConnectorPipelineCallback {
     /// the coordinator with an empty `CheckpointRequest` and the
     /// leader's manifest is useless for restart recovery.
     pub(crate) force_ckpt_rx: Option<crate::db::ForceCheckpointRx>,
+    pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
 }
 
 impl ConnectorPipelineCallback {
@@ -386,7 +385,7 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) = compile_sink_filter_sql(&self.filter_ctx, sql, &schema).await {
+            if let Some(compiled) = crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await {
                 self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
             } else {
                 tracing::error!(
@@ -452,6 +451,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             let dropped = batch.num_rows() as u64;
                             self.prom.events_dropped.inc_by(dropped);
                         }
+                        self.subscription_registry
+                            .send_batch(stream_name, batch.clone());
                     }
                 }
             }
@@ -476,6 +477,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                     if batch.num_rows() > 0 {
                         store.update(stream_name, batch);
                         updates += 1;
+                        self.subscription_registry
+                            .send_batch(stream_name, batch.clone());
                     }
                 }
             }
@@ -524,7 +527,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         for batch in shared.iter() {
                             let filtered: Cow<RecordBatch> = match &filter_state {
                                 SinkFilterDispatch::Compiled(phys) => {
-                                    match apply_compiled_sink_filter(batch, phys) {
+                                    match crate::filter_compile::apply(batch, phys.as_ref()) {
                                         Ok(Some(fb)) => Cow::Owned(fb),
                                         Ok(None) => continue,
                                         Err(e) => {
@@ -979,6 +982,10 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         bp
     }
 
+    fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        self.subscription_registry.broadcast_barrier(epoch, checkpoint_id);
+    }
+
     fn has_deferred_input(&self) -> bool {
         // In cluster mode, always claim pending input so the coordinator
         // runs `execute_cycle` each idle tick — otherwise a follower with
@@ -1221,85 +1228,6 @@ fn update_partial_cache_from_batch(
 /// Encode an Arrow schema as a hex-encoded IPC flatbuffer for `ConnectorConfig`.
 pub(crate) fn encode_arrow_schema(schema: &arrow_schema::Schema) -> String {
     laminar_connectors::config::encode_arrow_schema_ipc(schema)
-}
-
-/// Apply a compiled `PhysicalExpr` filter to a batch.
-fn apply_compiled_sink_filter(
-    batch: &RecordBatch,
-    filter: &Arc<dyn PhysicalExpr>,
-) -> Result<Option<RecordBatch>, DbError> {
-    if batch.num_rows() == 0 {
-        return Ok(None);
-    }
-    let result = filter
-        .evaluate(batch)
-        .map_err(|e| DbError::Pipeline(format!("sink filter evaluate: {e}")))?;
-    let mask = result
-        .into_array(batch.num_rows())
-        .map_err(|e| DbError::Pipeline(format!("sink filter to array: {e}")))?;
-    let bool_arr = mask
-        .as_any()
-        .downcast_ref::<arrow::array::BooleanArray>()
-        .ok_or_else(|| DbError::Pipeline("sink filter not boolean".into()))?;
-    let filtered = arrow::compute::filter_record_batch(batch, bool_arr)
-        .map_err(|e| DbError::Pipeline(format!("sink filter: {e}")))?;
-    if filtered.num_rows() == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(filtered))
-    }
-}
-
-/// Try to compile a sink filter SQL expression to a `PhysicalExpr`.
-///
-/// Plans the filter as a full SQL query against an empty table with the batch
-/// schema, then extracts the Filter predicate from the logical plan and
-/// compiles it. Returns `None` if compilation fails (caller falls back to
-/// SQL-based filter).
-async fn compile_sink_filter_sql(
-    ctx: &SessionContext,
-    filter_sql: &str,
-    batch_schema: &SchemaRef,
-) -> Option<Arc<dyn PhysicalExpr>> {
-    let table_name = "__compile_filter";
-    let empty =
-        datafusion::datasource::MemTable::try_new(batch_schema.clone(), vec![vec![]]).ok()?;
-    let _ = ctx.deregister_table(table_name);
-    ctx.register_table(table_name, Arc::new(empty)).ok()?;
-
-    let sql = format!("SELECT * FROM {table_name} WHERE {filter_sql}");
-    let plan = {
-        let df = ctx.sql(&sql).await.ok()?;
-        df.logical_plan().clone()
-    };
-    let _ = ctx.deregister_table(table_name);
-
-    // Walk plan to find Filter node
-    let filter_expr = find_filter_predicate(&plan)?;
-
-    // Compile against the batch schema
-    let df_schema = DFSchema::try_from(batch_schema.as_ref().clone()).ok()?;
-    let state = ctx.state();
-    let props = state.execution_props();
-    create_physical_expr(&filter_expr, &df_schema, props).ok()
-}
-
-/// Walk a logical plan to find the first Filter predicate.
-fn find_filter_predicate(plan: &datafusion_expr::LogicalPlan) -> Option<datafusion_expr::Expr> {
-    match plan {
-        datafusion_expr::LogicalPlan::Filter(f) => Some(f.predicate.clone()),
-        datafusion_expr::LogicalPlan::Projection(p) => find_filter_predicate(&p.input),
-        datafusion_expr::LogicalPlan::Sort(s) => find_filter_predicate(&s.input),
-        datafusion_expr::LogicalPlan::Limit(l) => find_filter_predicate(&l.input),
-        _ => {
-            for input in plan.inputs() {
-                if let Some(expr) = find_filter_predicate(input) {
-                    return Some(expr);
-                }
-            }
-            None
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1415,6 +1415,7 @@ impl LaminarDB {
             #[cfg(feature = "cluster-unstable")]
             last_follower_epoch: None,
             force_ckpt_rx: Some(force_ckpt_rx),
+            subscription_registry: Arc::clone(&self.subscription_registry),
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/subscription/mod.rs
+++ b/crates/laminar-db/src/subscription/mod.rs
@@ -1,0 +1,8 @@
+//! SUBSCRIBE substrate: per-name broadcast registry and per-portal pump.
+
+mod portal;
+mod registry;
+
+pub use portal::{PortalFrame, SubscriptionPortal};
+pub(crate) use portal::MAX_SUBSCRIBERS_PER_MV;
+pub(crate) use registry::SubscriptionRegistry;

--- a/crates/laminar-db/src/subscription/mod.rs
+++ b/crates/laminar-db/src/subscription/mod.rs
@@ -3,6 +3,6 @@
 mod portal;
 mod registry;
 
-pub use portal::{PortalFrame, SubscriptionPortal};
 pub(crate) use portal::MAX_SUBSCRIBERS_PER_MV;
+pub use portal::{PortalFrame, SubscriptionPortal};
 pub(crate) use registry::SubscriptionRegistry;

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -63,7 +63,11 @@ impl SubscriptionPortal {
         let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
         let closed = Arc::new(AtomicBool::new(false));
         tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
-        Self { schema, outbound, closed }
+        Self {
+            schema,
+            outbound,
+            closed,
+        }
     }
 
     /// Schema of the subscribed object.
@@ -115,9 +119,13 @@ async fn pump_loop(
                 },
                 None => PortalFrame::Batch(batch),
             },
-            Ok(MvUpdate::Barrier { epoch, checkpoint_id }) => {
-                PortalFrame::Barrier { epoch, checkpoint_id }
-            }
+            Ok(MvUpdate::Barrier {
+                epoch,
+                checkpoint_id,
+            }) => PortalFrame::Barrier {
+                epoch,
+                checkpoint_id,
+            },
             Err(broadcast::error::RecvError::Closed) => return,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
@@ -187,8 +195,9 @@ mod tests {
 
         reg.drop_name("mv");
 
-        let frame =
-            tokio::time::timeout(Duration::from_millis(500), portal.next_frame()).await.unwrap();
+        let frame = tokio::time::timeout(Duration::from_millis(500), portal.next_frame())
+            .await
+            .unwrap();
         assert!(frame.is_none());
     }
 

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -7,7 +7,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use crossfire::{mpsc, AsyncRx, MAsyncTx};
 use datafusion::physical_expr::PhysicalExpr;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 
 use super::registry::MvUpdate;
 
@@ -34,6 +34,7 @@ pub struct SubscriptionPortal {
     schema: SchemaRef,
     outbound: AsyncRx<mpsc::Array<PortalFrame>>,
     closed: Arc<AtomicBool>,
+    wake: Arc<Notify>,
 }
 
 impl SubscriptionPortal {
@@ -62,11 +63,20 @@ impl SubscriptionPortal {
     ) -> Self {
         let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
         let closed = Arc::new(AtomicBool::new(false));
-        tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
+        let wake = Arc::new(Notify::new());
+        tokio::spawn(pump_loop(
+            name.into(),
+            rx,
+            tx,
+            Arc::clone(&closed),
+            Arc::clone(&wake),
+            filter,
+        ));
         Self {
             schema,
             outbound,
             closed,
+            wake,
         }
     }
 
@@ -81,9 +91,11 @@ impl SubscriptionPortal {
         self.outbound.recv().await.ok()
     }
 
-    /// Signal the pump to stop. Idempotent.
+    /// Signal the pump to stop. Idempotent. Wakes the pump if it's parked
+    /// on `broadcast_rx.recv()` so it can re-check the flag and exit.
     pub fn close(&self) {
         self.closed.store(true, Ordering::Release);
+        self.wake.notify_waiters();
     }
 
     /// True after `close()` has been called.
@@ -104,10 +116,16 @@ async fn pump_loop(
     mut broadcast_rx: broadcast::Receiver<MvUpdate>,
     tx: MAsyncTx<mpsc::Array<PortalFrame>>,
     closed: Arc<AtomicBool>,
+    wake: Arc<Notify>,
     filter: Option<Arc<dyn PhysicalExpr>>,
 ) {
     while !closed.load(Ordering::Acquire) {
-        let frame = match broadcast_rx.recv().await {
+        let recv = tokio::select! {
+            biased;
+            () = wake.notified() => continue,
+            r = broadcast_rx.recv() => r,
+        };
+        let frame = match recv {
             Ok(MvUpdate::Batch(batch)) => match filter.as_ref() {
                 Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
                     Ok(Some(b)) => PortalFrame::Batch(b),

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -1,0 +1,222 @@
+//! Per-subscriber portal: pump task forwards broadcast updates to the wire.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use crossfire::{mpsc, AsyncRx, MAsyncTx};
+use datafusion::physical_expr::PhysicalExpr;
+use tokio::sync::broadcast;
+
+use super::registry::MvUpdate;
+
+/// One frame emitted toward the wire.
+#[derive(Debug, Clone)]
+pub enum PortalFrame {
+    /// Rows produced in a cycle.
+    Batch(RecordBatch),
+    /// Rows preceding this marker are durable as of `epoch`.
+    Barrier {
+        /// Engine checkpoint epoch.
+        epoch: u64,
+        /// Engine checkpoint id.
+        checkpoint_id: u64,
+    },
+}
+
+const OUTBOUND_CAPACITY: usize = 256;
+pub(crate) const MAX_SUBSCRIBERS_PER_MV: usize = 64;
+
+/// One SUBSCRIBE consumer.
+#[derive(Debug)]
+pub struct SubscriptionPortal {
+    schema: SchemaRef,
+    outbound: AsyncRx<mpsc::Array<PortalFrame>>,
+    closed: Arc<AtomicBool>,
+}
+
+impl SubscriptionPortal {
+    pub(crate) fn open(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+    ) -> Self {
+        Self::spawn(name, schema, rx, None)
+    }
+
+    pub(crate) fn open_with_filter(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+        filter: Arc<dyn PhysicalExpr>,
+    ) -> Self {
+        Self::spawn(name, schema, rx, Some(filter))
+    }
+
+    fn spawn(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
+        let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
+        let closed = Arc::new(AtomicBool::new(false));
+        tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
+        Self { schema, outbound, closed }
+    }
+
+    /// Schema of the subscribed object.
+    #[must_use]
+    pub fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    /// Next frame, or `None` once the pump exits.
+    pub async fn next_frame(&mut self) -> Option<PortalFrame> {
+        self.outbound.recv().await.ok()
+    }
+
+    /// Signal the pump to stop. Idempotent.
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    /// True after `close()` has been called.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for SubscriptionPortal {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+async fn pump_loop(
+    name: String,
+    mut broadcast_rx: broadcast::Receiver<MvUpdate>,
+    tx: MAsyncTx<mpsc::Array<PortalFrame>>,
+    closed: Arc<AtomicBool>,
+    filter: Option<Arc<dyn PhysicalExpr>>,
+) {
+    while !closed.load(Ordering::Acquire) {
+        let frame = match broadcast_rx.recv().await {
+            Ok(MvUpdate::Batch(batch)) => match filter.as_ref() {
+                Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
+                    Ok(Some(b)) => PortalFrame::Batch(b),
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::warn!(subscription = %name, error = %e, "filter failed; closing");
+                        return;
+                    }
+                },
+                None => PortalFrame::Batch(batch),
+            },
+            Ok(MvUpdate::Barrier { epoch, checkpoint_id }) => {
+                PortalFrame::Barrier { epoch, checkpoint_id }
+            }
+            Err(broadcast::error::RecvError::Closed) => return,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
+                return;
+            }
+        };
+        if tx.send(frame).await.is_err() {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+
+    use arrow_array::Int64Array;
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::super::registry::SubscriptionRegistry;
+    use super::*;
+
+    fn schema() -> SchemaRef {
+        StdArc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]))
+    }
+
+    fn batch(ids: &[i64]) -> RecordBatch {
+        RecordBatch::try_new(schema(), vec![StdArc::new(Int64Array::from(ids.to_vec()))]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn portal_forwards_batch_and_barrier() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        reg.send_batch("mv", batch(&[1, 2]));
+        reg.broadcast_barrier(7, 99);
+
+        let f1 = portal.next_frame().await.expect("frame 1");
+        let PortalFrame::Batch(b) = f1 else {
+            panic!("expected batch, got {f1:?}");
+        };
+        assert_eq!(b.num_rows(), 2);
+
+        let f2 = portal.next_frame().await.expect("frame 2");
+        let PortalFrame::Barrier {
+            epoch,
+            checkpoint_id,
+        } = f2
+        else {
+            panic!("expected barrier, got {f2:?}");
+        };
+        assert_eq!(epoch, 7);
+        assert_eq!(checkpoint_id, 99);
+    }
+
+    #[tokio::test]
+    async fn portal_closes_on_drop_name() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        reg.send_batch("mv", batch(&[1]));
+        let _ = portal.next_frame().await;
+
+        reg.drop_name("mv");
+
+        let frame =
+            tokio::time::timeout(Duration::from_millis(500), portal.next_frame()).await.unwrap();
+        assert!(frame.is_none());
+    }
+
+    #[tokio::test]
+    async fn portal_closes_on_lag() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        for i in 0..1024 {
+            reg.send_batch("mv", batch(&[i]));
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while portal.next_frame().await.is_some() {}
+        })
+        .await
+        .expect("portal must close after lag");
+    }
+
+    #[tokio::test]
+    async fn close_is_idempotent() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        portal.close();
+        portal.close();
+        assert!(portal.is_closed());
+    }
+}

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -1,0 +1,130 @@
+//! Per-name broadcast registry for SUBSCRIBE.
+
+#![allow(clippy::disallowed_types)] // cold path
+
+use std::collections::HashMap;
+
+use arrow_array::RecordBatch;
+use parking_lot::RwLock;
+use tokio::sync::broadcast;
+
+const BROADCAST_CAPACITY: usize = 256;
+
+#[derive(Clone, Debug)]
+pub(crate) enum MvUpdate {
+    Batch(RecordBatch),
+    Barrier { epoch: u64, checkpoint_id: u64 },
+}
+
+pub(crate) struct SubscriptionRegistry {
+    senders: RwLock<HashMap<String, broadcast::Sender<MvUpdate>>>,
+}
+
+impl SubscriptionRegistry {
+    pub(crate) fn new() -> Self {
+        Self { senders: RwLock::new(HashMap::new()) }
+    }
+
+    /// Attach a receiver, allocating the channel on first call.
+    pub(crate) fn subscribe(&self, name: &str) -> broadcast::Receiver<MvUpdate> {
+        if let Some(tx) = self.senders.read().get(name) {
+            return tx.subscribe();
+        }
+        self.senders
+            .write()
+            .entry(name.to_string())
+            .or_insert_with(|| broadcast::channel(BROADCAST_CAPACITY).0)
+            .subscribe()
+    }
+
+    /// Send a batch to subscribers of `name`. Cheap when nobody is attached.
+    pub(crate) fn send_batch(&self, name: &str, batch: RecordBatch) {
+        if let Some(tx) = self.senders.read().get(name) {
+            let _ = tx.send(MvUpdate::Batch(batch));
+        }
+    }
+
+    /// Broadcast a barrier marker to every registered name.
+    pub(crate) fn broadcast_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        let msg = MvUpdate::Barrier { epoch, checkpoint_id };
+        for tx in self.senders.read().values() {
+            let _ = tx.send(msg.clone());
+        }
+    }
+
+    /// Drop the broadcast for `name`. Existing receivers see `Closed`.
+    pub(crate) fn drop_name(&self, name: &str) -> bool {
+        self.senders.write().remove(name).is_some()
+    }
+
+    pub(crate) fn subscriber_count(&self, name: &str) -> usize {
+        self.senders.read().get(name).map_or(0, broadcast::Sender::receiver_count)
+    }
+}
+
+impl Default for SubscriptionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc as StdArc;
+
+    use arrow_array::Int64Array;
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::*;
+
+    fn batch(ids: &[i64]) -> RecordBatch {
+        let schema = StdArc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        RecordBatch::try_new(schema, vec![StdArc::new(Int64Array::from(ids.to_vec()))]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn round_trip() {
+        let reg = SubscriptionRegistry::new();
+        let mut rx = reg.subscribe("mv");
+
+        reg.send_batch("mv", batch(&[1, 2, 3]));
+        let MvUpdate::Batch(b) = rx.recv().await.unwrap() else {
+            panic!("expected batch");
+        };
+        assert_eq!(b.num_rows(), 3);
+
+        reg.broadcast_barrier(7, 42);
+        let MvUpdate::Barrier { epoch, checkpoint_id } = rx.recv().await.unwrap() else {
+            panic!("expected barrier");
+        };
+        assert_eq!((epoch, checkpoint_id), (7, 42));
+    }
+
+    #[tokio::test]
+    async fn no_subscribers_is_noop() {
+        let reg = SubscriptionRegistry::new();
+        reg.send_batch("nobody", batch(&[1]));
+        reg.broadcast_barrier(1, 1);
+        assert_eq!(reg.subscriber_count("nobody"), 0);
+    }
+
+    #[tokio::test]
+    async fn drop_name_closes_receivers() {
+        let reg = SubscriptionRegistry::new();
+        let mut rx = reg.subscribe("mv");
+        assert!(reg.drop_name("mv"));
+        assert!(matches!(rx.recv().await, Err(broadcast::error::RecvError::Closed)));
+    }
+
+    #[test]
+    fn subscriber_count_tracks_attach_drop() {
+        let reg = SubscriptionRegistry::new();
+        let r1 = reg.subscribe("mv");
+        let r2 = reg.subscribe("mv");
+        assert_eq!(reg.subscriber_count("mv"), 2);
+        drop(r1);
+        assert_eq!(reg.subscriber_count("mv"), 1);
+        drop(r2);
+        assert_eq!(reg.subscriber_count("mv"), 0);
+    }
+}

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -22,7 +22,9 @@ pub(crate) struct SubscriptionRegistry {
 
 impl SubscriptionRegistry {
     pub(crate) fn new() -> Self {
-        Self { senders: RwLock::new(HashMap::new()) }
+        Self {
+            senders: RwLock::new(HashMap::new()),
+        }
     }
 
     /// Attach a receiver, allocating the channel on first call.
@@ -46,7 +48,10 @@ impl SubscriptionRegistry {
 
     /// Broadcast a barrier marker to every registered name.
     pub(crate) fn broadcast_barrier(&self, epoch: u64, checkpoint_id: u64) {
-        let msg = MvUpdate::Barrier { epoch, checkpoint_id };
+        let msg = MvUpdate::Barrier {
+            epoch,
+            checkpoint_id,
+        };
         for tx in self.senders.read().values() {
             let _ = tx.send(msg.clone());
         }
@@ -58,7 +63,10 @@ impl SubscriptionRegistry {
     }
 
     pub(crate) fn subscriber_count(&self, name: &str) -> usize {
-        self.senders.read().get(name).map_or(0, broadcast::Sender::receiver_count)
+        self.senders
+            .read()
+            .get(name)
+            .map_or(0, broadcast::Sender::receiver_count)
     }
 }
 
@@ -94,7 +102,11 @@ mod tests {
         assert_eq!(b.num_rows(), 3);
 
         reg.broadcast_barrier(7, 42);
-        let MvUpdate::Barrier { epoch, checkpoint_id } = rx.recv().await.unwrap() else {
+        let MvUpdate::Barrier {
+            epoch,
+            checkpoint_id,
+        } = rx.recv().await.unwrap()
+        else {
             panic!("expected barrier");
         };
         assert_eq!((epoch, checkpoint_id), (7, 42));
@@ -113,7 +125,10 @@ mod tests {
         let reg = SubscriptionRegistry::new();
         let mut rx = reg.subscribe("mv");
         assert!(reg.drop_name("mv"));
-        assert!(matches!(rx.recv().await, Err(broadcast::error::RecvError::Closed)));
+        assert!(matches!(
+            rx.recv().await,
+            Err(broadcast::error::RecvError::Closed)
+        ));
     }
 
     #[test]

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -21,10 +21,16 @@ path = "src/main.rs"
 laminar-core = { path = "../laminar-core", version = "0.21.5" }
 laminar-storage = { path = "../laminar-storage", version = "0.21.5" }
 laminar-db = { path = "../laminar-db", version = "0.21.5", features = ["api"] }
+laminar-sql = { path = "../laminar-sql", version = "0.21.5" }
 
-# Arrow (for WS JSON serialization)
+# For pgwire dispatch on parsed AST
+sqlparser = { workspace = true }
+
+# Arrow (for WS JSON serialization + pgwire row encoder)
 arrow-array = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-json = { workspace = true }
+arrow-schema = { workspace = true }
 parking_lot = { workspace = true }
 
 # CLI and configuration
@@ -51,6 +57,11 @@ toml = "1.1"
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
+
+# Postgres wire — bare server, no TLS.
+pgwire = { version = "0.39", default-features = false, features = ["server-api"] }
+async-trait = { workspace = true }
+futures = { workspace = true }
 
 # Config helpers
 regex = { workspace = true }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -173,6 +173,9 @@ pub struct ServerSection {
     pub mode: String,
     #[serde(default = "default_bind")]
     pub bind: String,
+    /// Postgres wire bind address; `None` disables it.
+    #[serde(default)]
+    pub pgwire_bind: Option<String>,
 }
 
 impl Default for ServerSection {
@@ -180,6 +183,7 @@ impl Default for ServerSection {
         Self {
             mode: default_mode(),
             bind: default_bind(),
+            pgwire_bind: None,
         }
     }
 }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -111,6 +111,11 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             config.server.bind
         ));
     }
+    if let Some(addr) = &config.server.pgwire_bind {
+        if addr.parse::<std::net::SocketAddr>().is_err() {
+            errors.push(format!("invalid server pgwire_bind address: '{}'", addr));
+        }
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -9,6 +9,7 @@ mod cluster_config;
 mod config;
 mod http;
 mod metrics;
+mod pgwire;
 mod reload;
 mod server;
 mod watcher;
@@ -40,6 +41,9 @@ struct Args {
     log_level: String,
     #[arg(long)]
     admin_bind: Option<String>,
+    /// Postgres wire bind address (e.g. `127.0.0.1:5433`). Wildcard binds rejected.
+    #[arg(long)]
+    pgwire_bind: Option<String>,
     /// Validate checkpoints and exit without starting the server.
     #[arg(long)]
     validate_checkpoints: bool,
@@ -72,6 +76,10 @@ async fn main() -> Result<()> {
 
     if let Some(bind) = args.admin_bind {
         config.server.bind = bind;
+    }
+    if let Some(pg) = args.pgwire_bind {
+        // Empty string disables; a value overrides config.
+        config.server.pgwire_bind = if pg.is_empty() { None } else { Some(pg) };
     }
 
     if args.validate_checkpoints {

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -104,7 +104,10 @@ fn standard_response(db: &LaminarDB, stmt: Statement) -> PgWireResult<Response> 
             "0A000",
             "DDL/DML is not supported on pgwire; use HTTP /api/v1/sql",
         )),
-        other => Err(user_error("0A000", format!("not supported on pgwire: {other}"))),
+        other => Err(user_error(
+            "0A000",
+            format!("not supported on pgwire: {other}"),
+        )),
     }
 }
 
@@ -115,10 +118,7 @@ fn driver_select_response(query: sqlparser::ast::Query) -> PgWireResult<Response
     let SetExpr::Select(select) = *query.body else {
         return Err(unsupported_select());
     };
-    if select.projection.len() != 1
-        || !select.from.is_empty()
-        || select.selection.is_some()
-    {
+    if select.projection.len() != 1 || !select.from.is_empty() || select.selection.is_some() {
         return Err(unsupported_select());
     }
     let SelectItem::UnnamedExpr(expr) = &select.projection[0] else {
@@ -180,7 +180,9 @@ fn unsupported_select() -> PgWireError {
 /// since we don't honor isolation levels.
 fn apply_set(db: &LaminarDB, set: Set) -> PgWireResult<Response> {
     match set {
-        Set::SingleAssignment { variable, values, .. } => {
+        Set::SingleAssignment {
+            variable, values, ..
+        } => {
             let key = variable.to_string();
             let value = values
                 .first()
@@ -226,7 +228,13 @@ async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Res
 
 /// Single-row `text` response with one column.
 fn text_response(col: &str, ty: Type, value: String) -> Response {
-    let schema = Arc::new(vec![FieldInfo::new(col.into(), None, None, ty, FieldFormat::Text)]);
+    let schema = Arc::new(vec![FieldInfo::new(
+        col.into(),
+        None,
+        None,
+        ty,
+        FieldFormat::Text,
+    )]);
     let schema_for_row = Arc::clone(&schema);
     let row_stream = stream::iter(std::iter::once(Ok::<_, PgWireError>(()))).map(move |_| {
         let mut enc = DataRowEncoder::new(Arc::clone(&schema_for_row));
@@ -267,7 +275,12 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
     // so formatters are built once per batch rather than per cell. Then we
     // drain the row vec before reading the next frame.
     let row_stream = stream::unfold(
-        (portal, Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(), 0usize, Arc::clone(&fields)),
+        (
+            portal,
+            Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(),
+            0usize,
+            Arc::clone(&fields),
+        ),
         move |(mut portal, mut rows, mut idx, fields)| async move {
             loop {
                 if idx < rows.len() {
@@ -370,7 +383,9 @@ pub struct LaminarHandlerFactory {
 
 impl LaminarHandlerFactory {
     fn new(db: Arc<LaminarDB>) -> Self {
-        Self { handler: Arc::new(LaminarPgwireHandler { db }) }
+        Self {
+            handler: Arc::new(LaminarPgwireHandler { db }),
+        }
     }
 }
 
@@ -454,7 +469,11 @@ mod tests {
     }
 
     fn parse_one(sql: &str) -> StreamingStatement {
-        parse_streaming_sql(sql).unwrap().into_iter().next().unwrap()
+        parse_streaming_sql(sql)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
     }
 
     fn standard(sql: &str) -> Statement {
@@ -497,18 +516,20 @@ mod tests {
     #[tokio::test]
     async fn ddl_routed_to_http() {
         let db = LaminarDB::open().unwrap();
-        let err = standard_response(
-            &db,
-            standard("CREATE TABLE foo (id INT)"),
-        )
-        .unwrap_err();
+        let err = standard_response(&db, standard("CREATE TABLE foo (id INT)")).unwrap_err();
         assert!(err.to_string().contains("HTTP /api/v1/sql"));
     }
 
     #[tokio::test]
     async fn transaction_control_dispatches() {
         let db = LaminarDB::open().unwrap();
-        for sql in ["BEGIN", "BEGIN TRANSACTION", "START TRANSACTION", "COMMIT", "ROLLBACK"] {
+        for sql in [
+            "BEGIN",
+            "BEGIN TRANSACTION",
+            "START TRANSACTION",
+            "COMMIT",
+            "ROLLBACK",
+        ] {
             standard_response(&db, standard(sql)).unwrap();
         }
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,0 +1,542 @@
+//! Postgres wire endpoint. Anonymous TRUST auth, no TLS — wildcard binds
+//! are rejected at startup.
+
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{stream, Sink, StreamExt};
+use laminar_sql::parser::{parse_streaming_sql, StreamingStatement};
+use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::store::PortalStore;
+use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
+use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use pgwire::tokio::process_socket;
+use sqlparser::ast::{Expr, FunctionArguments, SelectItem, Set, SetExpr, Statement};
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+
+use laminar_db::subscription::{PortalFrame, SubscriptionPortal};
+use laminar_db::LaminarDB;
+
+use crate::server::ServerError;
+
+pub struct LaminarPgwireHandler {
+    db: Arc<LaminarDB>,
+}
+
+#[async_trait]
+impl NoopStartupHandler for LaminarPgwireHandler {
+    async fn post_startup<C>(
+        &self,
+        client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        info!(peer = %client.socket_addr(), "pgwire client connected");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for LaminarPgwireHandler {
+    async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+    where
+        C: ClientInfo + ClientPortalStore + Unpin + Send + Sync,
+        C::PortalStore: PortalStore,
+    {
+        if query.trim().is_empty() {
+            return Ok(vec![Response::EmptyQuery]);
+        }
+        let stmts = parse_streaming_sql(query)
+            .map_err(|e| user_error("42601", format!("parse error: {e}")))?;
+
+        let mut out = Vec::with_capacity(stmts.len());
+        for stmt in stmts {
+            out.push(match stmt {
+                StreamingStatement::Subscribe(s) => {
+                    let name = s.name.to_string();
+                    let portal = self
+                        .db
+                        .open_subscription(&name, s.filter_sql.as_deref())
+                        .await
+                        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+                    portal_to_response(portal)
+                }
+                StreamingStatement::Show(_) => engine_metadata_response(&self.db, query).await?,
+                StreamingStatement::Standard(s) => standard_response(&self.db, *s)?,
+                other => {
+                    return Err(user_error(
+                        "0A000",
+                        format!("not supported on pgwire (use HTTP /api/v1/sql): {other:?}"),
+                    ));
+                }
+            });
+        }
+        Ok(out)
+    }
+}
+
+/// Connection-setup statements: transaction control, `SET`, and a tiny set
+/// of catalog probes drivers send during handshake. Anything DDL/DML hits
+/// the "use HTTP" error.
+fn standard_response(db: &LaminarDB, stmt: Statement) -> PgWireResult<Response> {
+    match stmt {
+        Statement::StartTransaction { .. } => Ok(Response::Execution(Tag::new("BEGIN"))),
+        Statement::Commit { .. } => Ok(Response::Execution(Tag::new("COMMIT"))),
+        Statement::Rollback { .. } => Ok(Response::Execution(Tag::new("ROLLBACK"))),
+        Statement::Set(s) => apply_set(db, s),
+        Statement::Query(q) => driver_select_response(*q),
+        Statement::Insert { .. }
+        | Statement::Update { .. }
+        | Statement::Delete { .. }
+        | Statement::CreateTable { .. }
+        | Statement::CreateView { .. }
+        | Statement::Drop { .. } => Err(user_error(
+            "0A000",
+            "DDL/DML is not supported on pgwire; use HTTP /api/v1/sql",
+        )),
+        other => Err(user_error("0A000", format!("not supported on pgwire: {other}"))),
+    }
+}
+
+/// Handle the `SELECT`s drivers issue at connect time. Single literal,
+/// `SELECT version()`, and `SELECT current_schema()` are answered inline.
+/// Anything else is rejected — real queries belong on `/api/v1/sql`.
+fn driver_select_response(query: sqlparser::ast::Query) -> PgWireResult<Response> {
+    let SetExpr::Select(select) = *query.body else {
+        return Err(unsupported_select());
+    };
+    if select.projection.len() != 1
+        || !select.from.is_empty()
+        || select.selection.is_some()
+    {
+        return Err(unsupported_select());
+    }
+    let SelectItem::UnnamedExpr(expr) = &select.projection[0] else {
+        return Err(unsupported_select());
+    };
+
+    match expr {
+        Expr::Value(v) => match &v.value {
+            sqlparser::ast::Value::Number(n, _) => {
+                let parsed: i32 = n.parse().map_err(|_| unsupported_select())?;
+                Ok(text_response("?column?", Type::INT4, parsed.to_string()))
+            }
+            sqlparser::ast::Value::SingleQuotedString(s) => {
+                Ok(text_response("?column?", Type::VARCHAR, s.clone()))
+            }
+            _ => Err(unsupported_select()),
+        },
+        Expr::Function(func) => {
+            // Only no-arg builtins. `func.args` is `FunctionArguments::None`
+            // for `func()`, the only shape we accept.
+            if !matches!(func.args, FunctionArguments::List(ref a) if a.args.is_empty())
+                && !matches!(func.args, FunctionArguments::None)
+            {
+                return Err(unsupported_select());
+            }
+            let name = func.name.to_string().to_ascii_lowercase();
+            let (col, ty, value) = match name.as_str() {
+                "version" | "pg_catalog.version" => (
+                    "version",
+                    Type::VARCHAR,
+                    format!("LaminarDB {} on pgwire", env!("CARGO_PKG_VERSION")),
+                ),
+                "current_schema" | "pg_catalog.current_schema" => {
+                    ("current_schema", Type::VARCHAR, "public".to_string())
+                }
+                "current_database" | "pg_catalog.current_database" => {
+                    ("current_database", Type::VARCHAR, "laminar".to_string())
+                }
+                "current_user" | "session_user" | "user" => {
+                    ("current_user", Type::VARCHAR, "laminar".to_string())
+                }
+                _ => return Err(unsupported_select()),
+            };
+            Ok(text_response(col, ty, value))
+        }
+        _ => Err(unsupported_select()),
+    }
+}
+
+fn unsupported_select() -> PgWireError {
+    user_error(
+        "0A000",
+        "pgwire SELECT is limited to literals and connect-time builtins; use HTTP /api/v1/sql",
+    )
+}
+
+/// `SET` handling. We thread plain `SET name = value` to the engine's
+/// session-property store, and refuse `SET TRANSACTION`-class statements
+/// since we don't honor isolation levels.
+fn apply_set(db: &LaminarDB, set: Set) -> PgWireResult<Response> {
+    match set {
+        Set::SingleAssignment { variable, values, .. } => {
+            let key = variable.to_string();
+            let value = values
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+                .trim_matches('\'')
+                .to_string();
+            db.set_session_property(&key, &value);
+            Ok(Response::Execution(Tag::new("SET")))
+        }
+        // Refuse anything that implies semantics we do not provide.
+        Set::SetTransaction { .. } => Err(user_error(
+            "0A000",
+            "SET TRANSACTION is not supported (no transactional semantics)",
+        )),
+        // Lenient pass-through for the harmless catalog-style SETs drivers
+        // issue (NAMES, TIME ZONE, ROLE...). We don't honor them, but failing
+        // the connection is worse than silently accepting.
+        _ => Ok(Response::Execution(Tag::new("SET"))),
+    }
+}
+
+fn user_error(code: &str, msg: impl Into<String>) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".into(),
+        code.into(),
+        msg.into(),
+    )))
+}
+
+/// Run a SHOW through the engine and stream its `RecordBatch` to the wire.
+async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Response> {
+    use laminar_db::ExecuteResult;
+    let result = db
+        .execute(sql)
+        .await
+        .map_err(|e| user_error("XX000", e.to_string()))?;
+    let ExecuteResult::Metadata(batch) = result else {
+        return Err(user_error("XX000", "SHOW did not return metadata"));
+    };
+    Ok(record_batch_response(batch))
+}
+
+/// Single-row `text` response with one column.
+fn text_response(col: &str, ty: Type, value: String) -> Response {
+    let schema = Arc::new(vec![FieldInfo::new(col.into(), None, None, ty, FieldFormat::Text)]);
+    let schema_for_row = Arc::clone(&schema);
+    let row_stream = stream::iter(std::iter::once(Ok::<_, PgWireError>(()))).map(move |_| {
+        let mut enc = DataRowEncoder::new(Arc::clone(&schema_for_row));
+        enc.encode_field(&Some(value.as_str()))?;
+        Ok(enc.take_row())
+    });
+    Response::Query(QueryResponse::new(schema, row_stream))
+}
+
+fn record_batch_response(batch: arrow_array::RecordBatch) -> Response {
+    let fields = Arc::new(field_infos(&batch.schema()));
+    let nrows = batch.num_rows();
+
+    // Encode rows eagerly: SHOW outputs are tiny and this avoids the
+    // !Send formatter dance.
+    let mut rows = Vec::with_capacity(nrows);
+    {
+        let opts = arrow_cast::display::FormatOptions::default();
+        let formatters: Vec<_> = batch
+            .columns()
+            .iter()
+            .map(|c| arrow_cast::display::ArrayFormatter::try_new(c.as_ref(), &opts))
+            .collect::<Result<_, _>>()
+            .unwrap_or_default();
+        for row in 0..nrows {
+            rows.push(encode_row(&batch, row, &fields, &formatters));
+        }
+    }
+
+    let row_stream = stream::iter(rows);
+    Response::Query(QueryResponse::new(fields, row_stream))
+}
+
+fn portal_to_response(portal: SubscriptionPortal) -> Response {
+    let fields = Arc::new(field_infos(&portal.schema()));
+
+    // Each batch is converted to a Vec<DataRow> in one shot when received,
+    // so formatters are built once per batch rather than per cell. Then we
+    // drain the row vec before reading the next frame.
+    let row_stream = stream::unfold(
+        (portal, Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(), 0usize, Arc::clone(&fields)),
+        move |(mut portal, mut rows, mut idx, fields)| async move {
+            loop {
+                if idx < rows.len() {
+                    let row = std::mem::replace(&mut rows[idx], Ok(empty_row(&fields)));
+                    idx += 1;
+                    return Some((row, (portal, rows, idx, fields)));
+                }
+                rows.clear();
+                idx = 0;
+                match portal.next_frame().await? {
+                    PortalFrame::Batch(b) if b.num_rows() > 0 => {
+                        rows = encode_batch(&b, &fields);
+                    }
+                    PortalFrame::Batch(_) | PortalFrame::Barrier { .. } => {}
+                }
+            }
+        },
+    );
+    Response::Query(QueryResponse::new(fields, row_stream))
+}
+
+fn empty_row(fields: &Arc<Vec<FieldInfo>>) -> pgwire::messages::data::DataRow {
+    DataRowEncoder::new(Arc::clone(fields)).take_row()
+}
+
+fn encode_batch(
+    batch: &arrow_array::RecordBatch,
+    fields: &Arc<Vec<FieldInfo>>,
+) -> Vec<PgWireResult<pgwire::messages::data::DataRow>> {
+    let opts = arrow_cast::display::FormatOptions::default();
+    let formatters: Vec<_> = match batch
+        .columns()
+        .iter()
+        .map(|c| arrow_cast::display::ArrayFormatter::try_new(c.as_ref(), &opts))
+        .collect::<Result<_, _>>()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            return vec![Err(user_error("XX000", format!("format column: {e}")))];
+        }
+    };
+    (0..batch.num_rows())
+        .map(|row| encode_row(batch, row, fields, &formatters))
+        .collect()
+}
+
+fn field_infos(schema: &arrow_schema::Schema) -> Vec<FieldInfo> {
+    schema
+        .fields()
+        .iter()
+        .map(|f| {
+            FieldInfo::new(
+                f.name().clone(),
+                None,
+                None,
+                arrow_to_pg_type(f.data_type()),
+                FieldFormat::Text,
+            )
+        })
+        .collect()
+}
+
+fn encode_row(
+    batch: &arrow_array::RecordBatch,
+    row: usize,
+    fields: &Arc<Vec<FieldInfo>>,
+    formatters: &[arrow_cast::display::ArrayFormatter<'_>],
+) -> PgWireResult<pgwire::messages::data::DataRow> {
+    use arrow_array::Array;
+    let mut enc = DataRowEncoder::new(Arc::clone(fields));
+    for (i, col) in batch.columns().iter().enumerate() {
+        if col.is_null(row) {
+            enc.encode_field(&None::<&str>)?;
+        } else {
+            enc.encode_field(&Some(formatters[i].value(row).to_string()))?;
+        }
+    }
+    Ok(enc.take_row())
+}
+
+fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
+    use arrow_schema::DataType;
+    match dt {
+        DataType::Int8 | DataType::Int16 | DataType::Int32 => Type::INT4,
+        DataType::Int64 | DataType::UInt32 | DataType::UInt64 => Type::INT8,
+        DataType::UInt8 | DataType::UInt16 => Type::INT4,
+        DataType::Float32 | DataType::Float64 => Type::FLOAT8,
+        DataType::Utf8 | DataType::LargeUtf8 => Type::VARCHAR,
+        DataType::Boolean => Type::BOOL,
+        DataType::Timestamp(_, _) => Type::TIMESTAMP,
+        DataType::Date32 | DataType::Date64 => Type::DATE,
+        DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => Type::NUMERIC,
+        _ => Type::TEXT,
+    }
+}
+
+pub struct LaminarHandlerFactory {
+    handler: Arc<LaminarPgwireHandler>,
+}
+
+impl LaminarHandlerFactory {
+    fn new(db: Arc<LaminarDB>) -> Self {
+        Self { handler: Arc::new(LaminarPgwireHandler { db }) }
+    }
+}
+
+impl PgWireServerHandlers for LaminarHandlerFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+        Arc::clone(&self.handler)
+    }
+
+    fn startup_handler(&self) -> Arc<impl pgwire::api::auth::StartupHandler> {
+        Arc::clone(&self.handler)
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
+    if addr.ip().is_unspecified() {
+        return Err(ServerError::Http(format!(
+            "pgwire_bind '{addr}' binds to all interfaces and v1 has no auth; \
+             use a specific interface (e.g. 127.0.0.1)"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn serve(
+    db: Arc<LaminarDB>,
+    bind: &str,
+) -> Result<tokio::task::JoinHandle<()>, ServerError> {
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
+    validate_bind(&addr)?;
+
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
+
+    let factory = Arc::new(LaminarHandlerFactory::new(db));
+    info!(%addr, "pgwire listening");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((sock, peer)) => {
+                    let factory_ref = Arc::clone(&factory);
+                    tokio::spawn(async move {
+                        if let Err(e) = process_socket(sock, None, factory_ref).await {
+                            warn!(%peer, error = %e, "pgwire connection error");
+                        }
+                    });
+                }
+                Err(e) => {
+                    warn!(error = %e, "pgwire accept failed");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    });
+    Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_wildcard_bind() {
+        assert!(validate_bind(&"0.0.0.0:5433".parse().unwrap()).is_err());
+        assert!(validate_bind(&"[::]:5433".parse().unwrap()).is_err());
+    }
+
+    #[test]
+    fn accepts_localhost_bind() {
+        validate_bind(&"127.0.0.1:5433".parse().unwrap()).unwrap();
+        validate_bind(&"[::1]:5433".parse().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn accepts_specific_interface_bind() {
+        validate_bind(&"192.168.1.10:5433".parse().unwrap()).unwrap();
+    }
+
+    fn parse_one(sql: &str) -> StreamingStatement {
+        parse_streaming_sql(sql).unwrap().into_iter().next().unwrap()
+    }
+
+    fn standard(sql: &str) -> Statement {
+        match parse_one(sql) {
+            StreamingStatement::Standard(s) => *s,
+            other => panic!("expected Standard, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn select_one_dispatches() {
+        let db = LaminarDB::open().unwrap();
+        for sql in ["SELECT 1", "select 1", "/* hint */ SELECT 1"] {
+            standard_response(&db, standard(sql)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_select_builtins_dispatch() {
+        let db = LaminarDB::open().unwrap();
+        for sql in [
+            "SELECT version()",
+            "SELECT current_schema()",
+            "SELECT current_database()",
+            "SELECT current_user",
+        ] {
+            // current_user parses as Expr::Function with no parens in some versions;
+            // we accept whatever the parser gives us.
+            let _ = standard_response(&db, standard(sql));
+        }
+    }
+
+    #[tokio::test]
+    async fn select_with_from_is_rejected() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(&db, standard("SELECT 1 FROM foo")).unwrap_err();
+        assert!(err.to_string().contains("limited to literals"));
+    }
+
+    #[tokio::test]
+    async fn ddl_routed_to_http() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(
+            &db,
+            standard("CREATE TABLE foo (id INT)"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("HTTP /api/v1/sql"));
+    }
+
+    #[tokio::test]
+    async fn transaction_control_dispatches() {
+        let db = LaminarDB::open().unwrap();
+        for sql in ["BEGIN", "BEGIN TRANSACTION", "START TRANSACTION", "COMMIT", "ROLLBACK"] {
+            standard_response(&db, standard(sql)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn set_writes_to_session_properties() {
+        let db = LaminarDB::open().unwrap();
+        standard_response(&db, standard("SET extra_float_digits = 3")).unwrap();
+        assert_eq!(
+            db.get_session_property("extra_float_digits").as_deref(),
+            Some("3"),
+        );
+    }
+
+    #[tokio::test]
+    async fn set_transaction_isolation_is_rejected() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(
+            &db,
+            standard("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("SET TRANSACTION"));
+    }
+
+    #[test]
+    fn multi_statement_parses() {
+        let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
+        assert_eq!(stmts.len(), 3);
+    }
+}

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, Sink, StreamExt};
-use laminar_sql::parser::{parse_streaming_sql, StreamingStatement};
+use laminar_sql::parser::{parse_streaming_sql, ShowCommand, StreamingStatement};
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
@@ -71,7 +71,9 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
                         .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
                     portal_to_response(portal)
                 }
-                StreamingStatement::Show(_) => engine_metadata_response(&self.db, query).await?,
+                StreamingStatement::Show(cmd) => {
+                    engine_metadata_response(&self.db, &show_sql(&cmd)).await?
+                }
                 StreamingStatement::Standard(s) => standard_response(&self.db, *s)?,
                 other => {
                     return Err(user_error(
@@ -213,6 +215,23 @@ fn user_error(code: &str, msg: impl Into<String>) -> PgWireError {
     )))
 }
 
+/// Reconstruct a single SHOW statement from the parsed variant. Used by the
+/// pgwire dispatcher so a multi-statement query (`SHOW SOURCES; SHOW SINKS`)
+/// re-executes only the matching statement, not the whole input string.
+fn show_sql(cmd: &ShowCommand) -> String {
+    match cmd {
+        ShowCommand::Sources => "SHOW SOURCES".into(),
+        ShowCommand::Sinks => "SHOW SINKS".into(),
+        ShowCommand::Queries => "SHOW QUERIES".into(),
+        ShowCommand::MaterializedViews => "SHOW MATERIALIZED VIEWS".into(),
+        ShowCommand::Streams => "SHOW STREAMS".into(),
+        ShowCommand::Tables => "SHOW TABLES".into(),
+        ShowCommand::CheckpointStatus => "SHOW CHECKPOINT STATUS".into(),
+        ShowCommand::CreateSource { name } => format!("SHOW CREATE SOURCE {name}"),
+        ShowCommand::CreateSink { name } => format!("SHOW CREATE SINK {name}"),
+    }
+}
+
 /// Run a SHOW through the engine and stream its `RecordBatch` to the wire.
 async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Response> {
     use laminar_db::ExecuteResult;
@@ -294,7 +313,17 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     PortalFrame::Batch(b) if b.num_rows() > 0 => {
                         rows = encode_batch(&b, &fields);
                     }
-                    PortalFrame::Batch(_) | PortalFrame::Barrier { .. } => {}
+                    PortalFrame::Batch(_) => {}
+                    // Barriers are dropped on the SimpleQuery path. PG's
+                    // simple-query protocol has no out-of-band channel for
+                    // checkpoint markers; cursor support (follow-up) will
+                    // surface them via NoticeResponse.
+                    PortalFrame::Barrier {
+                        epoch,
+                        checkpoint_id,
+                    } => {
+                        tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
+                    }
                 }
             }
         },
@@ -426,20 +455,30 @@ pub async fn serve(
     let factory = Arc::new(LaminarHandlerFactory::new(db));
     info!(%addr, "pgwire listening");
 
+    // Track per-connection tasks so abort on the outer JoinHandle stops
+    // active sessions in addition to the accept loop.
     let handle = tokio::spawn(async move {
+        let mut sessions: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
         loop {
-            match listener.accept().await {
-                Ok((sock, peer)) => {
-                    let factory_ref = Arc::clone(&factory);
-                    tokio::spawn(async move {
-                        if let Err(e) = process_socket(sock, None, factory_ref).await {
-                            warn!(%peer, error = %e, "pgwire connection error");
-                        }
-                    });
+            tokio::select! {
+                Some(_) = sessions.join_next(), if !sessions.is_empty() => {
+                    // Reap completed sessions; nothing to do with the result.
                 }
-                Err(e) => {
-                    warn!(error = %e, "pgwire accept failed");
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((sock, peer)) => {
+                            let factory_ref = Arc::clone(&factory);
+                            sessions.spawn(async move {
+                                if let Err(e) = process_socket(sock, None, factory_ref).await {
+                                    warn!(%peer, error = %e, "pgwire connection error");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "pgwire accept failed");
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                    }
                 }
             }
         }

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -186,7 +186,19 @@ pub async fn run_server(
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        Some(crate::pgwire::serve(Arc::clone(&db), &bind).await?)
+        match crate::pgwire::serve(Arc::clone(&db), &bind).await {
+            Ok(h) => Some(h),
+            Err(e) => {
+                // Roll back: stop the HTTP server, the file watcher, and the
+                // pipeline before propagating the bind failure.
+                if let Some(wh) = &watcher_handle {
+                    wh.abort();
+                }
+                api_handle.abort();
+                let _ = db.shutdown().await;
+                return Err(e);
+            }
+        }
     } else {
         None
     };

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -25,6 +25,7 @@ pub enum ServerHandle {
     Embedded {
         db: Arc<LaminarDB>,
         api_handle: tokio::task::JoinHandle<()>,
+        pgwire_handle: Option<tokio::task::JoinHandle<()>>,
         watcher_handle: Option<tokio::task::JoinHandle<()>>,
     },
     #[cfg(feature = "cluster-unstable")]
@@ -38,6 +39,7 @@ impl ServerHandle {
             Self::Embedded {
                 db,
                 api_handle,
+                pgwire_handle,
                 watcher_handle,
             } => {
                 wait_for_termination_signal().await?;
@@ -46,6 +48,9 @@ impl ServerHandle {
 
                 if let Some(wh) = &watcher_handle {
                     wh.abort();
+                }
+                if let Some(pg) = &pgwire_handle {
+                    pg.abort();
                 }
                 db.shutdown()
                     .await
@@ -175,13 +180,21 @@ pub async fn run_server(
         .map_err(|e| ServerError::Start(e.to_string()))?;
     info!("Pipeline started");
 
+    let pgwire_bind = config.server.pgwire_bind.clone();
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
+    let pgwire_handle = if let Some(bind) = pgwire_bind {
+        Some(crate::pgwire::serve(Arc::clone(&db), &bind).await?)
+    } else {
+        None
+    };
+
     Ok(ServerHandle::Embedded {
         db,
         api_handle,
+        pgwire_handle,
         watcher_handle,
     })
 }

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -17,14 +17,15 @@ pub mod order_analyzer;
 mod sink_parser;
 mod source_parser;
 mod statements;
+mod subscribe_parser;
 mod tokenizer;
 mod window_rewriter;
 
 pub use lookup_table::CreateLookupTableStatement;
 pub use statements::{
     AlterSourceOperation, CreateSinkStatement, CreateSourceStatement, EmitClause, EmitStrategy,
-    FormatSpec, LateDataClause, ShowCommand, SinkFrom, StreamingStatement, WatermarkDef,
-    WindowFunction,
+    FormatSpec, LateDataClause, ShowCommand, SinkFrom, StreamingStatement, SubscribeStatement,
+    WatermarkDef, WindowFunction,
 };
 pub use window_rewriter::WindowRewriter;
 
@@ -211,6 +212,13 @@ impl StreamingParser {
                 Ok(vec![stmt])
             }
             StreamingDdlKind::Checkpoint => Ok(vec![StreamingStatement::Checkpoint]),
+            StreamingDdlKind::Subscribe => {
+                let mut parser =
+                    sqlparser::parser::Parser::new(&dialect).with_tokens_with_locations(tokens);
+                let stmt = subscribe_parser::parse_subscribe(&mut parser)
+                    .map_err(parse_error_to_parser_error)?;
+                Ok(vec![StreamingStatement::Subscribe(Box::new(stmt))])
+            }
             StreamingDdlKind::RestoreCheckpoint => {
                 let mut parser =
                     sqlparser::parser::Parser::new(&dialect).with_tokens_with_locations(tokens);

--- a/crates/laminar-sql/src/parser/statements.rs
+++ b/crates/laminar-sql/src/parser/statements.rs
@@ -191,6 +191,20 @@ pub enum StreamingStatement {
         /// The checkpoint ID to restore from
         checkpoint_id: u64,
     },
+
+    /// `SUBSCRIBE <name> [WHERE ...] [WITH (...)]`.
+    Subscribe(Box<SubscribeStatement>),
+}
+
+/// `SUBSCRIBE <name> [WHERE <fragment>] [WITH (...)]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubscribeStatement {
+    /// Target stream or materialized view name.
+    pub name: ObjectName,
+    /// Raw WHERE fragment, compiled by the engine against the target schema.
+    pub filter_sql: Option<String>,
+    /// Reserved for future WITH options.
+    pub options: HashMap<String, String>,
 }
 
 /// Operations for ALTER SOURCE statements.

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -1,0 +1,117 @@
+//! `SUBSCRIBE <name> [WHERE <fragment>] [WITH ('k' = 'v', ...)]` parser.
+
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::Parser;
+use sqlparser::tokenizer::Token;
+
+use super::statements::SubscribeStatement;
+use super::tokenizer::{expect_custom_keyword, parse_with_options};
+use super::ParseError;
+
+pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseError> {
+    expect_custom_keyword(parser, "SUBSCRIBE")?;
+
+    let name = parser.parse_object_name(false).map_err(ParseError::SqlParseError)?;
+
+    // Validate via sqlparser then round-trip; filter_compile re-parses anyway.
+    let filter_sql = if parser.parse_keyword(Keyword::WHERE) {
+        let expr = parser.parse_expr().map_err(ParseError::SqlParseError)?;
+        Some(expr.to_string())
+    } else {
+        None
+    };
+
+    let options = parse_with_options(parser)?;
+
+    match parser.peek_token().token {
+        Token::EOF | Token::SemiColon => {}
+        ref other => {
+            return Err(ParseError::StreamingError(format!(
+                "Unexpected tokens after SUBSCRIBE target: {other}"
+            )));
+        }
+    }
+
+    Ok(SubscribeStatement {
+        name,
+        filter_sql,
+        options,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::dialect::LaminarDialect;
+    use super::*;
+
+    fn parse(sql: &str) -> Result<SubscribeStatement, ParseError> {
+        let dialect = LaminarDialect::default();
+        let mut parser = Parser::new(&dialect)
+            .try_with_sql(sql)
+            .map_err(ParseError::SqlParseError)?;
+        parse_subscribe(&mut parser)
+    }
+
+    #[test]
+    fn ident_only() {
+        let stmt = parse("SUBSCRIBE foo").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert!(stmt.options.is_empty());
+    }
+
+    #[test]
+    fn with_options() {
+        let stmt = parse("SUBSCRIBE foo WITH ('snapshot' = 'true')").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert_eq!(stmt.options.get("snapshot").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn trailing_semicolon_ok() {
+        parse("SUBSCRIBE foo;").expect("parse");
+    }
+
+    #[test]
+    fn schema_qualified() {
+        let stmt = parse("SUBSCRIBE my_schema.foo").expect("parse");
+        assert_eq!(stmt.name.to_string(), "my_schema.foo");
+    }
+
+    #[test]
+    fn missing_target() {
+        assert!(parse("SUBSCRIBE").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        assert!(parse("SUBSCRIBE foo bar").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(parse("").is_err());
+    }
+
+    #[test]
+    fn parses_where_clause() {
+        let stmt = parse("SUBSCRIBE foo WHERE c > 10").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert!(stmt.filter_sql.as_deref().is_some_and(|s| s.contains('>')));
+    }
+
+    #[test]
+    fn where_then_with() {
+        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')")
+            .expect("parse");
+        assert!(stmt.filter_sql.is_some());
+        assert_eq!(
+            stmt.options.get("snapshot").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn rejects_with_before_where() {
+        assert!(parse("SUBSCRIBE foo WITH ('snapshot' = 'true') WHERE c > 1").is_err());
+    }
+}

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -11,7 +11,9 @@ use super::ParseError;
 pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseError> {
     expect_custom_keyword(parser, "SUBSCRIBE")?;
 
-    let name = parser.parse_object_name(false).map_err(ParseError::SqlParseError)?;
+    let name = parser
+        .parse_object_name(false)
+        .map_err(ParseError::SqlParseError)?;
 
     // Validate via sqlparser then round-trip; filter_compile re-parses anyway.
     let filter_sql = if parser.parse_keyword(Keyword::WHERE) {
@@ -63,7 +65,10 @@ mod tests {
     fn with_options() {
         let stmt = parse("SUBSCRIBE foo WITH ('snapshot' = 'true')").expect("parse");
         assert_eq!(stmt.name.to_string(), "foo");
-        assert_eq!(stmt.options.get("snapshot").map(String::as_str), Some("true"));
+        assert_eq!(
+            stmt.options.get("snapshot").map(String::as_str),
+            Some("true")
+        );
     }
 
     #[test]
@@ -101,8 +106,7 @@ mod tests {
 
     #[test]
     fn where_then_with() {
-        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')")
-            .expect("parse");
+        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')").expect("parse");
         assert!(stmt.filter_sql.is_some());
         assert_eq!(
             stmt.options.get("snapshot").map(String::as_str),

--- a/crates/laminar-sql/src/parser/tokenizer.rs
+++ b/crates/laminar-sql/src/parser/tokenizer.rs
@@ -98,6 +98,8 @@ pub enum StreamingDdlKind {
     Checkpoint,
     /// RESTORE FROM CHECKPOINT <id>
     RestoreCheckpoint,
+    /// SUBSCRIBE <name> [WITH (...)]
+    Subscribe,
     /// Not a streaming DDL statement
     None,
 }
@@ -123,6 +125,14 @@ pub fn detect_streaming_ddl(tokens: &[TokenWithSpan]) -> StreamingDdlKind {
     if let Token::Word(w) = &significant[0].token {
         if is_word_ci(w, "CHECKPOINT") {
             return StreamingDdlKind::Checkpoint;
+        }
+    }
+
+    // SUBSCRIBE <ident> — needs at least 2 tokens but we route here before
+    // the generic match below so the token-prefix detector recognises it.
+    if let Token::Word(w) = &significant[0].token {
+        if is_word_ci(w, "SUBSCRIBE") {
+            return StreamingDdlKind::Subscribe;
         }
     }
 
@@ -864,6 +874,18 @@ mod tests {
         assert_eq!(
             detect_streaming_ddl(&tokenize("RESTORE FROM CHECKPOINT 42")),
             StreamingDdlKind::RestoreCheckpoint
+        );
+    }
+
+    #[test]
+    fn test_detect_subscribe() {
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("SUBSCRIBE foo")),
+            StreamingDdlKind::Subscribe
+        );
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("subscribe foo with ('snapshot' = 'true')")),
+            StreamingDdlKind::Subscribe
         );
     }
 }

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -183,7 +183,8 @@ impl StreamingPlanner {
             | StreamingStatement::InsertInto { .. }
             | StreamingStatement::AlterSource { .. }
             | StreamingStatement::Checkpoint
-            | StreamingStatement::RestoreCheckpoint { .. } => {
+            | StreamingStatement::RestoreCheckpoint { .. }
+            | StreamingStatement::Subscribe(_) => {
                 // These statements are handled directly by the database facade
                 // and don't need query planning. Return as Standard pass-through.
                 Err(PlanningError::UnsupportedSql(format!(


### PR DESCRIPTION
## Summary

Adds `SUBSCRIBE <name> [WHERE <expr>] [WITH (...)]` over a pgwire endpoint,
letting external clients (psql, drivers) tail materialized views, named
streams, and sources as the engine produces them. Durable checkpoint epochs
flow through as barrier markers.

## What's new

- **Subscription substrate** — `crates/laminar-db/src/subscription/`:
  per-name `tokio::sync::broadcast` registry plus a per-portal pump task that
  forwards `MvUpdate::{Batch,Barrier}` frames to the network layer.
- **Engine wiring** — `update_mv_stores` and `push_to_streams` fan out to the
  registry; barriers are published from `handle_barrier` only after
  `checkpoint_with_barrier` reports the epoch durable.
- **`LaminarDB::open_subscription(name, filter_sql)`** — resolves MV / source /
  named-stream targets; filters compile to `PhysicalExpr` against the target
  schema. Streams without an explicit schema reject WHERE clauses with a clear
  error.
- **Shared filter compile** — `crates/laminar-db/src/filter_compile.rs`
  deduplicates the previous sink-filter and SUBSCRIBE-filter compile paths.
- **Drop semantics** — `DROP STREAM` / `DROP MATERIALIZED VIEW` closes
  attached subscribers via `RecvError::Closed`. The lock-order in the MV drop
  path is straightened so `subscription_registry.drop_name()` runs outside
  `mv_store.write()` + `connector_manager.lock()`.

## Wire layer

- pgwire 0.39 (server-api, no TLS) bound only when `--pgwire-bind` /
  `[server].pgwire_bind` is configured. Wildcard binds (`0.0.0.0`, `[::]`) are
  refused at startup — v1 has no auth.
- Statement dispatch goes through `parse_streaming_sql` (AST-based; no
  string-prefix matching). Multi-statement queries supported.
- `Statement::Set` for plain assignments writes to session properties via the
  new `LaminarDB::set_session_property`. `SET TRANSACTION ...` is rejected so
  we never silently accept isolation-level changes we don't honor.
- Driver connect-time builtins answered inline: `SELECT version()`,
  `current_schema()`, `current_database()`, `current_user`.
- DDL/DML returns a clean error directing the caller to HTTP `/api/v1/sql`.
- `SHOW` is forwarded to `db.execute()` and the `RecordBatch` is streamed back
  via `arrow_cast::display::ArrayFormatter`. Formatters are constructed once
  per batch, not per cell.

## Out of scope (follow-up FIRs)

- `RETAIN HISTORY` / `AS OF` resumption.
- Binary pgwire format.
- TLS / auth — until those land, the bind is localhost-only.
- Snapshot replay — v1 is tail-only.

## Test plan

- [x] `cargo test --no-default-features -p laminar-db -p laminar-sql --lib` —
      640 + 838 passing.
- [x] `cargo test --no-default-features -p laminar-server --bin laminardb` —
      11 pgwire unit tests covering bind validation, AST dispatch, SET
      handling, SET TRANSACTION rejection, DDL routing, multi-statement
      parsing, and driver connect-time builtins.
- [x] `cargo clippy --no-default-features -p laminar-db -p laminar-sql -p laminar-server --lib --bins --tests -- -D warnings` — clean.
- [x] Manual: `psql -h 127.0.0.1 -p 5433 -c "SUBSCRIBE my_mv WHERE c > 10"` after
      `CREATE MATERIALIZED VIEW my_mv AS ...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SUBSCRIBE statement to stream materialized-view or stream updates (yields update batches and durable barrier markers)
  * SUBSCRIBE supports WHERE filtering for filterable targets; filters for opaque streams are rejected
  * PostgreSQL wire endpoint for interactive clients, including SET session-property support

* **Configuration**
  * New pgwire_bind server option and --pgwire-bind CLI flag to enable/configure the pgwire endpoint

* **Bug Fixes**
  * DROP cleans up active subscriptions to avoid lingering subscribers and closed feeds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->