### PR TITLE
subscribe: RETAIN HISTORY + AS OF EPOCH for reconnect-without-gap

### DIFF
--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -1128,15 +1128,12 @@ impl LaminarDB {
     }
 
     /// Open a SUBSCRIBE portal against a named MV, source, or stream.
-    /// `filter_sql` is rejected on streams (their schema is opaque). `start`
-    /// controls whether the subscriber sees only future frames (`Tail`) or
-    /// replays history from a specific checkpoint epoch (`AsOfEpoch`).
+    /// `filter_sql` is rejected on streams (their schema is opaque).
     ///
     /// # Errors
-    /// Returns `StreamNotFound` if `name` is unknown; `Pipeline` if the
-    /// subscriber cap is reached or the filter fails to compile;
-    /// `InvalidOperation` if `AsOfEpoch(n)` was requested but `n` is no
-    /// longer retained.
+    /// `StreamNotFound` for unknown `name`; `Pipeline` for subscriber-cap
+    /// or filter-compile failures; `InvalidOperation` when `AsOfEpoch(n)`
+    /// is requested but `n` is no longer retained.
     pub async fn open_subscription(
         &self,
         name: &str,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -872,8 +872,15 @@ impl LaminarDB {
                 query,
                 emit_clause,
                 query_sql,
+                retention_bytes,
                 ..
-            } => self.handle_create_stream(name, query, emit_clause.as_ref(), query_sql),
+            } => self.handle_create_stream(
+                name,
+                query,
+                emit_clause.as_ref(),
+                query_sql,
+                *retention_bytes,
+            ),
             StreamingStatement::CreateContinuousQuery { .. }
             | StreamingStatement::CreateLookupTable(_)
             | StreamingStatement::DropLookupTable { .. } => self.handle_query(sql).await,
@@ -1121,15 +1128,20 @@ impl LaminarDB {
     }
 
     /// Open a SUBSCRIBE portal against a named MV, source, or stream.
-    /// `filter_sql` is rejected on streams (their schema is opaque).
+    /// `filter_sql` is rejected on streams (their schema is opaque). `start`
+    /// controls whether the subscriber sees only future frames (`Tail`) or
+    /// replays history from a specific checkpoint epoch (`AsOfEpoch`).
     ///
     /// # Errors
