### PR TITLE
pgwire: production hardening — connection cap, auth throttle, cert expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3087,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4869,6 +4922,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tikv-jemallocator",
+ "time",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -4879,6 +4933,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "x509-parser",
  "xxhash-rust",
 ]
 
@@ -5298,6 +5353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5544,6 +5605,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5786,6 +5857,15 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -7256,6 +7336,15 @@ checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
  "rustc_version",
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -9709,6 +9798,23 @@ dependencies = [
  "spki",
  "thiserror 2.0.18",
  "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -68,6 +68,8 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
     "tls12",
 ] }
 rustls-pemfile = "2"
+x509-parser = "0.16"
+time = "0.3"
 async-trait = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -230,6 +230,14 @@ pub struct ServerSection {
     /// TLS private key (PEM, PKCS#8 or RSA).
     #[serde(default)]
     pub pgwire_tls_key: Option<std::path::PathBuf>,
+    /// Cap on concurrent pgwire sessions. New TCP accepts above the cap are
+    /// closed immediately with a server log; in-flight sessions continue.
+    #[serde(default = "default_pgwire_max_connections")]
+    pub pgwire_max_connections: usize,
+}
+
+fn default_pgwire_max_connections() -> usize {
+    256
 }
 
 impl Default for ServerSection {
@@ -242,6 +250,7 @@ impl Default for ServerSection {
             pgwire_allow_remote: false,
             pgwire_tls_cert: None,
             pgwire_tls_key: None,
+            pgwire_max_connections: default_pgwire_max_connections(),
         }
     }
 }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -16,9 +16,7 @@ static ENV_VAR_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}").expect("valid regex")
 });
 
-/// Minimum acceptable pgwire password length, enforced at config load.
-/// MD5 auth offers no work factor, so length is the only knob; 12 is the
-/// usual NIST baseline.
+/// NIST baseline; MD5 has no work factor, so length is the only knob.
 const MIN_PGWIRE_PASSWORD_LEN: usize = 12;
 
 /// Load, parse, and validate a LaminarDB configuration file.
@@ -131,6 +129,12 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             ));
         }
     }
+    if config.server.pgwire_max_connections == 0 {
+        errors.push(
+            "pgwire_max_connections must be > 0; remove pgwire_bind to disable the listener"
+                .to_string(),
+        );
+    }
     match (
         &config.server.pgwire_tls_cert,
         &config.server.pgwire_tls_key,
@@ -213,31 +217,22 @@ pub struct ServerSection {
     /// Postgres wire bind address; `None` disables it.
     #[serde(default)]
     pub pgwire_bind: Option<String>,
-    /// Username -> plaintext password for MD5 auth on the pgwire listener.
-    /// Empty/absent → trust auth (only safe behind a localhost bind).
+    /// MD5 auth users. Empty → trust auth (loopback only).
     #[serde(default)]
     pub pgwire_users: std::collections::HashMap<String, Secret>,
-    /// Two-key rule: must be explicitly true to allow `pgwire_bind` on a
-    /// non-localhost address even when MD5 auth is configured. Defaults
-    /// false so a misconfigured `pgwire_users` map can't accidentally expose
-    /// the listener to the wider network.
+    /// Required true to bind pgwire on a non-loopback address.
     #[serde(default)]
     pub pgwire_allow_remote: bool,
-    /// TLS certificate (PEM). Setting this and `pgwire_tls_key` enables
-    /// TLS on the pgwire listener; both must be provided together.
+    /// PEM cert; pair with `pgwire_tls_key` to enable TLS.
     #[serde(default)]
     pub pgwire_tls_cert: Option<std::path::PathBuf>,
-    /// TLS private key (PEM, PKCS#8 or RSA).
+    /// PEM private key (PKCS#8 or RSA).
     #[serde(default)]
     pub pgwire_tls_key: Option<std::path::PathBuf>,
-    /// Cap on concurrent pgwire sessions. New TCP accepts above the cap are
-    /// closed immediately with a server log; in-flight sessions continue.
+    /// Concurrent session cap; excess accepts close immediately.
     #[serde(default = "default_pgwire_max_connections")]
     pub pgwire_max_connections: usize,
-    /// Maximum auth failures from a single peer IP within a 60s rolling
-    /// window. Subsequent connect attempts from that IP are dropped at
-    /// accept time until failures expire from the window. 0 disables
-    /// the throttle.
+    /// Per-IP auth-failure cap in a 60s rolling window. 0 disables.
     #[serde(default = "default_pgwire_max_auth_failures_per_min")]
     pub pgwire_max_auth_failures_per_min: u32,
 }
@@ -266,27 +261,21 @@ impl Default for ServerSection {
     }
 }
 
