### PR TITLE
feat(server): SUBSCRIBE over Postgres wire — auth, TLS, schema-aware filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4829,6 +4829,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pgwire",
  "prometheus",
+ "rand 0.10.0",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3042,17 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4787,24 +4808,31 @@ version = "0.21.10"
 dependencies = [
  "anyhow",
  "arrow-array",
+ "arrow-cast",
  "arrow-json",
+ "arrow-schema",
+ "async-trait",
  "axum",
  "chrono",
  "clap",
  "crossfire",
+ "futures",
  "gethostname",
  "humantime-serde",
  "laminar-core",
  "laminar-db",
+ "laminar-sql",
  "laminar-storage",
  "mimalloc",
  "notify",
  "openssl",
  "parking_lot 0.12.5",
+ "pgwire",
  "prometheus",
  "regex",
  "serde",
  "serde_json",
+ "sqlparser",
  "tempfile",
  "thiserror 2.0.18",
  "tikv-jemallocator",
@@ -4859,6 +4887,29 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
@@ -5164,6 +5215,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "mea"
@@ -6066,6 +6123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_interval_2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a055f44628dcf9c4e68f931535dabd3544a239655fdde25a3b0e95d4b36e9260"
+dependencies = [
+ "bytes",
+ "chrono",
+ "postgres-types",
+]
+
+[[package]]
 name = "pgpq"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6077,6 +6145,30 @@ dependencies = [
  "bytes",
  "enum_dispatch",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pgwire"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3cee243b682091188b90f22b07585ad6b43e699b52bc29422bd9ca6ce2c2deb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "derive-new",
+ "futures",
+ "hex",
+ "lazy-regex",
+ "md5",
+ "pg_interval_2",
+ "postgres-types",
+ "rand 0.10.0",
+ "ryu",
+ "serde_json",
+ "smol_str",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6253,6 +6345,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
+ "array-init",
  "bytes",
  "chrono",
  "fallible-iterator",
@@ -7585,6 +7678,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "snap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,6 @@ name = "laminar-server"
 version = "0.21.10"
 dependencies = [
  "anyhow",
- "arrow",
  "arrow-array",
  "arrow-cast",
  "arrow-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1077,6 +1078,16 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcder"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7c42c9913f68cf9390a225e81ad56a5c515347287eb98baa710090ca1de86d"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -3030,8 +3041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3430,6 +3454,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -4830,7 +4860,9 @@ dependencies = [
  "pgwire",
  "prometheus",
  "rand 0.10.0",
+ "rcgen",
  "regex",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sqlparser",
@@ -4839,6 +4871,8 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
+ "tokio-rustls",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",
@@ -6156,6 +6190,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3cee243b682091188b90f22b07585ad6b43e699b52bc29422bd9ca6ce2c2deb"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
  "bytes",
  "derive-new",
  "futures",
@@ -6165,12 +6201,16 @@ dependencies = [
  "pg_interval_2",
  "postgres-types",
  "rand 0.10.0",
+ "rustls-pki-types",
  "ryu",
  "serde_json",
  "smol_str",
+ "stringprep",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -6802,6 +6842,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "rdkafka"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7126,7 +7179,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -7314,7 +7367,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8093,6 +8146,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8154,6 +8228,21 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
+dependencies = [
+ "const-oid",
+ "ring",
+ "rustls",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls",
+ "x509-cert",
 ]
 
 [[package]]
@@ -8654,6 +8743,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -9586,6 +9681,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9eb9a0c822c67129d5b8fcc2806c6bc4f50496b420825069a440669bcfbf7f"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9616,6 +9742,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -9692,6 +9827,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,6 +4807,7 @@ name = "laminar-server"
 version = "0.21.10"
 dependencies = [
  "anyhow",
+ "arrow",
  "arrow-array",
  "arrow-cast",
  "arrow-json",
@@ -4837,6 +4838,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "tokio-postgres",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -1153,13 +1153,7 @@ impl LaminarDB {
                      subscribe to a materialized view"
                 )));
             }
-            Some(sql) => Some(
-                crate::filter_compile::compile(&self.ctx, sql, &schema)
-                    .await
-                    .ok_or_else(|| {
-                        DbError::Pipeline(format!("subscribe filter '{sql}' did not compile"))
-                    })?,
-            ),
+            Some(sql) => Some(crate::filter_compile::compile(&self.ctx, sql, &schema).await?),
         };
 
         let rx = self.subscription_registry.subscribe(name);

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -165,6 +165,12 @@ pub struct LaminarDB {
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
     /// SUBSCRIBE fan-out registry, shared with the pipeline callback.
     pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
+    /// Per-stream output schemas, populated at `start()` from the SQL
+    /// planner. Read by SUBSCRIBE so `WHERE` predicates can compile
+    /// against a real schema instead of the empty placeholder on
+    /// `StreamEntry::sink`.
+    pub(crate) stream_schemas:
+        Arc<parking_lot::RwLock<std::collections::HashMap<String, arrow_schema::SchemaRef>>>,
 }
 
 /// Oneshot reply carrying the full `CheckpointResult` back to the
@@ -345,6 +351,7 @@ impl LaminarDB {
             assignment_snapshot_store: parking_lot::Mutex::new(None),
             force_ckpt_tx: parking_lot::Mutex::new(None),
             subscription_registry: Arc::new(crate::subscription::SubscriptionRegistry::new()),
+            stream_schemas: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
         })
     }
 
@@ -1135,10 +1142,17 @@ impl LaminarDB {
             )));
         }
 
+        // Schema lookup order: MV registry, catalog source, stream-output
+        // schemas resolved at start(), then the StreamEntry sink as a last
+        // resort. The sink schema is a known placeholder (Schema::empty),
+        // so it disqualifies WHERE clauses but still permits unfiltered
+        // subscribe.
         let (schema, filterable) = if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
             (mv.schema, true)
         } else if let Some(src) = self.catalog.get_source(name) {
             (Arc::clone(&src.schema), true)
+        } else if let Some(schema) = self.stream_schemas.read().get(name).cloned() {
+            (schema, true)
         } else if let Some(entry) = self.catalog.get_stream_entry(name) {
             (entry.sink.schema(), false)
         } else {
@@ -1149,8 +1163,8 @@ impl LaminarDB {
             None => None,
             Some(_) if !filterable => {
                 return Err(DbError::Pipeline(format!(
-                    "WHERE on stream '{name}' is not supported (opaque schema); \
-                     subscribe to a materialized view"
+                    "WHERE on '{name}' is not supported: stream output schema \
+                     was not resolved (likely a planner failure at start())"
                 )));
             }
             Some(sql) => Some(crate::filter_compile::compile(&self.ctx, sql, &schema).await?),

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -1135,16 +1135,15 @@ impl LaminarDB {
             )));
         }
 
-        let (schema, filterable) =
-            if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
-                (mv.schema, true)
-            } else if let Some(src) = self.catalog.get_source(name) {
-                (Arc::clone(&src.schema), true)
-            } else if let Some(entry) = self.catalog.get_stream_entry(name) {
-                (entry.sink.schema(), false)
-            } else {
-                return Err(DbError::StreamNotFound(name.to_string()));
-            };
+        let (schema, filterable) = if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
+            (mv.schema, true)
+        } else if let Some(src) = self.catalog.get_source(name) {
+            (Arc::clone(&src.schema), true)
+        } else if let Some(entry) = self.catalog.get_stream_entry(name) {
+            (entry.sink.schema(), false)
+        } else {
+            return Err(DbError::StreamNotFound(name.to_string()));
+        };
 
         let filter = match filter_sql {
             None => None,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -163,6 +163,8 @@ pub struct LaminarDB {
     /// `None`, `db.checkpoint()` falls back to the direct coordinator
     /// path (only valid when the engine has no stateful operators).
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
+    /// SUBSCRIBE fan-out registry, shared with the pipeline callback.
+    pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
 }
 
 /// Oneshot reply carrying the full `CheckpointResult` back to the
@@ -342,6 +344,7 @@ impl LaminarDB {
             #[cfg(feature = "cluster-unstable")]
             assignment_snapshot_store: parking_lot::Mutex::new(None),
             force_ckpt_tx: parking_lot::Mutex::new(None),
+            subscription_registry: Arc::new(crate::subscription::SubscriptionRegistry::new()),
         })
     }
 
@@ -975,6 +978,9 @@ impl LaminarDB {
             StreamingStatement::AlterSource { name, operation } => {
                 self.handle_alter_source(name, operation)
             }
+            StreamingStatement::Subscribe(_) => Err(DbError::InvalidOperation(
+                "SUBSCRIBE requires the pgwire endpoint, not HTTP /api/v1/sql".into(),
+            )),
         }
     }
 
@@ -1072,6 +1078,13 @@ impl LaminarDB {
         self.session_properties.lock().clone()
     }
 
+    /// Set a session property. Keys are lowercased.
+    pub fn set_session_property(&self, key: &str, value: &str) {
+        self.session_properties
+            .lock()
+            .insert(key.to_lowercase(), value.to_string());
+    }
+
     /// Subscribe to a named stream or materialized view.
     ///
     /// # Errors
@@ -1101,6 +1114,62 @@ impl LaminarDB {
         self.catalog
             .get_stream_subscription(name)
             .ok_or_else(|| DbError::StreamNotFound(name.to_string()))
+    }
+
+    /// Open a SUBSCRIBE portal against a named MV, source, or stream.
+    /// `filter_sql` is rejected on streams (their schema is opaque).
+    ///
+    /// # Errors
+    /// Returns `StreamNotFound` if `name` is unknown, or `Pipeline` if the
+    /// subscriber cap is reached or the filter fails to compile.
+    pub async fn open_subscription(
+        &self,
+        name: &str,
+        filter_sql: Option<&str>,
+    ) -> Result<crate::subscription::SubscriptionPortal, DbError> {
+        let attached = self.subscription_registry.subscriber_count(name);
+        if attached >= crate::subscription::MAX_SUBSCRIBERS_PER_MV {
+            return Err(DbError::Pipeline(format!(
+                "subscriber cap reached for '{name}' ({attached}/{})",
+                crate::subscription::MAX_SUBSCRIBERS_PER_MV
+            )));
+        }
+
+        let (schema, filterable) =
+            if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
+                (mv.schema, true)
+            } else if let Some(src) = self.catalog.get_source(name) {
+                (Arc::clone(&src.schema), true)
+            } else if let Some(entry) = self.catalog.get_stream_entry(name) {
+                (entry.sink.schema(), false)
+            } else {
+                return Err(DbError::StreamNotFound(name.to_string()));
+            };
+
+        let filter = match filter_sql {
+            None => None,
+            Some(_) if !filterable => {
+                return Err(DbError::Pipeline(format!(
+                    "WHERE on stream '{name}' is not supported (opaque schema); \
+                     subscribe to a materialized view"
+                )));
+            }
+            Some(sql) => Some(
+                crate::filter_compile::compile(&self.ctx, sql, &schema)
+                    .await
+                    .ok_or_else(|| {
+                        DbError::Pipeline(format!("subscribe filter '{sql}' did not compile"))
+                    })?,
+            ),
+        };
+
+        let rx = self.subscription_registry.subscribe(name);
+        Ok(match filter {
+            Some(phys) => {
+                crate::subscription::SubscriptionPortal::open_with_filter(name, schema, rx, phys)
+            }
+            None => crate::subscription::SubscriptionPortal::open(name, schema, rx),
+        })
     }
 
     /// Handle EXPLAIN statement — show the streaming query plan.

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -165,12 +165,9 @@ pub struct LaminarDB {
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
     /// SUBSCRIBE fan-out registry, shared with the pipeline callback.
     pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
-    /// Per-stream output schemas, populated at `start()` from the SQL
-    /// planner. Read by SUBSCRIBE so `WHERE` predicates can compile
-    /// against a real schema instead of the empty placeholder on
-    /// `StreamEntry::sink`.
+    /// Stream output schemas resolved at `start()`; SUBSCRIBE WHERE reads this.
     pub(crate) stream_schemas:
-        Arc<parking_lot::RwLock<std::collections::HashMap<String, arrow_schema::SchemaRef>>>,
+        parking_lot::RwLock<std::collections::HashMap<String, arrow_schema::SchemaRef>>,
 }
 
 /// Oneshot reply carrying the full `CheckpointResult` back to the
@@ -351,7 +348,7 @@ impl LaminarDB {
             assignment_snapshot_store: parking_lot::Mutex::new(None),
             force_ckpt_tx: parking_lot::Mutex::new(None),
             subscription_registry: Arc::new(crate::subscription::SubscriptionRegistry::new()),
-            stream_schemas: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
+            stream_schemas: parking_lot::RwLock::new(std::collections::HashMap::new()),
         })
     }
 

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3846,8 +3846,8 @@ async fn open_subscription_with_invalid_filter_errors_at_open() {
         .unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("subscribe filter") || msg.contains("nonexistent_col"),
-        "expected filter compile error, got: {msg}"
+        msg.contains("nonexistent_col"),
+        "error must mention the bad column, got: {msg}"
     );
 }
 

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3800,7 +3800,10 @@ async fn open_subscription_resolves_named_stream() {
         .unwrap();
     db.start().await.unwrap();
 
-    let mut portal = db.open_subscription("all_trades", None).await.expect("portal opens");
+    let mut portal = db
+        .open_subscription("all_trades", None)
+        .await
+        .expect("portal opens");
 
     let handle = db.source_untyped("trades").unwrap();
     let schema = handle.schema().clone();
@@ -3816,13 +3819,10 @@ async fn open_subscription_resolves_named_stream() {
 
     // Wait up to 2s for the cycle to emit. The portal pump runs on the
     // main runtime; the engine's `push_to_streams` fires the broadcast.
-    let frame = tokio::time::timeout(
-        std::time::Duration::from_secs(2),
-        portal.next_frame(),
-    )
-    .await
-    .expect("portal must produce a frame within 2s")
-    .expect("frame");
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), portal.next_frame())
+        .await
+        .expect("portal must produce a frame within 2s")
+        .expect("frame");
     let crate::subscription::PortalFrame::Batch(b) = frame else {
         panic!("expected Batch, got {frame:?}");
     };

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3777,3 +3777,116 @@ async fn test_nullif_float_with_int_literal_runs_without_error() {
         "post-projection should evaluate without Float64==Int64 error"
     );
 }
+
+#[tokio::test]
+async fn open_subscription_resolves_unknown_name_to_error() {
+    let db = LaminarDB::open().unwrap();
+    let err = db.open_subscription("nope", None).await.unwrap_err();
+    assert!(matches!(err, DbError::StreamNotFound(_)));
+}
+
+#[tokio::test]
+async fn open_subscription_resolves_named_stream() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+
+    let mut portal = db.open_subscription("all_trades", None).await.expect("portal opens");
+
+    let handle = db.source_untyped("trades").unwrap();
+    let schema = handle.schema().clone();
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["AAPL"])),
+            Arc::new(arrow::array::Float64Array::from(vec![150.0])),
+        ],
+    )
+    .unwrap();
+    handle.push_arrow(batch).unwrap();
+
+    // Wait up to 2s for the cycle to emit. The portal pump runs on the
+    // main runtime; the engine's `push_to_streams` fires the broadcast.
+    let frame = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        portal.next_frame(),
+    )
+    .await
+    .expect("portal must produce a frame within 2s")
+    .expect("frame");
+    let crate::subscription::PortalFrame::Batch(b) = frame else {
+        panic!("expected Batch, got {frame:?}");
+    };
+    assert!(b.num_rows() >= 1);
+}
+
+#[tokio::test]
+async fn open_subscription_with_invalid_filter_errors_at_open() {
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+
+    let err = db
+        .open_subscription("trades", Some("nonexistent_col > 1"))
+        .await
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("subscribe filter") || msg.contains("nonexistent_col"),
+        "expected filter compile error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn open_subscription_with_filter_on_stream_is_rejected() {
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+
+    let err = db
+        .open_subscription("all_trades", Some("symbol = 'AAPL'"))
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("opaque"), "got: {err}");
+}
+
+#[tokio::test]
+async fn drop_stream_closes_subscription() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM s AS SELECT * FROM trades")
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+
+    let mut portal = db.open_subscription("s", None).await.unwrap();
+
+    db.execute("DROP STREAM s").await.unwrap();
+
+    // Pump exits, mpsc closes, next_frame eventually returns None.
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while portal.next_frame().await.is_some() {}
+    })
+    .await
+    .expect("portal must close");
+}

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3852,7 +3852,9 @@ async fn open_subscription_with_invalid_filter_errors_at_open() {
 }
 
 #[tokio::test]
-async fn open_subscription_with_filter_on_stream_is_rejected() {
+async fn open_subscription_with_filter_on_stream_before_start_is_rejected() {
+    // Before start(), stream_schemas is empty so we fall through to the
+    // placeholder path on StreamEntry::sink and refuse WHERE.
     let db = LaminarDB::open().unwrap();
     db.execute("CREATE SOURCE trades (symbol VARCHAR)")
         .await
@@ -3865,7 +3867,29 @@ async fn open_subscription_with_filter_on_stream_is_rejected() {
         .open_subscription("all_trades", Some("symbol = 'AAPL'"))
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("opaque"), "got: {err}");
+    assert!(err.to_string().contains("not resolved"), "got: {err}");
+}
+
+#[tokio::test]
+async fn open_subscription_with_filter_on_stream_after_start_compiles() {
+    let db = LaminarDB::open().unwrap();
+    let registry = prometheus::Registry::new();
+    let prom = Arc::new(crate::engine_metrics::EngineMetrics::new(&registry));
+    db.set_engine_metrics(Arc::clone(&prom));
+
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+    db.start().await.unwrap();
+
+    let portal = db
+        .open_subscription("all_trades", Some("symbol = 'AAPL'"))
+        .await
+        .expect("WHERE on a started stream must compile");
+    portal.close();
 }
 
 #[tokio::test]

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3817,16 +3817,20 @@ async fn open_subscription_resolves_named_stream() {
     .unwrap();
     handle.push_arrow(batch).unwrap();
 
-    // Wait up to 2s for the cycle to emit. The portal pump runs on the
-    // main runtime; the engine's `push_to_streams` fires the broadcast.
-    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), portal.next_frame())
-        .await
-        .expect("portal must produce a frame within 2s")
-        .expect("frame");
-    let crate::subscription::PortalFrame::Batch(b) = frame else {
-        panic!("expected Batch, got {frame:?}");
-    };
-    assert!(b.num_rows() >= 1);
+    // Wait up to 2s for a Batch frame, ignoring barrier markers.
+    let batch = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match portal.next_frame().await {
+                Some(crate::subscription::PortalFrame::Batch(b)) => break Some(b),
+                Some(crate::subscription::PortalFrame::Barrier { .. }) => {}
+                None => break None,
+            }
+        }
+    })
+    .await
+    .expect("portal must produce a Batch within 2s")
+    .expect("batch frame");
+    assert!(batch.num_rows() >= 1);
 }
 
 #[tokio::test]

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3823,7 +3823,7 @@ async fn open_subscription_resolves_named_stream() {
             match portal.next_frame().await {
                 Some(crate::subscription::PortalFrame::Batch(b)) => break Some(b),
                 Some(crate::subscription::PortalFrame::Barrier { .. }) => {}
-                None => break None,
+                Some(crate::subscription::PortalFrame::Lagged(_)) | None => break None,
             }
         }
     })

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -751,6 +751,8 @@ impl LaminarDB {
         }
         self.connector_manager.lock().unregister_stream(&name_str);
 
+        self.subscription_registry.drop_name(&name_str);
+
         // Notify the running coordinator to remove the query. If the
         // channel is saturated, surface a transient error so the caller
         // can retry rather than seeing a successful DROP that leaves the