-    /// Returns `StreamNotFound` if `name` is unknown, or `Pipeline` if the
-    /// subscriber cap is reached or the filter fails to compile.
+    /// Returns `StreamNotFound` if `name` is unknown; `Pipeline` if the
+    /// subscriber cap is reached or the filter fails to compile;
+    /// `InvalidOperation` if `AsOfEpoch(n)` was requested but `n` is no
+    /// longer retained.
     pub async fn open_subscription(
         &self,
         name: &str,
         filter_sql: Option<&str>,
+        start: crate::subscription::SubscribeStart,
     ) -> Result<crate::subscription::SubscriptionPortal, DbError> {
         let attached = self.subscription_registry.subscriber_count(name);
         if attached >= crate::subscription::MAX_SUBSCRIBERS_PER_MV {
@@ -1167,12 +1179,25 @@ impl LaminarDB {
             Some(sql) => Some(crate::filter_compile::compile(&self.ctx, sql, &schema).await?),
         };
 
-        let rx = self.subscription_registry.subscribe(name);
+        let (replay, rx) = self
+            .subscription_registry
+            .subscribe(name, start)
+            .map_err(|e| {
+                let requested = match start {
+                    crate::subscription::SubscribeStart::AsOfEpoch(n) => n,
+                    crate::subscription::SubscribeStart::Tail => 0,
+                };
+                DbError::InvalidOperation(format!(
+                    "epoch {requested} for stream '{name}' is no longer retained \
+                     (earliest retained is {})",
+                    e.earliest_retained
+                ))
+            })?;
         Ok(match filter {
-            Some(phys) => {
-                crate::subscription::SubscriptionPortal::open_with_filter(name, schema, rx, phys)
-            }
-            None => crate::subscription::SubscriptionPortal::open(name, schema, rx),
+            Some(phys) => crate::subscription::SubscriptionPortal::open_with_filter(
+                name, schema, replay, rx, phys,
+            ),
+            None => crate::subscription::SubscriptionPortal::open(name, schema, replay, rx),
         })
     }
 

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -3781,7 +3781,10 @@ async fn test_nullif_float_with_int_literal_runs_without_error() {
 #[tokio::test]
 async fn open_subscription_resolves_unknown_name_to_error() {
     let db = LaminarDB::open().unwrap();
-    let err = db.open_subscription("nope", None).await.unwrap_err();
+    let err = db
+        .open_subscription("nope", None, crate::subscription::SubscribeStart::Tail)
+        .await
+        .unwrap_err();
     assert!(matches!(err, DbError::StreamNotFound(_)));
 }
 
@@ -3801,7 +3804,11 @@ async fn open_subscription_resolves_named_stream() {
     db.start().await.unwrap();
 
     let mut portal = db
-        .open_subscription("all_trades", None)
+        .open_subscription(
+            "all_trades",
+            None,
+            crate::subscription::SubscribeStart::Tail,
+        )
         .await
         .expect("portal opens");
 
@@ -3841,7 +3848,11 @@ async fn open_subscription_with_invalid_filter_errors_at_open() {
         .unwrap();
 
     let err = db
-        .open_subscription("trades", Some("nonexistent_col > 1"))
+        .open_subscription(
+            "trades",
+            Some("nonexistent_col > 1"),
+            crate::subscription::SubscribeStart::Tail,
+        )
         .await
         .unwrap_err();
     let msg = err.to_string();
@@ -3864,7 +3875,11 @@ async fn open_subscription_with_filter_on_stream_before_start_is_rejected() {
         .unwrap();
 
     let err = db
-        .open_subscription("all_trades", Some("symbol = 'AAPL'"))
+        .open_subscription(
+            "all_trades",
+            Some("symbol = 'AAPL'"),
+            crate::subscription::SubscribeStart::Tail,
+        )
         .await
         .unwrap_err();
     assert!(err.to_string().contains("not resolved"), "got: {err}");
@@ -3886,7 +3901,11 @@ async fn open_subscription_with_filter_on_stream_after_start_compiles() {
     db.start().await.unwrap();
 
     let portal = db
-        .open_subscription("all_trades", Some("symbol = 'AAPL'"))
+        .open_subscription(
+            "all_trades",
+            Some("symbol = 'AAPL'"),
+            crate::subscription::SubscribeStart::Tail,
+        )
         .await
         .expect("WHERE on a started stream must compile");
     portal.close();
@@ -3907,7 +3926,10 @@ async fn drop_stream_closes_subscription() {
         .unwrap();
     db.start().await.unwrap();
 
-    let mut portal = db.open_subscription("s", None).await.unwrap();
+    let mut portal = db
+        .open_subscription("s", None, crate::subscription::SubscribeStart::Tail)
+        .await
+        .unwrap();
 
     db.execute("DROP STREAM s").await.unwrap();
 
@@ -3917,4 +3939,86 @@ async fn drop_stream_closes_subscription() {
     })
     .await
     .expect("portal must close");
+}
+
+#[tokio::test]
+async fn create_stream_with_retain_history_enables_as_of_replay() {
+    use crate::subscription::SubscribeStart;
+
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades WITH ('retain_history' = '4mb')")
+        .await
+        .unwrap();
+
+    // Drive the registry directly: barrier(1) -> batch -> barrier(2). We're
+    // not testing the pipeline; we're testing that DDL plumbed the cap so
+    // the buffer actually retains.
+    let reg = &db.subscription_registry;
+    reg.broadcast_barrier(1, 100);
+
+    let schema = db.source_untyped("trades").unwrap().schema().clone();
+    let batch = arrow_array::RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(arrow::array::StringArray::from(vec!["AAPL"])),
+            Arc::new(arrow::array::Float64Array::from(vec![150.0])),
+        ],
+    )
+    .unwrap();
+    reg.send_batch("all_trades", batch);
+    reg.broadcast_barrier(2, 200);
+
+    // Subscribe AS OF EPOCH 1 — should replay batch + barrier(2).
+    let mut portal = db
+        .open_subscription("all_trades", None, SubscribeStart::AsOfEpoch(1))
+        .await
+        .expect("AS OF EPOCH 1 must be retained");
+
+    let frames = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        let mut frames = Vec::new();
+        for _ in 0..2 {
+            if let Some(f) = portal.next_frame().await {
+                frames.push(f);
+            }
+        }
+        frames
+    })
+    .await
+    .expect("frames within 1s");
+    assert_eq!(frames.len(), 2);
+    assert!(matches!(
+        frames[0],
+        crate::subscription::PortalFrame::Batch(_)
+    ));
+    assert!(matches!(
+        frames[1],
+        crate::subscription::PortalFrame::Barrier { epoch: 2, .. }
+    ));
+}
+
+#[tokio::test]
+async fn open_subscription_as_of_unretained_returns_invalid_operation() {
+    use crate::subscription::SubscribeStart;
+
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE trades (symbol VARCHAR)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM all_trades AS SELECT * FROM trades")
+        .await
+        .unwrap();
+
+    // No retention configured: AS OF anything must be pruned.
+    let err = db
+        .open_subscription("all_trades", None, SubscribeStart::AsOfEpoch(1))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, DbError::InvalidOperation(_)),
+        "expected InvalidOperation, got: {err:?}"
+    );
+    assert!(err.to_string().contains("no longer retained"), "msg: {err}");
 }

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -653,7 +653,6 @@ impl LaminarDB {
         let name_str = name.to_string();
         self.catalog.register_stream(&name_str)?;
 
-        // None leaves retention off; AS OF on this stream will return pruned.
         if let Some(bytes) = retention_bytes {
             let cap = usize::try_from(bytes).unwrap_or(usize::MAX);
             self.subscription_registry.configure(&name_str, cap);

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -719,6 +719,7 @@ impl LaminarDB {
             .map_err(|e| {
                 self.catalog.drop_stream(&name_str);
                 self.connector_manager.lock().unregister_stream(&name_str);
+                self.subscription_registry.drop_name(&name_str);
                 DbError::Pipeline(format!(
                     "control channel busy, retry CREATE STREAM '{name_str}': {e}"
                 ))

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -648,9 +648,16 @@ impl LaminarDB {
         query: &StreamingStatement,
         emit_clause: Option<&laminar_sql::parser::EmitClause>,
         query_sql: &str,
+        retention_bytes: Option<u64>,
     ) -> Result<ExecuteResult, DbError> {
         let name_str = name.to_string();
         self.catalog.register_stream(&name_str)?;
+
+        // None leaves retention off; AS OF on this stream will return pruned.
+        if let Some(bytes) = retention_bytes {
+            let cap = usize::try_from(bytes).unwrap_or(usize::MAX);
+            self.subscription_registry.configure(&name_str, cap);
+        }
 
         let query_sql = query_sql.to_string();
 
@@ -668,6 +675,7 @@ impl LaminarDB {
                 or_replace: false,
                 if_not_exists: false,
                 query_sql: query_sql.clone(),
+                retention_bytes: None,
             };
             match planner.plan(&stmt) {
                 Ok(laminar_sql::planner::StreamingPlan::Query(ref qp)) => (
@@ -983,6 +991,7 @@ impl LaminarDB {
                 or_replace: false,
                 if_not_exists: false,
                 query_sql: query_sql.clone(),
+                retention_bytes: None,
             };
             match planner.plan(&stmt) {
                 Ok(laminar_sql::planner::StreamingPlan::Query(ref qp)) => (

--- a/crates/laminar-db/src/subscription/mod.rs
+++ b/crates/laminar-db/src/subscription/mod.rs
@@ -5,4 +5,5 @@ mod registry;
 
 pub(crate) use portal::MAX_SUBSCRIBERS_PER_MV;
 pub use portal::{PortalFrame, SubscriptionPortal};
+pub use registry::SubscribeStart;
 pub(crate) use registry::SubscriptionRegistry;

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -120,9 +120,8 @@ impl Drop for SubscriptionPortal {
     }
 }
 
-/// Translate one `MvUpdate` into a `PortalFrame`, applying the filter if any.
-/// Returns `Ok(None)` for batches the filter excluded entirely, and `Err(())`
-/// when the filter itself failed (the pump should close).
+/// `Ok(None)` when the filter excluded the batch; `Err(())` when the
+/// filter itself failed (caller should close the pump).
 fn translate(
     msg: MvUpdate,
     filter: Option<&Arc<dyn PhysicalExpr>>,

--- a/crates/laminar-db/src/subscription/portal.rs
+++ b/crates/laminar-db/src/subscription/portal.rs
@@ -46,23 +46,26 @@ impl SubscriptionPortal {
     pub(crate) fn open(
         name: impl Into<String>,
         schema: SchemaRef,
+        replay: Vec<MvUpdate>,
         rx: broadcast::Receiver<MvUpdate>,
     ) -> Self {
-        Self::spawn(name, schema, rx, None)
+        Self::spawn(name, schema, replay, rx, None)
     }
 
     pub(crate) fn open_with_filter(
         name: impl Into<String>,
         schema: SchemaRef,
+        replay: Vec<MvUpdate>,
         rx: broadcast::Receiver<MvUpdate>,
         filter: Arc<dyn PhysicalExpr>,
     ) -> Self {
-        Self::spawn(name, schema, rx, Some(filter))
+        Self::spawn(name, schema, replay, rx, Some(filter))
     }
 
     fn spawn(
         name: impl Into<String>,
         schema: SchemaRef,
+        replay: Vec<MvUpdate>,
         rx: broadcast::Receiver<MvUpdate>,
         filter: Option<Arc<dyn PhysicalExpr>>,
     ) -> Self {
@@ -71,6 +74,7 @@ impl SubscriptionPortal {
         let wake = Arc::new(Notify::new());
         tokio::spawn(pump_loop(
             name.into(),
+            replay,
             rx,
             tx,
             Arc::clone(&closed),
@@ -116,39 +120,67 @@ impl Drop for SubscriptionPortal {
     }
 }
 
+/// Translate one `MvUpdate` into a `PortalFrame`, applying the filter if any.
+/// Returns `Ok(None)` for batches the filter excluded entirely, and `Err(())`
+/// when the filter itself failed (the pump should close).
+fn translate(
+    msg: MvUpdate,
+    filter: Option<&Arc<dyn PhysicalExpr>>,
+    name: &str,
+) -> Result<Option<PortalFrame>, ()> {
+    match msg {
+        MvUpdate::Batch(batch) => match filter {
+            Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
+                Ok(Some(b)) => Ok(Some(PortalFrame::Batch(b))),
+                Ok(None) => Ok(None),
+                Err(e) => {
+                    tracing::warn!(subscription = %name, error = %e, "filter failed; closing");
+                    Err(())
+                }
+            },
+            None => Ok(Some(PortalFrame::Batch(batch))),
+        },
+        MvUpdate::Barrier {
+            epoch,
+            checkpoint_id,
+        } => Ok(Some(PortalFrame::Barrier {
+            epoch,
+            checkpoint_id,
+        })),
+    }
+}
+
 async fn pump_loop(
     name: String,
+    replay: Vec<MvUpdate>,
     mut broadcast_rx: broadcast::Receiver<MvUpdate>,
     tx: MAsyncTx<mpsc::Array<PortalFrame>>,
     closed: Arc<AtomicBool>,
     wake: Arc<Notify>,
     filter: Option<Arc<dyn PhysicalExpr>>,
 ) {
+    for msg in replay {
+        if closed.load(Ordering::Acquire) {
+            return;
+        }
+        match translate(msg, filter.as_ref(), &name) {
+            Ok(Some(frame)) => {
+                if tx.send(frame).await.is_err() {
+                    return;
+                }
+            }
+            Ok(None) => {}
+            Err(()) => return,
+        }
+    }
     while !closed.load(Ordering::Acquire) {
         let recv = tokio::select! {
             biased;
             () = wake.notified() => continue,
             r = broadcast_rx.recv() => r,
         };
-        let frame = match recv {
-            Ok(MvUpdate::Batch(batch)) => match filter.as_ref() {
-                Some(f) => match crate::filter_compile::apply(&batch, f.as_ref()) {
-                    Ok(Some(b)) => PortalFrame::Batch(b),
-                    Ok(None) => continue,
-                    Err(e) => {
-                        tracing::warn!(subscription = %name, error = %e, "filter failed; closing");
-                        return;
-                    }
-                },
-                None => PortalFrame::Batch(batch),
-            },
-            Ok(MvUpdate::Barrier {
-                epoch,
-                checkpoint_id,
-            }) => PortalFrame::Barrier {
-                epoch,
-                checkpoint_id,
-            },
+        let msg = match recv {
+            Ok(m) => m,
             Err(broadcast::error::RecvError::Closed) => return,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(subscription = %name, skipped = n, "lagged; closing");
@@ -156,8 +188,14 @@ async fn pump_loop(
                 return;
             }
         };
-        if tx.send(frame).await.is_err() {
-            return;
+        match translate(msg, filter.as_ref(), &name) {
+            Ok(Some(frame)) => {
+                if tx.send(frame).await.is_err() {
+                    return;
+                }
+            }
+            Ok(None) => {}
+            Err(()) => return,
         }
     }
 }
@@ -170,7 +208,7 @@ mod tests {
     use arrow_array::Int64Array;
     use arrow_schema::{DataType, Field, Schema};
 
-    use super::super::registry::SubscriptionRegistry;
+    use super::super::registry::{SubscribeStart, SubscriptionRegistry};
     use super::*;
 
     fn schema() -> SchemaRef {
@@ -184,8 +222,8 @@ mod tests {
     #[tokio::test]
     async fn portal_forwards_batch_and_barrier() {
         let reg = SubscriptionRegistry::new();
-        let rx = reg.subscribe("mv");
-        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+        let (replay, rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        let mut portal = SubscriptionPortal::open("mv", schema(), replay, rx);
 
         reg.send_batch("mv", batch(&[1, 2]));
         reg.broadcast_barrier(7, 99);
@@ -211,8 +249,8 @@ mod tests {
     #[tokio::test]
     async fn portal_closes_on_drop_name() {
         let reg = SubscriptionRegistry::new();
-        let rx = reg.subscribe("mv");
-        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+        let (replay, rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        let mut portal = SubscriptionPortal::open("mv", schema(), replay, rx);
 
         reg.send_batch("mv", batch(&[1]));
         let _ = portal.next_frame().await;
@@ -228,8 +266,8 @@ mod tests {
     #[tokio::test]
     async fn portal_emits_lagged_as_final_frame() {
         let reg = SubscriptionRegistry::new();
-        let rx = reg.subscribe("mv");
-        let mut portal = SubscriptionPortal::open("mv", schema(), rx);
+        let (replay, rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        let mut portal = SubscriptionPortal::open("mv", schema(), replay, rx);
 
         for i in 0..1024 {
             reg.send_batch("mv", batch(&[i]));
@@ -253,10 +291,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn portal_drains_replay_before_live() {
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 1 << 20);
+
+        // Two epochs of pre-existing history.
+        reg.broadcast_barrier(1, 1);
+        reg.send_batch("mv", batch(&[10]));
+        reg.broadcast_barrier(2, 2);
+        reg.send_batch("mv", batch(&[20]));
+
+        // Subscribe AS OF EPOCH 1: the client has everything up to and
+        // including the epoch-1 barrier; replay must cover everything after
+        // it. That's batch[10], then barrier(2), then batch[20].
+        let (replay, rx) = reg.subscribe("mv", SubscribeStart::AsOfEpoch(1)).unwrap();
+        let mut portal = SubscriptionPortal::open("mv", schema(), replay, rx);
+
+        reg.send_batch("mv", batch(&[30]));
+
+        let mut row_seq = Vec::new();
+        let mut barriers = Vec::new();
+        for _ in 0..4 {
+            match portal.next_frame().await.unwrap() {
+                PortalFrame::Batch(b) => {
+                    let v = b
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap()
+                        .value(0);
+                    row_seq.push(v);
+                }
+                PortalFrame::Barrier { epoch, .. } => barriers.push(epoch),
+                PortalFrame::Lagged(n) => panic!("unexpected lag: {n}"),
+            }
+        }
+        assert_eq!(row_seq, vec![10, 20, 30]);
+        assert_eq!(barriers, vec![2]);
+    }
+
+    #[tokio::test]
     async fn close_is_idempotent() {
         let reg = SubscriptionRegistry::new();
-        let rx = reg.subscribe("mv");
-        let portal = SubscriptionPortal::open("mv", schema(), rx);
+        let (replay, rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        let portal = SubscriptionPortal::open("mv", schema(), replay, rx);
 
         portal.close();
         portal.close();

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -1,11 +1,6 @@
-//! Per-name replayable broadcast log for SUBSCRIBE.
-//!
-//! Each registered name owns a `StreamLog`: a small ring buffer of recent
-//! `MvUpdate`s plus a live broadcast channel. Sending appends to the ring
-//! (with byte-bounded eviction) and broadcasts. Subscribing under the same
-//! lock atomically snapshots the ring and attaches a fresh receiver, so a
-//! consumer that asks for `AS OF EPOCH N` can replay the tail of the log
-//! and then stream live without a gap between the two.
+//! Per-name replayable broadcast log for SUBSCRIBE. Send and subscribe
+//! are serialized by one mutex per stream so the (replay snapshot, live
+//! receiver) pair an `AS OF EPOCH n` consumer gets has no gap.
 
 #![allow(clippy::disallowed_types)] // cold path
 
@@ -33,11 +28,9 @@ pub enum SubscribeStart {
     AsOfEpoch(u64),
 }
 
-/// Returned when `AsOfEpoch(n)` is requested but `n` is no longer in the log.
 #[derive(Debug)]
 pub(crate) struct ReplayPruned {
-    /// The earliest barrier epoch the log can still serve, or `0` if the log
-    /// is empty / has no barriers retained.
+    /// Earliest barrier epoch still in the log, or `0` if none retained.
     pub(crate) earliest_retained: u64,
 }
 
@@ -148,17 +141,12 @@ impl SubscriptionRegistry {
         }
     }
 
-    /// Set the retention byte cap for `name`, creating the log if needed.
-    /// `cap == 0` disables retention (the live broadcast still works, but
-    /// no replay buffer is kept).
+    /// `cap == 0` disables retention; the live broadcast still works.
     pub(crate) fn configure(&self, name: &str, cap: usize) {
         let log = self.get_or_create(name);
         log.set_cap(cap);
     }
 
-    /// Attach a receiver. If `start` is `AsOfEpoch(n)` and `n` is no longer
-    /// retained, returns the `ReplayPruned` error so the caller can surface
-    /// it as a typed wire-level error.
     pub(crate) fn subscribe(
         &self,
         name: &str,
@@ -168,14 +156,12 @@ impl SubscriptionRegistry {
         log.subscribe(start)
     }
 
-    /// Send a batch to subscribers of `name`. No-op if no log exists yet.
     pub(crate) fn send_batch(&self, name: &str, batch: RecordBatch) {
         if let Some(log) = self.streams.read().get(name).cloned() {
             log.send(MvUpdate::Batch(batch));
         }
     }
 
-    /// Broadcast a barrier marker to every registered name.
     pub(crate) fn broadcast_barrier(&self, epoch: u64, checkpoint_id: u64) {
         let msg = MvUpdate::Barrier {
             epoch,
@@ -186,7 +172,6 @@ impl SubscriptionRegistry {
         }
     }
 
-    /// Drop the log for `name`. Existing receivers see `Closed`.
     pub(crate) fn drop_name(&self, name: &str) -> bool {
         self.streams.write().remove(name).is_some()
     }

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -1,11 +1,19 @@
-//! Per-name broadcast registry for SUBSCRIBE.
+//! Per-name replayable broadcast log for SUBSCRIBE.
+//!
+//! Each registered name owns a `StreamLog`: a small ring buffer of recent
+//! `MvUpdate`s plus a live broadcast channel. Sending appends to the ring
+//! (with byte-bounded eviction) and broadcasts. Subscribing under the same
+//! lock atomically snapshots the ring and attaches a fresh receiver, so a
+//! consumer that asks for `AS OF EPOCH N` can replay the tail of the log
+//! and then stream live without a gap between the two.
 
 #![allow(clippy::disallowed_types)] // cold path
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 
 use arrow_array::RecordBatch;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use tokio::sync::broadcast;
 
 const BROADCAST_CAPACITY: usize = 256;
@@ -16,33 +24,154 @@ pub(crate) enum MvUpdate {
     Barrier { epoch: u64, checkpoint_id: u64 },
 }
 
+/// Where a new subscriber should start reading.
+#[derive(Clone, Copy, Debug)]
+pub enum SubscribeStart {
+    /// See only what's sent after subscribing.
+    Tail,
+    /// Replay everything emitted strictly after the barrier with `epoch == n`.
+    AsOfEpoch(u64),
+}
+
+/// Returned when `AsOfEpoch(n)` is requested but `n` is no longer in the log.
+#[derive(Debug)]
+pub(crate) struct ReplayPruned {
+    /// The earliest barrier epoch the log can still serve, or `0` if the log
+    /// is empty / has no barriers retained.
+    pub(crate) earliest_retained: u64,
+}
+
+struct StreamLog {
+    inner: Mutex<StreamLogInner>,
+}
+
+struct StreamLogInner {
+    buf: VecDeque<MvUpdate>,
+    bytes: usize,
+    cap: usize,
+    sender: broadcast::Sender<MvUpdate>,
+}
+
+impl StreamLog {
+    fn new(cap: usize) -> Self {
+        let (sender, _) = broadcast::channel(BROADCAST_CAPACITY);
+        Self {
+            inner: Mutex::new(StreamLogInner {
+                buf: VecDeque::new(),
+                bytes: 0,
+                cap,
+                sender,
+            }),
+        }
+    }
+
+    fn send(&self, msg: MvUpdate) {
+        let mut g = self.inner.lock();
+        if g.cap > 0 {
+            g.bytes += approx_size(&msg);
+            g.buf.push_back(msg.clone());
+            while g.bytes > g.cap && g.buf.len() > 1 {
+                if let Some(evicted) = g.buf.pop_front() {
+                    g.bytes = g.bytes.saturating_sub(approx_size(&evicted));
+                }
+            }
+        }
+        let _ = g.sender.send(msg);
+    }
+
+    fn subscribe(
+        &self,
+        start: SubscribeStart,
+    ) -> Result<(Vec<MvUpdate>, broadcast::Receiver<MvUpdate>), ReplayPruned> {
+        let g = self.inner.lock();
+        let replay = match start {
+            SubscribeStart::Tail => Vec::new(),
+            SubscribeStart::AsOfEpoch(n) => slice_after_epoch(&g.buf, n)?,
+        };
+        let rx = g.sender.subscribe();
+        Ok((replay, rx))
+    }
+
+    fn set_cap(&self, cap: usize) {
+        let mut g = self.inner.lock();
+        g.cap = cap;
+        while g.cap > 0 && g.bytes > g.cap && g.buf.len() > 1 {
+            if let Some(evicted) = g.buf.pop_front() {
+                g.bytes = g.bytes.saturating_sub(approx_size(&evicted));
+            }
+        }
+        if g.cap == 0 {
+            g.buf.clear();
+            g.bytes = 0;
+        }
+    }
+
+    fn subscriber_count(&self) -> usize {
+        self.inner.lock().sender.receiver_count()
+    }
+}
+
+fn slice_after_epoch(buf: &VecDeque<MvUpdate>, n: u64) -> Result<Vec<MvUpdate>, ReplayPruned> {
+    let mut found_at = None;
+    let mut earliest = u64::MAX;
+    for (i, msg) in buf.iter().enumerate() {
+        if let MvUpdate::Barrier { epoch, .. } = msg {
+            earliest = earliest.min(*epoch);
+            if *epoch == n {
+                found_at = Some(i);
+            }
+        }
+    }
+    match found_at {
+        Some(i) => Ok(buf.iter().skip(i + 1).cloned().collect()),
+        None => Err(ReplayPruned {
+            earliest_retained: if earliest == u64::MAX { 0 } else { earliest },
+        }),
+    }
+}
+
+fn approx_size(msg: &MvUpdate) -> usize {
+    match msg {
+        MvUpdate::Batch(b) => b.get_array_memory_size(),
+        MvUpdate::Barrier { .. } => 16,
+    }
+}
+
 pub(crate) struct SubscriptionRegistry {
-    senders: RwLock<HashMap<String, broadcast::Sender<MvUpdate>>>,
+    streams: RwLock<HashMap<String, Arc<StreamLog>>>,
 }
 
 impl SubscriptionRegistry {
     pub(crate) fn new() -> Self {
         Self {
-            senders: RwLock::new(HashMap::new()),
+            streams: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Attach a receiver, allocating the channel on first call.
-    pub(crate) fn subscribe(&self, name: &str) -> broadcast::Receiver<MvUpdate> {
-        if let Some(tx) = self.senders.read().get(name) {
-            return tx.subscribe();
-        }
-        self.senders
-            .write()
-            .entry(name.to_string())
-            .or_insert_with(|| broadcast::channel(BROADCAST_CAPACITY).0)
-            .subscribe()
+    /// Set the retention byte cap for `name`, creating the log if needed.
+    /// `cap == 0` disables retention (the live broadcast still works, but
+    /// no replay buffer is kept).
+    pub(crate) fn configure(&self, name: &str, cap: usize) {
+        let log = self.get_or_create(name);
+        log.set_cap(cap);
     }
 
-    /// Send a batch to subscribers of `name`. Cheap when nobody is attached.
+    /// Attach a receiver. If `start` is `AsOfEpoch(n)` and `n` is no longer
+    /// retained, returns the `ReplayPruned` error so the caller can surface
+    /// it as a typed wire-level error.
+    pub(crate) fn subscribe(
+        &self,
+        name: &str,
+        start: SubscribeStart,
+    ) -> Result<(Vec<MvUpdate>, broadcast::Receiver<MvUpdate>), ReplayPruned> {
+        let log = self.get_or_create(name);
+        log.subscribe(start)
+    }
+
+    /// Send a batch to subscribers of `name`. No-op if no log exists yet.
     pub(crate) fn send_batch(&self, name: &str, batch: RecordBatch) {
-        if let Some(tx) = self.senders.read().get(name) {
-            let _ = tx.send(MvUpdate::Batch(batch));
+        if let Some(log) = self.streams.read().get(name).cloned() {
+            log.send(MvUpdate::Batch(batch));
         }
     }
 
@@ -52,21 +181,33 @@ impl SubscriptionRegistry {
             epoch,
             checkpoint_id,
         };
-        for tx in self.senders.read().values() {
-            let _ = tx.send(msg.clone());
+        for log in self.streams.read().values() {
+            log.send(msg.clone());
         }
     }
 
-    /// Drop the broadcast for `name`. Existing receivers see `Closed`.
+    /// Drop the log for `name`. Existing receivers see `Closed`.
     pub(crate) fn drop_name(&self, name: &str) -> bool {
-        self.senders.write().remove(name).is_some()
+        self.streams.write().remove(name).is_some()
     }
 
     pub(crate) fn subscriber_count(&self, name: &str) -> usize {
-        self.senders
+        self.streams
             .read()
             .get(name)
-            .map_or(0, broadcast::Sender::receiver_count)
+            .map_or(0, |log| log.subscriber_count())
+    }
+
+    fn get_or_create(&self, name: &str) -> Arc<StreamLog> {
+        if let Some(log) = self.streams.read().get(name) {
+            return Arc::clone(log);
+        }
+        Arc::clone(
+            self.streams
+                .write()
+                .entry(name.to_string())
+                .or_insert_with(|| Arc::new(StreamLog::new(0))),
+        )
     }
 }
 
@@ -93,7 +234,8 @@ mod tests {
     #[tokio::test]
     async fn round_trip() {
         let reg = SubscriptionRegistry::new();
-        let mut rx = reg.subscribe("mv");
+        let (replay, mut rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        assert!(replay.is_empty());
 
         reg.send_batch("mv", batch(&[1, 2, 3]));
         let MvUpdate::Batch(b) = rx.recv().await.unwrap() else {
@@ -123,7 +265,7 @@ mod tests {
     #[tokio::test]
     async fn drop_name_closes_receivers() {
         let reg = SubscriptionRegistry::new();
-        let mut rx = reg.subscribe("mv");
+        let (_, mut rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
         assert!(reg.drop_name("mv"));
         assert!(matches!(
             rx.recv().await,
@@ -134,12 +276,113 @@ mod tests {
     #[test]
     fn subscriber_count_tracks_attach_drop() {
         let reg = SubscriptionRegistry::new();
-        let r1 = reg.subscribe("mv");
-        let r2 = reg.subscribe("mv");
+        let (_, r1) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        let (_, r2) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
         assert_eq!(reg.subscriber_count("mv"), 2);
         drop(r1);
         assert_eq!(reg.subscriber_count("mv"), 1);
         drop(r2);
         assert_eq!(reg.subscriber_count("mv"), 0);
+    }
+
+    #[test]
+    fn tail_subscribe_does_not_replay_history() {
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 1 << 20);
+        reg.broadcast_barrier(1, 1);
+        reg.send_batch("mv", batch(&[10]));
+        reg.broadcast_barrier(2, 2);
+
+        let (replay, _rx) = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        assert!(replay.is_empty());
+    }
+
+    #[test]
+    fn as_of_returns_messages_after_matching_barrier() {
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 1 << 20);
+        reg.broadcast_barrier(1, 10);
+        reg.send_batch("mv", batch(&[10]));
+        reg.broadcast_barrier(2, 20);
+        reg.send_batch("mv", batch(&[20]));
+        reg.broadcast_barrier(3, 30);
+
+        let (replay, _rx) = reg.subscribe("mv", SubscribeStart::AsOfEpoch(2)).unwrap();
+        // Everything after the epoch-2 barrier: one batch, then the epoch-3 barrier.
+        assert_eq!(replay.len(), 2);
+        assert!(matches!(&replay[0], MvUpdate::Batch(b) if b.num_rows() == 1));
+        assert!(matches!(
+            &replay[1],
+            MvUpdate::Barrier {
+                epoch: 3,
+                checkpoint_id: 30
+            }
+        ));
+    }
+
+    #[test]
+    fn as_of_below_head_is_pruned() {
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 1 << 20);
+        reg.broadcast_barrier(5, 50);
+        reg.send_batch("mv", batch(&[1]));
+        reg.broadcast_barrier(6, 60);
+
+        let err = reg
+            .subscribe("mv", SubscribeStart::AsOfEpoch(3))
+            .unwrap_err();
+        assert_eq!(err.earliest_retained, 5);
+    }
+
+    #[test]
+    fn unconfigured_log_does_not_retain() {
+        let reg = SubscriptionRegistry::new();
+        // No configure(): cap stays at 0; live still works but replay is empty.
+        let _ = reg.subscribe("mv", SubscribeStart::Tail).unwrap();
+        reg.broadcast_barrier(1, 1);
+        reg.send_batch("mv", batch(&[1]));
+
+        // Fresh AS OF EPOCH 1 should be pruned because nothing was buffered.
+        let err = reg
+            .subscribe("mv", SubscribeStart::AsOfEpoch(1))
+            .unwrap_err();
+        assert_eq!(err.earliest_retained, 0);
+    }
+
+    #[test]
+    fn eviction_trims_to_cap() {
+        let reg = SubscriptionRegistry::new();
+        // Cap small enough that one big batch will evict prior entries.
+        let one_batch_bytes = batch(&[0]).get_array_memory_size();
+        reg.configure("mv", one_batch_bytes + 1);
+
+        reg.broadcast_barrier(1, 1);
+        for i in 0..8i64 {
+            reg.send_batch("mv", batch(&[i]));
+        }
+        reg.broadcast_barrier(9, 9);
+
+        // The early barrier should have been evicted by now.
+        let err = reg
+            .subscribe("mv", SubscribeStart::AsOfEpoch(1))
+            .unwrap_err();
+        assert!(err.earliest_retained >= 9 || err.earliest_retained == 0);
+    }
+
+    #[test]
+    fn lowering_cap_trims_existing_buffer() {
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 1 << 20);
+        for i in 0..4i64 {
+            reg.send_batch("mv", batch(&[i]));
+        }
+        reg.broadcast_barrier(1, 1);
+
+        // Drop the cap to 0; everything should be evicted.
+        reg.configure("mv", 0);
+        let err = reg
+            .subscribe("mv", SubscribeStart::AsOfEpoch(1))
+            .unwrap_err();
+        assert_eq!(err.earliest_retained, 0);
     }
 }

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -63,11 +63,7 @@ impl StreamLog {
         if g.cap > 0 {
             g.bytes += approx_size(&msg);
             g.buf.push_back(msg.clone());
-            while g.bytes > g.cap && g.buf.len() > 1 {
-                if let Some(evicted) = g.buf.pop_front() {
-                    g.bytes = g.bytes.saturating_sub(approx_size(&evicted));
-                }
-            }
+            evict_to_cap(&mut g);
         }
         let _ = g.sender.send(msg);
     }
@@ -88,19 +84,19 @@ impl StreamLog {
     fn set_cap(&self, cap: usize) {
         let mut g = self.inner.lock();
         g.cap = cap;
-        while g.cap > 0 && g.bytes > g.cap && g.buf.len() > 1 {
-            if let Some(evicted) = g.buf.pop_front() {
-                g.bytes = g.bytes.saturating_sub(approx_size(&evicted));
-            }
-        }
-        if g.cap == 0 {
-            g.buf.clear();
-            g.bytes = 0;
-        }
+        evict_to_cap(&mut g);
     }
 
     fn subscriber_count(&self) -> usize {
         self.inner.lock().sender.receiver_count()
+    }
+}
+
+fn evict_to_cap(g: &mut StreamLogInner) {
+    while g.bytes > g.cap && !g.buf.is_empty() {
+        if let Some(evicted) = g.buf.pop_front() {
+            g.bytes = g.bytes.saturating_sub(approx_size(&evicted));
+        }
     }
 }
 
@@ -352,6 +348,21 @@ mod tests {
             .subscribe("mv", SubscribeStart::AsOfEpoch(1))
             .unwrap_err();
         assert!(err.earliest_retained >= 9 || err.earliest_retained == 0);
+    }
+
+    #[test]
+    fn single_oversize_message_is_evicted_not_retained() {
+        // A batch larger than the entire cap must not stick around — better
+        // to surface pruned at AS OF time than silently blow the budget.
+        let reg = SubscriptionRegistry::new();
+        reg.configure("mv", 8); // tiny cap, smaller than any real batch
+        reg.broadcast_barrier(1, 1);
+        reg.send_batch("mv", batch(&[1, 2, 3, 4, 5, 6, 7, 8]));
+
+        let err = reg
+            .subscribe("mv", SubscribeStart::AsOfEpoch(1))
+            .unwrap_err();
+        assert_eq!(err.earliest_retained, 0, "buffer should be empty");
     }
 
     #[test]

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -71,9 +71,13 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
             out.push(match stmt {
                 StreamingStatement::Subscribe(s) => {
                     let name = s.name.to_string();
+                    let start = match s.as_of_epoch {
+                        Some(n) => laminar_db::subscription::SubscribeStart::AsOfEpoch(n),
+                        None => laminar_db::subscription::SubscribeStart::Tail,
+                    };
                     let portal = self
                         .db
-                        .open_subscription(&name, s.filter_sql.as_deref())
+                        .open_subscription(&name, s.filter_sql.as_deref(), start)
                         .await
                         .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
                     portal_to_response(portal)
@@ -1158,6 +1162,27 @@ mod integration_tests {
         assert!(
             db_err.message().contains("no_such_col"),
             "filter error must name the bad column, got: {}",
+            db_err.message()
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn subscribe_as_of_unretained_returns_pg_error() {
+        // No retention configured on the `prices` MV from the default setup,
+        // so AS OF EPOCH 1 must come back as a typed PG error.
+        let (addr, handle) = spawn_server().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("SUBSCRIBE prices AS OF EPOCH 1")
+            .await
+            .expect_err("must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("no longer retained"),
+            "message: {}",
             db_err.message()
         );
 

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -476,9 +476,11 @@ fn parse_create_stream(
         .expect_keyword(sqlparser::keywords::Keyword::AS)
         .map_err(ParseError::SqlParseError)?;
 
-    // Collect remaining tokens and split at EMIT boundary
+    // Collect remaining tokens, then peel off the optional trailing
+    // `WITH (...)` before splitting query / EMIT.
     let remaining = collect_remaining_tokens(parser);
-    let (query_tokens, emit_tokens) = split_at_emit(&remaining);
+    let (head_tokens, with_tokens) = split_off_trailing_with(&remaining);
+    let (query_tokens, emit_tokens) = split_at_emit(&head_tokens);
 
     let query_sql = query_body_sql(original_sql, &query_tokens, &emit_tokens);
 
@@ -507,6 +509,16 @@ fn parse_create_stream(
         emit_parser::parse_emit_clause(&mut emit_parser)?
     };
 
+    let retention_bytes = match with_tokens {
+        None => None,
+        Some(tokens) => {
+            let mut with_parser =
+                sqlparser::parser::Parser::new(&stream_dialect).with_tokens_with_locations(tokens);
+            let opts = tokenizer::parse_with_options(&mut with_parser)?;
+            extract_retention_bytes(&opts)?
+        }
+    };
+
     Ok(StreamingStatement::CreateStream {
         name,
         query: Box::new(query_stmt),
@@ -514,7 +526,71 @@ fn parse_create_stream(
         or_replace,
         if_not_exists,
         query_sql,
+        retention_bytes,
     })
+}
+
+/// Find the last top-level `WITH (` and split the token stream there. The
+/// returned tail (when present) ends with EOF and is suitable for feeding to
+/// `parse_with_options`. CTE-style `WITH ident AS (...)` is ignored because
+/// it is followed by an identifier, not `(`.
+fn split_off_trailing_with(
+    tokens: &[sqlparser::tokenizer::TokenWithSpan],
+) -> (
+    Vec<sqlparser::tokenizer::TokenWithSpan>,
+    Option<Vec<sqlparser::tokenizer::TokenWithSpan>>,
+) {
+    use sqlparser::tokenizer::Token;
+    let mut depth: i32 = 0;
+    let mut last_with_idx: Option<usize> = None;
+    for (i, t) in tokens.iter().enumerate() {
+        match &t.token {
+            Token::LParen => depth += 1,
+            Token::RParen => depth -= 1,
+            Token::Word(w) if depth == 0 && w.value.eq_ignore_ascii_case("WITH") => {
+                if matches!(tokens.get(i + 1).map(|t| &t.token), Some(Token::LParen)) {
+                    last_with_idx = Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    match last_with_idx {
+        None => (tokens.to_vec(), None),
+        Some(i) => {
+            let mut head = tokens[..i].to_vec();
+            head.push(sqlparser::tokenizer::TokenWithSpan {
+                token: Token::EOF,
+                span: sqlparser::tokenizer::Span::empty(),
+            });
+            let tail = tokens[i..].to_vec();
+            (head, Some(tail))
+        }
+    }
+}
+
+/// Pull `RETAIN_HISTORY` out of the WITH-options map and parse it as a byte
+/// size. Unknown keys are rejected so typos surface immediately.
+fn extract_retention_bytes(
+    opts: &std::collections::HashMap<String, String>,
+) -> Result<Option<u64>, ParseError> {
+    for key in opts.keys() {
+        if !key.eq_ignore_ascii_case("retain_history") {
+            return Err(ParseError::StreamingError(format!(
+                "unknown CREATE STREAM option '{key}' (expected RETAIN_HISTORY)"
+            )));
+        }
+    }
+    match opts
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("retain_history"))
+    {
+        None => Ok(None),
+        Some((_, v)) => {
+            let bytes = lookup_table::ByteSize::parse(v)?;
+            Ok(Some(bytes.as_bytes()))
+        }
+    }
 }
 
 /// Slice `original_sql` from the first query token to the start of EMIT
@@ -1359,6 +1435,45 @@ mod tests {
             }
             _ => panic!("Expected CreateStream, got {stmt:?}"),
         }
+    }
+
+    #[test]
+    fn create_stream_with_retain_history() {
+        let stmt = parse_one(
+            "CREATE STREAM trades AS SELECT * FROM events WITH ('retain_history' = '64mb')",
+        );
+        let StreamingStatement::CreateStream {
+            retention_bytes, ..
+        } = stmt
+        else {
+            panic!("expected CreateStream");
+        };
+        assert_eq!(retention_bytes, Some(64 * 1024 * 1024));
+    }
+
+    #[test]
+    fn create_stream_with_retain_history_after_emit() {
+        let stmt = parse_one(
+            "CREATE STREAM trades AS SELECT COUNT(*) FROM events EMIT ON WINDOW CLOSE \
+             WITH ('retain_history' = '8mb')",
+        );
+        let StreamingStatement::CreateStream {
+            retention_bytes,
+            emit_clause,
+            ..
+        } = stmt
+        else {
+            panic!("expected CreateStream");
+        };
+        assert_eq!(retention_bytes, Some(8 * 1024 * 1024));
+        assert_eq!(emit_clause, Some(EmitClause::OnWindowClose));
+    }
+
+    #[test]
+    fn create_stream_rejects_unknown_with_option() {
+        let res = parse_streaming_sql("CREATE STREAM s AS SELECT * FROM e WITH ('bogus' = '1')");
+        let err = res.expect_err("unknown WITH key must error");
+        assert!(err.to_string().contains("bogus"), "got: {err}");
     }
 
     #[test]

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -482,7 +482,12 @@ fn parse_create_stream(
     let (head_tokens, with_tokens) = split_off_trailing_with(&remaining);
     let (query_tokens, emit_tokens) = split_at_emit(&head_tokens);
 
-    let query_sql = query_body_sql(original_sql, &query_tokens, &emit_tokens);
+    let query_sql = query_body_sql(
+        original_sql,
+        &query_tokens,
+        &emit_tokens,
+        with_tokens.as_deref(),
+    );
 
     let stream_dialect = LaminarDialect::default();
 
@@ -593,13 +598,15 @@ fn extract_retention_bytes(
     }
 }
 
-/// Slice `original_sql` from the first query token to the start of EMIT
-/// (or end of input). Preserves custom streaming syntax that sqlparser's
-/// AST would drop. Falls back to joining token text if spans are empty.
+/// Slice `original_sql` from the first query token to whichever trailing
+/// clause comes next (`EMIT` or `WITH`), or end of input if neither is
+/// present. Preserves custom streaming syntax that sqlparser's AST would
+/// drop. Falls back to joining token text if spans are empty.
 pub(super) fn query_body_sql(
     original_sql: &str,
     query_tokens: &[sqlparser::tokenizer::TokenWithSpan],
     emit_tokens: &[sqlparser::tokenizer::TokenWithSpan],
+    with_tokens: Option<&[sqlparser::tokenizer::TokenWithSpan]>,
 ) -> String {
     use sqlparser::tokenizer::Token;
 
@@ -608,10 +615,11 @@ pub(super) fn query_body_sql(
             .iter()
             .find(|t| !matches!(t.token, Token::EOF))?;
         let start = location_to_byte_offset(original_sql, first.span.start)?;
-        let end = match emit_tokens.first() {
-            Some(t) => location_to_byte_offset(original_sql, t.span.start)?,
-            None => original_sql.len(),
-        };
+        let trailer_starts = [emit_tokens.first(), with_tokens.and_then(|t| t.first())]
+            .into_iter()
+            .flatten()
+            .filter_map(|t| location_to_byte_offset(original_sql, t.span.start));
+        let end = trailer_starts.min().unwrap_or(original_sql.len());
         let slice = original_sql.get(start..end)?;
         Some(
             slice
@@ -896,7 +904,7 @@ fn parse_create_materialized_view(
     let remaining = collect_remaining_tokens(parser);
     let (query_tokens, emit_tokens) = split_at_emit(&remaining);
 
-    let query_sql = query_body_sql(original_sql, &query_tokens, &emit_tokens);
+    let query_sql = query_body_sql(original_sql, &query_tokens, &emit_tokens, None);
 
     let mv_dialect = LaminarDialect::default();
 
@@ -1474,6 +1482,27 @@ mod tests {
         let res = parse_streaming_sql("CREATE STREAM s AS SELECT * FROM e WITH ('bogus' = '1')");
         let err = res.expect_err("unknown WITH key must error");
         assert!(err.to_string().contains("bogus"), "got: {err}");
+    }
+
+    #[test]
+    fn create_stream_with_retain_history_excludes_with_from_query_sql() {
+        // Regression: query_body_sql used to extend to original_sql.len() when
+        // EMIT was absent, which sucked the trailing WITH clause into query_sql
+        // and broke planner re-parsing.
+        let stmt = parse_one(
+            "CREATE STREAM trades AS SELECT * FROM events WITH ('retain_history' = '64mb')",
+        );
+        let StreamingStatement::CreateStream { query_sql, .. } = stmt else {
+            panic!("expected CreateStream");
+        };
+        assert!(
+            !query_sql.to_uppercase().contains("RETAIN_HISTORY"),
+            "query_sql leaked WITH clause: {query_sql}"
+        );
+        assert!(
+            query_sql.contains("FROM events"),
+            "query_sql should still hold the SELECT body, got: {query_sql}"
+        );
     }
 
     #[test]

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -535,10 +535,8 @@ fn parse_create_stream(
     })
 }
 
-/// Find the last top-level `WITH (` and split the token stream there. The
-/// returned tail (when present) ends with EOF and is suitable for feeding to
-/// `parse_with_options`. CTE-style `WITH ident AS (...)` is ignored because
-/// it is followed by an identifier, not `(`.
+/// Split off a trailing `WITH (` at depth 0. CTE-style `WITH ident AS (...)`
+/// is ignored because it's followed by an identifier, not `(`.
 fn split_off_trailing_with(
     tokens: &[sqlparser::tokenizer::TokenWithSpan],
 ) -> (
@@ -574,8 +572,7 @@ fn split_off_trailing_with(
     }
 }
 
-/// Pull `RETAIN_HISTORY` out of the WITH-options map and parse it as a byte
-/// size. Unknown keys are rejected so typos surface immediately.
+/// Unknown keys are rejected so typos surface immediately.
 fn extract_retention_bytes(
     opts: &std::collections::HashMap<String, String>,
 ) -> Result<Option<u64>, ParseError> {

--- a/crates/laminar-sql/src/parser/statements.rs
+++ b/crates/laminar-sql/src/parser/statements.rs
@@ -142,6 +142,11 @@ pub enum StreamingStatement {
         if_not_exists: bool,
         /// Raw query text between `AS` and `EMIT`.
         query_sql: String,
+        /// `RETAIN_HISTORY` cap in bytes from the trailing `WITH (...)` clause.
+        /// `None` means retention is off (matches today's behavior); `Some(n)`
+        /// keeps `n` bytes of recent broadcast updates so SUBSCRIBE clients
+        /// can resume `AS OF EPOCH N` after a brief disconnect.
+        retention_bytes: Option<u64>,
     },
 
     /// DROP STREAM statement
@@ -196,13 +201,17 @@ pub enum StreamingStatement {
     Subscribe(Box<SubscribeStatement>),
 }
 
-/// `SUBSCRIBE <name> [WHERE <fragment>] [WITH (...)]`.
+/// `SUBSCRIBE <name> [AS OF EPOCH n] [WHERE <fragment>] [WITH (...)]`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SubscribeStatement {
     /// Target stream or materialized view name.
     pub name: ObjectName,
     /// Raw WHERE fragment, compiled by the engine against the target schema.
     pub filter_sql: Option<String>,
+    /// `AS OF EPOCH n`: replay everything emitted strictly after the
+    /// barrier with `epoch == n` before delivering live updates. Errors at
+    /// open if the requested epoch is no longer retained.
+    pub as_of_epoch: Option<u64>,
     /// Reserved for future WITH options.
     pub options: HashMap<String, String>,
 }

--- a/crates/laminar-sql/src/parser/statements.rs
+++ b/crates/laminar-sql/src/parser/statements.rs
@@ -142,10 +142,7 @@ pub enum StreamingStatement {
         if_not_exists: bool,
         /// Raw query text between `AS` and `EMIT`.
         query_sql: String,
-        /// `RETAIN_HISTORY` cap in bytes from the trailing `WITH (...)` clause.
-        /// `None` means retention is off (matches today's behavior); `Some(n)`
-        /// keeps `n` bytes of recent broadcast updates so SUBSCRIBE clients
-        /// can resume `AS OF EPOCH N` after a brief disconnect.
+        /// `RETAIN_HISTORY` cap in bytes from the trailing `WITH (...)`.
         retention_bytes: Option<u64>,
     },
 
@@ -208,9 +205,7 @@ pub struct SubscribeStatement {
     pub name: ObjectName,
     /// Raw WHERE fragment, compiled by the engine against the target schema.
     pub filter_sql: Option<String>,
-    /// `AS OF EPOCH n`: replay everything emitted strictly after the
-    /// barrier with `epoch == n` before delivering live updates. Errors at
-    /// open if the requested epoch is no longer retained.
+    /// `AS OF EPOCH n`: replay everything emitted strictly after barrier `n`.
     pub as_of_epoch: Option<u64>,
     /// Reserved for future WITH options.
     pub options: HashMap<String, String>,

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -44,9 +44,6 @@ pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseE
     })
 }
 
-/// Parses an optional `AS OF EPOCH <integer>` clause. Returns `Ok(None)` if
-/// the next token isn't `AS`. EPOCH is the only spelling for now; TIMESTAMP
-/// resolution is a follow-up.
 fn parse_as_of_epoch(parser: &mut Parser) -> Result<Option<u64>, ParseError> {
     if !parser.parse_keyword(Keyword::AS) {
         return Ok(None);

--- a/crates/laminar-sql/src/parser/subscribe_parser.rs
+++ b/crates/laminar-sql/src/parser/subscribe_parser.rs
@@ -15,6 +15,8 @@ pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseE
         .parse_object_name(false)
         .map_err(ParseError::SqlParseError)?;
 
+    let as_of_epoch = parse_as_of_epoch(parser)?;
+
     // Validate via sqlparser then round-trip; filter_compile re-parses anyway.
     let filter_sql = if parser.parse_keyword(Keyword::WHERE) {
         let expr = parser.parse_expr().map_err(ParseError::SqlParseError)?;
@@ -37,8 +39,34 @@ pub fn parse_subscribe(parser: &mut Parser) -> Result<SubscribeStatement, ParseE
     Ok(SubscribeStatement {
         name,
         filter_sql,
+        as_of_epoch,
         options,
     })
+}
+
+/// Parses an optional `AS OF EPOCH <integer>` clause. Returns `Ok(None)` if
+/// the next token isn't `AS`. EPOCH is the only spelling for now; TIMESTAMP
+/// resolution is a follow-up.
+fn parse_as_of_epoch(parser: &mut Parser) -> Result<Option<u64>, ParseError> {
+    if !parser.parse_keyword(Keyword::AS) {
+        return Ok(None);
+    }
+    if !parser.parse_keyword(Keyword::OF) {
+        return Err(ParseError::StreamingError(
+            "expected `OF` after `AS`".to_string(),
+        ));
+    }
+    expect_custom_keyword(parser, "EPOCH")?;
+    match parser.next_token().token {
+        Token::Number(n, _) => n.parse::<u64>().map(Some).map_err(|_| {
+            ParseError::StreamingError(format!(
+                "invalid epoch: {n} (expected non-negative integer)"
+            ))
+        }),
+        other => Err(ParseError::StreamingError(format!(
+            "expected integer after `AS OF EPOCH`, found {other}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -117,5 +145,39 @@ mod tests {
     #[test]
     fn rejects_with_before_where() {
         assert!(parse("SUBSCRIBE foo WITH ('snapshot' = 'true') WHERE c > 1").is_err());
+    }
+
+    #[test]
+    fn parses_as_of_epoch() {
+        let stmt = parse("SUBSCRIBE foo AS OF EPOCH 42").expect("parse");
+        assert_eq!(stmt.as_of_epoch, Some(42));
+    }
+
+    #[test]
+    fn as_of_then_where_then_with() {
+        let stmt = parse("SUBSCRIBE foo AS OF EPOCH 7 WHERE c > 1 WITH ('snapshot' = 'true')")
+            .expect("parse");
+        assert_eq!(stmt.as_of_epoch, Some(7));
+        assert!(stmt.filter_sql.is_some());
+        assert_eq!(
+            stmt.options.get("snapshot").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn rejects_as_of_without_epoch_keyword() {
+        // `AS OF SYSTEM TIME ...` is not yet supported.
+        assert!(parse("SUBSCRIBE foo AS OF SYSTEM TIME '...'").is_err());
+    }
+
+    #[test]
+    fn rejects_as_of_with_non_integer() {
+        assert!(parse("SUBSCRIBE foo AS OF EPOCH 'abc'").is_err());
+    }
+
+    #[test]
+    fn rejects_negative_epoch() {
+        assert!(parse("SUBSCRIBE foo AS OF EPOCH -1").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Lets a SUBSCRIBE client reconnect after a network blip and resume from where it left off without missing rows. Today the broadcast queue drops anything a slow consumer misses (lag → SQLSTATE 54000, full disconnect).

Each per-name `SubscriptionRegistry` entry becomes a `StreamLog`: a byte-bounded `VecDeque<MvUpdate>` plus the existing `broadcast::Sender`, both serialized by one mutex. Sending appends + broadcasts under the lock; subscribing snapshots the deque and attaches a fresh receiver under the same lock, so the `(replay_slice, live_receiver)` pair has no gap.

## Surface

```sql
CREATE STREAM trades AS SELECT * FROM events
  WITH ('retain_history' = '64mb');

SUBSCRIBE TO trades AS OF EPOCH 42;
```

`AS OF EPOCH n` replays everything strictly after the matching `MvUpdate::Barrier`. When `n` is no longer retained, `open_subscription` returns `DbError::InvalidOperation` naming the requested and earliest-retained epochs; pgwire surfaces it as a typed PG error.

## Reused, not rebuilt

- `ByteSize::parse` for `'64mb'` (existing in `parser/lookup_table.rs`)
- `parse_with_options` for the `WITH (...)` body
- `MvUpdate::Barrier { epoch, .. }` as the replay index — no new metadata
- The existing depth-tracked token-scan pattern from `split_at_emit` for peeling the trailing `WITH (...)` off `CREATE STREAM`

## Not done (intentional follow-ups)

- Durable history (per-epoch sidecar files; survives restart)
- `AS OF TIMESTAMP '…'` resolving to an epoch
- Emitting epoch markers on the wire so clients can persist a resume token without manual config

## Test plan

- [x] `cargo test --workspace --no-default-features --lib` — 2,352 tests passing
- [x] `cargo clippy --workspace --no-default-features --tests -- -D warnings` — clean
- [x] Unit tests in `subscription::registry`: Tail / AsOf hit / AsOf below head pruned / eviction trims to cap / lowering cap trims existing buffer / unconfigured log does not retain
- [x] Unit test in `subscription::portal`: portal drains replay before live, ordering verified
- [x] E2E in `laminar-db`: `CREATE STREAM ... WITH retain_history` enables `AS OF` replay; unretained `AS OF` returns `InvalidOperation`
- [x] pgwire integration: `SUBSCRIBE foo AS OF EPOCH n` with no retention returns a typed PG error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds replayable SUBSCRIBE history with AS OF EPOCH so clients can reconnect without gaps; retention is opt-in per stream. Also tightens DDL rollback, parser handling, and strictly enforces the history cap.

- **New Features**
  - `CREATE STREAM ... WITH ('retain_history' = '64mb')` enables per-stream history (default off).
  - `SUBSCRIBE <name> AS OF EPOCH <n>` replays updates strictly after the matching barrier, then streams live; if pruned, returns a typed PG error naming the earliest retained epoch.
  - Internals: memory-capped per-stream log; subscribe snapshots and attaches a receiver under one lock to avoid any gap between replay and live.

- **Bug Fixes**
  - DDL rollback now drops the `SubscriptionRegistry` entry if `CREATE STREAM` fails to send on the control channel.
  - Parser excludes trailing `WITH (...)` from `query_sql`, preventing start-up reparse issues.
  - Parser rejects unknown `CREATE STREAM ... WITH` options (surfaces typos early).
  - Eviction to the retention cap is strict; a single oversize message is not retained.

<sup>Written for commit b00a32f93d9918f6b529db7f65ff736ceff1a01e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `RETAIN_HISTORY` option for `CREATE STREAM` to configure retention of historical stream data for replay functionality
  * Added `AS OF EPOCH` clause for `SUBSCRIBE` statements to resume subscriptions from a specific historical point in time
  * Enhanced error reporting when subscription data for a requested epoch is no longer retained by the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->