-/// String wrapped to keep its plaintext out of `Debug` output and incidental
-/// log lines. Use `Secret::expose` only at the point of use.
+/// String that redacts itself in `Debug` output.
 #[derive(Clone, PartialEq, Eq, Deserialize)]
 #[serde(transparent)]
 pub struct Secret(String);
 
 impl Secret {
-    /// Constructor; intended for tests and bridge code.
     #[cfg(test)]
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
 
-    /// Plaintext access. Only call at the point the value is actually used
-    /// (e.g., handing it to a hash function); never store the returned `&str`
-    /// elsewhere.
     pub fn expose(&self) -> &str {
         &self.0
     }
 
-    /// Char count of the wrapped value, for length validation.
     pub fn len(&self) -> usize {
         self.0.chars().count()
     }
@@ -802,6 +791,25 @@ bind = "not-a-socket-addr"
         match err {
             ConfigError::ValidationErrors { errors } => {
                 assert!(errors.iter().any(|e| e.contains("invalid server bind")));
+            }
+            _ => panic!("expected ValidationErrors"),
+        }
+    }
+
+    #[test]
+    fn test_validate_zero_max_connections() {
+        let toml = r#"
+[server]
+pgwire_max_connections = 0
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        let err = validate_config(&config).unwrap_err();
+        match err {
+            ConfigError::ValidationErrors { errors } => {
+                assert!(
+                    errors.iter().any(|e| e.contains("must be > 0")),
+                    "errors: {errors:?}"
+                );
             }
             _ => panic!("expected ValidationErrors"),
         }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -234,10 +234,20 @@ pub struct ServerSection {
     /// closed immediately with a server log; in-flight sessions continue.
     #[serde(default = "default_pgwire_max_connections")]
     pub pgwire_max_connections: usize,
+    /// Maximum auth failures from a single peer IP within a 60s rolling
+    /// window. Subsequent connect attempts from that IP are dropped at
+    /// accept time until failures expire from the window. 0 disables
+    /// the throttle.
+    #[serde(default = "default_pgwire_max_auth_failures_per_min")]
+    pub pgwire_max_auth_failures_per_min: u32,
 }
 
 fn default_pgwire_max_connections() -> usize {
     256
+}
+
+fn default_pgwire_max_auth_failures_per_min() -> u32 {
+    10
 }
 
 impl Default for ServerSection {
@@ -251,6 +261,7 @@ impl Default for ServerSection {
             pgwire_tls_cert: None,
             pgwire_tls_key: None,
             pgwire_max_connections: default_pgwire_max_connections(),
+            pgwire_max_auth_failures_per_min: default_pgwire_max_auth_failures_per_min(),
         }
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -611,6 +611,7 @@ pub async fn serve(
     users: HashMap<String, Secret>,
     allow_remote: bool,
     tls: Option<TlsPaths<'_>>,
+    max_connections: usize,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
@@ -669,6 +670,17 @@ pub async fn serve(
                 accepted = listener.accept() => {
                     match accepted {
                         Ok((sock, peer)) => {
+                            if sessions.len() >= max_connections {
+                                tracing::info!(
+                                    target: "audit",
+                                    event = "pgwire.connection_rejected",
+                                    peer = %peer,
+                                    reason = "max_connections",
+                                    in_flight = sessions.len(),
+                                );
+                                drop(sock);
+                                continue;
+                            }
                             let factory_ref = Arc::clone(&factory);
                             let tls_ref = tls_acceptor.clone();
                             let peer_str = peer.to_string();
@@ -823,7 +835,7 @@ mod tests {
     #[tokio::test]
     async fn serve_rejects_remote_bind_in_trust_mode() {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
-        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None)
+        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None, 256)
             .await
             .expect_err("trust + 0.0.0.0 must fail");
         assert!(err.to_string().contains("trust auth"), "got: {err}");
@@ -834,7 +846,7 @@ mod tests {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         let mut users = HashMap::new();
         users.insert("alice".into(), Secret::new("wonderland-key"));
-        let err = serve(db, "0.0.0.0:0", users, false, None)
+        let err = serve(db, "0.0.0.0:0", users, false, None, 256)
             .await
             .expect_err("md5 + 0.0.0.0 without allow_remote must fail");
         assert!(
@@ -874,7 +886,7 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None)
+        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None, 256)
             .await
             .expect("pgwire serve");
         (addr, handle)
@@ -1092,6 +1104,50 @@ mod integration_tests {
         handle.abort();
     }
 
+    #[tokio::test]
+    async fn connection_cap_drops_excess_clients() {
+        // Cap of 1; first client occupies the slot, second is dropped.
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+            .await
+            .expect("create source");
+        db.execute("CREATE MATERIALIZED VIEW prices AS SELECT symbol, price FROM trades")
+            .await
+            .expect("create mv");
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            None,
+            1,
+        )
+        .await
+        .expect("pgwire serve");
+
+        // First client occupies the slot via SUBSCRIBE (stays open until drop).
+        let first = connect(addr).await;
+        let _bg = tokio::spawn(async move {
+            let _ = first.simple_query("SUBSCRIBE prices").await;
+        });
+        // Give the server a moment to register the session in the JoinSet.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Second connect: server accepts the TCP, then closes it because the
+        // cap is hit. tokio_postgres surfaces this as an IO error during
+        // startup. Exact string varies; just assert it failed.
+        let conn_str = format!(
+            "host={} port={} user=any dbname=laminardb",
+            addr.ip(),
+            addr.port()
+        );
+        let result = tokio_postgres::connect(&conn_str, NoTls).await;
+        assert!(result.is_err(), "second connect must be refused");
+
+        handle.abort();
+    }
+
     /// Self-signed cert+key written to a tempdir for the duration of the
     /// test. `rcgen` is the well-maintained option for ad-hoc certs.
     fn self_signed_pem() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
@@ -1119,6 +1175,7 @@ mod integration_tests {
                 cert: &cert_path,
                 key: &key_path,
             }),
+            256,
         )
         .await
         .expect("pgwire serve");

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1,7 +1,6 @@
-//! Postgres wire endpoint. Trust auth by default; MD5 password auth when
-//! `[server].pgwire_users` is non-empty. Non-loopback binds require both
-//! MD5 auth AND `pgwire_allow_remote = true` (two-key rule). TLS via
-//! tokio-rustls when `pgwire_tls_cert` and `pgwire_tls_key` are set.
+//! Postgres wire endpoint. Trust by default; MD5 with `pgwire_users`;
+//! TLS with `pgwire_tls_cert` + `pgwire_tls_key`. Non-loopback binds
+//! require `pgwire_allow_remote = true`.
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -508,15 +507,12 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
     }
 }
 
-/// Cert + private-key paths for the pgwire TLS listener.
 pub struct TlsPaths<'a> {
     pub cert: &'a std::path::Path,
     pub key: &'a std::path::Path,
 }
 
-/// Warn if the key file is readable by anyone other than the owner.
-/// PostgreSQL refuses to start in this case; we warn rather than fail
-/// because dev environments often run with looser perms.
+/// Warn if the key file is group/other-readable.
 #[cfg(unix)]
 fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
     use std::os::unix::fs::MetadataExt;
@@ -526,8 +522,7 @@ fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
             warn!(
                 path = %path.display(),
                 mode = format!("{:o}", mode & 0o777),
-                "pgwire_tls_key permissions are too broad — postgres rejects \
-                 anything looser than 0600. Tighten before exposing the listener.",
+                "pgwire_tls_key permissions are too broad; tighten to 0600",
             );
         }
     }
