### PR TITLE
pgwire: TLS via tokio-rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1077,6 +1078,16 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcder"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7c42c9913f68cf9390a225e81ad56a5c515347287eb98baa710090ca1de86d"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -3030,8 +3041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3430,6 +3454,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -4830,7 +4860,9 @@ dependencies = [
  "pgwire",
  "prometheus",
  "rand 0.10.0",
+ "rcgen",
  "regex",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlparser",
@@ -4839,6 +4871,8 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
+ "tokio-rustls",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",
@@ -6156,6 +6190,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3cee243b682091188b90f22b07585ad6b43e699b52bc29422bd9ca6ce2c2deb"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
  "bytes",
  "derive-new",
  "futures",
@@ -6165,12 +6201,16 @@ dependencies = [
  "pg_interval_2",
  "postgres-types",
  "rand 0.10.0",
+ "rustls-pki-types",
  "ryu",
  "serde_json",
  "smol_str",
+ "stringprep",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -6802,6 +6842,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "rdkafka"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7126,7 +7179,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -7314,7 +7367,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8093,6 +8146,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8154,6 +8228,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -8654,6 +8743,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -9586,6 +9681,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9eb9a0c822c67129d5b8fcc2806c6bc4f50496b420825069a440669bcfbf7f"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9616,6 +9742,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -9692,6 +9827,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -58,8 +58,16 @@ axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
-# Postgres wire — bare server, no TLS.
-pgwire = { version = "0.39", default-features = false, features = ["server-api"] }
+# Postgres wire with optional TLS (aws-lc-rs backend).
+pgwire = { version = "0.39", default-features = false, features = [
+    "server-api",
+    "_aws-lc-rs",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "aws-lc-rs",
+    "tls12",
+] }
+rustls-pemfile = "2"
 async-trait = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
@@ -95,6 +103,8 @@ mimalloc = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio-postgres = "0.7"
+tokio-postgres-rustls = "0.13"
+rcgen = "0.13"
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -161,9 +161,20 @@ Clients then connect with the password using the standard Postgres MD5 challenge
 PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb user=alice" -c "SUBSCRIBE avg_price"
 ```
 
-> **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM and TLS work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
+> **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
 
 Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
+
+### TLS
+
+Optional. Setting both `pgwire_tls_cert` and `pgwire_tls_key` enables TLS via [`tokio-rustls`](https://crates.io/crates/tokio-rustls) (aws-lc-rs backend). Both must be PEM-encoded; the key may be PKCS#8 or RSA.
+
+```toml
+pgwire_tls_cert = "/etc/laminar/pgwire.crt"
+pgwire_tls_key  = "/etc/laminar/pgwire.key"
+```
+
+Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work. Cert rotation requires a server restart; hot reload is a follow-up.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -131,6 +131,23 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             ));
         }
     }
+    match (
+        &config.server.pgwire_tls_cert,
+        &config.server.pgwire_tls_key,
+    ) {
+        (Some(_), None) | (None, Some(_)) => {
+            errors.push("pgwire_tls_cert and pgwire_tls_key must be set together".to_string());
+        }
+        (Some(cert), Some(key)) => {
+            if !cert.exists() {
+                errors.push(format!("pgwire_tls_cert not found: {}", cert.display()));
+            }
+            if !key.exists() {
+                errors.push(format!("pgwire_tls_key not found: {}", key.display()));
+            }
+        }
+        (None, None) => {}
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {
@@ -206,6 +223,13 @@ pub struct ServerSection {
     /// the listener to the wider network.
     #[serde(default)]
     pub pgwire_allow_remote: bool,
+    /// TLS certificate (PEM). Setting this and `pgwire_tls_key` enables
+    /// TLS on the pgwire listener; both must be provided together.
+    #[serde(default)]
+    pub pgwire_tls_cert: Option<std::path::PathBuf>,
+    /// TLS private key (PEM, PKCS#8 or RSA).
+    #[serde(default)]
+    pub pgwire_tls_key: Option<std::path::PathBuf>,
 }
 
 impl Default for ServerSection {
@@ -216,6 +240,8 @@ impl Default for ServerSection {
             pgwire_bind: None,
             pgwire_users: std::collections::HashMap::new(),
             pgwire_allow_remote: false,
+            pgwire_tls_cert: None,
+            pgwire_tls_key: None,
         }
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -514,6 +514,50 @@ pub struct TlsPaths<'a> {
     pub key: &'a std::path::Path,
 }
 
+/// Warn if the key file is readable by anyone other than the owner.
+/// PostgreSQL refuses to start in this case; we warn rather than fail
+/// because dev environments often run with looser perms.
+#[cfg(unix)]
+fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
+    use std::os::unix::fs::MetadataExt;
+    if let Ok(meta) = file.metadata() {
+        let mode = meta.mode();
+        if mode & 0o077 != 0 {
+            warn!(
+                path = %path.display(),
+                mode = format!("{:o}", mode & 0o777),
+                "pgwire_tls_key permissions are too broad — postgres rejects \
+                 anything looser than 0600. Tighten before exposing the listener.",
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_key_world_readable(_file: &std::fs::File, _path: &std::path::Path) {}
+
+/// Map the result of `process_socket` to a stable audit-log code so SOC
+/// dashboards can split TLS handshake errors from auth failures and from
+/// generic runtime errors.
+fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
+    match result {
+        Ok(()) => "ok",
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("28P01") {
+                "auth_failed"
+            } else if msg.contains("HandshakeFailure")
+                || msg.contains("rustls")
+                || msg.contains("tls")
+            {
+                "tls_failed"
+            } else {
+                "error"
+            }
+        }
+    }
+}
+
 #[allow(clippy::result_large_err)]
 fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, ServerError> {
     use std::fs::File;
@@ -533,6 +577,7 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
 
     let key_file = File::open(paths.key)
         .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
+    warn_if_key_world_readable(&key_file, paths.key);
     let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
         .map_err(|e| ServerError::Http(format!("parse pgwire_tls_key: {e}")))?
         .ok_or_else(|| {
@@ -625,11 +670,7 @@ pub async fn serve(
                             );
                             sessions.spawn(async move {
                                 let result = process_socket(sock, tls_ref, factory_ref).await;
-                                let outcome = match &result {
-                                    Ok(()) => "ok",
-                                    Err(e) if e.to_string().contains("28P01") => "auth_failed",
-                                    Err(_) => "error",
-                                };
+                                let outcome = classify_outcome(&result);
                                 tracing::info!(
                                     target: "audit",
                                     event = "pgwire.connection_closed",
@@ -748,6 +789,24 @@ mod tests {
     fn multi_statement_parses() {
         let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
         assert_eq!(stmts.len(), 3);
+    }
+
+    #[test]
+    fn classify_outcome_buckets_errors() {
+        use std::io::{Error, ErrorKind};
+        assert_eq!(super::classify_outcome(&Ok(())), "ok");
+        assert_eq!(
+            super::classify_outcome(&Err(Error::other("FATAL: 28P01 bad pass"))),
+            "auth_failed"
+        );
+        assert_eq!(
+            super::classify_outcome(&Err(Error::other("rustls HandshakeFailure"))),
+            "tls_failed"
+        );
+        assert_eq!(
+            super::classify_outcome(&Err(Error::new(ErrorKind::BrokenPipe, "broken"))),
+            "error"
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,6 +1,7 @@
 //! Postgres wire endpoint. Trust auth by default; MD5 password auth when
 //! `[server].pgwire_users` is non-empty. Non-loopback binds require both
-//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). No TLS yet.
+//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). TLS via
+//! tokio-rustls when `pgwire_tls_cert` and `pgwire_tls_key` are set.
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -507,11 +508,53 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
     }
 }
 
+/// Cert + private-key paths for the pgwire TLS listener.
+pub struct TlsPaths<'a> {
+    pub cert: &'a std::path::Path,
+    pub key: &'a std::path::Path,
+}
+
+#[allow(clippy::result_large_err)]
+fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, ServerError> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let cert_file = File::open(paths.cert)
+        .map_err(|e| ServerError::Http(format!("open pgwire_tls_cert: {e}")))?;
+    let certs = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| ServerError::Http(format!("parse pgwire_tls_cert: {e}")))?;
+    if certs.is_empty() {
+        return Err(ServerError::Http(format!(
+            "pgwire_tls_cert {} contains no certificates",
+            paths.cert.display()
+        )));
+    }
+
+    let key_file = File::open(paths.key)
+        .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
+    let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
+        .map_err(|e| ServerError::Http(format!("parse pgwire_tls_key: {e}")))?
+        .ok_or_else(|| {
+            ServerError::Http(format!(
+                "pgwire_tls_key {} contains no private key",
+                paths.key.display()
+            ))
+        })?;
+
+    let server_config = tokio_rustls::rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
+    Ok(tokio_rustls::TlsAcceptor::from(Arc::new(server_config)))
+}
+
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
     users: HashMap<String, Secret>,
     allow_remote: bool,
+    tls: Option<TlsPaths<'_>>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
@@ -534,6 +577,11 @@ pub async fn serve(
         _ => {}
     }
 
+    let tls_acceptor = match tls {
+        Some(paths) => Some(load_tls_acceptor(paths)?),
+        None => None,
+    };
+
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
@@ -542,13 +590,15 @@ pub async fn serve(
         .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
+    let tls_mode = if tls_acceptor.is_some() { "on" } else { "off" };
     if auth_mode == "trust" {
         warn!(
             addr = %local_addr,
+            tls = tls_mode,
             "pgwire listening with TRUST auth — any client reaching this address is admin",
         );
     } else {
-        info!(addr = %local_addr, auth = auth_mode, "pgwire listening");
+        info!(addr = %local_addr, auth = auth_mode, tls = tls_mode, "pgwire listening");
     }
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
@@ -564,15 +614,17 @@ pub async fn serve(
                     match accepted {
                         Ok((sock, peer)) => {
                             let factory_ref = Arc::clone(&factory);
+                            let tls_ref = tls_acceptor.clone();
                             let peer_str = peer.to_string();
                             tracing::info!(
                                 target: "audit",
                                 event = "pgwire.connection_accepted",
                                 peer = %peer,
                                 auth = auth_mode,
+                                tls = tls_mode,
                             );
                             sessions.spawn(async move {
-                                let result = process_socket(sock, None, factory_ref).await;
+                                let result = process_socket(sock, tls_ref, factory_ref).await;
                                 let outcome = match &result {
                                     Ok(()) => "ok",
                                     Err(e) if e.to_string().contains("28P01") => "auth_failed",
@@ -701,7 +753,7 @@ mod tests {
     #[tokio::test]
     async fn serve_rejects_remote_bind_in_trust_mode() {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
-        let err = serve(db, "0.0.0.0:0", HashMap::new(), false)
+        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None)
             .await
             .expect_err("trust + 0.0.0.0 must fail");
         assert!(err.to_string().contains("trust auth"), "got: {err}");
@@ -712,7 +764,7 @@ mod tests {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         let mut users = HashMap::new();
         users.insert("alice".into(), Secret::new("wonderland-key"));
-        let err = serve(db, "0.0.0.0:0", users, false)
+        let err = serve(db, "0.0.0.0:0", users, false, None)
             .await
             .expect_err("md5 + 0.0.0.0 without allow_remote must fail");
         assert!(
@@ -752,7 +804,7 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false)
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None)
             .await
             .expect("pgwire serve");
         (addr, handle)
@@ -973,6 +1025,73 @@ mod integration_tests {
 
         let db_err = err.as_db_error().expect("typed PG error");
         assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// Self-signed cert+key written to a tempdir for the duration of the
+    /// test. `rcgen` is the well-maintained option for ad-hoc certs.
+    fn self_signed_pem() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let cert =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()]).expect("rcgen issue cert");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, cert.cert.pem()).unwrap();
+        std::fs::write(&key_path, cert.key_pair.serialize_pem()).unwrap();
+        (dir, cert_path, key_path)
+    }
+
+    #[tokio::test]
+    async fn tls_handshake_succeeds() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+            }),
+        )
+        .await
+        .expect("pgwire serve");
+
+        // Build a client TLS config that trusts the same self-signed cert.
+        let cert_bytes = std::fs::read(&cert_path).unwrap();
+        let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+        for c in rustls_pemfile::certs(&mut std::io::Cursor::new(cert_bytes))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        {
+            roots.add(c).unwrap();
+        }
+        let client_cfg = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(client_cfg);
+        let (client, conn) = tokio_postgres::connect(&conn_str, tls)
+            .await
+            .expect("TLS handshake + connect");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("query over TLS");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
 
         handle.abort();
     }

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -183,12 +183,25 @@ pub async fn run_server(
     let pgwire_bind = config.server.pgwire_bind.clone();
     let pgwire_users = config.server.pgwire_users.clone();
     let pgwire_allow_remote = config.server.pgwire_allow_remote;
+    let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
+    let pgwire_tls_key = config.server.pgwire_tls_key.clone();
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        match crate::pgwire::serve(Arc::clone(&db), &bind, pgwire_users, pgwire_allow_remote).await
+        let tls = match (&pgwire_tls_cert, &pgwire_tls_key) {
+            (Some(c), Some(k)) => Some(crate::pgwire::TlsPaths { cert: c, key: k }),
+            _ => None,
+        };
+        match crate::pgwire::serve(
+            Arc::clone(&db),
+            &bind,
+            pgwire_users,
+            pgwire_allow_remote,
+            tls,
+        )
+        .await
         {
             Ok((_, h)) => Some(h),
             Err(e) => {


### PR DESCRIPTION
## Summary

Optional TLS on the pgwire listener via \`tokio-rustls\` (aws-lc-rs backend, the same one pgwire uses internally for SCRAM). Stacked on #367.

Setting both \`pgwire_tls_cert\` and \`pgwire_tls_key\` enables TLS; both are required together. PEM cert and key are loaded once with \`rustls-pemfile\` at listener startup so cert format / file errors fail loud — not at first connection.

### Implementation

- \`pgwire::serve\` takes \`Option<TlsPaths>\`; \`load_tls_acceptor\` produces an \`Arc<TlsAcceptor>\` that's cloned into each session. Cert chain validation (file exists, parseable, contains at least one cert + private key) lives at startup.
- Config: \`pgwire_tls_cert\` / \`pgwire_tls_key\` are \`PathBuf\`. Load-time validation rejects asymmetric configs (cert without key or vice versa) and missing files.
- Unix permission warning: log a \`WARN\` if the key file is readable by group/other (\`mode & 0o077 != 0\`). Postgres flat-out refuses to start in this case; we warn rather than fail because dev boxes often run with looser perms.
- Audit log accept event carries \`tls=on/off\`. The session-end \`outcome\` classifier distinguishes \`tls_failed\` from \`auth_failed\` and generic \`error\` so SOC dashboards can split cipher-policy mismatches and cert rotation issues from auth and runtime failures.
- README documents the cert/key TOML fields and the \`sslmode=require\` client-side flow.

### Test

\`rcgen\` issues a self-signed cert into a tempdir at test time; the test client trusts that cert via \`tokio-postgres-rustls\` and runs \`SELECT version()\` over the encrypted channel. Full end-to-end TLS handshake on every test run — no fixtures, no committed certs.

### Filed as follow-ups

- Cert-expiry warning at load time
- mTLS via \`with_client_cert_verifier\`
- Hot-reload of cert/key without dropping in-flight connections
- Min-TLS-version pin for PCI/FedRAMP

## Test plan

- [x] \`cargo clippy -p laminar-server --no-default-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p laminar-server --no-default-features --bin laminardb pgwire\` — 23 passing (13 unit + 10 integration, +1 TLS)
- [x] \`classify_outcome\` unit test covers all four buckets
- [x] \`cargo fmt --all\` — clean