### PR TITLE
ci: trigger CI on push to feat/, fix/, chore/ branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, "feature/*"]
+    branches: [main, develop, "feat/*", "feature/*", "fix/*", "chore/*"]
   pull_request:
     branches: [main, develop]
   workflow_dispatch:


### PR DESCRIPTION
Push trigger said `feature/*` but the repo convention is `feat/<name>`, so CI never fired on push for any of the SUBSCRIBE pgwire branches. Bit us twice — both #369 and #371 needed close+reopen to wake CI because `pull_request` events don't reliably re-fire on base-branch retargeting either.

Widen to `feat/`, `feature/`, `fix/`, `chore/`.