@@ -536,9 +531,7 @@ fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
 #[cfg(not(unix))]
 fn warn_if_key_world_readable(_file: &std::fs::File, _path: &std::path::Path) {}
 
-/// Per-IP rolling-window auth-failure tracker. Cheap parking_lot mutex over
-/// a HashMap; expected key set is small (active client IPs) and lookups
-/// happen at TCP accept time, not on the hot data path.
+/// Rolling-window auth-failure count per peer IP.
 #[derive(Debug, Default)]
 struct FailureTracker {
     inner: parking_lot::Mutex<
@@ -547,8 +540,6 @@ struct FailureTracker {
 }
 
 impl FailureTracker {
-    /// Drop expired entries and return whether `ip` has hit `limit` failures
-    /// inside `window`. `limit == 0` disables the throttle.
     fn is_blocked(&self, ip: std::net::IpAddr, limit: u32, window: std::time::Duration) -> bool {
         if limit == 0 {
             return false;
@@ -569,17 +560,27 @@ impl FailureTracker {
     }
 
     fn record_failure(&self, ip: std::net::IpAddr) {
-        self.inner
-            .lock()
+        let mut inner = self.inner.lock();
+        // When full, evict the entry whose newest failure is oldest.
+        if !inner.contains_key(&ip) && inner.len() >= MAX_TRACKED_IPS {
+            if let Some(oldest) = inner
+                .iter()
+                .min_by_key(|(_, q)| q.back().copied())
+                .map(|(k, _)| *k)
+            {
+                inner.remove(&oldest);
+            }
+        }
+        inner
             .entry(ip)
             .or_default()
             .push_back(std::time::Instant::now());
     }
 }
 
-/// Map the result of `process_socket` to a stable audit-log code so SOC
-/// dashboards can split TLS handshake errors from auth failures and from
-/// generic runtime errors.
+const MAX_TRACKED_IPS: usize = 4096;
+
+/// Stable audit code for a session's exit status.
 fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
     match result {
         Ok(()) => "ok",
@@ -599,9 +600,7 @@ fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
     }
 }
 
-/// Reject certs already past `notAfter`; warn when expiry is within 30 days.
-/// Saves operators a debugging session: an expired cert otherwise loads fine
-/// and only fails at first client handshake with an opaque error.
+/// Reject certs past `notAfter`; warn within 30 days.
 #[allow(clippy::result_large_err)]
 fn check_cert_expiry(
     der: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
@@ -618,8 +617,6 @@ fn check_cert_expiry(
             path.display()
         )));
     }
