### PR TITLE
pgwire stage 2: docs, integration test, lag-as-typed-error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,6 @@ name = "laminar-server"
 version = "0.21.10"
 dependencies = [
  "anyhow",
- "arrow",
  "arrow-array",
  "arrow-cast",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,6 +4807,7 @@ name = "laminar-server"
 version = "0.21.10"
 dependencies = [
  "anyhow",
+ "arrow",
  "arrow-array",
  "arrow-cast",
  "arrow-json",
@@ -4837,6 +4838,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-postgres",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3823,7 +3823,7 @@ async fn open_subscription_resolves_named_stream() {
             match portal.next_frame().await {
                 Some(crate::subscription::PortalFrame::Batch(b)) => break Some(b),
                 Some(crate::subscription::PortalFrame::Barrier { .. }) => {}
-                None => break None,
+                Some(crate::subscription::PortalFrame::Lagged(_)) | None => break None,
             }
         }
     })

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn portal_emits_lagged_then_closes() {
+    async fn portal_emits_lagged_as_final_frame() {
         let reg = SubscriptionRegistry::new();
         let rx = reg.subscribe("mv");
         let mut portal = SubscriptionPortal::open("mv", schema(), rx);
@@ -235,17 +235,21 @@ mod tests {
             reg.send_batch("mv", batch(&[i]));
         }
 
-        let mut saw_lagged = false;
-        tokio::time::timeout(Duration::from_secs(1), async {
+        let frames = tokio::time::timeout(Duration::from_secs(1), async {
+            let mut frames = Vec::new();
             while let Some(frame) = portal.next_frame().await {
-                if let PortalFrame::Lagged(_) = frame {
-                    saw_lagged = true;
-                }
+                frames.push(frame);
             }
+            frames
         })
         .await
         .expect("portal must close after lag");
-        assert!(saw_lagged, "expected a Lagged frame before close");
+
+        assert!(
+            matches!(frames.last(), Some(PortalFrame::Lagged(_))),
+            "last frame must be Lagged, got: {:?}",
+            frames.last()
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -23,6 +23,11 @@ pub enum PortalFrame {
         /// Engine checkpoint id.
         checkpoint_id: u64,
     },
+    /// Consumer fell behind by `skipped` messages and the broadcast dropped
+    /// them. The portal closes immediately after this frame; the wire layer
+    /// translates it into a client-visible error so the disconnect isn't
+    /// silent.
+    Lagged(u64),
 }
 
 const OUTBOUND_CAPACITY: usize = 256;
@@ -147,6 +152,7 @@ async fn pump_loop(
             Err(broadcast::error::RecvError::Closed) => return,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
+                let _ = tx.send(PortalFrame::Lagged(n)).await;
                 return;
             }
         };
@@ -220,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn portal_closes_on_lag() {
+    async fn portal_emits_lagged_then_closes() {
         let reg = SubscriptionRegistry::new();
         let rx = reg.subscribe("mv");
         let mut portal = SubscriptionPortal::open("mv", schema(), rx);
@@ -229,11 +235,17 @@ mod tests {
             reg.send_batch("mv", batch(&[i]));
         }
 
+        let mut saw_lagged = false;
         tokio::time::timeout(Duration::from_secs(1), async {
-            while portal.next_frame().await.is_some() {}
+            while let Some(frame) = portal.next_frame().await {
+                if let PortalFrame::Lagged(_) = frame {
+                    saw_lagged = true;
+                }
+            }
         })
         .await
         .expect("portal must close after lag");
+        assert!(saw_lagged, "expected a Lagged frame before close");
     }
 
     #[tokio::test]

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -94,8 +94,6 @@ mimalloc = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio-postgres = "0.7"
-arrow = { workspace = true }
-prometheus = { workspace = true }
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -93,6 +93,9 @@ mimalloc = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio-postgres = "0.7"
+arrow = { workspace = true }
+prometheus = { workspace = true }
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -6,6 +6,7 @@ Standalone server binary for LaminarDB. Reads a TOML configuration file, constru
 
 - **TOML configuration** with `${VAR}` and `${VAR:-default}` environment variable substitution
 - **REST API** (Axum) for health checks, pipeline introspection, ad-hoc SQL, and manual checkpoints
+- **Postgres wire protocol** (optional) for `SUBSCRIBE` streaming via `psql` and any libpq client
 - **Prometheus metrics** at `/metrics`
 - **Hot reload** — edit the TOML file and changes are applied automatically (file watcher with debounce), or `POST /api/v1/reload`
 - **Checkpoint validation** — `--validate-checkpoints` flag validates all stored checkpoints and exits
@@ -55,6 +56,7 @@ See the [Configuration Reference](https://laminardb.io/docs/) for every field, o
 [server]
 mode = "embedded"           # "embedded" (single-node) or "cluster" (multi-node scaffolding, not production-hardened)
 bind = "0.0.0.0:8080"       # HTTP API bind address
+pgwire_bind = "127.0.0.1:5433"  # optional; enables Postgres wire protocol for SUBSCRIBE
 log_level = "info"
 # Worker thread count is taken from $TOKIO_WORKER_THREADS — defaults to logical CPUs.
 
@@ -124,6 +126,20 @@ format = "json"
 | POST | `/api/v1/reload` | Hot-reload configuration |
 | GET | `/api/v1/cluster` | Cluster status (only available when `server.mode = "cluster"`) |
 | GET | `/ws/{name}` | WebSocket upgrade for push-based subscriptions to a stream |
+
+## Postgres Wire Protocol
+
+When `[server].pgwire_bind` is set, the server also listens for Postgres clients and serves a small subset of the SimpleQuery protocol:
+
+- `SUBSCRIBE <name> [WHERE <predicate>]` — streams materialized-view rows as they're produced. The query stays open until the client disconnects.
+- `SHOW`, `SET <key> = <value>`, and a handful of driver builtins (`SELECT version()`, `current_database()`, etc.) are accepted so standard psql / libpq clients can connect.
+- `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
+
+Filters are compiled with DataFusion against the materialized view's schema, so any DataFusion-supported predicate works (`WHERE price > 100`, `WHERE symbol IN ('AAPL', 'MSFT')`, etc.). Subscribing to a raw stream rejects `WHERE` because stream schemas are opaque to the planner.
+
+```bash
+psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"
+```
 
 ## Hot Reload
 

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -131,11 +131,11 @@ format = "json"
 
 When `[server].pgwire_bind` is set, the server also listens for Postgres clients and serves a small subset of the SimpleQuery protocol:
 
-- `SUBSCRIBE <name> [WHERE <predicate>]` — streams materialized-view rows as they're produced. The query stays open until the client disconnects.
+- `SUBSCRIBE <name> [WHERE <predicate>]` — streams rows as they're produced. `<name>` may be a materialized view, a source, or a named stream. The query stays open until the client disconnects.
 - `SHOW`, `SET <key> = <value>`, and a handful of driver builtins (`SELECT version()`, `current_database()`, etc.) are accepted so standard psql / libpq clients can connect.
 - `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
 
-Filters are compiled with DataFusion against the materialized view's schema, so any DataFusion-supported predicate works (`WHERE price > 100`, `WHERE symbol IN ('AAPL', 'MSFT')`, etc.). Subscribing to a raw stream rejects `WHERE` because stream schemas are opaque to the planner.
+`WHERE` is compiled with DataFusion against the target's schema and works on materialized views and sources. It is rejected on named streams because their output schema isn't introspectable.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -442,7 +442,7 @@ fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
-) -> Result<tokio::task::JoinHandle<()>, ServerError> {
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
         .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
@@ -451,9 +451,12 @@ pub async fn serve(
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
     let factory = Arc::new(LaminarHandlerFactory::new(db));
-    info!(%addr, "pgwire listening");
+    info!(addr = %local_addr, "pgwire listening");
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
@@ -483,7 +486,7 @@ pub async fn serve(
             }
         }
     });
-    Ok(handle)
+    Ok((local_addr, handle))
 }
 
 #[cfg(test)]
@@ -598,5 +601,133 @@ mod tests {
     fn multi_statement_parses() {
         let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
         assert_eq!(stmts.len(), 3);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    //! End-to-end pgwire driven by `tokio_postgres` against an in-process
+    //! `LaminarDB`. Verifies the wire-protocol surface — handshake, SimpleQuery
+    //! dispatch, error reporting — that unit tests can't reach. Engine-level
+    //! row flow is covered in `laminar-db`'s `db::tests`.
+
+    use std::sync::Arc;
+
+    use laminar_db::LaminarDB;
+    use tokio_postgres::{NoTls, SimpleQueryMessage};
+
+    async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+            .await
+            .expect("create source");
+        db.execute(
+            "CREATE MATERIALIZED VIEW prices AS \
+             SELECT symbol, price FROM trades",
+        )
+        .await
+        .expect("create mv");
+        db.start().await.expect("db starts");
+
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0")
+            .await
+            .expect("pgwire serve");
+        (addr, handle)
+    }
+
+    async fn connect(addr: std::net::SocketAddr) -> tokio_postgres::Client {
+        let conn_str = format!(
+            "host={} port={} user=any dbname=laminardb",
+            addr.ip(),
+            addr.port()
+        );
+        let (client, conn) = tokio_postgres::connect(&conn_str, NoTls)
+            .await
+            .expect("pgwire connect");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        client
+    }
+
+    fn first_row_value(messages: &[SimpleQueryMessage], col: usize) -> Option<&str> {
+        messages.iter().find_map(|m| match m {
+            SimpleQueryMessage::Row(r) => r.get(col),
+            _ => None,
+        })
+    }
+
+    #[tokio::test]
+    async fn handshake_and_builtins() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("version");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
+
+        let messages = client
+            .simple_query("SELECT current_database()")
+            .await
+            .expect("current_database");
+        assert_eq!(first_row_value(&messages, 0), Some("laminar"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn show_streams_runs() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        // No assertion on contents — just that the dispatch path returns rows
+        // without error. Engine-level SHOW behavior is covered in laminar-db.
+        client
+            .simple_query("SHOW STREAMS")
+            .await
+            .expect("SHOW STREAMS");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn subscribe_unknown_name_returns_pg_error() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("SUBSCRIBE no_such_view")
+            .await
+            .expect_err("must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("no_such_view"),
+            "message: {}",
+            db_err.message()
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn ddl_returns_pg_error_pointing_at_http() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("CREATE SOURCE more_trades (sym VARCHAR)")
+            .await
+            .expect_err("DDL must be rejected");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("/api/v1/sql"),
+            "message: {}",
+            db_err.message()
+        );
+
+        handle.abort();
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -324,12 +324,10 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     } => {
                         tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
                     }
-                    // Surface lag as a typed PG error before the stream ends.
-                    // SQLSTATE 57014 = query_canceled — closest standard match
-                    // for "the server stopped serving you on purpose".
+                    // Lag → typed error so the disconnect isn't silent.
                     PortalFrame::Lagged(n) => {
                         let err = user_error(
-                            "57014",
+                            "54000",
                             format!("subscription lagged: skipped {n} messages, terminating"),
                         );
                         return Some((Err(err), (portal, rows, idx, fields)));

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -324,6 +324,16 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     } => {
                         tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
                     }
+                    // Surface lag as a typed PG error before the stream ends.
+                    // SQLSTATE 57014 = query_canceled — closest standard match
+                    // for "the server stopped serving you on purpose".
+                    PortalFrame::Lagged(n) => {
+                        let err = user_error(
+                            "57014",
+                            format!("subscription lagged: skipped {n} messages, terminating"),
+                        );
+                        return Some((Err(err), (portal, rows, idx, fields)));
+                    }
                 }
             }
         },

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -187,7 +187,7 @@ pub async fn run_server(
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
         match crate::pgwire::serve(Arc::clone(&db), &bind).await {
-            Ok(h) => Some(h),
+            Ok((_, h)) => Some(h),
             Err(e) => {
                 // Roll back: stop the HTTP server, the file watcher, and the
                 // pipeline before propagating the bind failure.

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -288,10 +288,9 @@ When the server is started with `pgwire_bind` set, materialized views can be str
 SUBSCRIBE <mv_name> [WHERE <predicate>]
 ```
 
-- `<mv_name>` is the name of a materialized view created with `CREATE MATERIALIZED VIEW ...`.
-- The optional `WHERE` clause is compiled by DataFusion against the view's schema and applied per batch before the row reaches the wire.
+- `<mv_name>` may be a materialized view, a source, or a named stream.
+- The optional `WHERE` clause is compiled by DataFusion against the target's schema and applied per batch before the row reaches the wire. It works on materialized views and sources; named streams reject `WHERE` because their output schema isn't introspectable.
 - The query stays open until the client disconnects; rows arrive as they're produced upstream.
-- `SUBSCRIBE` against a raw stream is rejected — stream schemas aren't introspectable.
 
 ---
 

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -280,6 +280,19 @@ while let Some(rows) = sub.poll() {
 
 **Critical:** `FromRow` struct field order must match the SQL `SELECT` column order. Field names don't matter — only position.
 
+### SUBSCRIBE over the Postgres wire protocol
+
+When the server is started with `pgwire_bind` set, materialized views can be streamed directly to any libpq client (psql, JDBC, asyncpg, etc.):
+
+```sql
+SUBSCRIBE <mv_name> [WHERE <predicate>]
+```
+
+- `<mv_name>` is the name of a materialized view created with `CREATE MATERIALIZED VIEW ...`.
+- The optional `WHERE` clause is compiled by DataFusion against the view's schema and applied per batch before the row reaches the wire.
+- The query stays open until the client disconnects; rows arrive as they're produced upstream.
+- `SUBSCRIBE` against a raw stream is rejected — stream schemas aren't introspectable.
+
 ---
 
 ## Watermarks


### PR DESCRIPTION
## Summary

Stage 2 follow-ups to the SUBSCRIBE-over-pgwire work in #364. Stacked on `feat/subscribe-pgwire`; retarget to `main` once #364 lands.

- **Docs (`3ec6234f`)** — server README and SQL reference document `pgwire_bind`, the accepted SimpleQuery subset, and the `SUBSCRIBE <name> [WHERE <pred>]` syntax (works on MVs, sources, and named streams; WHERE rejected only on streams).
- **`tokio_postgres` integration test (`4697b21b`)** — drives the listener with a real libpq client on `127.0.0.1:0`. Covers handshake, `SELECT version()` / `current_database()`, `SHOW STREAMS`, SUBSCRIBE error reporting, and DDL rejection. `serve()` now returns `(SocketAddr, JoinHandle)` so port 0 works for tests; the single call site in `server.rs` is updated.
- **Lag → typed error (`e776bb0c`)** — `PortalFrame::Lagged(u64)` reintroduced; the broadcast pump emits it before exiting, and the pgwire response stream renders it as `SQLSTATE 54000` (`program_limit_exceeded`) so libpq clients see a real PG error instead of a silent disconnect. (Followed FIR's NoticeResponse intent in spirit; chose ErrorResponse because we are terminating — Notice + immediate close would be misleading.)
- **Review pass (`cbd362ee`)** — corrects doc claims about WHERE on streams vs MVs, drops unused dev-deps (`arrow`, `prometheus`), tightens the lag test to assert the **last** frame is Lagged, and trims a multi-line internal-monologue comment to one line.

Skipped from FIR for separate PRs: MD5 password auth (~80 LOC), TLS (~50 LOC), RETAIN HISTORY + AS OF (~400 LOC), binary format, stream-side schema, DECLARE/FETCH.

Filed a follow-up task (stage 2.5): `filter_compile::compile` currently swallows every failure as `Option::None`, which surfaced as an opaque "subscribe filter '...' did not compile" message during integration testing. Should change to `Result<_, DbError>` so the wire layer can report whether it was column-not-found vs type-mismatch vs planner failure. ~30 LOC, deferred so this PR stays focused.

## Test plan

- [x] \`cargo clippy -p laminar-server -p laminar-db --no-default-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p laminar-db --no-default-features --lib subscription::\` — 8 passing
- [x] \`cargo test -p laminar-server --no-default-features --bin laminardb pgwire\` — 15 passing (11 unit + 4 integration)
- [x] \`cargo fmt --all\` — clean
- [ ] CI green