@@ -869,6 +871,7 @@ impl LaminarDB {
             // Try dropping as stream first
             if self.catalog.drop_stream(dep) {
                 self.connector_manager.lock().unregister_stream(dep);
+                self.subscription_registry.drop_name(dep);
             }
             // Try dropping as MV (cascade further)
             {
@@ -878,6 +881,7 @@ impl LaminarDB {
                     let mut mgr = self.connector_manager.lock();
                     for v in &views {
                         mgr.unregister_stream(&v.name);
+                        self.subscription_registry.drop_name(&v.name);
                     }
                 }
             }
@@ -1130,6 +1134,10 @@ impl LaminarDB {
                 mv_store.drop_mv(dropped);
                 let _ = self.ctx.deregister_table(dropped);
             }
+        }
+        // Drop subscription channels outside the locks (registry never nests in mv_store).
+        for dropped in &dropped_names {
+            self.subscription_registry.drop_name(dropped);
         }
 
         Ok(ExecuteResult::Ddl(DdlInfo {

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -1,5 +1,6 @@
 //! Shared SQL filter compile + apply for sinks and SUBSCRIBE.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
@@ -11,20 +12,44 @@ use datafusion_expr::{Expr, LogicalPlan};
 
 use crate::error::DbError;
 
+static COMPILE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Registers a temporary table on construction and deregisters on drop, so a
+/// concurrent compile or an early return can never leak the registration onto
+/// the shared `SessionContext`.
+struct ScopedTable<'a> {
+    ctx: &'a SessionContext,
+    name: String,
+}
+
+impl<'a> ScopedTable<'a> {
+    fn new(ctx: &'a SessionContext, schema: &SchemaRef) -> Option<Self> {
+        let name = format!(
+            "__filter_compile_{}",
+            COMPILE_SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
+        ctx.register_table(&name, Arc::new(empty)).ok()?;
+        Some(Self { ctx, name })
+    }
+}
+
+impl Drop for ScopedTable<'_> {
+    fn drop(&mut self) {
+        let _ = self.ctx.deregister_table(&self.name);
+    }
+}
+
 /// Compile `filter_sql` against `schema`. Returns `None` on any failure.
 pub(crate) async fn compile(
     ctx: &SessionContext,
     filter_sql: &str,
     schema: &SchemaRef,
 ) -> Option<Arc<dyn PhysicalExpr>> {
-    let table = "__filter_compile";
-    let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
-    let _ = ctx.deregister_table(table);
-    ctx.register_table(table, Arc::new(empty)).ok()?;
-
-    let sql = format!("SELECT * FROM {table} WHERE {filter_sql}");
+    let scoped = ScopedTable::new(ctx, schema)?;
+    let sql = format!("SELECT * FROM {} WHERE {filter_sql}", scoped.name);
     let plan = ctx.sql(&sql).await.ok()?.logical_plan().clone();
-    let _ = ctx.deregister_table(table);
+    drop(scoped);
 
     let expr = find_predicate(&plan)?;
     let df_schema = DFSchema::try_from(schema.as_ref().clone()).ok()?;

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -1,0 +1,65 @@
+//! Shared SQL filter compile + apply for sinks and SUBSCRIBE.
+
+use std::sync::Arc;
+
+use arrow_array::{BooleanArray, RecordBatch};
+use arrow::datatypes::SchemaRef;
+use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion::prelude::SessionContext;
+use datafusion_common::DFSchema;
+use datafusion_expr::{Expr, LogicalPlan};
+
+use crate::error::DbError;
+
+/// Compile `filter_sql` against `schema`. Returns `None` on any failure.
+pub(crate) async fn compile(
+    ctx: &SessionContext,
+    filter_sql: &str,
+    schema: &SchemaRef,
+) -> Option<Arc<dyn PhysicalExpr>> {
+    let table = "__filter_compile";
+    let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
+    let _ = ctx.deregister_table(table);
+    ctx.register_table(table, Arc::new(empty)).ok()?;
+
+    let sql = format!("SELECT * FROM {table} WHERE {filter_sql}");
+    let plan = ctx.sql(&sql).await.ok()?.logical_plan().clone();
+    let _ = ctx.deregister_table(table);
+
+    let expr = find_predicate(&plan)?;
+    let df_schema = DFSchema::try_from(schema.as_ref().clone()).ok()?;
+    create_physical_expr(&expr, &df_schema, ctx.state().execution_props()).ok()
+}
+
+fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {
+    match plan {
+        LogicalPlan::Filter(f) => Some(f.predicate.clone()),
+        LogicalPlan::Projection(p) => find_predicate(&p.input),
+        LogicalPlan::Sort(s) => find_predicate(&s.input),
+        LogicalPlan::Limit(l) => find_predicate(&l.input),
+        _ => plan.inputs().iter().find_map(|i| find_predicate(i)),
+    }
+}
+
+/// Apply a compiled boolean predicate. `Ok(None)` if every row is filtered out.
+pub(crate) fn apply(
+    batch: &RecordBatch,
+    expr: &dyn PhysicalExpr,
+) -> Result<Option<RecordBatch>, DbError> {
+    if batch.num_rows() == 0 {
+        return Ok(None);
+    }
+    let result = expr
+        .evaluate(batch)
+        .map_err(|e| DbError::Pipeline(format!("filter eval: {e}")))?;
+    let array = result
+        .into_array(batch.num_rows())
+        .map_err(|e| DbError::Pipeline(format!("filter to_array: {e}")))?;
+    let mask = array
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| DbError::Pipeline("filter must return BooleanArray".into()))?;
+    let filtered = arrow::compute::filter_record_batch(batch, mask)
+        .map_err(|e| DbError::Pipeline(format!("filter: {e}")))?;
+    if filtered.num_rows() == 0 { Ok(None) } else { Ok(Some(filtered)) }
+}

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -58,17 +58,21 @@ pub(crate) async fn compile(
         .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}': {e}")))?
         .logical_plan()
         .clone();
-    drop(scoped);
 
     let expr = find_predicate(&plan).ok_or_else(|| {
         DbError::Pipeline(format!(
             "filter '{filter_sql}' did not lower to a predicate (DataFusion may have folded it away)"
         ))
     })?;
-    let df_schema = DFSchema::try_from(schema.as_ref().clone())
+    // The `SELECT * FROM <scoped.name> WHERE ...` planner produces a predicate
+    // whose columns are qualified by the temp table. Build the DFSchema with
+    // the same qualifier so `create_physical_expr` resolves them.
+    let df_schema = DFSchema::try_from_qualified_schema(scoped.name.as_str(), schema.as_ref())
         .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (df_schema): {e}")))?;
-    create_physical_expr(&expr, &df_schema, ctx.state().execution_props())
-        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (physical): {e}")))
+    let phys = create_physical_expr(&expr, &df_schema, ctx.state().execution_props())
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (physical): {e}")))?;
+    drop(scoped);
+    Ok(phys)
 }
 
 fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -23,14 +23,16 @@ struct ScopedTable<'a> {
 }
 
 impl<'a> ScopedTable<'a> {
-    fn new(ctx: &'a SessionContext, schema: &SchemaRef) -> Option<Self> {
+    fn new(ctx: &'a SessionContext, schema: &SchemaRef) -> Result<Self, DbError> {
         let name = format!(
             "__filter_compile_{}",
             COMPILE_SEQ.fetch_add(1, Ordering::Relaxed)
         );
-        let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]]).ok()?;
-        ctx.register_table(&name, Arc::new(empty)).ok()?;
-        Some(Self { ctx, name })
+        let empty = datafusion::datasource::MemTable::try_new(schema.clone(), vec![vec![]])
+            .map_err(|e| DbError::Pipeline(format!("filter compile (build temp table): {e}")))?;
+        ctx.register_table(&name, Arc::new(empty))
+            .map_err(|e| DbError::Pipeline(format!("filter compile (register temp table): {e}")))?;
+        Ok(Self { ctx, name })
     }
 }
 
@@ -40,20 +42,33 @@ impl Drop for ScopedTable<'_> {
     }
 }
 
-/// Compile `filter_sql` against `schema`. Returns `None` on any failure.
+/// Compile `filter_sql` into a `PhysicalExpr` against `schema`. Each failure
+/// (planner, predicate extraction, physical lowering) is reported with enough
+/// context that the caller can surface a meaningful message to the user.
 pub(crate) async fn compile(
     ctx: &SessionContext,
     filter_sql: &str,
     schema: &SchemaRef,
-) -> Option<Arc<dyn PhysicalExpr>> {
+) -> Result<Arc<dyn PhysicalExpr>, DbError> {
     let scoped = ScopedTable::new(ctx, schema)?;
     let sql = format!("SELECT * FROM {} WHERE {filter_sql}", scoped.name);
-    let plan = ctx.sql(&sql).await.ok()?.logical_plan().clone();
+    let plan = ctx
+        .sql(&sql)
+        .await
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}': {e}")))?
+        .logical_plan()
+        .clone();
     drop(scoped);
 
-    let expr = find_predicate(&plan)?;
-    let df_schema = DFSchema::try_from(schema.as_ref().clone()).ok()?;
-    create_physical_expr(&expr, &df_schema, ctx.state().execution_props()).ok()
+    let expr = find_predicate(&plan).ok_or_else(|| {
+        DbError::Pipeline(format!(
+            "filter '{filter_sql}' did not lower to a predicate (DataFusion may have folded it away)"
+        ))
+    })?;
+    let df_schema = DFSchema::try_from(schema.as_ref().clone())
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (df_schema): {e}")))?;
+    create_physical_expr(&expr, &df_schema, ctx.state().execution_props())
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (physical): {e}")))
 }
 
 fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -58,21 +58,19 @@ pub(crate) async fn compile(
         .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}': {e}")))?
         .logical_plan()
         .clone();
+    // The predicate columns are qualified by the temp table name; capture
+    // that qualifier into the DFSchema before dropping `scoped`.
+    let df_schema = DFSchema::try_from_qualified_schema(scoped.name.as_str(), schema.as_ref())
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (df_schema): {e}")))?;
+    drop(scoped);
 
     let expr = find_predicate(&plan).ok_or_else(|| {
         DbError::Pipeline(format!(
             "filter '{filter_sql}' did not lower to a predicate (DataFusion may have folded it away)"
         ))
     })?;
-    // The `SELECT * FROM <scoped.name> WHERE ...` planner produces a predicate
-    // whose columns are qualified by the temp table. Build the DFSchema with
-    // the same qualifier so `create_physical_expr` resolves them.
-    let df_schema = DFSchema::try_from_qualified_schema(scoped.name.as_str(), schema.as_ref())
-        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (df_schema): {e}")))?;
-    let phys = create_physical_expr(&expr, &df_schema, ctx.state().execution_props())
-        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (physical): {e}")))?;
-    drop(scoped);
-    Ok(phys)
+    create_physical_expr(&expr, &df_schema, ctx.state().execution_props())
+        .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (physical): {e}")))
 }
 
 fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use arrow_array::{BooleanArray, RecordBatch};
 use arrow::datatypes::SchemaRef;
+use arrow_array::{BooleanArray, RecordBatch};
 use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion::prelude::SessionContext;
 use datafusion_common::DFSchema;
@@ -61,5 +61,9 @@ pub(crate) fn apply(
         .ok_or_else(|| DbError::Pipeline("filter must return BooleanArray".into()))?;
     let filtered = arrow::compute::filter_record_batch(batch, mask)
         .map_err(|e| DbError::Pipeline(format!("filter: {e}")))?;
-    if filtered.num_rows() == 0 { Ok(None) } else { Ok(Some(filtered)) }
+    if filtered.num_rows() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(filtered))
+    }
 }

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -54,6 +54,7 @@ mod eowc_state;
 pub mod api;
 mod ddl;
 mod error;
+mod filter_compile;
 mod handle;
 mod interval_join;
 mod key_column;
@@ -78,6 +79,9 @@ mod show_commands;
 mod sink_task;
 mod sql_analysis;
 mod sql_utils;
+/// External `SUBSCRIBE` substrate: per-name broadcast channel and the
+/// per-portal pump task.
+pub mod subscription;
 mod table_backend;
 mod table_cache_mode;
 mod table_provider;

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -95,4 +95,9 @@ pub trait PipelineCallback: Send + 'static {
     fn has_deferred_input(&self) -> bool {
         false
     }
+
+    /// Forward a durable checkpoint epoch to external SUBSCRIBE consumers.
+    fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        let _ = (epoch, checkpoint_id);
+    }
 }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -859,8 +859,11 @@ impl StreamingCoordinator {
             // that was persisted, so external offset state (Kafka group
             // offsets, ack tokens) advances only with the durable manifest.
             let fan_out = checkpoints.clone();
+            let checkpoint_id = self.pending_barrier.checkpoint_id;
             if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
                 self.broadcast_epoch_committed(epoch, &fan_out);
+                // Wire barrier = durable epoch.
+                callback.publish_barrier(epoch, checkpoint_id);
             } else {
                 tracing::warn!(
                     checkpoint_id = self.pending_barrier.checkpoint_id,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -385,7 +385,9 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) = crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await {
+            if let Some(compiled) =
+                crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await
+            {
                 self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
             } else {
                 tracing::error!(
@@ -983,7 +985,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
-        self.subscription_registry.broadcast_barrier(epoch, checkpoint_id);
+        self.subscription_registry
+            .broadcast_barrier(epoch, checkpoint_id);
     }
 
     fn has_deferred_input(&self) -> bool {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -385,19 +385,21 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) =
-                crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await
-            {
-                self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
-            } else {
-                tracing::error!(
-                    sink = %sink_name,
-                    filter = %sql,
-                    "[LDB-1100] sink filter did not compile to a PhysicalExpr; \
-                     fail-closed: ALL rows from this stream will be dropped \
-                     for this sink. Track via sink_filter_rejected_rows_total."
-                );
-                self.compiled_sink_filters[i] = SinkFilter::Rejected;
+            match crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await {
+                Ok(compiled) => {
+                    self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        sink = %sink_name,
+                        filter = %sql,
+                        error = %e,
+                        "[LDB-1100] sink filter did not compile; fail-closed: \
+                         ALL rows from this stream will be dropped for this sink. \
+                         Track via sink_filter_rejected_rows_total."
+                    );
+                    self.compiled_sink_filters[i] = SinkFilter::Rejected;
+                }
             }
             self.pending_sink_filter_compiles = self.pending_sink_filter_compiles.saturating_sub(1);
         }

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -7,10 +7,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::SchemaRef;
-use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
+use datafusion::physical_expr::PhysicalExpr;
 use datafusion::prelude::SessionContext;
-use datafusion_common::DFSchema;
 use laminar_connectors::checkpoint::SourceCheckpoint;
 use laminar_core::alloc::{PriorityClass, PriorityGuard};
 use laminar_core::streaming;
@@ -109,6 +107,7 @@ pub(crate) struct ConnectorPipelineCallback {
     /// the coordinator with an empty `CheckpointRequest` and the
     /// leader's manifest is useless for restart recovery.
     pub(crate) force_ckpt_rx: Option<crate::db::ForceCheckpointRx>,
+    pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
 }
 
 impl ConnectorPipelineCallback {
@@ -386,7 +385,7 @@ impl ConnectorPipelineCallback {
             };
             let schema = batch.schema();
             let sql = filter_sql.as_deref().unwrap();
-            if let Some(compiled) = compile_sink_filter_sql(&self.filter_ctx, sql, &schema).await {
+            if let Some(compiled) = crate::filter_compile::compile(&self.filter_ctx, sql, &schema).await {
                 self.compiled_sink_filters[i] = SinkFilter::Compiled(compiled);
             } else {
                 tracing::error!(
@@ -452,6 +451,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                             let dropped = batch.num_rows() as u64;
                             self.prom.events_dropped.inc_by(dropped);
                         }
+                        self.subscription_registry
+                            .send_batch(stream_name, batch.clone());
                     }
                 }
             }
@@ -476,6 +477,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                     if batch.num_rows() > 0 {
                         store.update(stream_name, batch);
                         updates += 1;
+                        self.subscription_registry
+                            .send_batch(stream_name, batch.clone());
                     }
                 }
             }