-    // x509-parser's ASN1Time uses the `time` crate. Convert to a `Duration`
-    // for the 30-day window comparison.
     let remaining = not_after.to_datetime() - now.to_datetime();
     if remaining <= time::Duration::days(30) {
         warn!(
@@ -631,11 +628,7 @@ fn check_cert_expiry(
     Ok(())
 }
 
-/// Install aws-lc-rs as the process-wide rustls CryptoProvider. Idempotent —
-/// rustls returns `Err` if a provider is already installed, which we ignore.
-/// Required because other crates in the dep tree (delta-lake, iceberg) pull
-/// in rustls with their own provider features, leaving the auto-pick
-/// ambiguous.
+/// Idempotent install of aws-lc-rs as rustls' default provider.
 fn ensure_tls_provider() {
     let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
@@ -658,7 +651,9 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
             paths.cert.display()
         )));
     }
-    check_cert_expiry(&certs[0], paths.cert)?;
+    for cert in &certs {
+        check_cert_expiry(cert, paths.cert)?;
+    }
 
     let key_file = File::open(paths.key)
         .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
@@ -966,6 +961,24 @@ mod tests {
         }
         // Window of 0 means every recorded failure is already expired.
         assert!(!tracker.is_blocked(ip, 5, Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn failure_tracker_caps_distinct_ips() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let tracker = super::FailureTracker::default();
+        // Push past the cap; map size must stay bounded.
+        for i in 0..(super::MAX_TRACKED_IPS + 100) {
+            #[allow(clippy::cast_possible_truncation)]
+            let ip: IpAddr = Ipv4Addr::new(10, 0, (i / 256) as u8, (i % 256) as u8).into();
+            tracker.record_failure(ip);
+        }
+        let len = tracker.inner.lock().len();
+        assert!(
+            len <= super::MAX_TRACKED_IPS,
+            "tracker exceeded cap: {len} > {}",
+            super::MAX_TRACKED_IPS
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -599,6 +599,38 @@ fn classify_outcome(result: &Result<(), std::io::Error>) -> &'static str {
     }
 }
 
+/// Reject certs already past `notAfter`; warn when expiry is within 30 days.
+/// Saves operators a debugging session: an expired cert otherwise loads fine
+/// and only fails at first client handshake with an opaque error.
+#[allow(clippy::result_large_err)]
+fn check_cert_expiry(
+    der: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
+    path: &std::path::Path,
+) -> Result<(), ServerError> {
+    use x509_parser::prelude::FromDer;
+    let (_, cert) = x509_parser::certificate::X509Certificate::from_der(der.as_ref())
+        .map_err(|e| ServerError::Http(format!("parse pgwire_tls_cert {}: {e}", path.display())))?;
+    let now = x509_parser::time::ASN1Time::now();
+    let not_after = cert.validity().not_after;
+    if not_after < now {
+        return Err(ServerError::Http(format!(
+            "pgwire_tls_cert {} expired at {not_after}",
+            path.display()
+        )));
+    }
+    // x509-parser's ASN1Time uses the `time` crate. Convert to a `Duration`
+    // for the 30-day window comparison.
+    let remaining = not_after.to_datetime() - now.to_datetime();
+    if remaining <= time::Duration::days(30) {
+        warn!(
+            path = %path.display(),
+            expires_at = %not_after,
+            "pgwire_tls_cert expires within 30 days; rotate before it lapses",
+        );
+    }
+    Ok(())
+}
+
 /// Install aws-lc-rs as the process-wide rustls CryptoProvider. Idempotent —
 /// rustls returns `Err` if a provider is already installed, which we ignore.
 /// Required because other crates in the dep tree (delta-lake, iceberg) pull
@@ -626,6 +658,7 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
             paths.cert.display()
         )));
     }
+    check_cert_expiry(&certs[0], paths.cert)?;
 
     let key_file = File::open(paths.key)
         .map_err(|e| ServerError::Http(format!("open pgwire_tls_key: {e}")))?;
@@ -1264,6 +1297,44 @@ mod integration_tests {
         std::fs::write(&cert_path, cert.cert.pem()).unwrap();
         std::fs::write(&key_path, cert.key_pair.serialize_pem()).unwrap();
         (dir, cert_path, key_path)
+    }
+
+    /// Self-signed cert with notAfter in the past, for the expiry test.
+    fn expired_self_signed_pem() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let mut params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
+        let one_year_ago = time::OffsetDateTime::now_utc() - time::Duration::days(365);
+        params.not_before = one_year_ago - time::Duration::days(2);
+        params.not_after = one_year_ago;
+        let key = rcgen::KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        std::fs::write(&cert_path, cert.pem()).unwrap();
+        std::fs::write(&key_path, key.serialize_pem()).unwrap();
+        (dir, cert_path, key_path)
+    }
+
+    #[tokio::test]
+    async fn tls_load_rejects_expired_cert() {
+        let (_dir, cert_path, key_path) = expired_self_signed_pem();
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let err = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+            }),
+            256,
+            10,
+        )
+        .await
+        .expect_err("expired cert must be rejected");
+        assert!(err.to_string().contains("expired"), "got: {err}");
     }
 
     #[tokio::test]

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -536,6 +536,47 @@ fn warn_if_key_world_readable(file: &std::fs::File, path: &std::path::Path) {
 #[cfg(not(unix))]
 fn warn_if_key_world_readable(_file: &std::fs::File, _path: &std::path::Path) {}
 
+/// Per-IP rolling-window auth-failure tracker. Cheap parking_lot mutex over
+/// a HashMap; expected key set is small (active client IPs) and lookups
+/// happen at TCP accept time, not on the hot data path.
+#[derive(Debug, Default)]
+struct FailureTracker {
+    inner: parking_lot::Mutex<
+        HashMap<std::net::IpAddr, std::collections::VecDeque<std::time::Instant>>,
+    >,
+}
+
+impl FailureTracker {
+    /// Drop expired entries and return whether `ip` has hit `limit` failures
+    /// inside `window`. `limit == 0` disables the throttle.
+    fn is_blocked(&self, ip: std::net::IpAddr, limit: u32, window: std::time::Duration) -> bool {
+        if limit == 0 {
+            return false;
+        }
+        let cutoff = std::time::Instant::now() - window;
+        let mut inner = self.inner.lock();
+        let Some(failures) = inner.get_mut(&ip) else {
+            return false;
+        };
+        while failures.front().is_some_and(|t| *t < cutoff) {
+            failures.pop_front();
+        }
+        let blocked = failures.len() >= limit as usize;
+        if failures.is_empty() {
+            inner.remove(&ip);
+        }
+        blocked
+    }
+
+    fn record_failure(&self, ip: std::net::IpAddr) {
+        self.inner
+            .lock()
+            .entry(ip)
+            .or_default()
+            .push_back(std::time::Instant::now());
+    }
+}
+
 /// Map the result of `process_socket` to a stable audit-log code so SOC
 /// dashboards can split TLS handshake errors from auth failures and from
 /// generic runtime errors.
@@ -612,6 +653,7 @@ pub async fn serve(
     allow_remote: bool,
     tls: Option<TlsPaths<'_>>,
     max_connections: usize,
+    max_auth_failures_per_min: u32,
 ) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ServerError> {
     let addr: SocketAddr = bind
         .parse()
@@ -660,6 +702,7 @@ pub async fn serve(
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
+    let failures = Arc::new(FailureTracker::default());
     let handle = tokio::spawn(async move {
         let mut sessions: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
         loop {
@@ -681,8 +724,23 @@ pub async fn serve(
                                 drop(sock);
                                 continue;
                             }
+                            if failures.is_blocked(
+                                peer.ip(),
+                                max_auth_failures_per_min,
+                                std::time::Duration::from_secs(60),
+                            ) {
+                                tracing::warn!(
+                                    target: "audit",
+                                    event = "pgwire.connection_rejected",
+                                    peer = %peer,
+                                    reason = "auth_failure_throttle",
+                                );
+                                drop(sock);
+                                continue;
+                            }
                             let factory_ref = Arc::clone(&factory);
                             let tls_ref = tls_acceptor.clone();
+                            let failures_ref = Arc::clone(&failures);
                             let peer_str = peer.to_string();
                             tracing::info!(
                                 target: "audit",
@@ -691,9 +749,13 @@ pub async fn serve(
                                 auth = auth_mode,
                                 tls = tls_mode,
                             );
+                            let peer_ip = peer.ip();
                             sessions.spawn(async move {
                                 let result = process_socket(sock, tls_ref, factory_ref).await;
                                 let outcome = classify_outcome(&result);
+                                if outcome == "auth_failed" {
+                                    failures_ref.record_failure(peer_ip);
+                                }
                                 tracing::info!(
                                     target: "audit",
                                     event = "pgwire.connection_closed",
@@ -832,10 +894,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn failure_tracker_blocks_after_threshold() {
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::time::Duration;
+        let ip: IpAddr = Ipv4Addr::LOCALHOST.into();
+        let tracker = super::FailureTracker::default();
+        let limit = 3;
+        let window = Duration::from_secs(60);
+
+        for _ in 0..limit {
+            assert!(!tracker.is_blocked(ip, limit, window));
+            tracker.record_failure(ip);
+        }
+        assert!(tracker.is_blocked(ip, limit, window));
+    }
+
+    #[test]
+    fn failure_tracker_disabled_when_limit_zero() {
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::time::Duration;
+        let ip: IpAddr = Ipv4Addr::LOCALHOST.into();
+        let tracker = super::FailureTracker::default();
+        for _ in 0..100 {
+            tracker.record_failure(ip);
+        }
+        assert!(!tracker.is_blocked(ip, 0, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn failure_tracker_expires_old_entries() {
+        use std::net::{IpAddr, Ipv4Addr};
+        use std::time::Duration;
+        let ip: IpAddr = Ipv4Addr::LOCALHOST.into();
+        let tracker = super::FailureTracker::default();
+        for _ in 0..5 {
+            tracker.record_failure(ip);
+        }
+        // Window of 0 means every recorded failure is already expired.
+        assert!(!tracker.is_blocked(ip, 5, Duration::from_secs(0)));
+    }
+
     #[tokio::test]
     async fn serve_rejects_remote_bind_in_trust_mode() {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
-        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None, 256)
+        let err = serve(db, "0.0.0.0:0", HashMap::new(), false, None, 256, 10)
             .await
             .expect_err("trust + 0.0.0.0 must fail");
         assert!(err.to_string().contains("trust auth"), "got: {err}");
@@ -846,7 +949,7 @@ mod tests {
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         let mut users = HashMap::new();
         users.insert("alice".into(), Secret::new("wonderland-key"));
-        let err = serve(db, "0.0.0.0:0", users, false, None, 256)
+        let err = serve(db, "0.0.0.0:0", users, false, None, 256, 10)
             .await
             .expect_err("md5 + 0.0.0.0 without allow_remote must fail");
         assert!(
@@ -886,9 +989,10 @@ mod integration_tests {
         .expect("create mv");
         db.start().await.expect("db starts");
 
-        let (addr, handle) = super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None, 256)
-            .await
-            .expect("pgwire serve");
+        let (addr, handle) =
+            super::serve(Arc::clone(&db), "127.0.0.1:0", users, false, None, 256, 10)
+                .await
+                .expect("pgwire serve");
         (addr, handle)
     }
 
@@ -1122,6 +1226,7 @@ mod integration_tests {
             false,
             None,
             1,
+            10,
         )
         .await
         .expect("pgwire serve");
@@ -1176,6 +1281,7 @@ mod integration_tests {
                 key: &key_path,
             }),
             256,
+            10,
         )
         .await
         .expect("pgwire serve");

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -185,6 +185,7 @@ pub async fn run_server(
     let pgwire_allow_remote = config.server.pgwire_allow_remote;
     let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
     let pgwire_tls_key = config.server.pgwire_tls_key.clone();
+    let pgwire_max_connections = config.server.pgwire_max_connections;
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
@@ -200,6 +201,7 @@ pub async fn run_server(
             pgwire_users,
             pgwire_allow_remote,
             tls,
+            pgwire_max_connections,
         )
         .await
         {

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -186,6 +186,7 @@ pub async fn run_server(
     let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
     let pgwire_tls_key = config.server.pgwire_tls_key.clone();
     let pgwire_max_connections = config.server.pgwire_max_connections;
+    let pgwire_max_auth_failures = config.server.pgwire_max_auth_failures_per_min;
     let (app_state, api_handle) =
         start_http_api(Arc::clone(&db), registry, config_path.clone(), config).await?;
     let watcher_handle = spawn_config_watcher(&app_state, config_path);
@@ -202,6 +203,7 @@ pub async fn run_server(
             pgwire_allow_remote,
             tls,
             pgwire_max_connections,
+            pgwire_max_auth_failures,
         )
         .await
         {


### PR DESCRIPTION
## Summary

Three small operational hardening commits, stacked on #369. Branch name is a misnomer — binary format turned out to need extended-query support first (every libpq client ignores the format code on SimpleQuery), so this PR pivoted to the harder-edged production-readiness items instead.

### Changes

**\`2c1b1c23\` — cap concurrent pgwire sessions.** \`pgwire_max_connections\` config knob, default 256. New TCP accepts above the cap close immediately with an audit-log event; in-flight sessions continue. \`JoinSet\` was unbounded today — a leaked client or DoS would exhaust the file descriptor table. Integration test sets cap to 1, occupies the slot with a long SUBSCRIBE, asserts the second \`tokio_postgres::connect\` fails.

**\`46146120\` — rate-limit auth failures per peer IP.** \`pgwire_max_auth_failures_per_min\` config knob, default 10. A peer that hits the threshold inside a 60s rolling window is dropped at accept time until failures expire from the window. \`limit==0\` disables the throttle. \`FailureTracker\` is a small \`parking_lot::Mutex<HashMap<IpAddr, VecDeque<Instant>>>\` — \`governor\` would be overkill for this fail-then-throttle pattern. Three unit tests: threshold trip, disabled, window expiry.

**\`97cd257c\` — refuse expired TLS certs at startup.** \`check_cert_expiry\` parses the leaf cert with \`x509-parser\`, refuses any cert whose \`notAfter\` is past, warns if within 30 days. Saves operators a debugging session: the symptom otherwise is opaque \`HandshakeFailure\` errors from clients. Test issues a deliberately-expired self-signed cert via \`rcgen\` and asserts \`serve()\` rejects it.

### Why not binary format?

Postgres's wire protocol has SimpleQuery and ExtendedQuery paths. SimpleQuery — what \`SUBSCRIBE\` uses — always uses text format in PostgreSQL's own implementation, and almost every libpq-derived client (psql, JDBC simple-query, asyncpg simple) hard-codes the text-decode path regardless of what the server's \`RowDescription\` advertises. Encoding binary on SimpleQuery just breaks every client.

The actual unlock is **DECLARE/FETCH or extended-query handler** (~150 LOC, FIR P3) → then binary format becomes meaningful (~120 LOC). Filed those as a logical pair for a future PR.

### Filed during principal review

| # | Item | Why |
|---|---|---|
| 7 | Pre-hashed \`md5{hex}\` password support | matches \`pg_hba.conf\`; avoids plaintext at rest |
| 10 | mTLS via \`with_client_cert_verifier\` | client cert auth for service-to-service |
| 11 | Hot-reload TLS cert | atomic \`Arc<TlsAcceptor>\` swap on SIGHUP |
| 12 | Min-TLS-version pin | PCI/FedRAMP compliance |

## Test plan

- [x] \`cargo clippy -p laminar-server --no-default-features --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p laminar-server --no-default-features --bin laminardb pgwire\` — 28 passing (was 23; +1 cap, +3 tracker, +1 expiry)
- [x] \`cargo fmt --all\` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limit on concurrent pgwire connections
  * Added per-IP authentication failure throttling with configurable maximum failed attempts per minute
  * Added TLS certificate expiry validation with alerts for certificates nearing expiration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->