@@ -524,7 +527,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         for batch in shared.iter() {
                             let filtered: Cow<RecordBatch> = match &filter_state {
                                 SinkFilterDispatch::Compiled(phys) => {
-                                    match apply_compiled_sink_filter(batch, phys) {
+                                    match crate::filter_compile::apply(batch, phys.as_ref()) {
                                         Ok(Some(fb)) => Cow::Owned(fb),
                                         Ok(None) => continue,
                                         Err(e) => {
@@ -979,6 +982,10 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         bp
     }
 
+    fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        self.subscription_registry.broadcast_barrier(epoch, checkpoint_id);
+    }
+
     fn has_deferred_input(&self) -> bool {
         // In cluster mode, always claim pending input so the coordinator
         // runs `execute_cycle` each idle tick — otherwise a follower with
@@ -1221,85 +1228,6 @@ fn update_partial_cache_from_batch(
 /// Encode an Arrow schema as a hex-encoded IPC flatbuffer for `ConnectorConfig`.
 pub(crate) fn encode_arrow_schema(schema: &arrow_schema::Schema) -> String {
     laminar_connectors::config::encode_arrow_schema_ipc(schema)
-}
-
-/// Apply a compiled `PhysicalExpr` filter to a batch.
-fn apply_compiled_sink_filter(
-    batch: &RecordBatch,
-    filter: &Arc<dyn PhysicalExpr>,
-) -> Result<Option<RecordBatch>, DbError> {
-    if batch.num_rows() == 0 {
-        return Ok(None);
-    }
-    let result = filter
-        .evaluate(batch)
-        .map_err(|e| DbError::Pipeline(format!("sink filter evaluate: {e}")))?;
-    let mask = result
-        .into_array(batch.num_rows())
-        .map_err(|e| DbError::Pipeline(format!("sink filter to array: {e}")))?;
-    let bool_arr = mask
-        .as_any()
-        .downcast_ref::<arrow::array::BooleanArray>()
-        .ok_or_else(|| DbError::Pipeline("sink filter not boolean".into()))?;
-    let filtered = arrow::compute::filter_record_batch(batch, bool_arr)
-        .map_err(|e| DbError::Pipeline(format!("sink filter: {e}")))?;
-    if filtered.num_rows() == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(filtered))
-    }
-}
-
-/// Try to compile a sink filter SQL expression to a `PhysicalExpr`.
-///
-/// Plans the filter as a full SQL query against an empty table with the batch
-/// schema, then extracts the Filter predicate from the logical plan and
-/// compiles it. Returns `None` if compilation fails (caller falls back to
-/// SQL-based filter).
-async fn compile_sink_filter_sql(
-    ctx: &SessionContext,
-    filter_sql: &str,
-    batch_schema: &SchemaRef,
-) -> Option<Arc<dyn PhysicalExpr>> {
-    let table_name = "__compile_filter";
-    let empty =
-        datafusion::datasource::MemTable::try_new(batch_schema.clone(), vec![vec![]]).ok()?;
-    let _ = ctx.deregister_table(table_name);
-    ctx.register_table(table_name, Arc::new(empty)).ok()?;
-
-    let sql = format!("SELECT * FROM {table_name} WHERE {filter_sql}");
-    let plan = {
-        let df = ctx.sql(&sql).await.ok()?;
-        df.logical_plan().clone()
-    };
-    let _ = ctx.deregister_table(table_name);
-
-    // Walk plan to find Filter node
-    let filter_expr = find_filter_predicate(&plan)?;
-
-    // Compile against the batch schema
-    let df_schema = DFSchema::try_from(batch_schema.as_ref().clone()).ok()?;
-    let state = ctx.state();
-    let props = state.execution_props();
-    create_physical_expr(&filter_expr, &df_schema, props).ok()
-}
-
-/// Walk a logical plan to find the first Filter predicate.
-fn find_filter_predicate(plan: &datafusion_expr::LogicalPlan) -> Option<datafusion_expr::Expr> {
-    match plan {
-        datafusion_expr::LogicalPlan::Filter(f) => Some(f.predicate.clone()),
-        datafusion_expr::LogicalPlan::Projection(p) => find_filter_predicate(&p.input),
-        datafusion_expr::LogicalPlan::Sort(s) => find_filter_predicate(&s.input),
-        datafusion_expr::LogicalPlan::Limit(l) => find_filter_predicate(&l.input),
-        _ => {
-            for input in plan.inputs() {
-                if let Some(expr) = find_filter_predicate(input) {
-                    return Some(expr);
-                }
-            }
-            None
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -728,8 +728,18 @@ impl LaminarDB {
 
         // Resolve each stream's output schema with DataFusion so sinks
         // downstream see it via `_arrow_schema` (mirrors the source path
-        // above).
+        // above). Publish the result into `LaminarDB::stream_schemas` so
+        // SUBSCRIBE WHERE can compile predicates against the real schema.
         let stream_output_schemas = resolve_stream_output_schemas(&self.ctx, &stream_regs).await?;
+        {
+            let mut schemas = self.stream_schemas.write();
+            schemas.clear();
+            schemas.extend(
+                stream_output_schemas
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Arc::clone(v))),
+            );
+        }
 
         // Build sinks. Each runs in its own tokio task with a bounded
         // command channel and shares one event channel back to the

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1415,6 +1415,7 @@ impl LaminarDB {
             #[cfg(feature = "cluster-unstable")]
             last_follower_epoch: None,
             force_ckpt_rx: Some(force_ckpt_rx),
+            subscription_registry: Arc::clone(&self.subscription_registry),
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/subscription/mod.rs
+++ b/crates/laminar-db/src/subscription/mod.rs
@@ -1,0 +1,8 @@
+//! SUBSCRIBE substrate: per-name broadcast registry and per-portal pump.
+
+mod portal;
+mod registry;
+
+pub use portal::{PortalFrame, SubscriptionPortal};
+pub(crate) use portal::MAX_SUBSCRIBERS_PER_MV;
+pub(crate) use registry::SubscriptionRegistry;

--- a/crates/laminar-db/src/subscription/mod.rs
+++ b/crates/laminar-db/src/subscription/mod.rs
@@ -3,6 +3,6 @@
 mod portal;
 mod registry;
 
-pub use portal::{PortalFrame, SubscriptionPortal};
 pub(crate) use portal::MAX_SUBSCRIBERS_PER_MV;
+pub use portal::{PortalFrame, SubscriptionPortal};
 pub(crate) use registry::SubscriptionRegistry;

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn portal_emits_lagged_then_closes() {
+    async fn portal_emits_lagged_as_final_frame() {
         let reg = SubscriptionRegistry::new();
         let rx = reg.subscribe("mv");
         let mut portal = SubscriptionPortal::open("mv", schema(), rx);
@@ -235,17 +235,21 @@ mod tests {
             reg.send_batch("mv", batch(&[i]));
         }
 
-        let mut saw_lagged = false;
-        tokio::time::timeout(Duration::from_secs(1), async {
+        let frames = tokio::time::timeout(Duration::from_secs(1), async {
+            let mut frames = Vec::new();
             while let Some(frame) = portal.next_frame().await {
-                if let PortalFrame::Lagged(_) = frame {
-                    saw_lagged = true;
-                }
+                frames.push(frame);
             }
+            frames
         })
         .await
         .expect("portal must close after lag");
-        assert!(saw_lagged, "expected a Lagged frame before close");
+
+        assert!(
+            matches!(frames.last(), Some(PortalFrame::Lagged(_))),
+            "last frame must be Lagged, got: {:?}",
+            frames.last()
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -63,7 +63,11 @@ impl SubscriptionPortal {
         let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
         let closed = Arc::new(AtomicBool::new(false));
         tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
-        Self { schema, outbound, closed }
+        Self {
+            schema,
+            outbound,
+            closed,
+        }
     }
 
     /// Schema of the subscribed object.
@@ -115,9 +119,13 @@ async fn pump_loop(
                 },
                 None => PortalFrame::Batch(batch),
             },
-            Ok(MvUpdate::Barrier { epoch, checkpoint_id }) => {
-                PortalFrame::Barrier { epoch, checkpoint_id }
-            }
+            Ok(MvUpdate::Barrier {
+                epoch,
+                checkpoint_id,
+            }) => PortalFrame::Barrier {
+                epoch,
+                checkpoint_id,
+            },
             Err(broadcast::error::RecvError::Closed) => return,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
@@ -187,8 +195,9 @@ mod tests {
 
         reg.drop_name("mv");
 
-        let frame =
-            tokio::time::timeout(Duration::from_millis(500), portal.next_frame()).await.unwrap();
+        let frame = tokio::time::timeout(Duration::from_millis(500), portal.next_frame())
+            .await
+            .unwrap();
         assert!(frame.is_none());
     }
 

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -23,6 +23,11 @@ pub enum PortalFrame {
         /// Engine checkpoint id.
         checkpoint_id: u64,
     },
+    /// Consumer fell behind by `skipped` messages and the broadcast dropped
+    /// them. The portal closes immediately after this frame; the wire layer
+    /// translates it into a client-visible error so the disconnect isn't
+    /// silent.
+    Lagged(u64),
 }
 
 const OUTBOUND_CAPACITY: usize = 256;
@@ -147,6 +152,7 @@ async fn pump_loop(
             Err(broadcast::error::RecvError::Closed) => return,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
+                let _ = tx.send(PortalFrame::Lagged(n)).await;
                 return;
             }
         };
@@ -220,7 +226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn portal_closes_on_lag() {
+    async fn portal_emits_lagged_then_closes() {
         let reg = SubscriptionRegistry::new();
         let rx = reg.subscribe("mv");
         let mut portal = SubscriptionPortal::open("mv", schema(), rx);
@@ -229,11 +235,17 @@ mod tests {
             reg.send_batch("mv", batch(&[i]));
         }
 
+        let mut saw_lagged = false;
         tokio::time::timeout(Duration::from_secs(1), async {
-            while portal.next_frame().await.is_some() {}
+            while let Some(frame) = portal.next_frame().await {
+                if let PortalFrame::Lagged(_) = frame {
+                    saw_lagged = true;
+                }
+            }
         })
         .await
         .expect("portal must close after lag");
+        assert!(saw_lagged, "expected a Lagged frame before close");
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -7,7 +7,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use crossfire::{mpsc, AsyncRx, MAsyncTx};
 use datafusion::physical_expr::PhysicalExpr;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 
 use super::registry::MvUpdate;
 
@@ -34,6 +34,7 @@ pub struct SubscriptionPortal {
     schema: SchemaRef,
     outbound: AsyncRx<mpsc::Array<PortalFrame>>,
     closed: Arc<AtomicBool>,
+    wake: Arc<Notify>,
 }
 
 impl SubscriptionPortal {
@@ -62,11 +63,20 @@ impl SubscriptionPortal {
     ) -> Self {
         let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
         let closed = Arc::new(AtomicBool::new(false));
-        tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
+        let wake = Arc::new(Notify::new());
+        tokio::spawn(pump_loop(
+            name.into(),
+            rx,
+            tx,
+            Arc::clone(&closed),
+            Arc::clone(&wake),
+            filter,
+        ));
         Self {
             schema,
             outbound,
             closed,
+            wake,
         }
     }
 
@@ -81,9 +91,11 @@ impl SubscriptionPortal {
         self.outbound.recv().await.ok()
     }
 
-    /// Signal the pump to stop. Idempotent.
+    /// Signal the pump to stop. Idempotent. Wakes the pump if it's parked
+    /// on `broadcast_rx.recv()` so it can re-check the flag and exit.
     pub fn close(&self) {
         self.closed.store(true, Ordering::Release);
+        self.wake.notify_waiters();
     }
 
     /// True after `close()` has been called.
@@ -104,10 +116,16 @@ async fn pump_loop(
     mut broadcast_rx: broadcast::Receiver<MvUpdate>,
     tx: MAsyncTx<mpsc::Array<PortalFrame>>,
     closed: Arc<AtomicBool>,
+    wake: Arc<Notify>,
     filter: Option<Arc<dyn PhysicalExpr>>,
 ) {
     while !closed.load(Ordering::Acquire) {
-        let frame = match broadcast_rx.recv().await {
+        let recv = tokio::select! {
+            biased;
+            () = wake.notified() => continue,
+            r = broadcast_rx.recv() => r,
+        };
+        let frame = match recv {
             Ok(MvUpdate::Batch(batch)) => match filter.as_ref() {
                 Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
                     Ok(Some(b)) => PortalFrame::Batch(b),

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -1,0 +1,222 @@
+//! Per-subscriber portal: pump task forwards broadcast updates to the wire.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use crossfire::{mpsc, AsyncRx, MAsyncTx};
+use datafusion::physical_expr::PhysicalExpr;
+use tokio::sync::broadcast;
+
+use super::registry::MvUpdate;
+
+/// One frame emitted toward the wire.
+#[derive(Debug, Clone)]
+pub enum PortalFrame {
+    /// Rows produced in a cycle.
+    Batch(RecordBatch),
+    /// Rows preceding this marker are durable as of `epoch`.
+    Barrier {
+        /// Engine checkpoint epoch.
+        epoch: u64,
+        /// Engine checkpoint id.
+        checkpoint_id: u64,
+    },
+}
+
+const OUTBOUND_CAPACITY: usize = 256;
+pub(crate) const MAX_SUBSCRIBERS_PER_MV: usize = 64;
+
+/// One SUBSCRIBE consumer.
+#[derive(Debug)]
+pub struct SubscriptionPortal {
+    schema: SchemaRef,
+    outbound: AsyncRx<mpsc::Array<PortalFrame>>,
+    closed: Arc<AtomicBool>,
+}
+
+impl SubscriptionPortal {
+    pub(crate) fn open(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+    ) -> Self {
+        Self::spawn(name, schema, rx, None)
+    }
+
+    pub(crate) fn open_with_filter(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+        filter: Arc<dyn PhysicalExpr>,
+    ) -> Self {
+        Self::spawn(name, schema, rx, Some(filter))
+    }
+
+    fn spawn(
+        name: impl Into<String>,
+        schema: SchemaRef,
+        rx: broadcast::Receiver<MvUpdate>,
+        filter: Option<Arc<dyn PhysicalExpr>>,
+    ) -> Self {
+        let (tx, outbound) = mpsc::bounded_async::<PortalFrame>(OUTBOUND_CAPACITY);
+        let closed = Arc::new(AtomicBool::new(false));
+        tokio::spawn(pump_loop(name.into(), rx, tx, Arc::clone(&closed), filter));
+        Self { schema, outbound, closed }
+    }
+
+    /// Schema of the subscribed object.
+    #[must_use]
+    pub fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    /// Next frame, or `None` once the pump exits.
+    pub async fn next_frame(&mut self) -> Option<PortalFrame> {
+        self.outbound.recv().await.ok()
+    }
+
+    /// Signal the pump to stop. Idempotent.
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    /// True after `close()` has been called.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for SubscriptionPortal {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+async fn pump_loop(
+    name: String,
+    mut broadcast_rx: broadcast::Receiver<MvUpdate>,
+    tx: MAsyncTx<mpsc::Array<PortalFrame>>,
+    closed: Arc<AtomicBool>,
+    filter: Option<Arc<dyn PhysicalExpr>>,
+) {
+    while !closed.load(Ordering::Acquire) {
+        let frame = match broadcast_rx.recv().await {
+            Ok(MvUpdate::Batch(batch)) => match filter.as_ref() {
+                Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
+                    Ok(Some(b)) => PortalFrame::Batch(b),
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::warn!(subscription = %name, error = %e, "filter failed; closing");
+                        return;
+                    }
+                },
+                None => PortalFrame::Batch(batch),
+            },
+            Ok(MvUpdate::Barrier { epoch, checkpoint_id }) => {
+                PortalFrame::Barrier { epoch, checkpoint_id }
+            }
+            Err(broadcast::error::RecvError::Closed) => return,
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
+                return;
+            }
+        };
+        if tx.send(frame).await.is_err() {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+
+    use arrow_array::Int64Array;
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::super::registry::SubscriptionRegistry;
+    use super::*;
+
+    fn schema() -> SchemaRef {
+        StdArc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]))
+    }
+
+    fn batch(ids: &[i64]) -> RecordBatch {
+        RecordBatch::try_new(schema(), vec![StdArc::new(Int64Array::from(ids.to_vec()))]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn portal_forwards_batch_and_barrier() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        reg.send_batch("mv", batch(&[1, 2]));
+        reg.broadcast_barrier(7, 99);
+
+        let f1 = portal.next_frame().await.expect("frame 1");
+        let PortalFrame::Batch(b) = f1 else {
+            panic!("expected batch, got {f1:?}");
+        };
+        assert_eq!(b.num_rows(), 2);
+
+        let f2 = portal.next_frame().await.expect("frame 2");
+        let PortalFrame::Barrier {
+            epoch,
+            checkpoint_id,
+        } = f2
+        else {
+            panic!("expected barrier, got {f2:?}");
+        };
+        assert_eq!(epoch, 7);
+        assert_eq!(checkpoint_id, 99);
+    }
+
+    #[tokio::test]
+    async fn portal_closes_on_drop_name() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        reg.send_batch("mv", batch(&[1]));
+        let _ = portal.next_frame().await;
+
+        reg.drop_name("mv");
+
+        let frame =
+            tokio::time::timeout(Duration::from_millis(500), portal.next_frame()).await.unwrap();
+        assert!(frame.is_none());
+    }
+
+    #[tokio::test]
+    async fn portal_closes_on_lag() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        for i in 0..1024 {
+            reg.send_batch("mv", batch(&[i]));
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while portal.next_frame().await.is_some() {}
+        })
+        .await
+        .expect("portal must close after lag");
+    }
+
+    #[tokio::test]
+    async fn close_is_idempotent() {
+        let reg = SubscriptionRegistry::new();
+        let rx = reg.subscribe("mv");
+        let portal = SubscriptionPortal::open("mv", schema(), rx);
+
+        portal.close();
+        portal.close();
+        assert!(portal.is_closed());
+    }
+}

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -1,0 +1,130 @@
+//! Per-name broadcast registry for SUBSCRIBE.
+
+#![allow(clippy::disallowed_types)] // cold path
+
+use std::collections::HashMap;
+
+use arrow_array::RecordBatch;
+use parking_lot::RwLock;
+use tokio::sync::broadcast;
+
+const BROADCAST_CAPACITY: usize = 256;
+
+#[derive(Clone, Debug)]
+pub(crate) enum MvUpdate {
+    Batch(RecordBatch),
+    Barrier { epoch: u64, checkpoint_id: u64 },
+}
+
+pub(crate) struct SubscriptionRegistry {
+    senders: RwLock<HashMap<String, broadcast::Sender<MvUpdate>>>,
+}
+
+impl SubscriptionRegistry {
+    pub(crate) fn new() -> Self {
+        Self { senders: RwLock::new(HashMap::new()) }
+    }
+
+    /// Attach a receiver, allocating the channel on first call.
+    pub(crate) fn subscribe(&self, name: &str) -> broadcast::Receiver<MvUpdate> {
+        if let Some(tx) = self.senders.read().get(name) {
+            return tx.subscribe();
+        }
+        self.senders
+            .write()
+            .entry(name.to_string())
+            .or_insert_with(|| broadcast::channel(BROADCAST_CAPACITY).0)
+            .subscribe()
+    }
+
+    /// Send a batch to subscribers of `name`. Cheap when nobody is attached.
+    pub(crate) fn send_batch(&self, name: &str, batch: RecordBatch) {
+        if let Some(tx) = self.senders.read().get(name) {
+            let _ = tx.send(MvUpdate::Batch(batch));
+        }
+    }
+
+    /// Broadcast a barrier marker to every registered name.
+    pub(crate) fn broadcast_barrier(&self, epoch: u64, checkpoint_id: u64) {
+        let msg = MvUpdate::Barrier { epoch, checkpoint_id };
+        for tx in self.senders.read().values() {
+            let _ = tx.send(msg.clone());
+        }
+    }
+
+    /// Drop the broadcast for `name`. Existing receivers see `Closed`.
+    pub(crate) fn drop_name(&self, name: &str) -> bool {
+        self.senders.write().remove(name).is_some()
+    }
+
+    pub(crate) fn subscriber_count(&self, name: &str) -> usize {
+        self.senders.read().get(name).map_or(0, broadcast::Sender::receiver_count)
+    }
+}
+
+impl Default for SubscriptionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc as StdArc;
+
+    use arrow_array::Int64Array;
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::*;
+
+    fn batch(ids: &[i64]) -> RecordBatch {
+        let schema = StdArc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        RecordBatch::try_new(schema, vec![StdArc::new(Int64Array::from(ids.to_vec()))]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn round_trip() {
+        let reg = SubscriptionRegistry::new();
+        let mut rx = reg.subscribe("mv");
+
+        reg.send_batch("mv", batch(&[1, 2, 3]));
+        let MvUpdate::Batch(b) = rx.recv().await.unwrap() else {
+            panic!("expected batch");
+        };
+        assert_eq!(b.num_rows(), 3);
+
+        reg.broadcast_barrier(7, 42);
+        let MvUpdate::Barrier { epoch, checkpoint_id } = rx.recv().await.unwrap() else {
+            panic!("expected barrier");
+        };
+        assert_eq!((epoch, checkpoint_id), (7, 42));
+    }
+
+    #[tokio::test]
+    async fn no_subscribers_is_noop() {
+        let reg = SubscriptionRegistry::new();
+        reg.send_batch("nobody", batch(&[1]));
+        reg.broadcast_barrier(1, 1);
+        assert_eq!(reg.subscriber_count("nobody"), 0);
+    }
+
+    #[tokio::test]
+    async fn drop_name_closes_receivers() {
+        let reg = SubscriptionRegistry::new();
+        let mut rx = reg.subscribe("mv");
+        assert!(reg.drop_name("mv"));
+        assert!(matches!(rx.recv().await, Err(broadcast::error::RecvError::Closed)));
+    }
+
+    #[test]
+    fn subscriber_count_tracks_attach_drop() {
+        let reg = SubscriptionRegistry::new();
+        let r1 = reg.subscribe("mv");
+        let r2 = reg.subscribe("mv");
+        assert_eq!(reg.subscriber_count("mv"), 2);
+        drop(r1);
+        assert_eq!(reg.subscriber_count("mv"), 1);
+        drop(r2);
+        assert_eq!(reg.subscriber_count("mv"), 0);
+    }
+}

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -22,7 +22,9 @@ pub(crate) struct SubscriptionRegistry {
 
 impl SubscriptionRegistry {
     pub(crate) fn new() -> Self {
-        Self { senders: RwLock::new(HashMap::new()) }
+        Self {
+            senders: RwLock::new(HashMap::new()),
+        }
     }
 
     /// Attach a receiver, allocating the channel on first call.
@@ -46,7 +48,10 @@ impl SubscriptionRegistry {
 
     /// Broadcast a barrier marker to every registered name.
     pub(crate) fn broadcast_barrier(&self, epoch: u64, checkpoint_id: u64) {
-        let msg = MvUpdate::Barrier { epoch, checkpoint_id };
+        let msg = MvUpdate::Barrier {
+            epoch,
+            checkpoint_id,
+        };
         for tx in self.senders.read().values() {
             let _ = tx.send(msg.clone());
         }
@@ -58,7 +63,10 @@ impl SubscriptionRegistry {
     }
 
     pub(crate) fn subscriber_count(&self, name: &str) -> usize {
-        self.senders.read().get(name).map_or(0, broadcast::Sender::receiver_count)
+        self.senders
+            .read()
+            .get(name)
+            .map_or(0, broadcast::Sender::receiver_count)
     }
 }
 
@@ -94,7 +102,11 @@ mod tests {
         assert_eq!(b.num_rows(), 3);
 
         reg.broadcast_barrier(7, 42);
-        let MvUpdate::Barrier { epoch, checkpoint_id } = rx.recv().await.unwrap() else {
+        let MvUpdate::Barrier {
+            epoch,
+            checkpoint_id,
+        } = rx.recv().await.unwrap()
+        else {
             panic!("expected barrier");
         };
         assert_eq!((epoch, checkpoint_id), (7, 42));
@@ -113,7 +125,10 @@ mod tests {
         let reg = SubscriptionRegistry::new();
         let mut rx = reg.subscribe("mv");
         assert!(reg.drop_name("mv"));
-        assert!(matches!(rx.recv().await, Err(broadcast::error::RecvError::Closed)));
+        assert!(matches!(
+            rx.recv().await,
+            Err(broadcast::error::RecvError::Closed)
+        ));
     }
 
     #[test]

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -94,8 +94,6 @@ mimalloc = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio-postgres = "0.7"
-arrow = { workspace = true }
-prometheus = { workspace = true }
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -62,6 +62,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 pgwire = { version = "0.39", default-features = false, features = ["server-api"] }
 async-trait = { workspace = true }
 futures = { workspace = true }
+rand = { workspace = true }
 
 # Config helpers
 regex = { workspace = true }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -21,10 +21,16 @@ path = "src/main.rs"
 laminar-core = { path = "../laminar-core", version = "0.21.5" }
 laminar-storage = { path = "../laminar-storage", version = "0.21.5" }
 laminar-db = { path = "../laminar-db", version = "0.21.5", features = ["api"] }
+laminar-sql = { path = "../laminar-sql", version = "0.21.5" }
 
-# Arrow (for WS JSON serialization)
+# For pgwire dispatch on parsed AST
+sqlparser = { workspace = true }
+
+# Arrow (for WS JSON serialization + pgwire row encoder)
 arrow-array = { workspace = true }
+arrow-cast = { workspace = true }
 arrow-json = { workspace = true }
+arrow-schema = { workspace = true }
 parking_lot = { workspace = true }
 
 # CLI and configuration
@@ -51,6 +57,11 @@ toml = "1.1"
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
+
+# Postgres wire — bare server, no TLS.
+pgwire = { version = "0.39", default-features = false, features = ["server-api"] }
+async-trait = { workspace = true }
+futures = { workspace = true }
 
 # Config helpers
 regex = { workspace = true }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -58,8 +58,16 @@ axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
-# Postgres wire — bare server, no TLS.
-pgwire = { version = "0.39", default-features = false, features = ["server-api"] }
+# Postgres wire with optional TLS (aws-lc-rs backend).
+pgwire = { version = "0.39", default-features = false, features = [
+    "server-api",
+    "_aws-lc-rs",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "aws-lc-rs",
+    "tls12",
+] }
+rustls-pemfile = "2"
 async-trait = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
@@ -95,6 +103,8 @@ mimalloc = { workspace = true, optional = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio-postgres = "0.7"
+tokio-postgres-rustls = "0.13"
+rcgen = "0.13"
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -93,6 +93,9 @@ mimalloc = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio-postgres = "0.7"
+arrow = { workspace = true }
+prometheus = { workspace = true }
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -6,6 +6,7 @@ Standalone server binary for LaminarDB. Reads a TOML configuration file, constru
 
 - **TOML configuration** with `${VAR}` and `${VAR:-default}` environment variable substitution
 - **REST API** (Axum) for health checks, pipeline introspection, ad-hoc SQL, and manual checkpoints
+- **Postgres wire protocol** (optional) for `SUBSCRIBE` streaming via `psql` and any libpq client
 - **Prometheus metrics** at `/metrics`
 - **Hot reload** — edit the TOML file and changes are applied automatically (file watcher with debounce), or `POST /api/v1/reload`
 - **Checkpoint validation** — `--validate-checkpoints` flag validates all stored checkpoints and exits
@@ -55,6 +56,7 @@ See the [Configuration Reference](https://laminardb.io/docs/) for every field, o
 [server]
 mode = "embedded"           # "embedded" (single-node) or "cluster" (multi-node scaffolding, not production-hardened)
 bind = "0.0.0.0:8080"       # HTTP API bind address
+pgwire_bind = "127.0.0.1:5433"  # optional; enables Postgres wire protocol for SUBSCRIBE
 log_level = "info"
 # Worker thread count is taken from $TOKIO_WORKER_THREADS — defaults to logical CPUs.
 
@@ -124,6 +126,20 @@ format = "json"
 | POST | `/api/v1/reload` | Hot-reload configuration |
 | GET | `/api/v1/cluster` | Cluster status (only available when `server.mode = "cluster"`) |
 | GET | `/ws/{name}` | WebSocket upgrade for push-based subscriptions to a stream |
+
+## Postgres Wire Protocol
+
+When `[server].pgwire_bind` is set, the server also listens for Postgres clients and serves a small subset of the SimpleQuery protocol:
+
+- `SUBSCRIBE <name> [WHERE <predicate>]` — streams materialized-view rows as they're produced. The query stays open until the client disconnects.
+- `SHOW`, `SET <key> = <value>`, and a handful of driver builtins (`SELECT version()`, `current_database()`, etc.) are accepted so standard psql / libpq clients can connect.
+- `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
+
+Filters are compiled with DataFusion against the materialized view's schema, so any DataFusion-supported predicate works (`WHERE price > 100`, `WHERE symbol IN ('AAPL', 'MSFT')`, etc.). Subscribing to a raw stream rejects `WHERE` because stream schemas are opaque to the planner.
+
+```bash
+psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"
+```
 
 ## Hot Reload
 

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -58,6 +58,12 @@ mode = "embedded"           # "embedded" (single-node) or "cluster" (multi-node 
 bind = "0.0.0.0:8080"       # HTTP API bind address
 pgwire_bind = "127.0.0.1:5433"  # optional; enables Postgres wire protocol for SUBSCRIBE
 log_level = "info"
+# Optional MD5 password auth for the pgwire listener. When this map is set,
+# the listener requires MD5 auth and is allowed to bind to non-localhost
+# interfaces. When empty, auth is "trust" and the bind must be localhost.
+# [server.pgwire_users]
+# alice = "${ALICE_PASSWORD}"
+# bob   = "${BOB_PASSWORD}"
 # Worker thread count is taken from $TOKIO_WORKER_THREADS — defaults to logical CPUs.
 
 [state]
@@ -136,6 +142,23 @@ When `[server].pgwire_bind` is set, the server also listens for Postgres clients
 - `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
 
 `WHERE` is compiled with DataFusion against the target's schema and works on materialized views and sources. It is rejected on named streams because their output schema isn't introspectable.
+
+### Authentication
+
+By default the listener uses **trust** auth and rejects non-localhost binds — the assumption is that any caller who can reach the loopback interface is already trusted. To bind to a routable address, configure password auth:
+
+```toml
+[server.pgwire_users]
+alice = "${ALICE_PASSWORD}"
+```
+
+Clients then connect with the password using the standard Postgres MD5 challenge flow:
+
+```bash
+PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb user=alice" -c "SUBSCRIBE avg_price"
+```
+
+Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables (or a secret manager) rather than committing them. There is no SCRAM, no role hierarchy, and no TLS yet — see the FIR follow-ups.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -131,11 +131,11 @@ format = "json"
 
 When `[server].pgwire_bind` is set, the server also listens for Postgres clients and serves a small subset of the SimpleQuery protocol:
 
-- `SUBSCRIBE <name> [WHERE <predicate>]` — streams materialized-view rows as they're produced. The query stays open until the client disconnects.
+- `SUBSCRIBE <name> [WHERE <predicate>]` — streams rows as they're produced. `<name>` may be a materialized view, a source, or a named stream. The query stays open until the client disconnects.
 - `SHOW`, `SET <key> = <value>`, and a handful of driver builtins (`SELECT version()`, `current_database()`, etc.) are accepted so standard psql / libpq clients can connect.
 - `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
 
-Filters are compiled with DataFusion against the materialized view's schema, so any DataFusion-supported predicate works (`WHERE price > 100`, `WHERE symbol IN ('AAPL', 'MSFT')`, etc.). Subscribing to a raw stream rejects `WHERE` because stream schemas are opaque to the planner.
+`WHERE` is compiled with DataFusion against the target's schema and works on materialized views and sources. It is rejected on named streams because their output schema isn't introspectable.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -145,11 +145,14 @@ When `[server].pgwire_bind` is set, the server also listens for Postgres clients
 
 ### Authentication
 
-By default the listener uses **trust** auth and rejects non-localhost binds — the assumption is that any caller who can reach the loopback interface is already trusted. To bind to a routable address, configure password auth:
+By default the listener uses **trust** auth and rejects non-localhost binds — the assumption is that any caller who can reach the loopback interface is already trusted. To bind to a routable address, configure MD5 password auth and explicitly opt in to remote binds:
 
 ```toml
+pgwire_bind = "0.0.0.0:5433"
+pgwire_allow_remote = true        # required even with auth on, two-key rule
+
 [server.pgwire_users]
-alice = "${ALICE_PASSWORD}"
+alice = "${ALICE_PASSWORD}"       # min 12 chars, validated at config load
 ```
 
 Clients then connect with the password using the standard Postgres MD5 challenge flow:
@@ -158,7 +161,9 @@ Clients then connect with the password using the standard Postgres MD5 challenge
 PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb user=alice" -c "SUBSCRIBE avg_price"
 ```
 
-Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables (or a secret manager) rather than committing them. There is no SCRAM, no role hierarchy, and no TLS yet — see the FIR follow-ups.
+> **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM and TLS work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
+
+Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -161,9 +161,20 @@ Clients then connect with the password using the standard Postgres MD5 challenge
 PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb user=alice" -c "SUBSCRIBE avg_price"
 ```
 
-> **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM and TLS work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
+> **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
 
 Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
+
+### TLS
+
+Optional. Setting both `pgwire_tls_cert` and `pgwire_tls_key` enables TLS via [`tokio-rustls`](https://crates.io/crates/tokio-rustls) (aws-lc-rs backend). Both must be PEM-encoded; the key may be PKCS#8 or RSA.
+
+```toml
+pgwire_tls_cert = "/etc/laminar/pgwire.crt"
+pgwire_tls_key  = "/etc/laminar/pgwire.key"
+```
+
+Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work. Cert rotation requires a server restart; hot reload is a follow-up.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -173,6 +173,9 @@ pub struct ServerSection {
     pub mode: String,
     #[serde(default = "default_bind")]
     pub bind: String,
+    /// Postgres wire bind address; `None` disables it.
+    #[serde(default)]
+    pub pgwire_bind: Option<String>,
 }
 
 impl Default for ServerSection {
@@ -180,6 +183,7 @@ impl Default for ServerSection {
         Self {
             mode: default_mode(),
             bind: default_bind(),
+            pgwire_bind: None,
         }
     }
 }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -181,6 +181,10 @@ pub struct ServerSection {
     /// Postgres wire bind address; `None` disables it.
     #[serde(default)]
     pub pgwire_bind: Option<String>,
+    /// Username -> plaintext password for MD5 auth on the pgwire listener.
+    /// Empty/absent → trust auth (only safe behind a localhost bind).
+    #[serde(default)]
+    pub pgwire_users: std::collections::HashMap<String, String>,
 }
 
 impl Default for ServerSection {
@@ -189,6 +193,7 @@ impl Default for ServerSection {
             mode: default_mode(),
             bind: default_bind(),
             pgwire_bind: None,
+            pgwire_users: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -16,6 +16,11 @@ static ENV_VAR_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}").expect("valid regex")
 });
 
+/// Minimum acceptable pgwire password length, enforced at config load.
+/// MD5 auth offers no work factor, so length is the only knob; 12 is the
+/// usual NIST baseline.
+const MIN_PGWIRE_PASSWORD_LEN: usize = 12;
+
 /// Load, parse, and validate a LaminarDB configuration file.
 pub fn load_config(path: &Path) -> Result<ServerConfig, ConfigError> {
     let raw = std::fs::read_to_string(path).map_err(|e| ConfigError::FileRead {
@@ -116,6 +121,16 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             errors.push(format!("invalid server pgwire_bind address: '{}'", addr));
         }
     }
+    for (user, password) in &config.server.pgwire_users {
+        if user.is_empty() {
+            errors.push("pgwire_users contains an empty username".to_string());
+        }
+        if password.len() < MIN_PGWIRE_PASSWORD_LEN {
+            errors.push(format!(
+                "pgwire_users['{user}']: password must be at least {MIN_PGWIRE_PASSWORD_LEN} characters"
+            ));
+        }
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {
@@ -184,7 +199,13 @@ pub struct ServerSection {
     /// Username -> plaintext password for MD5 auth on the pgwire listener.
     /// Empty/absent → trust auth (only safe behind a localhost bind).
     #[serde(default)]
-    pub pgwire_users: std::collections::HashMap<String, String>,
+    pub pgwire_users: std::collections::HashMap<String, Secret>,
+    /// Two-key rule: must be explicitly true to allow `pgwire_bind` on a
+    /// non-localhost address even when MD5 auth is configured. Defaults
+    /// false so a misconfigured `pgwire_users` map can't accidentally expose
+    /// the listener to the wider network.
+    #[serde(default)]
+    pub pgwire_allow_remote: bool,
 }
 
 impl Default for ServerSection {
@@ -194,7 +215,40 @@ impl Default for ServerSection {
             bind: default_bind(),
             pgwire_bind: None,
             pgwire_users: std::collections::HashMap::new(),
+            pgwire_allow_remote: false,
         }
+    }
+}
+
+/// String wrapped to keep its plaintext out of `Debug` output and incidental
+/// log lines. Use `Secret::expose` only at the point of use.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[serde(transparent)]
+pub struct Secret(String);
+
+impl Secret {
+    /// Constructor; intended for tests and bridge code.
+    #[cfg(test)]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Plaintext access. Only call at the point the value is actually used
+    /// (e.g., handing it to a hash function); never store the returned `&str`
+    /// elsewhere.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// Char count of the wrapped value, for length validation.
+    pub fn len(&self) -> usize {
+        self.0.chars().count()
+    }
+}
+
+impl std::fmt::Debug for Secret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("[REDACTED]")
     }
 }
 
@@ -705,6 +759,43 @@ bind = "not-a-socket-addr"
             }
             _ => panic!("expected ValidationErrors"),
         }
+    }
+
+    #[test]
+    fn test_validate_short_pgwire_password() {
+        let toml = r#"
+[server]
+[server.pgwire_users]
+alice = "short"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        let err = validate_config(&config).unwrap_err();
+        match err {
+            ConfigError::ValidationErrors { errors } => {
+                assert!(
+                    errors.iter().any(|e| e.contains("at least 12 characters")),
+                    "errors: {errors:?}"
+                );
+            }
+            _ => panic!("expected ValidationErrors"),
+        }
+    }
+
+    #[test]
+    fn test_validate_pgwire_password_redacted_in_debug() {
+        let toml = r#"
+[server]
+[server.pgwire_users]
+alice = "wonderland-key"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        validate_config(&config).unwrap();
+        let dump = format!("{:?}", config.server);
+        assert!(!dump.contains("wonderland"), "secret leaked: {dump}");
+        assert!(
+            dump.contains("REDACTED"),
+            "expected REDACTED marker: {dump}"
+        );
     }
 
     #[test]

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -111,6 +111,11 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             config.server.bind
         ));
     }
+    if let Some(addr) = &config.server.pgwire_bind {
+        if addr.parse::<std::net::SocketAddr>().is_err() {
+            errors.push(format!("invalid server pgwire_bind address: '{}'", addr));
+        }
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -131,6 +131,23 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             ));
         }
     }
+    match (
+        &config.server.pgwire_tls_cert,
+        &config.server.pgwire_tls_key,
+    ) {
+        (Some(_), None) | (None, Some(_)) => {
+            errors.push("pgwire_tls_cert and pgwire_tls_key must be set together".to_string());
+        }
+        (Some(cert), Some(key)) => {
+            if !cert.exists() {
+                errors.push(format!("pgwire_tls_cert not found: {}", cert.display()));
+            }
+            if !key.exists() {
+                errors.push(format!("pgwire_tls_key not found: {}", key.display()));
+            }
+        }
+        (None, None) => {}
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {
@@ -206,6 +223,13 @@ pub struct ServerSection {
     /// the listener to the wider network.
     #[serde(default)]
     pub pgwire_allow_remote: bool,
+    /// TLS certificate (PEM). Setting this and `pgwire_tls_key` enables
+    /// TLS on the pgwire listener; both must be provided together.
+    #[serde(default)]
+    pub pgwire_tls_cert: Option<std::path::PathBuf>,
+    /// TLS private key (PEM, PKCS#8 or RSA).
+    #[serde(default)]
+    pub pgwire_tls_key: Option<std::path::PathBuf>,
 }
 
 impl Default for ServerSection {
@@ -216,6 +240,8 @@ impl Default for ServerSection {
             pgwire_bind: None,
             pgwire_users: std::collections::HashMap::new(),
             pgwire_allow_remote: false,
+            pgwire_tls_cert: None,
+            pgwire_tls_key: None,
         }
     }
 }

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -9,6 +9,7 @@ mod cluster_config;
 mod config;
 mod http;
 mod metrics;
+mod pgwire;
 mod reload;
 mod server;
 mod watcher;
@@ -40,6 +41,9 @@ struct Args {
     log_level: String,
     #[arg(long)]
     admin_bind: Option<String>,
+    /// Postgres wire bind address (e.g. `127.0.0.1:5433`). Wildcard binds rejected.
+    #[arg(long)]
+    pgwire_bind: Option<String>,
     /// Validate checkpoints and exit without starting the server.
     #[arg(long)]
     validate_checkpoints: bool,
@@ -72,6 +76,10 @@ async fn main() -> Result<()> {
 
     if let Some(bind) = args.admin_bind {
         config.server.bind = bind;
+    }
+    if let Some(pg) = args.pgwire_bind {
+        // Empty string disables; a value overrides config.
+        config.server.pgwire_bind = if pg.is_empty() { None } else { Some(pg) };
     }
 
     if args.validate_checkpoints {

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -514,6 +514,50 @@ pub struct TlsPaths<'a> {
     pub key: &'a std::path::Path,
 }
 
+/// Warn if the key file is readable by anyone other than the owner.
+/// PostgreSQL refuses to start in this case; we warn rather than fail
+/// because dev environments often run with looser perms.
+#[cfg(unix)]
+fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
+    use std::os::unix::fs::MetadataExt;
+    if let Ok(meta) = file.metadata() {
+        let mode = meta.mode();
+        if mode & 0o077 != 0 {
+            warn!(
+                path = %path.display(),
+                mode = format!("{:o}", mode & 0o777),
+                "pgwire_tls_key permissions are too broad — postgres rejects \
+                 anything looser than 0600. Tighten before exposing the listener.",
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_key_world_readable(_file: &std::fs::File, _path: &std::path::Path) {}
+
+/// Map the result of `process_socket` to a stable audit-log code so SOC
+/// dashboards can split TLS handshake errors from auth failures and from
+/// generic runtime errors.
+fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
+    match result {
+        Ok(()) => "ok",
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("28P01") {
+                "auth_failed"
+            } else if msg.contains("HandshakeFailure")
+                || msg.contains("rustls")
+                || msg.contains("tls")
+            {
+                "tls_failed"
+            } else {
+                "error"
+            }
+        }
+    }
+}
+
 #[allow(clippy::result_large_err)]
 fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, ServerError> {
     use std::fs::File;
@@ -533,6 +577,7 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
 
     let key_file = File::open(paths.key)
         .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
+    warn_if_key_world_readable(&key_file, paths.key);
     let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
         .map_err(|e| ServerError::Http(format!("parse pgwire_tls_key: {e}")))?
         .ok_or_else(|| {
@@ -625,11 +670,7 @@ pub async fn serve(
                             );
                             sessions.spawn(async move {
                                 let result = process_socket(sock, tls_ref, factory_ref).await;
-                                let outcome = match &result {
-                                    Ok(()) => "ok",
-                                    Err(e) if e.to_string().contains("28P01") => "auth_failed",
-                                    Err(_) => "error",
-                                };
+                                let outcome = classify_outcome(&result);
                                 tracing::info!(
                                     target: "audit",
                                     event = "pgwire.connection_closed",
@@ -748,6 +789,24 @@ mod tests {
     fn multi_statement_parses() {
         let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
         assert_eq!(stmts.len(), 3);
+    }
+
+    #[test]
+    fn classify_outcome_buckets_errors() {
+        use std::io::{Error, ErrorKind};
+        assert_eq!(super::classify_outcome(&Ok(())), "ok");
+        assert_eq!(
+            super::classify_outcome(&Err(Error::other("FATAL: 28P01 bad pass"))),
+            "auth_failed"
+        );
+        assert_eq!(
+            super::classify_outcome(&Err(Error::other("rustls HandshakeFailure"))),
+            "tls_failed"
+        );
+        assert_eq!(
+            super::classify_outcome(&Err(Error::new(ErrorKind::BrokenPipe, "broken"))),
+            "error"
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -442,7 +442,7 @@ fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
-) -> Result<tokio::task::JoinHandle<()>, ServerError> {
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
         .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
@@ -451,9 +451,12 @@ pub async fn serve(
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
     let factory = Arc::new(LaminarHandlerFactory::new(db));
-    info!(%addr, "pgwire listening");
+    info!(addr = %local_addr, "pgwire listening");
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
@@ -483,7 +486,7 @@ pub async fn serve(
             }
         }
     });
-    Ok(handle)
+    Ok((local_addr, handle))
 }
 
 #[cfg(test)]
@@ -598,5 +601,133 @@ mod tests {
     fn multi_statement_parses() {
         let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
         assert_eq!(stmts.len(), 3);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    //! End-to-end pgwire driven by `tokio_postgres` against an in-process
+    //! `LaminarDB`. Verifies the wire-protocol surface — handshake, SimpleQuery
+    //! dispatch, error reporting — that unit tests can't reach. Engine-level
+    //! row flow is covered in `laminar-db`'s `db::tests`.
+
+    use std::sync::Arc;
+
+    use laminar_db::LaminarDB;
+    use tokio_postgres::{NoTls, SimpleQueryMessage};
+
+    async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+            .await
+            .expect("create source");
+        db.execute(
+            "CREATE MATERIALIZED VIEW prices AS \
+             SELECT symbol, price FROM trades",
+        )
+        .await
+        .expect("create mv");
+        db.start().await.expect("db starts");
+
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0")
+            .await
+            .expect("pgwire serve");
+        (addr, handle)
+    }
+
+    async fn connect(addr: std::net::SocketAddr) -> tokio_postgres::Client {
+        let conn_str = format!(
+            "host={} port={} user=any dbname=laminardb",
+            addr.ip(),
+            addr.port()
+        );
+        let (client, conn) = tokio_postgres::connect(&conn_str, NoTls)
+            .await
+            .expect("pgwire connect");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        client
+    }
+
+    fn first_row_value(messages: &[SimpleQueryMessage], col: usize) -> Option<&str> {
+        messages.iter().find_map(|m| match m {
+            SimpleQueryMessage::Row(r) => r.get(col),
+            _ => None,
+        })
+    }
+
+    #[tokio::test]
+    async fn handshake_and_builtins() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("version");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
+
+        let messages = client
+            .simple_query("SELECT current_database()")
+            .await
+            .expect("current_database");
+        assert_eq!(first_row_value(&messages, 0), Some("laminar"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn show_streams_runs() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        // No assertion on contents — just that the dispatch path returns rows
+        // without error. Engine-level SHOW behavior is covered in laminar-db.
+        client
+            .simple_query("SHOW STREAMS")
+            .await
+            .expect("SHOW STREAMS");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn subscribe_unknown_name_returns_pg_error() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("SUBSCRIBE no_such_view")
+            .await
+            .expect_err("must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("no_such_view"),
+            "message: {}",
+            db_err.message()
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn ddl_returns_pg_error_pointing_at_http() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("CREATE SOURCE more_trades (sym VARCHAR)")
+            .await
+            .expect_err("DDL must be rejected");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("/api/v1/sql"),
+            "message: {}",
+            db_err.message()
+        );
+
+        handle.abort();
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,6 +1,7 @@
 //! Postgres wire endpoint. Trust auth by default; MD5 password auth when
 //! `[server].pgwire_users` is non-empty. Non-loopback binds require both
-//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). No TLS yet.
+//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). TLS via
+//! tokio-rustls when `pgwire_tls_cert` and `pgwire_tls_key` are set.
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -507,11 +508,53 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
     }
 }
 
+/// Cert + private-key paths for the pgwire TLS listener.
+pub struct TlsPaths<'a> {
+    pub cert: &'a std::path::Path,
+    pub key: &'a std::path::Path,
+}
+
+#[allow(clippy::result_large_err)]
+fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, ServerError> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let cert_file = File::open(paths.cert)
+        .map_err(|e| ServerError::Http(format!("open pgwire_tls_cert: {e}")))?;
+    let certs = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| ServerError::Http(format!("parse pgwire_tls_cert: {e}")))?;
+    if certs.is_empty() {
+        return Err(ServerError::Http(format!(
+            "pgwire_tls_cert {} contains no certificates",
+            paths.cert.display()
+        )));
+    }
+
+    let key_file = File::open(paths.key)
+        .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
+    let key = rustls_pemfile::private_key(&mut BufReader::new(key_file))
+        .map_err(|e| ServerError::Http(format!("parse pgwire_tls_key: {e}")))?
+        .ok_or_else(|| {
+            ServerError::Http(format!(
+                "pgwire_tls_key {} contains no private key",
+                paths.key.display()
+            ))
+        })?;
+
+    let server_config = tokio_rustls::rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
+    Ok(tokio_rustls::TlsAcceptor::from(Arc::new(server_config)))
+}
+
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
     users: HashMap<String, Secret>,
     allow_remote: bool,
+    tls: Option<TlsPaths<'_>>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
@@ -534,6 +577,11 @@ pub async fn serve(
         _ => {}
     }
 
+    let tls_acceptor = match tls {
+        Some(paths) => Some(load_tls_acceptor(paths)?),
+        None => None,
+    };
+
     let listener = TcpListener::bind(addr)
         .await
         .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
@@ -542,13 +590,15 @@ pub async fn serve(
         .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
+    let tls_mode = if tls_acceptor.is_some() { "on" } else { "off" };
     if auth_mode == "trust" {
         warn!(
             addr = %local_addr,
+            tls = tls_mode,
             "pgwire listening with TRUST auth — any client reaching this address is admin",
         );
     } else {
-        info!(addr = %local_addr, auth = auth_mode, "pgwire listening");
+        info!(addr = %local_addr, auth = auth_mode, tls = tls_mode, "pgwire listening");
     }
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
@@ -564,15 +614,17 @@ pub async fn serve(
                     match accepted {
                         Ok((sock, peer)) => {
                             let factory_ref = Arc::clone(&factory);
+                            let tls_ref = tls_acceptor.clone();
                             let peer_str = peer.to_string();
                             tracing::info!(
                                 target: "audit",
                                 event = "pgwire.connection_accepted",
                                 peer = %peer,
                                 auth = auth_mode,
+                                tls = tls_mode,
                             );
                             sessions.spawn(async move {
-                                let result = process_socket(sock, None, factory_ref).await;
+                                let result = process_socket(sock, tls_ref, factory_ref).await;
                                 let outcome = match &result {
                                     Ok(()) => "ok",
                                     Err(e) if e.to_string().contains("28P01") => "auth_failed",
@@ -701,7 +753,7 @@ mod tests {
     #[tokio::test]
     async fn serve_rejects_remote_bind_in_trust_mode() {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
-        let err = serve(db, "0.0.0.0:0", HashMap::new(), false)
+        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None)
             .await
             .expect_err("trust + 0.0.0.0 must fail");
         assert!(err.to_string().contains("trust auth"), "got: {err}");
@@ -712,7 +764,7 @@ mod tests {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         let mut users = HashMap::new();
         users.insert("alice".into(), Secret::new("wonderland-key"));
-        let err = serve(db, "0.0.0.0:0", users, false)
+        let err = serve(db, "0.0.0.0:0", users, false, None)
             .await
             .expect_err("md5 + 0.0.0.0 without allow_remote must fail");
         assert!(
@@ -752,7 +804,7 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false)
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None)
             .await
             .expect("pgwire serve");
         (addr, handle)
@@ -973,6 +1025,73 @@ mod integration_tests {
 
         let db_err = err.as_db_error().expect("typed PG error");
         assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// Self-signed cert+key written to a tempdir for the duration of the
+    /// test. `rcgen` is the well-maintained option for ad-hoc certs.
+    fn self_signed_pem() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let cert =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()]).expect("rcgen issue cert");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, cert.cert.pem()).unwrap();
+        std::fs::write(&key_path, cert.key_pair.serialize_pem()).unwrap();
+        (dir, cert_path, key_path)
+    }
+
+    #[tokio::test]
+    async fn tls_handshake_succeeds() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+            }),
+        )
+        .await
+        .expect("pgwire serve");
+
+        // Build a client TLS config that trusts the same self-signed cert.
+        let cert_bytes = std::fs::read(&cert_path).unwrap();
+        let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+        for c in rustls_pemfile::certs(&mut std::io::Cursor::new(cert_bytes))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        {
+            roots.add(c).unwrap();
+        }
+        let client_cfg = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(client_cfg);
+        let (client, conn) = tokio_postgres::connect(&conn_str, tls)
+            .await
+            .expect("TLS handshake + connect");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("query over TLS");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
 
         handle.abort();
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -952,10 +952,9 @@ mod integration_tests {
 
     #[tokio::test]
     async fn subscribe_with_valid_where_is_accepted() {
-        // Smoke: WHERE on a known column compiles. We cap the read at 500ms
-        // and accept either a clean ack or a timeout — the test is asserting
-        // we got past compile, not that rows actually flow (no upstream
-        // pushes happen here).
+        // SUBSCRIBE never returns CommandComplete, so a successful compile
+        // shows up as a timeout. Anything else — Ok(Ok) or Ok(Err) — is a
+        // regression.
         let (addr, handle) = spawn_server().await;
         let client = connect(addr).await;
 
@@ -965,16 +964,10 @@ mod integration_tests {
         )
         .await;
 
-        // If we got a result, it must not be a compile error. A timeout is
-        // fine — it means the subscribe is open and waiting for rows.
-        if let Ok(Err(e)) = r {
-            let db_err = e.as_db_error().expect("typed PG error");
-            assert!(
-                !db_err.message().contains("did not compile"),
-                "filter must compile cleanly, got: {}",
-                db_err.message()
-            );
-        }
+        assert!(
+            r.is_err(),
+            "subscribe must stay open until timeout, got: {r:?}"
+        );
 
         handle.abort();
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,6 +1,6 @@
-//! Postgres wire endpoint. Wildcard binds are rejected at startup.
-//! Auth: trust by default; MD5 password auth when `[server].pgwire_users`
-//! is non-empty. No TLS yet.
+//! Postgres wire endpoint. Trust auth by default; MD5 password auth when
+//! `[server].pgwire_users` is non-empty. Non-loopback binds require both
+//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). No TLS yet.
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -29,6 +29,7 @@ use tracing::{info, warn};
 use laminar_db::subscription::{PortalFrame, SubscriptionPortal};
 use laminar_db::LaminarDB;
 
+use crate::config::Secret;
 use crate::server::ServerError;
 
 pub struct LaminarPgwireHandler {
@@ -420,33 +421,25 @@ fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
     }
 }
 
-/// `AuthSource` for `Md5PasswordAuthStartupHandler`. Generates a fresh 4-byte
-/// salt per connection, looks up the user's plaintext password from the
-/// configured map, and returns the salted-hash the client is expected to send.
+/// Per-call salt + stored plaintext for the MD5 challenge flow.
 #[derive(Debug)]
 struct LaminarAuthSource {
-    users: Arc<HashMap<String, String>>,
+    users: Arc<HashMap<String, Secret>>,
 }
 
 #[async_trait]
 impl AuthSource for LaminarAuthSource {
     async fn get_password(&self, login: &LoginInfo) -> PgWireResult<Password> {
-        let user = login.user().ok_or_else(|| {
-            PgWireError::UserError(Box::new(ErrorInfo::new(
-                "FATAL".into(),
-                "28P01".into(),
-                "user is required".into(),
-            )))
-        })?;
-        let password = self.users.get(user).ok_or_else(|| {
-            PgWireError::UserError(Box::new(ErrorInfo::new(
-                "FATAL".into(),
-                "28P01".into(),
-                format!("password authentication failed for user '{user}'"),
-            )))
-        })?;
+        let user = login.user().unwrap_or("");
+        // Indistinguishable from a wrong-password failure: both branches must
+        // surface the same wire error so a client can't probe which usernames
+        // are configured. pgwire emits exactly this variant on bad password.
+        let password = self
+            .users
+            .get(user)
+            .ok_or_else(|| PgWireError::InvalidPassword(user.to_string()))?;
         let salt: [u8; 4] = rand::random();
-        let expected = hash_md5_password(user, password, &salt);
+        let expected = hash_md5_password(user, password.expose(), &salt);
         Ok(Password::new(Some(salt.to_vec()), expected.into_bytes()))
     }
 }
@@ -486,7 +479,7 @@ pub struct LaminarHandlerFactory {
 }
 
 impl LaminarHandlerFactory {
-    fn new(db: Arc<LaminarDB>, users: HashMap<String, String>) -> Self {
+    fn new(db: Arc<LaminarDB>, users: HashMap<String, Secret>) -> Self {
         let handler = Arc::new(LaminarPgwireHandler { db });
         let startup = if users.is_empty() {
             Arc::new(StartupAuth::Trust(Arc::clone(&handler)))
@@ -514,27 +507,31 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
     }
 }
 
-#[allow(clippy::result_large_err)]
-fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
-    if addr.ip().is_unspecified() {
-        return Err(ServerError::Http(format!(
-            "pgwire_bind '{addr}' binds to all interfaces and v1 has no auth; \
-             use a specific interface (e.g. 127.0.0.1)"
-        )));
-    }
-    Ok(())
-}
-
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
-    users: HashMap<String, String>,
+    users: HashMap<String, Secret>,
+    allow_remote: bool,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
         .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
-    if users.is_empty() {
-        validate_bind(&addr)?;
+
+    let auth_mode = if users.is_empty() { "trust" } else { "md5" };
+    let is_remote_bind = !addr.ip().is_loopback();
+    match (auth_mode, is_remote_bind, allow_remote) {
+        ("trust", true, _) => {
+            return Err(ServerError::Http(format!(
+                "pgwire_bind '{addr}' is not loopback and pgwire_users is empty (trust auth); \
+             configure pgwire_users + pgwire_allow_remote=true, or bind to 127.0.0.1"
+            )))
+        }
+        ("md5", true, false) => {
+            return Err(ServerError::Http(format!(
+                "pgwire_bind '{addr}' is not loopback; set pgwire_allow_remote=true to opt in"
+            )))
+        }
+        _ => {}
     }
 
     let listener = TcpListener::bind(addr)
@@ -544,9 +541,15 @@ pub async fn serve(
         .local_addr()
         .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
-    let auth_mode = if users.is_empty() { "trust" } else { "md5" };
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
-    info!(addr = %local_addr, auth = auth_mode, "pgwire listening");
+    if auth_mode == "trust" {
+        warn!(
+            addr = %local_addr,
+            "pgwire listening with TRUST auth — any client reaching this address is admin",
+        );
+    } else {
+        info!(addr = %local_addr, auth = auth_mode, "pgwire listening");
+    }
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
@@ -561,9 +564,28 @@ pub async fn serve(
                     match accepted {
                         Ok((sock, peer)) => {
                             let factory_ref = Arc::clone(&factory);
+                            let peer_str = peer.to_string();
+                            tracing::info!(
+                                target: "audit",
+                                event = "pgwire.connection_accepted",
+                                peer = %peer,
+                                auth = auth_mode,
+                            );
                             sessions.spawn(async move {
-                                if let Err(e) = process_socket(sock, None, factory_ref).await {
-                                    warn!(%peer, error = %e, "pgwire connection error");
+                                let result = process_socket(sock, None, factory_ref).await;
+                                let outcome = match &result {
+                                    Ok(()) => "ok",
+                                    Err(e) if e.to_string().contains("28P01") => "auth_failed",
+                                    Err(_) => "error",
+                                };
+                                tracing::info!(
+                                    target: "audit",
+                                    event = "pgwire.connection_closed",
+                                    peer = %peer_str,
+                                    outcome,
+                                );
+                                if let Err(e) = result {
+                                    warn!(peer = %peer_str, error = %e, "pgwire connection error");
                                 }
                             });
                         }
@@ -582,23 +604,6 @@ pub async fn serve(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rejects_wildcard_bind() {
-        assert!(validate_bind(&"0.0.0.0:5433".parse().unwrap()).is_err());
-        assert!(validate_bind(&"[::]:5433".parse().unwrap()).is_err());
-    }
-
-    #[test]
-    fn accepts_localhost_bind() {
-        validate_bind(&"127.0.0.1:5433".parse().unwrap()).unwrap();
-        validate_bind(&"[::1]:5433".parse().unwrap()).unwrap();
-    }
-
-    #[test]
-    fn accepts_specific_interface_bind() {
-        validate_bind(&"192.168.1.10:5433".parse().unwrap()).unwrap();
-    }
 
     fn parse_one(sql: &str) -> StreamingStatement {
         parse_streaming_sql(sql)
@@ -692,6 +697,29 @@ mod tests {
         let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
         assert_eq!(stmts.len(), 3);
     }
+
+    #[tokio::test]
+    async fn serve_rejects_remote_bind_in_trust_mode() {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        let err = serve(db, "0.0.0.0:0", HashMap::new(), false)
+            .await
+            .expect_err("trust + 0.0.0.0 must fail");
+        assert!(err.to_string().contains("trust auth"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn serve_rejects_remote_bind_without_explicit_optin() {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        let mut users = HashMap::new();
+        users.insert("alice".into(), Secret::new("wonderland-key"));
+        let err = serve(db, "0.0.0.0:0", users, false)
+            .await
+            .expect_err("md5 + 0.0.0.0 without allow_remote must fail");
+        assert!(
+            err.to_string().contains("pgwire_allow_remote"),
+            "got: {err}"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -707,8 +735,10 @@ mod integration_tests {
     use laminar_db::LaminarDB;
     use tokio_postgres::{NoTls, SimpleQueryMessage};
 
+    use super::Secret;
+
     async fn spawn_server_with(
-        users: HashMap<String, String>,
+        users: HashMap<String, Secret>,
     ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
@@ -722,7 +752,7 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users)
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false)
             .await
             .expect("pgwire serve");
         (addr, handle)
@@ -876,11 +906,13 @@ mod integration_tests {
         handle.abort();
     }
 
-    async fn md5_users() -> HashMap<String, String> {
+    async fn md5_users() -> HashMap<String, Secret> {
         let mut u = HashMap::new();
-        u.insert("alice".into(), "wonderland".into());
+        u.insert("alice".to_string(), Secret::new(TEST_PASSWORD));
         u
     }
+
+    const TEST_PASSWORD: &str = "wonderland-key";
 
     async fn connect_with_password(
         addr: std::net::SocketAddr,
@@ -903,7 +935,7 @@ mod integration_tests {
     async fn md5_auth_accepts_correct_password() {
         let (addr, handle) = spawn_server_with(md5_users().await).await;
 
-        let client = connect_with_password(addr, "alice", "wonderland")
+        let client = connect_with_password(addr, "alice", TEST_PASSWORD)
             .await
             .expect("auth must succeed");
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -721,6 +721,54 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn subscribe_with_valid_where_is_accepted() {
+        // Smoke: WHERE on a known column compiles. We cap the read at 500ms
+        // and accept either a clean ack or a timeout — the test is asserting
+        // we got past compile, not that rows actually flow (no upstream
+        // pushes happen here).
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let r = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            client.simple_query("SUBSCRIBE prices WHERE symbol = 'AAPL'"),
+        )
+        .await;
+
+        // If we got a result, it must not be a compile error. A timeout is
+        // fine — it means the subscribe is open and waiting for rows.
+        if let Ok(Err(e)) = r {
+            let db_err = e.as_db_error().expect("typed PG error");
+            assert!(
+                !db_err.message().contains("did not compile"),
+                "filter must compile cleanly, got: {}",
+                db_err.message()
+            );
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn subscribe_with_unknown_column_in_where_returns_pg_error() {
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("SUBSCRIBE prices WHERE no_such_col > 1")
+            .await
+            .expect_err("must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("no_such_col"),
+            "filter error must name the bad column, got: {}",
+            db_err.message()
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
     async fn ddl_returns_pg_error_pointing_at_http() {
         let (addr, handle) = spawn_server().await;
         let client = connect(addr).await;

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -324,12 +324,10 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     } => {
                         tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
                     }
-                    // Surface lag as a typed PG error before the stream ends.
-                    // SQLSTATE 57014 = query_canceled — closest standard match
-                    // for "the server stopped serving you on purpose".
+                    // Lag → typed error so the disconnect isn't silent.
                     PortalFrame::Lagged(n) => {
                         let err = user_error(
-                            "57014",
+                            "54000",
                             format!("subscription lagged: skipped {n} messages, terminating"),
                         );
                         return Some((Err(err), (portal, rows, idx, fields)));

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -324,6 +324,16 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     } => {
                         tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
                     }
+                    // Surface lag as a typed PG error before the stream ends.
+                    // SQLSTATE 57014 = query_canceled — closest standard match
+                    // for "the server stopped serving you on purpose".
+                    PortalFrame::Lagged(n) => {
+                        let err = user_error(
+                            "57014",
+                            format!("subscription lagged: skipped {n} messages, terminating"),
+                        );
+                        return Some((Err(err), (portal, rows, idx, fields)));
+                    }
                 }
             }
         },

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -558,10 +558,21 @@ fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
     }
 }
 
+/// Install aws-lc-rs as the process-wide rustls CryptoProvider. Idempotent —
+/// rustls returns `Err` if a provider is already installed, which we ignore.
+/// Required because other crates in the dep tree (delta-lake, iceberg) pull
+/// in rustls with their own provider features, leaving the auto-pick
+/// ambiguous.
+fn ensure_tls_provider() {
+    let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 #[allow(clippy::result_large_err)]
 fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, ServerError> {
     use std::fs::File;
     use std::io::BufReader;
+
+    ensure_tls_provider();
 
     let cert_file = File::open(paths.cert)
         .map_err(|e| ServerError::Http(format!("open pgwire_tls_cert: {e}")))?;
@@ -1121,6 +1132,7 @@ mod integration_tests {
         {
             roots.add(c).unwrap();
         }
+        super::ensure_tls_provider();
         let client_cfg = tokio_rustls::rustls::ClientConfig::builder()
             .with_root_certificates(roots)
             .with_no_client_auth();

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -104,7 +104,10 @@ fn standard_response(db: &LaminarDB, stmt: Statement) -> PgWireResult<Response> 
             "0A000",
             "DDL/DML is not supported on pgwire; use HTTP /api/v1/sql",
         )),
-        other => Err(user_error("0A000", format!("not supported on pgwire: {other}"))),
+        other => Err(user_error(
+            "0A000",
+            format!("not supported on pgwire: {other}"),
+        )),
     }
 }
 
@@ -115,10 +118,7 @@ fn driver_select_response(query: sqlparser::ast::Query) -> PgWireResult<Response
     let SetExpr::Select(select) = *query.body else {
         return Err(unsupported_select());
     };
-    if select.projection.len() != 1
-        || !select.from.is_empty()
-        || select.selection.is_some()
-    {
+    if select.projection.len() != 1 || !select.from.is_empty() || select.selection.is_some() {
         return Err(unsupported_select());
     }
     let SelectItem::UnnamedExpr(expr) = &select.projection[0] else {
@@ -180,7 +180,9 @@ fn unsupported_select() -> PgWireError {
 /// since we don't honor isolation levels.
 fn apply_set(db: &LaminarDB, set: Set) -> PgWireResult<Response> {
     match set {
-        Set::SingleAssignment { variable, values, .. } => {
+        Set::SingleAssignment {
+            variable, values, ..
+        } => {
             let key = variable.to_string();
             let value = values
                 .first()
@@ -226,7 +228,13 @@ async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Res
 
 /// Single-row `text` response with one column.
 fn text_response(col: &str, ty: Type, value: String) -> Response {
-    let schema = Arc::new(vec![FieldInfo::new(col.into(), None, None, ty, FieldFormat::Text)]);
+    let schema = Arc::new(vec![FieldInfo::new(
+        col.into(),
+        None,
+        None,
+        ty,
+        FieldFormat::Text,
+    )]);
     let schema_for_row = Arc::clone(&schema);
     let row_stream = stream::iter(std::iter::once(Ok::<_, PgWireError>(()))).map(move |_| {
         let mut enc = DataRowEncoder::new(Arc::clone(&schema_for_row));
@@ -267,7 +275,12 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
     // so formatters are built once per batch rather than per cell. Then we
     // drain the row vec before reading the next frame.
     let row_stream = stream::unfold(
-        (portal, Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(), 0usize, Arc::clone(&fields)),
+        (
+            portal,
+            Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(),
+            0usize,
+            Arc::clone(&fields),
+        ),
         move |(mut portal, mut rows, mut idx, fields)| async move {
             loop {
                 if idx < rows.len() {
@@ -370,7 +383,9 @@ pub struct LaminarHandlerFactory {
 
 impl LaminarHandlerFactory {
     fn new(db: Arc<LaminarDB>) -> Self {
-        Self { handler: Arc::new(LaminarPgwireHandler { db }) }
+        Self {
+            handler: Arc::new(LaminarPgwireHandler { db }),
+        }
     }
 }
 
@@ -454,7 +469,11 @@ mod tests {
     }
 
     fn parse_one(sql: &str) -> StreamingStatement {
-        parse_streaming_sql(sql).unwrap().into_iter().next().unwrap()
+        parse_streaming_sql(sql)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
     }
 
     fn standard(sql: &str) -> Statement {
@@ -497,18 +516,20 @@ mod tests {
     #[tokio::test]
     async fn ddl_routed_to_http() {
         let db = LaminarDB::open().unwrap();
-        let err = standard_response(
-            &db,
-            standard("CREATE TABLE foo (id INT)"),
-        )
-        .unwrap_err();
+        let err = standard_response(&db, standard("CREATE TABLE foo (id INT)")).unwrap_err();
         assert!(err.to_string().contains("HTTP /api/v1/sql"));
     }
 
     #[tokio::test]
     async fn transaction_control_dispatches() {
         let db = LaminarDB::open().unwrap();
-        for sql in ["BEGIN", "BEGIN TRANSACTION", "START TRANSACTION", "COMMIT", "ROLLBACK"] {
+        for sql in [
+            "BEGIN",
+            "BEGIN TRANSACTION",
+            "START TRANSACTION",
+            "COMMIT",
+            "ROLLBACK",
+        ] {
             standard_response(&db, standard(sql)).unwrap();
         }
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,0 +1,542 @@
+//! Postgres wire endpoint. Anonymous TRUST auth, no TLS — wildcard binds
+//! are rejected at startup.
+
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{stream, Sink, StreamExt};
+use laminar_sql::parser::{parse_streaming_sql, StreamingStatement};
+use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::store::PortalStore;
+use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
+use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use pgwire::tokio::process_socket;
+use sqlparser::ast::{Expr, FunctionArguments, SelectItem, Set, SetExpr, Statement};
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+
+use laminar_db::subscription::{PortalFrame, SubscriptionPortal};
+use laminar_db::LaminarDB;
+
+use crate::server::ServerError;
+
+pub struct LaminarPgwireHandler {
+    db: Arc<LaminarDB>,
+}
+
+#[async_trait]
+impl NoopStartupHandler for LaminarPgwireHandler {
+    async fn post_startup<C>(
+        &self,
+        client: &mut C,
+        _message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        info!(peer = %client.socket_addr(), "pgwire client connected");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SimpleQueryHandler for LaminarPgwireHandler {
+    async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+    where
+        C: ClientInfo + ClientPortalStore + Unpin + Send + Sync,
+        C::PortalStore: PortalStore,
+    {
+        if query.trim().is_empty() {
+            return Ok(vec![Response::EmptyQuery]);
+        }
+        let stmts = parse_streaming_sql(query)
+            .map_err(|e| user_error("42601", format!("parse error: {e}")))?;
+
+        let mut out = Vec::with_capacity(stmts.len());
+        for stmt in stmts {
+            out.push(match stmt {
+                StreamingStatement::Subscribe(s) => {
+                    let name = s.name.to_string();
+                    let portal = self
+                        .db
+                        .open_subscription(&name, s.filter_sql.as_deref())
+                        .await
+                        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+                    portal_to_response(portal)
+                }
+                StreamingStatement::Show(_) => engine_metadata_response(&self.db, query).await?,
+                StreamingStatement::Standard(s) => standard_response(&self.db, *s)?,
+                other => {
+                    return Err(user_error(
+                        "0A000",
+                        format!("not supported on pgwire (use HTTP /api/v1/sql): {other:?}"),
+                    ));
+                }
+            });
+        }
+        Ok(out)
+    }
+}
+
+/// Connection-setup statements: transaction control, `SET`, and a tiny set
+/// of catalog probes drivers send during handshake. Anything DDL/DML hits
+/// the "use HTTP" error.
+fn standard_response(db: &LaminarDB, stmt: Statement) -> PgWireResult<Response> {
+    match stmt {
+        Statement::StartTransaction { .. } => Ok(Response::Execution(Tag::new("BEGIN"))),
+        Statement::Commit { .. } => Ok(Response::Execution(Tag::new("COMMIT"))),
+        Statement::Rollback { .. } => Ok(Response::Execution(Tag::new("ROLLBACK"))),
+        Statement::Set(s) => apply_set(db, s),
+        Statement::Query(q) => driver_select_response(*q),
+        Statement::Insert { .. }
+        | Statement::Update { .. }
+        | Statement::Delete { .. }
+        | Statement::CreateTable { .. }
+        | Statement::CreateView { .. }
+        | Statement::Drop { .. } => Err(user_error(
+            "0A000",
+            "DDL/DML is not supported on pgwire; use HTTP /api/v1/sql",
+        )),
+        other => Err(user_error("0A000", format!("not supported on pgwire: {other}"))),
+    }
+}
+
+/// Handle the `SELECT`s drivers issue at connect time. Single literal,
+/// `SELECT version()`, and `SELECT current_schema()` are answered inline.
+/// Anything else is rejected — real queries belong on `/api/v1/sql`.
+fn driver_select_response(query: sqlparser::ast::Query) -> PgWireResult<Response> {
+    let SetExpr::Select(select) = *query.body else {
+        return Err(unsupported_select());
+    };
+    if select.projection.len() != 1
+        || !select.from.is_empty()
+        || select.selection.is_some()
+    {
+        return Err(unsupported_select());
+    }
+    let SelectItem::UnnamedExpr(expr) = &select.projection[0] else {
+        return Err(unsupported_select());
+    };
+
+    match expr {
+        Expr::Value(v) => match &v.value {
+            sqlparser::ast::Value::Number(n, _) => {
+                let parsed: i32 = n.parse().map_err(|_| unsupported_select())?;
+                Ok(text_response("?column?", Type::INT4, parsed.to_string()))
+            }
+            sqlparser::ast::Value::SingleQuotedString(s) => {
+                Ok(text_response("?column?", Type::VARCHAR, s.clone()))
+            }
+            _ => Err(unsupported_select()),
+        },
+        Expr::Function(func) => {
+            // Only no-arg builtins. `func.args` is `FunctionArguments::None`
+            // for `func()`, the only shape we accept.
+            if !matches!(func.args, FunctionArguments::List(ref a) if a.args.is_empty())
+                && !matches!(func.args, FunctionArguments::None)
+            {
+                return Err(unsupported_select());
+            }
+            let name = func.name.to_string().to_ascii_lowercase();
+            let (col, ty, value) = match name.as_str() {
+                "version" | "pg_catalog.version" => (
+                    "version",
+                    Type::VARCHAR,
+                    format!("LaminarDB {} on pgwire", env!("CARGO_PKG_VERSION")),
+                ),
+                "current_schema" | "pg_catalog.current_schema" => {
+                    ("current_schema", Type::VARCHAR, "public".to_string())
+                }
+                "current_database" | "pg_catalog.current_database" => {
+                    ("current_database", Type::VARCHAR, "laminar".to_string())
+                }
+                "current_user" | "session_user" | "user" => {
+                    ("current_user", Type::VARCHAR, "laminar".to_string())
+                }
+                _ => return Err(unsupported_select()),
+            };
+            Ok(text_response(col, ty, value))
+        }
+        _ => Err(unsupported_select()),
+    }
+}
+
+fn unsupported_select() -> PgWireError {
+    user_error(
+        "0A000",
+        "pgwire SELECT is limited to literals and connect-time builtins; use HTTP /api/v1/sql",
+    )
+}
+
+/// `SET` handling. We thread plain `SET name = value` to the engine's
+/// session-property store, and refuse `SET TRANSACTION`-class statements
+/// since we don't honor isolation levels.
+fn apply_set(db: &LaminarDB, set: Set) -> PgWireResult<Response> {
+    match set {
+        Set::SingleAssignment { variable, values, .. } => {
+            let key = variable.to_string();
+            let value = values
+                .first()
+                .map(ToString::to_string)
+                .unwrap_or_default()
+                .trim_matches('\'')
+                .to_string();
+            db.set_session_property(&key, &value);
+            Ok(Response::Execution(Tag::new("SET")))
+        }
+        // Refuse anything that implies semantics we do not provide.
+        Set::SetTransaction { .. } => Err(user_error(
+            "0A000",
+            "SET TRANSACTION is not supported (no transactional semantics)",
+        )),
+        // Lenient pass-through for the harmless catalog-style SETs drivers
+        // issue (NAMES, TIME ZONE, ROLE...). We don't honor them, but failing
+        // the connection is worse than silently accepting.
+        _ => Ok(Response::Execution(Tag::new("SET"))),
+    }
+}
+
+fn user_error(code: &str, msg: impl Into<String>) -> PgWireError {
+    PgWireError::UserError(Box::new(ErrorInfo::new(
+        "ERROR".into(),
+        code.into(),
+        msg.into(),
+    )))
+}
+
+/// Run a SHOW through the engine and stream its `RecordBatch` to the wire.
+async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Response> {
+    use laminar_db::ExecuteResult;
+    let result = db
+        .execute(sql)
+        .await
+        .map_err(|e| user_error("XX000", e.to_string()))?;
+    let ExecuteResult::Metadata(batch) = result else {
+        return Err(user_error("XX000", "SHOW did not return metadata"));
+    };
+    Ok(record_batch_response(batch))
+}
+
+/// Single-row `text` response with one column.
+fn text_response(col: &str, ty: Type, value: String) -> Response {
+    let schema = Arc::new(vec![FieldInfo::new(col.into(), None, None, ty, FieldFormat::Text)]);
+    let schema_for_row = Arc::clone(&schema);
+    let row_stream = stream::iter(std::iter::once(Ok::<_, PgWireError>(()))).map(move |_| {
+        let mut enc = DataRowEncoder::new(Arc::clone(&schema_for_row));
+        enc.encode_field(&Some(value.as_str()))?;
+        Ok(enc.take_row())
+    });
+    Response::Query(QueryResponse::new(schema, row_stream))
+}
+
+fn record_batch_response(batch: arrow_array::RecordBatch) -> Response {
+    let fields = Arc::new(field_infos(&batch.schema()));
+    let nrows = batch.num_rows();
+
+    // Encode rows eagerly: SHOW outputs are tiny and this avoids the
+    // !Send formatter dance.
+    let mut rows = Vec::with_capacity(nrows);
+    {
+        let opts = arrow_cast::display::FormatOptions::default();
+        let formatters: Vec<_> = batch
+            .columns()
+            .iter()
+            .map(|c| arrow_cast::display::ArrayFormatter::try_new(c.as_ref(), &opts))
+            .collect::<Result<_, _>>()
+            .unwrap_or_default();
+        for row in 0..nrows {
+            rows.push(encode_row(&batch, row, &fields, &formatters));
+        }
+    }
+
+    let row_stream = stream::iter(rows);
+    Response::Query(QueryResponse::new(fields, row_stream))
+}
+
+fn portal_to_response(portal: SubscriptionPortal) -> Response {
+    let fields = Arc::new(field_infos(&portal.schema()));
+
+    // Each batch is converted to a Vec<DataRow> in one shot when received,
+    // so formatters are built once per batch rather than per cell. Then we
+    // drain the row vec before reading the next frame.
+    let row_stream = stream::unfold(
+        (portal, Vec::<PgWireResult<pgwire::messages::data::DataRow>>::new(), 0usize, Arc::clone(&fields)),
+        move |(mut portal, mut rows, mut idx, fields)| async move {
+            loop {
+                if idx < rows.len() {
+                    let row = std::mem::replace(&mut rows[idx], Ok(empty_row(&fields)));
+                    idx += 1;
+                    return Some((row, (portal, rows, idx, fields)));
+                }
+                rows.clear();
+                idx = 0;
+                match portal.next_frame().await? {
+                    PortalFrame::Batch(b) if b.num_rows() > 0 => {
+                        rows = encode_batch(&b, &fields);
+                    }
+                    PortalFrame::Batch(_) | PortalFrame::Barrier { .. } => {}
+                }
+            }
+        },
+    );
+    Response::Query(QueryResponse::new(fields, row_stream))
+}
+
+fn empty_row(fields: &Arc<Vec<FieldInfo>>) -> pgwire::messages::data::DataRow {
+    DataRowEncoder::new(Arc::clone(fields)).take_row()
+}
+
+fn encode_batch(
+    batch: &arrow_array::RecordBatch,
+    fields: &Arc<Vec<FieldInfo>>,
+) -> Vec<PgWireResult<pgwire::messages::data::DataRow>> {
+    let opts = arrow_cast::display::FormatOptions::default();
+    let formatters: Vec<_> = match batch
+        .columns()
+        .iter()
+        .map(|c| arrow_cast::display::ArrayFormatter::try_new(c.as_ref(), &opts))
+        .collect::<Result<_, _>>()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            return vec![Err(user_error("XX000", format!("format column: {e}")))];
+        }
+    };
+    (0..batch.num_rows())
+        .map(|row| encode_row(batch, row, fields, &formatters))
+        .collect()
+}
+
+fn field_infos(schema: &arrow_schema::Schema) -> Vec<FieldInfo> {
+    schema
+        .fields()
+        .iter()
+        .map(|f| {
+            FieldInfo::new(
+                f.name().clone(),
+                None,
+                None,
+                arrow_to_pg_type(f.data_type()),
+                FieldFormat::Text,
+            )
+        })
+        .collect()
+}
+
+fn encode_row(
+    batch: &arrow_array::RecordBatch,
+    row: usize,
+    fields: &Arc<Vec<FieldInfo>>,
+    formatters: &[arrow_cast::display::ArrayFormatter<'_>],
+) -> PgWireResult<pgwire::messages::data::DataRow> {
+    use arrow_array::Array;
+    let mut enc = DataRowEncoder::new(Arc::clone(fields));
+    for (i, col) in batch.columns().iter().enumerate() {
+        if col.is_null(row) {
+            enc.encode_field(&None::<&str>)?;
+        } else {
+            enc.encode_field(&Some(formatters[i].value(row).to_string()))?;
+        }
+    }
+    Ok(enc.take_row())
+}
+
+fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
+    use arrow_schema::DataType;
+    match dt {
+        DataType::Int8 | DataType::Int16 | DataType::Int32 => Type::INT4,
+        DataType::Int64 | DataType::UInt32 | DataType::UInt64 => Type::INT8,
+        DataType::UInt8 | DataType::UInt16 => Type::INT4,
+        DataType::Float32 | DataType::Float64 => Type::FLOAT8,
+        DataType::Utf8 | DataType::LargeUtf8 => Type::VARCHAR,
+        DataType::Boolean => Type::BOOL,
+        DataType::Timestamp(_, _) => Type::TIMESTAMP,
+        DataType::Date32 | DataType::Date64 => Type::DATE,
+        DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => Type::NUMERIC,
+        _ => Type::TEXT,
+    }
+}
+
+pub struct LaminarHandlerFactory {
+    handler: Arc<LaminarPgwireHandler>,
+}
+
+impl LaminarHandlerFactory {
+    fn new(db: Arc<LaminarDB>) -> Self {
+        Self { handler: Arc::new(LaminarPgwireHandler { db }) }
+    }
+}
+
+impl PgWireServerHandlers for LaminarHandlerFactory {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
+        Arc::clone(&self.handler)
+    }
+
+    fn startup_handler(&self) -> Arc<impl pgwire::api::auth::StartupHandler> {
+        Arc::clone(&self.handler)
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
+    if addr.ip().is_unspecified() {
+        return Err(ServerError::Http(format!(
+            "pgwire_bind '{addr}' binds to all interfaces and v1 has no auth; \
+             use a specific interface (e.g. 127.0.0.1)"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn serve(
+    db: Arc<LaminarDB>,
+    bind: &str,
+) -> Result<tokio::task::JoinHandle<()>, ServerError> {
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
+    validate_bind(&addr)?;
+
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| ServerError::Http(format!("pgwire bind {addr}: {e}")))?;
+
+    let factory = Arc::new(LaminarHandlerFactory::new(db));
+    info!(%addr, "pgwire listening");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((sock, peer)) => {
+                    let factory_ref = Arc::clone(&factory);
+                    tokio::spawn(async move {
+                        if let Err(e) = process_socket(sock, None, factory_ref).await {
+                            warn!(%peer, error = %e, "pgwire connection error");
+                        }
+                    });
+                }
+                Err(e) => {
+                    warn!(error = %e, "pgwire accept failed");
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
+    });
+    Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_wildcard_bind() {
+        assert!(validate_bind(&"0.0.0.0:5433".parse().unwrap()).is_err());
+        assert!(validate_bind(&"[::]:5433".parse().unwrap()).is_err());
+    }
+
+    #[test]
+    fn accepts_localhost_bind() {
+        validate_bind(&"127.0.0.1:5433".parse().unwrap()).unwrap();
+        validate_bind(&"[::1]:5433".parse().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn accepts_specific_interface_bind() {
+        validate_bind(&"192.168.1.10:5433".parse().unwrap()).unwrap();
+    }
+
+    fn parse_one(sql: &str) -> StreamingStatement {
+        parse_streaming_sql(sql).unwrap().into_iter().next().unwrap()
+    }
+
+    fn standard(sql: &str) -> Statement {
+        match parse_one(sql) {
+            StreamingStatement::Standard(s) => *s,
+            other => panic!("expected Standard, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn select_one_dispatches() {
+        let db = LaminarDB::open().unwrap();
+        for sql in ["SELECT 1", "select 1", "/* hint */ SELECT 1"] {
+            standard_response(&db, standard(sql)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_select_builtins_dispatch() {
+        let db = LaminarDB::open().unwrap();
+        for sql in [
+            "SELECT version()",
+            "SELECT current_schema()",
+            "SELECT current_database()",
+            "SELECT current_user",
+        ] {
+            // current_user parses as Expr::Function with no parens in some versions;
+            // we accept whatever the parser gives us.
+            let _ = standard_response(&db, standard(sql));
+        }
+    }
+
+    #[tokio::test]
+    async fn select_with_from_is_rejected() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(&db, standard("SELECT 1 FROM foo")).unwrap_err();
+        assert!(err.to_string().contains("limited to literals"));
+    }
+
+    #[tokio::test]
+    async fn ddl_routed_to_http() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(
+            &db,
+            standard("CREATE TABLE foo (id INT)"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("HTTP /api/v1/sql"));
+    }
+
+    #[tokio::test]
+    async fn transaction_control_dispatches() {
+        let db = LaminarDB::open().unwrap();
+        for sql in ["BEGIN", "BEGIN TRANSACTION", "START TRANSACTION", "COMMIT", "ROLLBACK"] {
+            standard_response(&db, standard(sql)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn set_writes_to_session_properties() {
+        let db = LaminarDB::open().unwrap();
+        standard_response(&db, standard("SET extra_float_digits = 3")).unwrap();
+        assert_eq!(
+            db.get_session_property("extra_float_digits").as_deref(),
+            Some("3"),
+        );
+    }
+
+    #[tokio::test]
+    async fn set_transaction_isolation_is_rejected() {
+        let db = LaminarDB::open().unwrap();
+        let err = standard_response(
+            &db,
+            standard("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("SET TRANSACTION"));
+    }
+
+    #[test]
+    fn multi_statement_parses() {
+        let stmts = parse_streaming_sql("BEGIN; SELECT 1; COMMIT").unwrap();
+        assert_eq!(stmts.len(), 3);
+    }
+}

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,6 +1,8 @@
-//! Postgres wire endpoint. Anonymous TRUST auth, no TLS — wildcard binds
-//! are rejected at startup.
+//! Postgres wire endpoint. Wildcard binds are rejected at startup.
+//! Auth: trust by default; MD5 password auth when `[server].pgwire_users`
+//! is non-empty. No TLS yet.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -8,7 +10,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::{stream, Sink, StreamExt};
 use laminar_sql::parser::{parse_streaming_sql, ShowCommand, StreamingStatement};
+use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
 use pgwire::api::auth::noop::NoopStartupHandler;
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
 use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
 use pgwire::api::store::PortalStore;
@@ -414,15 +420,87 @@ fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
     }
 }
 
+/// `AuthSource` for `Md5PasswordAuthStartupHandler`. Generates a fresh 4-byte
+/// salt per connection, looks up the user's plaintext password from the
+/// configured map, and returns the salted-hash the client is expected to send.
+#[derive(Debug)]
+struct LaminarAuthSource {
+    users: Arc<HashMap<String, String>>,
+}
+
+#[async_trait]
+impl AuthSource for LaminarAuthSource {
+    async fn get_password(&self, login: &LoginInfo) -> PgWireResult<Password> {
+        let user = login.user().ok_or_else(|| {
+            PgWireError::UserError(Box::new(ErrorInfo::new(
+                "FATAL".into(),
+                "28P01".into(),
+                "user is required".into(),
+            )))
+        })?;
+        let password = self.users.get(user).ok_or_else(|| {
+            PgWireError::UserError(Box::new(ErrorInfo::new(
+                "FATAL".into(),
+                "28P01".into(),
+                format!("password authentication failed for user '{user}'"),
+            )))
+        })?;
+        let salt: [u8; 4] = rand::random();
+        let expected = hash_md5_password(user, password, &salt);
+        Ok(Password::new(Some(salt.to_vec()), expected.into_bytes()))
+    }
+}
+
+type Md5Handler = Md5PasswordAuthStartupHandler<LaminarAuthSource, DefaultServerParameterProvider>;
+
+/// Startup-phase dispatch. `Md5` requires password auth; `Trust` accepts any
+/// connection. Selected once at listener startup based on whether
+/// `pgwire_users` is non-empty.
+enum StartupAuth {
+    Trust(Arc<LaminarPgwireHandler>),
+    Md5(Arc<Md5Handler>),
+}
+
+#[async_trait]
+impl StartupHandler for StartupAuth {
+    async fn on_startup<C>(
+        &self,
+        client: &mut C,
+        message: PgWireFrontendMessage,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        match self {
+            Self::Trust(h) => h.on_startup(client, message).await,
+            Self::Md5(h) => h.on_startup(client, message).await,
+        }
+    }
+}
+
 pub struct LaminarHandlerFactory {
     handler: Arc<LaminarPgwireHandler>,
+    startup: Arc<StartupAuth>,
 }
 
 impl LaminarHandlerFactory {
-    fn new(db: Arc<LaminarDB>) -> Self {
-        Self {
-            handler: Arc::new(LaminarPgwireHandler { db }),
-        }
+    fn new(db: Arc<LaminarDB>, users: HashMap<String, String>) -> Self {
+        let handler = Arc::new(LaminarPgwireHandler { db });
+        let startup = if users.is_empty() {
+            Arc::new(StartupAuth::Trust(Arc::clone(&handler)))
+        } else {
+            let auth = LaminarAuthSource {
+                users: Arc::new(users),
+            };
+            let md5 = Md5PasswordAuthStartupHandler::new(
+                Arc::new(auth),
+                Arc::new(DefaultServerParameterProvider::default()),
+            );
+            Arc::new(StartupAuth::Md5(Arc::new(md5)))
+        };
+        Self { handler, startup }
     }
 }
 
@@ -431,8 +509,8 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
         Arc::clone(&self.handler)
     }
 
-    fn startup_handler(&self) -> Arc<impl pgwire::api::auth::StartupHandler> {
-        Arc::clone(&self.handler)
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
+        Arc::clone(&self.startup)
     }
 }
 
@@ -450,11 +528,14 @@ fn validate_bind(addr: &SocketAddr) -> Result<(), ServerError> {
 pub async fn serve(
     db: Arc<LaminarDB>,
     bind: &str,
+    users: HashMap<String, String>,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
         .map_err(|e| ServerError::Http(format!("invalid pgwire_bind '{bind}': {e}")))?;
-    validate_bind(&addr)?;
+    if users.is_empty() {
+        validate_bind(&addr)?;
+    }
 
     let listener = TcpListener::bind(addr)
         .await
@@ -463,8 +544,9 @@ pub async fn serve(
         .local_addr()
         .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
-    let factory = Arc::new(LaminarHandlerFactory::new(db));
-    info!(addr = %local_addr, "pgwire listening");
+    let auth_mode = if users.is_empty() { "trust" } else { "md5" };
+    let factory = Arc::new(LaminarHandlerFactory::new(db, users));
+    info!(addr = %local_addr, auth = auth_mode, "pgwire listening");
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
@@ -619,12 +701,15 @@ mod integration_tests {
     //! dispatch, error reporting — that unit tests can't reach. Engine-level
     //! row flow is covered in `laminar-db`'s `db::tests`.
 
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use laminar_db::LaminarDB;
     use tokio_postgres::{NoTls, SimpleQueryMessage};
 
-    async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    async fn spawn_server_with(
+        users: HashMap<String, String>,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
             .await
@@ -637,10 +722,14 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0")
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users)
             .await
             .expect("pgwire serve");
         (addr, handle)
+    }
+
+    async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        spawn_server_with(HashMap::new()).await
     }
 
     async fn connect(addr: std::net::SocketAddr) -> tokio_postgres::Client {
@@ -783,6 +872,75 @@ mod integration_tests {
             "message: {}",
             db_err.message()
         );
+
+        handle.abort();
+    }
+
+    async fn md5_users() -> HashMap<String, String> {
+        let mut u = HashMap::new();
+        u.insert("alice".into(), "wonderland".into());
+        u
+    }
+
+    async fn connect_with_password(
+        addr: std::net::SocketAddr,
+        user: &str,
+        password: &str,
+    ) -> Result<tokio_postgres::Client, tokio_postgres::Error> {
+        let conn_str = format!(
+            "host={} port={} user={user} password={password} dbname=laminardb",
+            addr.ip(),
+            addr.port()
+        );
+        let (client, conn) = tokio_postgres::connect(&conn_str, NoTls).await?;
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+        Ok(client)
+    }
+
+    #[tokio::test]
+    async fn md5_auth_accepts_correct_password() {
+        let (addr, handle) = spawn_server_with(md5_users().await).await;
+
+        let client = connect_with_password(addr, "alice", "wonderland")
+            .await
+            .expect("auth must succeed");
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("query after auth");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn md5_auth_rejects_wrong_password() {
+        let (addr, handle) = spawn_server_with(md5_users().await).await;
+
+        let err = connect_with_password(addr, "alice", "not-the-password")
+            .await
+            .expect_err("auth must fail");
+
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn md5_auth_rejects_unknown_user() {
+        let (addr, handle) = spawn_server_with(md5_users().await).await;
+
+        let err = connect_with_password(addr, "mallory", "anything")
+            .await
+            .expect_err("auth must fail");
+
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
 
         handle.abort();
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, Sink, StreamExt};
-use laminar_sql::parser::{parse_streaming_sql, StreamingStatement};
+use laminar_sql::parser::{parse_streaming_sql, ShowCommand, StreamingStatement};
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::query::SimpleQueryHandler;
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
@@ -71,7 +71,9 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
                         .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
                     portal_to_response(portal)
                 }
-                StreamingStatement::Show(_) => engine_metadata_response(&self.db, query).await?,
+                StreamingStatement::Show(cmd) => {
+                    engine_metadata_response(&self.db, &show_sql(&cmd)).await?
+                }
                 StreamingStatement::Standard(s) => standard_response(&self.db, *s)?,
                 other => {
                     return Err(user_error(
@@ -213,6 +215,23 @@ fn user_error(code: &str, msg: impl Into<String>) -> PgWireError {
     )))
 }
 
+/// Reconstruct a single SHOW statement from the parsed variant. Used by the
+/// pgwire dispatcher so a multi-statement query (`SHOW SOURCES; SHOW SINKS`)
+/// re-executes only the matching statement, not the whole input string.
+fn show_sql(cmd: &ShowCommand) -> String {
+    match cmd {
+        ShowCommand::Sources => "SHOW SOURCES".into(),
+        ShowCommand::Sinks => "SHOW SINKS".into(),
+        ShowCommand::Queries => "SHOW QUERIES".into(),
+        ShowCommand::MaterializedViews => "SHOW MATERIALIZED VIEWS".into(),
+        ShowCommand::Streams => "SHOW STREAMS".into(),
+        ShowCommand::Tables => "SHOW TABLES".into(),
+        ShowCommand::CheckpointStatus => "SHOW CHECKPOINT STATUS".into(),
+        ShowCommand::CreateSource { name } => format!("SHOW CREATE SOURCE {name}"),
+        ShowCommand::CreateSink { name } => format!("SHOW CREATE SINK {name}"),
+    }
+}
+
 /// Run a SHOW through the engine and stream its `RecordBatch` to the wire.
 async fn engine_metadata_response(db: &LaminarDB, sql: &str) -> PgWireResult<Response> {
     use laminar_db::ExecuteResult;
@@ -294,7 +313,17 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                     PortalFrame::Batch(b) if b.num_rows() > 0 => {
                         rows = encode_batch(&b, &fields);
                     }
-                    PortalFrame::Batch(_) | PortalFrame::Barrier { .. } => {}
+                    PortalFrame::Batch(_) => {}
+                    // Barriers are dropped on the SimpleQuery path. PG's
+                    // simple-query protocol has no out-of-band channel for
+                    // checkpoint markers; cursor support (follow-up) will
+                    // surface them via NoticeResponse.
+                    PortalFrame::Barrier {
+                        epoch,
+                        checkpoint_id,
+                    } => {
+                        tracing::trace!(epoch, checkpoint_id, "pgwire SUBSCRIBE: dropping barrier")
+                    }
                 }
             }
         },
@@ -426,20 +455,30 @@ pub async fn serve(
     let factory = Arc::new(LaminarHandlerFactory::new(db));
     info!(%addr, "pgwire listening");
 
+    // Track per-connection tasks so abort on the outer JoinHandle stops
+    // active sessions in addition to the accept loop.
     let handle = tokio::spawn(async move {
+        let mut sessions: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
         loop {
-            match listener.accept().await {
-                Ok((sock, peer)) => {
-                    let factory_ref = Arc::clone(&factory);
-                    tokio::spawn(async move {
-                        if let Err(e) = process_socket(sock, None, factory_ref).await {
-                            warn!(%peer, error = %e, "pgwire connection error");
-                        }
-                    });
+            tokio::select! {
+                Some(_) = sessions.join_next(), if !sessions.is_empty() => {
+                    // Reap completed sessions; nothing to do with the result.
                 }
-                Err(e) => {
-                    warn!(error = %e, "pgwire accept failed");
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                accepted = listener.accept() => {
+                    match accepted {
+                        Ok((sock, peer)) => {
+                            let factory_ref = Arc::clone(&factory);
+                            sessions.spawn(async move {
+                                if let Err(e) = process_socket(sock, None, factory_ref).await {
+                                    warn!(%peer, error = %e, "pgwire connection error");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "pgwire accept failed");
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                    }
                 }
             }
         }

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -186,7 +186,19 @@ pub async fn run_server(
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        Some(crate::pgwire::serve(Arc::clone(&db), &bind).await?)
+        match crate::pgwire::serve(Arc::clone(&db), &bind).await {
+            Ok(h) => Some(h),
+            Err(e) => {
+                // Roll back: stop the HTTP server, the file watcher, and the
+                // pipeline before propagating the bind failure.
+                if let Some(wh) = &watcher_handle {
+                    wh.abort();
+                }
+                api_handle.abort();
+                let _ = db.shutdown().await;
+                return Err(e);
+            }
+        }
     } else {
         None
     };

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -181,12 +181,13 @@ pub async fn run_server(
     info!("Pipeline started");
 
     let pgwire_bind = config.server.pgwire_bind.clone();
+    let pgwire_users = config.server.pgwire_users.clone();
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        match crate::pgwire::serve(Arc::clone(&db), &bind).await {
+        match crate::pgwire::serve(Arc::clone(&db), &bind, pgwire_users).await {
             Ok((_, h)) => Some(h),
             Err(e) => {
                 // Roll back: stop the HTTP server, the file watcher, and the

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -182,12 +182,14 @@ pub async fn run_server(
 
     let pgwire_bind = config.server.pgwire_bind.clone();
     let pgwire_users = config.server.pgwire_users.clone();
+    let pgwire_allow_remote = config.server.pgwire_allow_remote;
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        match crate::pgwire::serve(Arc::clone(&db), &bind, pgwire_users).await {
+        match crate::pgwire::serve(Arc::clone(&db), &bind, pgwire_users, pgwire_allow_remote).await
+        {
             Ok((_, h)) => Some(h),
             Err(e) => {
                 // Roll back: stop the HTTP server, the file watcher, and the

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -187,7 +187,7 @@ pub async fn run_server(
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
         match crate::pgwire::serve(Arc::clone(&db), &bind).await {
-            Ok(h) => Some(h),
+            Ok((_, h)) => Some(h),
             Err(e) => {
                 // Roll back: stop the HTTP server, the file watcher, and the
                 // pipeline before propagating the bind failure.

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -25,6 +25,7 @@ pub enum ServerHandle {
     Embedded {
         db: Arc<LaminarDB>,
         api_handle: tokio::task::JoinHandle<()>,
+        pgwire_handle: Option<tokio::task::JoinHandle<()>>,
         watcher_handle: Option<tokio::task::JoinHandle<()>>,
     },
     #[cfg(feature = "cluster-unstable")]
@@ -38,6 +39,7 @@ impl ServerHandle {
             Self::Embedded {
                 db,
                 api_handle,
+                pgwire_handle,
                 watcher_handle,
             } => {
                 wait_for_termination_signal().await?;
@@ -46,6 +48,9 @@ impl ServerHandle {
 
                 if let Some(wh) = &watcher_handle {
                     wh.abort();
+                }
+                if let Some(pg) = &pgwire_handle {
+                    pg.abort();
                 }
                 db.shutdown()
                     .await
@@ -175,13 +180,21 @@ pub async fn run_server(
         .map_err(|e| ServerError::Start(e.to_string()))?;
     info!("Pipeline started");
 
+    let pgwire_bind = config.server.pgwire_bind.clone();
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
+    let pgwire_handle = if let Some(bind) = pgwire_bind {
+        Some(crate::pgwire::serve(Arc::clone(&db), &bind).await?)
+    } else {
+        None
+    };
+
     Ok(ServerHandle::Embedded {
         db,
         api_handle,
+        pgwire_handle,
         watcher_handle,
     })
 }

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -183,12 +183,25 @@ pub async fn run_server(
     let pgwire_bind = config.server.pgwire_bind.clone();
     let pgwire_users = config.server.pgwire_users.clone();
     let pgwire_allow_remote = config.server.pgwire_allow_remote;
+    let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
+    let pgwire_tls_key = config.server.pgwire_tls_key.clone();
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
-        match crate::pgwire::serve(Arc::clone(&db), &bind, pgwire_users, pgwire_allow_remote).await
+        let tls = match (&pgwire_tls_cert, &pgwire_tls_key) {
+            (Some(c), Some(k)) => Some(crate::pgwire::TlsPaths { cert: c, key: k }),
+            _ => None,
+        };
+        match crate::pgwire::serve(
+            Arc::clone(&db),
+            &bind,
+            pgwire_users,
+            pgwire_allow_remote,
+            tls,
+        )
+        .await
         {
             Ok((_, h)) => Some(h),
             Err(e) => {

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -17,14 +17,15 @@ pub mod order_analyzer;
 mod sink_parser;
 mod source_parser;
 mod statements;
+mod subscribe_parser;
 mod tokenizer;
 mod window_rewriter;
 
 pub use lookup_table::CreateLookupTableStatement;
 pub use statements::{
     AlterSourceOperation, CreateSinkStatement, CreateSourceStatement, EmitClause, EmitStrategy,
-    FormatSpec, LateDataClause, ShowCommand, SinkFrom, StreamingStatement, WatermarkDef,
-    WindowFunction,
+    FormatSpec, LateDataClause, ShowCommand, SinkFrom, StreamingStatement, SubscribeStatement,
+    WatermarkDef, WindowFunction,
 };
 pub use window_rewriter::WindowRewriter;
 
@@ -211,6 +212,13 @@ impl StreamingParser {
                 Ok(vec![stmt])
             }
             StreamingDdlKind::Checkpoint => Ok(vec![StreamingStatement::Checkpoint]),
+            StreamingDdlKind::Subscribe => {
+                let mut parser =
+                    sqlparser::parser::Parser::new(&dialect).with_tokens_with_locations(tokens);
+                let stmt = subscribe_parser::parse_subscribe(&mut parser)
+                    .map_err(parse_error_to_parser_error)?;
+                Ok(vec![StreamingStatement::Subscribe(Box::new(stmt))])
+            }
             StreamingDdlKind::RestoreCheckpoint => {
                 let mut parser =
                     sqlparser::parser::Parser::new(&dialect).with_tokens_with_locations(tokens);

--- a/crates/laminar-sql/src/parser/statements.rs
+++ b/crates/laminar-sql/src/parser/statements.rs
@@ -191,6 +191,20 @@ pub enum StreamingStatement {
         /// The checkpoint ID to restore from
         checkpoint_id: u64,
     },
+
+    /// `SUBSCRIBE <name> [WHERE ...] [WITH (...)]`.
+    Subscribe(Box<SubscribeStatement>),
+}
+
+/// `SUBSCRIBE <name> [WHERE <fragment>] [WITH (...)]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubscribeStatement {
+    /// Target stream or materialized view name.
+    pub name: ObjectName,
+    /// Raw WHERE fragment, compiled by the engine against the target schema.
+    pub filter_sql: Option<String>,
+    /// Reserved for future WITH options.
+    pub options: HashMap<String, String>,
 }
 
 /// Operations for ALTER SOURCE statements.

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -1,0 +1,117 @@
+//! `SUBSCRIBE <name> [WHERE <fragment>] [WITH ('k' = 'v', ...)]` parser.
+
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::Parser;
+use sqlparser::tokenizer::Token;
+
+use super::statements::SubscribeStatement;
+use super::tokenizer::{expect_custom_keyword, parse_with_options};
+use super::ParseError;
+
+pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseError> {
+    expect_custom_keyword(parser, "SUBSCRIBE")?;
+
+    let name = parser.parse_object_name(false).map_err(ParseError::SqlParseError)?;
+
+    // Validate via sqlparser then round-trip; filter_compile re-parses anyway.
+    let filter_sql = if parser.parse_keyword(Keyword::WHERE) {
+        let expr = parser.parse_expr().map_err(ParseError::SqlParseError)?;
+        Some(expr.to_string())
+    } else {
+        None
+    };
+
+    let options = parse_with_options(parser)?;
+
+    match parser.peek_token().token {
+        Token::EOF | Token::SemiColon => {}
+        ref other => {
+            return Err(ParseError::StreamingError(format!(
+                "Unexpected tokens after SUBSCRIBE target: {other}"
+            )));
+        }
+    }
+
+    Ok(SubscribeStatement {
+        name,
+        filter_sql,
+        options,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::dialect::LaminarDialect;
+    use super::*;
+
+    fn parse(sql: &str) -> Result<SubscribeStatement, ParseError> {
+        let dialect = LaminarDialect::default();
+        let mut parser = Parser::new(&dialect)
+            .try_with_sql(sql)
+            .map_err(ParseError::SqlParseError)?;
+        parse_subscribe(&mut parser)
+    }
+
+    #[test]
+    fn ident_only() {
+        let stmt = parse("SUBSCRIBE foo").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert!(stmt.options.is_empty());
+    }
+
+    #[test]
+    fn with_options() {
+        let stmt = parse("SUBSCRIBE foo WITH ('snapshot' = 'true')").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert_eq!(stmt.options.get("snapshot").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn trailing_semicolon_ok() {
+        parse("SUBSCRIBE foo;").expect("parse");
+    }
+
+    #[test]
+    fn schema_qualified() {
+        let stmt = parse("SUBSCRIBE my_schema.foo").expect("parse");
+        assert_eq!(stmt.name.to_string(), "my_schema.foo");
+    }
+
+    #[test]
+    fn missing_target() {
+        assert!(parse("SUBSCRIBE").is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        assert!(parse("SUBSCRIBE foo bar").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(parse("").is_err());
+    }
+
+    #[test]
+    fn parses_where_clause() {
+        let stmt = parse("SUBSCRIBE foo WHERE c > 10").expect("parse");
+        assert_eq!(stmt.name.to_string(), "foo");
+        assert!(stmt.filter_sql.as_deref().is_some_and(|s| s.contains('>')));
+    }
+
+    #[test]
+    fn where_then_with() {
+        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')")
+            .expect("parse");
+        assert!(stmt.filter_sql.is_some());
+        assert_eq!(
+            stmt.options.get("snapshot").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn rejects_with_before_where() {
+        assert!(parse("SUBSCRIBE foo WITH ('snapshot' = 'true') WHERE c > 1").is_err());
+    }
+}

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -11,7 +11,9 @@ use super::ParseError;
 pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseError> {
     expect_custom_keyword(parser, "SUBSCRIBE")?;
 
-    let name = parser.parse_object_name(false).map_err(ParseError::SqlParseError)?;
+    let name = parser
+        .parse_object_name(false)
+        .map_err(ParseError::SqlParseError)?;
 
     // Validate via sqlparser then round-trip; filter_compile re-parses anyway.
     let filter_sql = if parser.parse_keyword(Keyword::WHERE) {
@@ -63,7 +65,10 @@ mod tests {
     fn with_options() {
         let stmt = parse("SUBSCRIBE foo WITH ('snapshot' = 'true')").expect("parse");
         assert_eq!(stmt.name.to_string(), "foo");
-        assert_eq!(stmt.options.get("snapshot").map(String::as_str), Some("true"));
+        assert_eq!(
+            stmt.options.get("snapshot").map(String::as_str),
+            Some("true")
+        );
     }
 
     #[test]
@@ -101,8 +106,7 @@ mod tests {
 
     #[test]
     fn where_then_with() {
-        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')")
-            .expect("parse");
+        let stmt = parse("SUBSCRIBE foo WHERE a = 1 WITH ('snapshot' = 'true')").expect("parse");
         assert!(stmt.filter_sql.is_some());
         assert_eq!(
             stmt.options.get("snapshot").map(String::as_str),

--- a/crates/laminar-sql/src/parser/tokenizer.rs
+++ b/crates/laminar-sql/src/parser/tokenizer.rs
@@ -98,6 +98,8 @@ pub enum StreamingDdlKind {
     Checkpoint,
     /// RESTORE FROM CHECKPOINT <id>
     RestoreCheckpoint,
+    /// SUBSCRIBE <name> [WITH (...)]
+    Subscribe,
     /// Not a streaming DDL statement
     None,
 }
@@ -123,6 +125,14 @@ pub fn detect_streaming_ddl(tokens: &[TokenWithSpan]) -> StreamingDdlKind {
     if let Token::Word(w) = &significant[0].token {
         if is_word_ci(w, "CHECKPOINT") {
             return StreamingDdlKind::Checkpoint;
+        }
+    }
+
+    // SUBSCRIBE <ident> — needs at least 2 tokens but we route here before
+    // the generic match below so the token-prefix detector recognises it.
+    if let Token::Word(w) = &significant[0].token {
+        if is_word_ci(w, "SUBSCRIBE") {
+            return StreamingDdlKind::Subscribe;
         }
     }
 
@@ -864,6 +874,18 @@ mod tests {
         assert_eq!(
             detect_streaming_ddl(&tokenize("RESTORE FROM CHECKPOINT 42")),
             StreamingDdlKind::RestoreCheckpoint
+        );
+    }
+
+    #[test]
+    fn test_detect_subscribe() {
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("SUBSCRIBE foo")),
+            StreamingDdlKind::Subscribe
+        );
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("subscribe foo with ('snapshot' = 'true')")),
+            StreamingDdlKind::Subscribe
         );
     }
 }

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -183,7 +183,8 @@ impl StreamingPlanner {
             | StreamingStatement::InsertInto { .. }
             | StreamingStatement::AlterSource { .. }
             | StreamingStatement::Checkpoint
-            | StreamingStatement::RestoreCheckpoint { .. } => {
+            | StreamingStatement::RestoreCheckpoint { .. }
+            | StreamingStatement::Subscribe(_) => {
                 // These statements are handled directly by the database facade
                 // and don't need query planning. Return as Standard pass-through.
                 Err(PlanningError::UnsupportedSql(format!(

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -288,10 +288,9 @@ When the server is started with `pgwire_bind` set, materialized views can be str
 SUBSCRIBE <mv_name> [WHERE <predicate>]
 ```
 
-- `<mv_name>` is the name of a materialized view created with `CREATE MATERIALIZED VIEW ...`.
-- The optional `WHERE` clause is compiled by DataFusion against the view's schema and applied per batch before the row reaches the wire.
+- `<mv_name>` may be a materialized view, a source, or a named stream.
+- The optional `WHERE` clause is compiled by DataFusion against the target's schema and applied per batch before the row reaches the wire. It works on materialized views and sources; named streams reject `WHERE` because their output schema isn't introspectable.
 - The query stays open until the client disconnects; rows arrive as they're produced upstream.
-- `SUBSCRIBE` against a raw stream is rejected — stream schemas aren't introspectable.
 
 ---
 

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -280,6 +280,19 @@ while let Some(rows) = sub.poll() {
 
 **Critical:** `FromRow` struct field order must match the SQL `SELECT` column order. Field names don't matter — only position.
 
+### SUBSCRIBE over the Postgres wire protocol
+
+When the server is started with `pgwire_bind` set, materialized views can be streamed directly to any libpq client (psql, JDBC, asyncpg, etc.):
+
+```sql
+SUBSCRIBE <mv_name> [WHERE <predicate>]
+```
+
+- `<mv_name>` is the name of a materialized view created with `CREATE MATERIALIZED VIEW ...`.
+- The optional `WHERE` clause is compiled by DataFusion against the view's schema and applied per batch before the row reaches the wire.
+- The query stays open until the client disconnects; rows arrive as they're produced upstream.
+- `SUBSCRIBE` against a raw stream is rejected — stream schemas aren't introspectable.
+
 ---
 
 ## Watermarks


### PR DESCRIPTION
## Summary

Combined PR that supersedes the stacked series #364–#368. Adds a Postgres-wire endpoint to LaminarDB with \`SUBSCRIBE\` for streaming materialized-view rows, MD5 password auth, optional TLS, and DataFusion-compiled \`WHERE\` predicates that work on materialized views, sources, and named streams.

History is preserved as 15 commits — each stage is a coherent unit and reviewable in order. Squash-merging is fine if you want a single landing commit.

## Surface

| TOML | Effect |
|---|---|
| \`server.pgwire_bind\` | Enable the listener (e.g. \`127.0.0.1:5433\`). |
| \`server.pgwire_users\` | \`{user = password}\` map. Empty → trust + localhost-only. Non-empty → MD5 auth. |
| \`server.pgwire_allow_remote\` | Two-key opt-in for non-loopback binds even with auth on. |
| \`server.pgwire_tls_cert\` / \`pgwire_tls_key\` | Optional PEM cert + key. Both required together; loaded once at startup. |

Accepted SimpleQuery subset:
- \`SUBSCRIBE <name> [WHERE <pred>]\` — streams rows as produced. \`<name>\` may be a materialized view, source, or named stream. \`WHERE\` is rejected on streams that haven't been resolved by \`start()\`.
- \`SHOW\`, \`SET key = value\`, and the connect-time builtins \`psql\`/JDBC/asyncpg need (\`SELECT version()\`, \`current_database()\`, etc.).
- DDL/DML rejected with a typed error pointing to \`POST /api/v1/sql\`.

## Stage-by-stage

1. **\`0ad1edfb feat(server): SUBSCRIBE over the Postgres wire protocol\`** — minimal listener built on \`pgwire 0.39\` with \`server-api\`. \`SubscriptionRegistry\` (broadcast fan-out) + \`SubscriptionPortal\` (per-consumer pump) live in \`laminar-db\`. Filter compile lives in \`laminar-db/src/filter_compile.rs\`, shared with the sink-filter path. AST dispatch via \`parse_streaming_sql\` (no string-prefix matching).
2. **\`d93f4dcb style: cargo fmt\`** — mechanical.
3. **\`eb9aa1b0 fix: address review feedback on SUBSCRIBE pgwire path\`** — RAII guard for the temp filter table, \`Notify\`-based wake on portal close, \`JoinSet\` for session lifecycle, server rollback on pgwire startup failure.
4. **\`a5360e26 fix(server): validate pgwire_bind as SocketAddr like bind\`** — config-load validation parity with \`bind\`.
5. **Stage 2** (\`3ec6234f\` docs, \`4697b21b\` integration test, \`e776bb0c\` lag→typed error, \`cbd362ee\` review) — README + SQL reference, \`tokio_postgres\` integration suite (\`127.0.0.1:0\` per test), lag surfaces as SQLSTATE \`54000\` instead of silent disconnect.
6. **Stage 2.5** (\`7af76889\` typed errors from \`filter_compile\`) — replaces the opaque \`Option::None\` return with \`Result<_, DbError>\`. Caller messages now name the bad column / planner failure.
7. **MD5 auth** (\`ba5a0ac3\`, \`9e10771c\` review) — \`pgwire::api::auth::md5pass::hash_md5_password\` reused; no hand-rolled crypto. \`StartupAuth\` enum dispatches between trust and MD5 (necessary because \`StartupHandler::on_startup\` is a generic method, not dyn-dispatchable). \`Secret\` newtype redacts in \`Debug\`. Username enumeration closed: unknown user and wrong password both surface \`PgWireError::InvalidPassword(user)\`. Two-key rule (\`pgwire_allow_remote\`) for non-loopback binds. Audit-log events on accept/close. Trust mode is \`WARN\`.
8. **TLS** (\`52cc7c0a\`, \`f65295d7\` review) — \`tokio-rustls\` aws-lc-rs backend (matches what pgwire uses for SCRAM internally). \`load_tls_acceptor\` validates files at startup; Unix permission warning if key is group/other-readable. Audit \`outcome\` distinguishes \`tls_failed\` from \`auth_failed\` and generic \`error\`. End-to-end test issues a self-signed cert via \`rcgen\` and runs the full handshake through \`tokio-postgres-rustls\`.
9. **Stream-side schema** (\`e8889c44\`, \`b51f9e45\` review) — publishes the \`resolve_stream_output_schemas\` map (already computed at \`start()\` for sink configs) into a new \`stream_schemas\` field, so SUBSCRIBE WHERE compiles on named streams. Caught a latent qualifier-mismatch bug in \`filter_compile\` masked by the original \`Option::None\` return; fix uses \`DFSchema::try_from_qualified_schema\` to match the temp-table qualifier.

## Filed as follow-ups (not in this PR)

- Rate-limit auth attempts per peer IP (\`governor\`)
- Cap concurrent pgwire connections
- Pre-hashed \`md5{hex}\` password support (compatible with \`pg_hba.conf\`)
- Cert-expiry warning at load
- mTLS via \`with_client_cert_verifier\`
- Hot-reload TLS cert without dropping connections
- Min-TLS-version pin for PCI/FedRAMP

## Test plan

- [x] \`cargo clippy -p laminar-db -p laminar-server --no-default-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p laminar-server --no-default-features --bin laminardb pgwire\` — 23 passing (13 unit + 10 integration; covers handshake, SHOW, SUBSCRIBE error paths, DDL rejection, MD5 auth success/wrong-pwd/unknown-user, TLS handshake, SUBSCRIBE WHERE with valid/unknown columns)
- [x] \`cargo test -p laminar-db --no-default-features --lib subscription open_subscription\` — 13 passing
- [x] \`cargo test -p laminar-server --no-default-features --bin laminardb config::\` — 22 passing (covers password-length validation and \`Secret\` redaction)
- [x] \`cargo fmt --all\` — clean
- [x] CI green on the underlying #364 branch (Format, Clippy, MSRV, Cargo Deny, Security Audit, Documentation, Feature Matrix, Test ubuntu-latest, Test windows-latest, Coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SUBSCRIBE statement for real-time subscriptions to streams and materialized views via Postgres wire protocol
  * Added optional WHERE clause filtering for subscriptions
  * Enabled Postgres wire protocol endpoint with MD5 authentication and TLS support
  * Added pgwire configuration options for bind address, user credentials, and certificate management

* **Documentation**
  * Added SUBSCRIBE SQL reference documentation
  * Added Postgres wire protocol configuration and usage guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->