### PR TITLE
pgwire: extended-query + binary format for SUBSCRIBE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -225,7 +236,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -407,7 +418,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -462,7 +473,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -474,7 +485,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -581,7 +592,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -592,7 +603,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1334,7 +1345,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1343,8 +1354,22 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
+ "borsh-derive",
  "bytes",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1374,7 +1399,7 @@ version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "base64 0.22.1",
  "bitvec",
  "getrandom 0.2.17",
@@ -1418,14 +1443,36 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive 0.6.12",
+ "ptr_meta 0.1.4",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
 dependencies = [
- "bytecheck_derive",
- "ptr_meta",
+ "bytecheck_derive 0.8.2",
+ "ptr_meta 0.3.1",
  "rancor",
  "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1436,7 +1483,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1627,7 +1674,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2031,7 +2078,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2065,7 +2112,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2079,7 +2126,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2090,7 +2137,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2101,7 +2148,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2233,7 +2280,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2df29b9592a5d55b8238eaf67d2f21963d5a08cd1a8b7670134405206caabd"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2496,7 +2543,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325a00081898945d48d6194d9ca26120e523c993be3bb7c084061a5a2a72e787"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2517,7 +2564,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809bbcb1e0dbec5d0ce30d493d135aea7564f1ba4550395f7f94321223df2dae"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2599,7 +2646,7 @@ checksum = "ba01c55ade8278a791b429f7bf5cb1de64de587a342d084b18245edfae7096e2"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2628,7 +2675,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3a86264bb9163e7360b6622e789bc7fcbb43672e78a8493f0bc369a41a57c6"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2667,7 +2714,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae769ea5d688b4e74e9be5cad6f9d9f295b540825355868a3ab942380dd97ce"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "chrono",
  "datafusion-common",
@@ -2703,7 +2750,7 @@ version = "52.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79949cbb109c2a45c527bfe0d956b9f2916807c05d4d2e66f3fd0af827ac2b61"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -2889,7 +2936,7 @@ checksum = "32a311416f16d4793d2aa35f2c76d36ab9b14c808eba00ef24759b47b666255e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3053,7 +3100,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3108,7 +3155,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3129,7 +3176,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3140,7 +3187,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3151,7 +3198,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3172,7 +3219,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3182,7 +3229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3204,7 +3251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -3249,7 +3296,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3351,7 +3398,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3363,7 +3410,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3778,7 +3825,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3938,6 +3985,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4634,7 +4684,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4813,7 +4863,7 @@ dependencies = [
  "object_store 0.13.2",
  "parking_lot 0.12.5",
  "rand 0.10.0",
- "rkyv",
+ "rkyv 0.8.15",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4833,7 +4883,7 @@ dependencies = [
 name = "laminar-db"
 version = "0.21.10"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-array",
  "arrow-ipc",
@@ -4858,7 +4908,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rdkafka",
- "rkyv",
+ "rkyv 0.8.15",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4882,7 +4932,7 @@ dependencies = [
  "laminar-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5000,7 +5050,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5243,7 +5293,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5257,7 +5307,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5268,7 +5318,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5279,7 +5329,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5483,7 +5533,7 @@ dependencies = [
  "macro_magic",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5503,7 +5553,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5769,7 +5819,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5942,7 +5992,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6124,7 +6174,7 @@ version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6a2926a30477c0b95fea6c28c3072712b139337a242c2cc64817bdc20a8854"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
@@ -6177,7 +6227,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6273,6 +6323,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
+ "chrono",
  "derive-new",
  "futures",
  "hex",
@@ -6281,6 +6332,7 @@ dependencies = [
  "pg_interval_2",
  "postgres-types",
  "rand 0.10.0",
+ "rust_decimal",
  "rustls-pki-types",
  "ryu",
  "serde_json",
@@ -6369,7 +6421,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6505,7 +6557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6536,7 +6588,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6626,7 +6678,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6670,11 +6722,31 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive 0.1.4",
+]
+
+[[package]]
+name = "ptr_meta"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
 dependencies = [
- "ptr_meta_derive",
+ "ptr_meta_derive 0.3.1",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6685,7 +6757,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6813,7 +6885,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
- "ptr_meta",
+ "ptr_meta 0.3.1",
 ]
 
 [[package]]
@@ -6983,7 +7055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7041,7 +7113,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7081,11 +7153,20 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck 0.6.12",
+]
+
+[[package]]
+name = "rend"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 dependencies = [
- "bytecheck",
+ "bytecheck 0.8.2",
 ]
 
 [[package]]
@@ -7265,21 +7346,50 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck 0.6.12",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta 0.1.4",
+ "rend 0.4.2",
+ "rkyv_derive 0.7.46",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
 dependencies = [
- "bytecheck",
+ "bytecheck 0.8.2",
  "bytes",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "munge",
- "ptr_meta",
+ "ptr_meta 0.3.1",
  "rancor",
- "rend",
- "rkyv_derive",
+ "rend 0.5.3",
+ "rkyv_derive 0.8.15",
  "tinyvec",
  "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7290,7 +7400,7 @@ checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7311,6 +7421,24 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "postgres-types",
+ "rand 0.8.5",
+ "rkyv 0.7.46",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7538,6 +7666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,7 +7752,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7663,7 +7797,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7715,7 +7849,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7888,7 +8022,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7936,7 +8070,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7947,7 +8081,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7968,7 +8102,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7976,6 +8110,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -8005,7 +8150,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8105,7 +8250,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8116,7 +8261,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8252,7 +8397,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8280,7 +8425,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8590,7 +8735,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8640,7 +8785,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8721,7 +8866,7 @@ checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8732,7 +8877,7 @@ checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8743,7 +8888,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8779,7 +8924,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8949,7 +9094,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9055,6 +9200,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -9092,7 +9238,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -9283,7 +9429,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9294,7 +9440,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9696,7 +9842,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -9712,7 +9858,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -9877,7 +10023,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -9904,7 +10050,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9924,7 +10070,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -9945,7 +10091,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9978,7 +10124,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -1127,6 +1127,33 @@ impl LaminarDB {
             .ok_or_else(|| DbError::StreamNotFound(name.to_string()))
     }
 
+    /// Schema a `SUBSCRIBE` against `name` would emit, plus a `filterable`
+    /// flag that's `false` only when the schema came from a `StreamEntry`
+    /// sink placeholder (`Schema::empty`) — a `WHERE` clause can't compile
+    /// against that and must be rejected.
+    ///
+    /// Lookup order: MV registry → catalog source → `start()`-resolved
+    /// stream output → `StreamEntry` sink (placeholder).
+    #[must_use]
+    pub fn lookup_subscription_schema(
+        &self,
+        name: &str,
+    ) -> Option<(arrow_schema::SchemaRef, bool)> {
+        if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
+            return Some((mv.schema, true));
+        }
+        if let Some(src) = self.catalog.get_source(name) {
+            return Some((Arc::clone(&src.schema), true));
+        }
+        if let Some(schema) = self.stream_schemas.read().get(name).cloned() {
+            return Some((schema, true));
+        }
+        if let Some(entry) = self.catalog.get_stream_entry(name) {
+            return Some((entry.sink.schema(), false));
+        }
+        None
+    }
+
     /// Open a SUBSCRIBE portal against a named MV, source, or stream.
     /// `filter_sql` is rejected on streams (their schema is opaque).
     ///
@@ -1148,22 +1175,9 @@ impl LaminarDB {
             )));
         }
 
-        // Schema lookup order: MV registry, catalog source, stream-output
-        // schemas resolved at start(), then the StreamEntry sink as a last
-        // resort. The sink schema is a known placeholder (Schema::empty),
-        // so it disqualifies WHERE clauses but still permits unfiltered
-        // subscribe.
-        let (schema, filterable) = if let Some(mv) = self.mv_registry.lock().get(name).cloned() {
-            (mv.schema, true)
-        } else if let Some(src) = self.catalog.get_source(name) {
-            (Arc::clone(&src.schema), true)
-        } else if let Some(schema) = self.stream_schemas.read().get(name).cloned() {
-            (schema, true)
-        } else if let Some(entry) = self.catalog.get_stream_entry(name) {
-            (entry.sink.schema(), false)
-        } else {
-            return Err(DbError::StreamNotFound(name.to_string()));
-        };
+        let (schema, filterable) = self
+            .lookup_subscription_schema(name)
+            .ok_or_else(|| DbError::StreamNotFound(name.to_string()))?;
 
         let filter = match filter_sql {
             None => None,

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -58,10 +58,14 @@ axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 
-# Postgres wire with optional TLS (aws-lc-rs backend).
+# Postgres wire with optional TLS (aws-lc-rs backend). pg-type-chrono and
+# pg-type-rust-decimal pull in the postgres-types ToSql impls used by the
+# extended-query binary-format encoders for TIMESTAMP/DATE/NUMERIC columns.
 pgwire = { version = "0.39", default-features = false, features = [
     "server-api",
     "_aws-lc-rs",
+    "pg-type-chrono",
+    "pg-type-rust-decimal",
 ] }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "aws-lc-rs",

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -444,42 +444,42 @@ fn encode_field_binary(
     row: usize,
     name: &str,
 ) -> PgWireResult<()> {
-    use arrow_array::{cast::AsArray, types::*, BooleanArray, Date32Array, Date64Array};
+    use arrow_array::{cast::AsArray, types::*};
     use arrow_schema::DataType;
 
     if col.is_null(row) {
         return enc.encode_field(&None::<&str>);
     }
 
-    // Each arm pulls the typed array from `col` and hands the value to
-    // `DataRowEncoder` which calls `postgres-types::ToSql` for the wire
-    // format. The casts widen narrower Arrow ints to the matching
-    // Postgres OID (`arrow_to_pg_type`).
+    // Pull the typed Arrow value and pass it to `DataRowEncoder`, which
+    // calls `postgres-types::ToSql` for the wire format. The `as $cast`
+    // arm widens a narrower Arrow int to the matching Postgres OID (see
+    // `arrow_to_pg_type`); only lossless `From` casts go through here.
     macro_rules! prim {
-        ($ArrowTy:ty, $cast:expr) => {{
-            let arr = col.as_primitive::<$ArrowTy>();
-            #[allow(clippy::redundant_closure_call)]
-            enc.encode_field(&Some(($cast)(arr.value(row))))
-        }};
+        ($ty:ty as $cast:ty) => {
+            enc.encode_field(&Some(<$cast>::from(col.as_primitive::<$ty>().value(row))))
+        };
+        ($ty:ty) => {
+            enc.encode_field(&Some(col.as_primitive::<$ty>().value(row)))
+        };
     }
 
     match col.data_type() {
-        DataType::Int8 => prim!(Int8Type, |x: i8| i32::from(x)),
-        DataType::Int16 => prim!(Int16Type, |x: i16| i32::from(x)),
-        DataType::Int32 => prim!(Int32Type, |x: i32| x),
-        DataType::Int64 => prim!(Int64Type, |x: i64| x),
-        DataType::UInt8 => prim!(UInt8Type, |x: u8| i32::from(x)),
-        DataType::UInt16 => prim!(UInt16Type, |x: u16| i32::from(x)),
-        DataType::UInt32 => prim!(UInt32Type, |x: u32| i64::from(x)),
-        DataType::UInt64 => prim!(UInt64Type, |x: u64| i64::try_from(x).unwrap_or(i64::MAX)),
-        DataType::Float32 => prim!(Float32Type, |x: f32| f64::from(x)),
-        DataType::Float64 => prim!(Float64Type, |x: f64| x),
-        DataType::Boolean => enc.encode_field(&Some(
-            col.as_any()
-                .downcast_ref::<BooleanArray>()
-                .unwrap()
-                .value(row),
-        )),
+        DataType::Int8 => prim!(Int8Type as i32),
+        DataType::Int16 => prim!(Int16Type as i32),
+        DataType::Int32 => prim!(Int32Type),
+        DataType::Int64 => prim!(Int64Type),
+        DataType::UInt8 => prim!(UInt8Type as i32),
+        DataType::UInt16 => prim!(UInt16Type as i32),
+        DataType::UInt32 => prim!(UInt32Type as i64),
+        DataType::UInt64 => {
+            // PG has no unsigned 64; saturate so we never wrap.
+            let v = col.as_primitive::<UInt64Type>().value(row);
+            enc.encode_field(&Some(i64::try_from(v).unwrap_or(i64::MAX)))
+        }
+        DataType::Float32 => prim!(Float32Type as f64),
+        DataType::Float64 => prim!(Float64Type),
+        DataType::Boolean => enc.encode_field(&Some(col.as_boolean().value(row))),
         DataType::Utf8 => enc.encode_field(&Some(col.as_string::<i32>().value(row))),
         DataType::LargeUtf8 => enc.encode_field(&Some(col.as_string::<i64>().value(row))),
         DataType::Timestamp(unit, _tz) => {
@@ -513,21 +513,13 @@ fn encode_field_binary(
             enc.encode_field(&Some(dt))
         }
         DataType::Date32 => {
-            let v = col
-                .as_any()
-                .downcast_ref::<Date32Array>()
-                .unwrap()
-                .value(row);
+            let v = col.as_primitive::<Date32Type>().value(row);
             let dt = arrow_array::temporal_conversions::date32_to_datetime(v)
                 .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
             enc.encode_field(&Some(dt.date()))
         }
         DataType::Date64 => {
-            let v = col
-                .as_any()
-                .downcast_ref::<Date64Array>()
-                .unwrap()
-                .value(row);
+            let v = col.as_primitive::<Date64Type>().value(row);
             let dt = arrow_array::temporal_conversions::date64_to_datetime(v)
                 .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
             enc.encode_field(&Some(dt.date()))
@@ -1896,8 +1888,6 @@ mod integration_tests {
     /// the first row.
     #[tokio::test]
     async fn extended_query_binary_timestamp() {
-        use std::time::{SystemTime, UNIX_EPOCH};
-
         let db = Arc::new(LaminarDB::open().expect("db opens"));
         // `WATERMARK FOR ts AS ts - INTERVAL '0' SECOND` declares event time
         // so the streaming pipeline drives progress on the timestamp
@@ -1925,19 +1915,22 @@ mod integration_tests {
         .await
         .expect("pgwire serve");
 
-        // Push one row: ts = 2026-05-09T00:00:00Z, sym = AAPL.
-        let ts_us = 1_778_544_000_000_000_i64; // 2026-05-09T00:00:00Z in microseconds
-        let handle_src = db.source_untyped("events").expect("source");
-        let schema = handle_src.schema().clone();
+        let expected = chrono::NaiveDate::from_ymd_opt(2026, 5, 9)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let ts_us = expected.and_utc().timestamp_micros();
+
+        let src = db.source_untyped("events").expect("source");
         let batch = arrow_array::RecordBatch::try_new(
-            Arc::clone(&schema),
+            src.schema().clone(),
             vec![
                 Arc::new(arrow_array::TimestampMicrosecondArray::from(vec![ts_us])),
                 Arc::new(arrow_array::StringArray::from(vec!["AAPL"])),
             ],
         )
         .expect("batch");
-        handle_src.push_arrow(batch).expect("push");
+        src.push_arrow(batch).expect("push");
 
         let mut client = connect(addr).await;
         let tx = client.transaction().await.expect("BEGIN");
@@ -1953,17 +1946,11 @@ mod integration_tests {
         .expect("query_portal");
         assert_eq!(rows.len(), 1);
 
-        // Decoded round-trip via tokio_postgres' chrono mapping
-        // (TIMESTAMP → NaiveDateTime).
         let ts: chrono::NaiveDateTime = rows[0].get(0);
         let sym: &str = rows[0].get(1);
-
-        let expected_ts = SystemTime::UNIX_EPOCH + std::time::Duration::from_micros(ts_us as u64);
-        let expected_naive = chrono::DateTime::<chrono::Utc>::from(expected_ts).naive_utc();
-        assert_eq!(ts, expected_naive);
+        assert_eq!(ts, expected);
         assert_eq!(sym, "AAPL");
 
-        let _ = UNIX_EPOCH;
         handle.abort();
     }
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -15,8 +15,10 @@ use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::auth::{
     AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
 };
-use pgwire::api::query::SimpleQueryHandler;
+use pgwire::api::portal::{Format, Portal};
+use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{DataRowEncoder, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
+use pgwire::api::stmt::QueryParser;
 use pgwire::api::store::PortalStore;
 use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
@@ -26,7 +28,7 @@ use sqlparser::ast::{Expr, FunctionArguments, SelectItem, Set, SetExpr, Statemen
 use tokio::net::TcpListener;
 use tracing::{info, warn};
 
-use laminar_db::subscription::{PortalFrame, SubscriptionPortal};
+use laminar_db::subscription::{PortalFrame, SubscribeStart, SubscriptionPortal};
 use laminar_db::LaminarDB;
 
 use crate::config::Secret;
@@ -72,15 +74,15 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
                 StreamingStatement::Subscribe(s) => {
                     let name = s.name.to_string();
                     let start = match s.as_of_epoch {
-                        Some(n) => laminar_db::subscription::SubscribeStart::AsOfEpoch(n),
-                        None => laminar_db::subscription::SubscribeStart::Tail,
+                        Some(n) => SubscribeStart::AsOfEpoch(n),
+                        None => SubscribeStart::Tail,
                     };
                     let portal = self
                         .db
                         .open_subscription(&name, s.filter_sql.as_deref(), start)
                         .await
                         .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
-                    portal_to_response(portal)
+                    portal_to_response(portal, None)
                 }
                 StreamingStatement::Show(cmd) => {
                     engine_metadata_response(&self.db, &show_sql(&cmd)).await?
@@ -275,7 +277,7 @@ fn text_response(col: &str, ty: Type, value: String) -> Response {
 }
 
 fn record_batch_response(batch: arrow_array::RecordBatch) -> Response {
-    let fields = Arc::new(field_infos(&batch.schema()));
+    let fields = Arc::new(field_infos(&batch.schema(), None));
     let nrows = batch.num_rows();
 
     // Encode rows eagerly: SHOW outputs are tiny and this avoids the
@@ -298,8 +300,14 @@ fn record_batch_response(batch: arrow_array::RecordBatch) -> Response {
     Response::Query(QueryResponse::new(fields, row_stream))
 }
 
-fn portal_to_response(portal: SubscriptionPortal) -> Response {
-    let fields = Arc::new(field_infos(&portal.schema()));
+/// Stream a `SubscriptionPortal`'s frames as a pgwire `Response::Query`.
+///
+/// `result_format` is `None` on the SimpleQuery path (text always) and
+/// `Some(format)` on the extended-query path, where the `Bind` message
+/// supplies per-column format codes. Binary-encoded fields use
+/// `postgres-types` `ToSql` impls dispatched per Arrow type.
+fn portal_to_response(portal: SubscriptionPortal, result_format: Option<Format>) -> Response {
+    let fields = Arc::new(field_infos(&portal.schema(), result_format.as_ref()));
 
     // Each batch is converted to a Vec<DataRow> in one shot when received,
     // so formatters are built once per batch rather than per cell. Then we
@@ -325,10 +333,9 @@ fn portal_to_response(portal: SubscriptionPortal) -> Response {
                         rows = encode_batch(&b, &fields);
                     }
                     PortalFrame::Batch(_) => {}
-                    // Barriers are dropped on the SimpleQuery path. PG's
-                    // simple-query protocol has no out-of-band channel for
-                    // checkpoint markers; cursor support (follow-up) will
-                    // surface them via NoticeResponse.
+                    // Barriers are dropped: PG has no out-of-band marker
+                    // for checkpoint epochs on either protocol path. Reads
+                    // are at-most-once-after-epoch via `AS OF EPOCH n`.
                     PortalFrame::Barrier {
                         epoch,
                         checkpoint_id,
@@ -375,17 +382,21 @@ fn encode_batch(
         .collect()
 }
 
-fn field_infos(schema: &arrow_schema::Schema) -> Vec<FieldInfo> {
+/// Build pgwire `FieldInfo`s from an Arrow schema. `result_format` (from a
+/// `Bind`) sets per-column text/binary; `None` defaults all-text.
+fn field_infos(schema: &arrow_schema::Schema, result_format: Option<&Format>) -> Vec<FieldInfo> {
     schema
         .fields()
         .iter()
-        .map(|f| {
+        .enumerate()
+        .map(|(i, f)| {
+            let format = result_format.map_or(FieldFormat::Text, |rf| rf.format_for(i));
             FieldInfo::new(
                 f.name().clone(),
                 None,
                 None,
                 arrow_to_pg_type(f.data_type()),
-                FieldFormat::Text,
+                format,
             )
         })
         .collect()
@@ -397,16 +408,112 @@ fn encode_row(
     fields: &Arc<Vec<FieldInfo>>,
     formatters: &[arrow_cast::display::ArrayFormatter<'_>],
 ) -> PgWireResult<pgwire::messages::data::DataRow> {
-    use arrow_array::Array;
     let mut enc = DataRowEncoder::new(Arc::clone(fields));
     for (i, col) in batch.columns().iter().enumerate() {
-        if col.is_null(row) {
-            enc.encode_field(&None::<&str>)?;
-        } else {
-            enc.encode_field(&Some(formatters[i].value(row).to_string()))?;
+        let info = &fields[i];
+        match info.format() {
+            FieldFormat::Text => encode_field_text(&mut enc, col.as_ref(), row, &formatters[i])?,
+            FieldFormat::Binary => {
+                encode_field_binary(&mut enc, col.as_ref(), row, info.name())?
+            }
         }
     }
     Ok(enc.take_row())
+}
+
+fn encode_field_text(
+    enc: &mut DataRowEncoder,
+    col: &dyn arrow_array::Array,
+    row: usize,
+    formatter: &arrow_cast::display::ArrayFormatter<'_>,
+) -> PgWireResult<()> {
+    if col.is_null(row) {
+        enc.encode_field(&None::<&str>)
+    } else {
+        enc.encode_field(&Some(formatter.value(row).to_string()))
+    }
+}
+
+/// Binary-encode a single Arrow value via `postgres-types` `ToSql`.
+///
+/// Coverage: Int{8,16,32,64}, UInt{8,16,32,64}, Float{32,64}, Bool,
+/// Utf8/LargeUtf8, Timestamp (any unit, naive), Date32, Date64. UInt64
+/// is widened to INT8 with saturation since Postgres has no unsigned 64.
+/// Any other column type yields `0A000` — client should request text.
+fn encode_field_binary(
+    enc: &mut DataRowEncoder,
+    col: &dyn arrow_array::Array,
+    row: usize,
+    name: &str,
+) -> PgWireResult<()> {
+    use arrow_array::{cast::AsArray, types::*, BooleanArray, Date32Array, Date64Array};
+    use arrow_schema::DataType;
+
+    if col.is_null(row) {
+        return enc.encode_field(&None::<&str>);
+    }
+
+    // Each arm pulls the typed array from `col` and hands the value to
+    // `DataRowEncoder` which calls `postgres-types::ToSql` for the wire
+    // format. The casts widen narrower Arrow ints to the matching
+    // Postgres OID (`arrow_to_pg_type`).
+    macro_rules! prim {
+        ($ArrowTy:ty, $cast:expr) => {{
+            let arr = col.as_primitive::<$ArrowTy>();
+            #[allow(clippy::redundant_closure_call)]
+            enc.encode_field(&Some(($cast)(arr.value(row))))
+        }};
+    }
+
+    match col.data_type() {
+        DataType::Int8 => prim!(Int8Type, |x: i8| i32::from(x)),
+        DataType::Int16 => prim!(Int16Type, |x: i16| i32::from(x)),
+        DataType::Int32 => prim!(Int32Type, |x: i32| x),
+        DataType::Int64 => prim!(Int64Type, |x: i64| x),
+        DataType::UInt8 => prim!(UInt8Type, |x: u8| i32::from(x)),
+        DataType::UInt16 => prim!(UInt16Type, |x: u16| i32::from(x)),
+        DataType::UInt32 => prim!(UInt32Type, |x: u32| i64::from(x)),
+        DataType::UInt64 => prim!(UInt64Type, |x: u64| i64::try_from(x).unwrap_or(i64::MAX)),
+        DataType::Float32 => prim!(Float32Type, |x: f32| f64::from(x)),
+        DataType::Float64 => prim!(Float64Type, |x: f64| x),
+        DataType::Boolean => {
+            enc.encode_field(&Some(col.as_any().downcast_ref::<BooleanArray>().unwrap().value(row)))
+        }
+        DataType::Utf8 => enc.encode_field(&Some(col.as_string::<i32>().value(row))),
+        DataType::LargeUtf8 => enc.encode_field(&Some(col.as_string::<i64>().value(row))),
+        DataType::Timestamp(unit, _tz) => {
+            use arrow_array::temporal_conversions::{
+                timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_s_to_datetime,
+                timestamp_us_to_datetime,
+            };
+            use arrow_schema::TimeUnit;
+            let raw = col.as_primitive::<Int64Type>().value(row);
+            let dt = match unit {
+                TimeUnit::Second => timestamp_s_to_datetime(raw),
+                TimeUnit::Millisecond => timestamp_ms_to_datetime(raw),
+                TimeUnit::Microsecond => timestamp_us_to_datetime(raw),
+                TimeUnit::Nanosecond => timestamp_ns_to_datetime(raw),
+            }
+            .ok_or_else(|| user_error("22008", format!("timestamp out of range: {raw}")))?;
+            enc.encode_field(&Some(dt))
+        }
+        DataType::Date32 => {
+            let v = col.as_any().downcast_ref::<Date32Array>().unwrap().value(row);
+            let dt = arrow_array::temporal_conversions::date32_to_datetime(v)
+                .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
+            enc.encode_field(&Some(dt.date()))
+        }
+        DataType::Date64 => {
+            let v = col.as_any().downcast_ref::<Date64Array>().unwrap().value(row);
+            let dt = arrow_array::temporal_conversions::date64_to_datetime(v)
+                .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
+            enc.encode_field(&Some(dt.date()))
+        }
+        other => Err(user_error(
+            "0A000",
+            format!("binary format not supported for column '{name}' (type {other:?})"),
+        )),
+    }
 }
 
 fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
@@ -506,8 +613,187 @@ impl PgWireServerHandlers for LaminarHandlerFactory {
         Arc::clone(&self.handler)
     }
 
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
+        Arc::clone(&self.handler)
+    }
+
     fn startup_handler(&self) -> Arc<impl StartupHandler> {
         Arc::clone(&self.startup)
+    }
+}
+
+/// Parsed statement carried through `Parse` → `Bind` → `Execute`.
+#[derive(Clone, Debug)]
+pub enum LaminarStmt {
+    /// `SUBSCRIBE` with its schema resolved at parse time so `Describe` can
+    /// answer before the portal is bound.
+    Subscribe {
+        name: String,
+        filter_sql: Option<String>,
+        as_of_epoch: Option<u64>,
+        schema: arrow_schema::SchemaRef,
+    },
+    Show(ShowCommand),
+    Standard(Box<Statement>),
+}
+
+/// Resolves SQL to `LaminarStmt`, looking up stream schemas against the
+/// live `LaminarDB` so the extended-query `Describe` returns columns
+/// without running the query.
+#[derive(Clone)]
+pub struct LaminarQueryParser {
+    db: Arc<LaminarDB>,
+}
+
+#[async_trait]
+impl QueryParser for LaminarQueryParser {
+    type Statement = LaminarStmt;
+
+    async fn parse_sql<C>(
+        &self,
+        _client: &C,
+        sql: &str,
+        _types: &[Option<Type>],
+    ) -> PgWireResult<Self::Statement>
+    where
+        C: ClientInfo + Unpin + Send + Sync,
+    {
+        let mut stmts = parse_streaming_sql(sql)
+            .map_err(|e| user_error("42601", format!("parse error: {e}")))?;
+        let stmt = stmts
+            .pop()
+            .ok_or_else(|| user_error("42601", "empty statement"))?;
+        if !stmts.is_empty() {
+            return Err(user_error(
+                "42601",
+                "extended query: multiple statements per Parse are not supported",
+            ));
+        }
+
+        match stmt {
+            StreamingStatement::Subscribe(s) => {
+                let name = s.name.to_string();
+                let (schema, _) =
+                    self.db.lookup_subscription_schema(&name).ok_or_else(|| {
+                        user_error("42P01", format!("SUBSCRIBE '{name}': stream not found"))
+                    })?;
+                Ok(LaminarStmt::Subscribe {
+                    name,
+                    filter_sql: s.filter_sql,
+                    as_of_epoch: s.as_of_epoch,
+                    schema,
+                })
+            }
+            StreamingStatement::Show(cmd) => Ok(LaminarStmt::Show(cmd)),
+            StreamingStatement::Standard(s) => Ok(LaminarStmt::Standard(s)),
+            other => Err(user_error(
+                "0A000",
+                format!("not supported on pgwire (use HTTP /api/v1/sql): {other:?}"),
+            )),
+        }
+    }
+
+    fn get_parameter_types(&self, _stmt: &Self::Statement) -> PgWireResult<Vec<Type>> {
+        // SUBSCRIBE has no `$N` placeholders.
+        Ok(Vec::new())
+    }
+
+    fn get_result_schema(
+        &self,
+        stmt: &Self::Statement,
+        column_format: Option<&Format>,
+    ) -> PgWireResult<Vec<FieldInfo>> {
+        // SHOW and Standard are tiny single-row outputs whose schema only
+        // materialises after execution; clients see it on Execute's
+        // RowDescription instead.
+        match stmt {
+            LaminarStmt::Subscribe { schema, .. } => Ok(field_infos(schema, column_format)),
+            LaminarStmt::Show(_) | LaminarStmt::Standard(_) => Ok(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl ExtendedQueryHandler for LaminarPgwireHandler {
+    type Statement = LaminarStmt;
+    type QueryParser = LaminarQueryParser;
+
+    fn query_parser(&self) -> Arc<Self::QueryParser> {
+        Arc::new(LaminarQueryParser {
+            db: Arc::clone(&self.db),
+        })
+    }
+
+    async fn do_query<C>(
+        &self,
+        _client: &mut C,
+        portal: &Portal<Self::Statement>,
+        _max_rows: usize,
+    ) -> PgWireResult<Response>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        match &portal.statement.statement {
+            LaminarStmt::Subscribe {
+                name,
+                filter_sql,
+                as_of_epoch,
+                ..
+            } => {
+                let start = match as_of_epoch {
+                    Some(n) => SubscribeStart::AsOfEpoch(*n),
+                    None => SubscribeStart::Tail,
+                };
+                let sub = self
+                    .db
+                    .open_subscription(name, filter_sql.as_deref(), start)
+                    .await
+                    .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+                Ok(portal_to_response(
+                    sub,
+                    Some(portal.result_column_format.clone()),
+                ))
+            }
+            LaminarStmt::Show(cmd) => engine_metadata_response(&self.db, &show_sql(cmd)).await,
+            LaminarStmt::Standard(s) => standard_response(&self.db, *s.clone()),
+        }
+    }
+
+    /// Per-Sync portal cleanup: only the unnamed portal is destroyed.
+    ///
+    /// The pgwire 0.39 default `on_sync` calls `clear_portals()`, which wipes
+    /// every named portal on the connection. PostgreSQL keeps named portals
+    /// alive until `Close` or end-of-transaction, so the default would break
+    /// any client that does `Bind named_portal; Sync; Execute named_portal;`
+    /// — the standard JDBC / asyncpg / tokio-postgres pattern for chunked
+    /// fetches via `setFetchSize` / `query_portal`.
+    async fn on_sync<C>(
+        &self,
+        client: &mut C,
+        _message: pgwire::messages::extendedquery::Sync,
+    ) -> PgWireResult<()>
+    where
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
+    {
+        use futures::SinkExt;
+        use pgwire::messages::response::ReadyForQuery;
+
+        // Drop only the unnamed portal; named portals survive Sync.
+        client.portal_store().rm_portal("");
+
+        client
+            .send(PgWireBackendMessage::ReadyForQuery(ReadyForQuery::new(
+                client.transaction_status(),
+            )))
+            .await?;
+        client.flush().await?;
+        Ok(())
     }
 }
 
@@ -1428,6 +1714,177 @@ mod integration_tests {
             .expect("query over TLS");
         let v = first_row_value(&messages, 0).expect("row");
         assert!(v.contains("LaminarDB"), "version: {v}");
+
+        handle.abort();
+    }
+
+    /// Push one row into the `trades` source so subsequent SUBSCRIBE
+    /// reads have something to drain. Returns the schema for tests
+    /// that want to build their own batches.
+    async fn push_one_trade(
+        db: &Arc<LaminarDB>,
+        symbol: &str,
+        price: f64,
+    ) -> arrow_schema::SchemaRef {
+        let handle = db.source_untyped("trades").expect("source handle");
+        let schema = handle.schema().clone();
+        let batch = arrow_array::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow_array::StringArray::from(vec![symbol])),
+                Arc::new(arrow_array::Float64Array::from(vec![price])),
+            ],
+        )
+        .expect("batch");
+        handle.push_arrow(batch).expect("push");
+        schema
+    }
+
+    /// Ingest a row and return both the running server and the underlying db
+    /// so tests can keep pushing rows after the listener is up.
+    async fn spawn_with_data() -> (
+        Arc<LaminarDB>,
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+            .await
+            .expect("create source");
+        db.execute(
+            "CREATE MATERIALIZED VIEW prices AS \
+             SELECT symbol, price FROM trades",
+        )
+        .await
+        .expect("create mv");
+        db.start().await.expect("db starts");
+
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            None,
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+        (db, addr, handle)
+    }
+
+    /// `prepare()` triggers `Parse` + `Describe(Statement)`. Verifies the
+    /// extended-query parser resolves stream schemas at parse time and
+    /// returns column metadata to the client.
+    #[tokio::test]
+    async fn extended_query_describe_subscribe_returns_columns() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let stmt = client
+            .prepare("SUBSCRIBE prices")
+            .await
+            .expect("prepare SUBSCRIBE prices");
+
+        let cols = stmt.columns();
+        assert_eq!(cols.len(), 2, "expected 2 columns, got {}", cols.len());
+        assert_eq!(cols[0].name(), "symbol");
+        assert_eq!(cols[1].name(), "price");
+        assert_eq!(cols[0].type_(), &tokio_postgres::types::Type::VARCHAR);
+        assert_eq!(cols[1].type_(), &tokio_postgres::types::Type::FLOAT8);
+
+        handle.abort();
+    }
+
+    /// Unknown stream → typed PG error at `Parse` time, before any rows
+    /// are pulled.
+    #[tokio::test]
+    async fn extended_query_prepare_unknown_stream_errors() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .prepare("SUBSCRIBE no_such_view")
+            .await
+            .expect_err("must fail at Parse");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(db_err.message().contains("no_such_view"));
+
+        handle.abort();
+    }
+
+    /// Bind + Execute with `max_rows=1` against a portal returns one row at a
+    /// time and `PortalSuspended`. Drives the binary-format encoders for
+    /// VARCHAR + FLOAT8.
+    #[tokio::test]
+    async fn extended_query_binary_chunked_subscribe() {
+        let (db, addr, handle) = spawn_with_data().await;
+        let mut client = connect(addr).await;
+
+        // Push two rows BEFORE the SUBSCRIBE so the portal sees them via
+        // replay rather than racing the listener.
+        push_one_trade(&db, "AAPL", 150.5).await;
+        push_one_trade(&db, "GOOG", 2700.25).await;
+
+        // tokio_postgres' `bind` + `query_portal` uses the extended-query
+        // protocol with binary format for known column types. This is the
+        // path JDBC and asyncpg take with prepared statements.
+        let tx = client.transaction().await.expect("BEGIN");
+        let stmt = tx.prepare("SUBSCRIBE prices").await.expect("prepare");
+        let portal = tx.bind(&stmt, &[]).await.expect("bind portal");
+
+        // Pull rows in chunks. `query_portal` returns up to `max_rows` rows
+        // for the current Execute, surfacing `PortalSuspended` as a normal
+        // partial result.
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            tx.query_portal(&portal, 1),
+        )
+        .await
+        .expect("first chunk arrives within 2s")
+        .expect("query_portal #1");
+        assert_eq!(first.len(), 1);
+        let symbol: &str = first[0].get(0);
+        let price: f64 = first[0].get(1);
+        assert_eq!(symbol, "AAPL");
+        assert!((price - 150.5).abs() < 1e-9);
+
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            tx.query_portal(&portal, 1),
+        )
+        .await
+        .expect("second chunk arrives within 2s")
+        .expect("query_portal #2");
+        assert_eq!(second.len(), 1);
+        let symbol: &str = second[0].get(0);
+        let price: f64 = second[0].get(1);
+        assert_eq!(symbol, "GOOG");
+        assert!((price - 2700.25).abs() < 1e-9);
+
+        // Don't roll back — the SUBSCRIBE never completes, so let the
+        // server-side abort tear it down.
+        handle.abort();
+    }
+
+    /// DDL on the extended-query path is refused at `Parse` with a typed
+    /// 0A000 error pointing at the HTTP endpoint — same surface as the
+    /// SimpleQuery path.
+    #[tokio::test]
+    async fn extended_query_ddl_rejected() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .prepare("CREATE SOURCE more_trades (sym VARCHAR)")
+            .await
+            .expect_err("DDL must be rejected at Parse");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert!(
+            db_err.message().contains("/api/v1/sql"),
+            "message: {}",
+            db_err.message()
+        );
 
         handle.abort();
     }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -413,9 +413,7 @@ fn encode_row(
         let info = &fields[i];
         match info.format() {
             FieldFormat::Text => encode_field_text(&mut enc, col.as_ref(), row, &formatters[i])?,
-            FieldFormat::Binary => {
-                encode_field_binary(&mut enc, col.as_ref(), row, info.name())?
-            }
+            FieldFormat::Binary => encode_field_binary(&mut enc, col.as_ref(), row, info.name())?,
         }
     }
     Ok(enc.take_row())
@@ -476,35 +474,60 @@ fn encode_field_binary(
         DataType::UInt64 => prim!(UInt64Type, |x: u64| i64::try_from(x).unwrap_or(i64::MAX)),
         DataType::Float32 => prim!(Float32Type, |x: f32| f64::from(x)),
         DataType::Float64 => prim!(Float64Type, |x: f64| x),
-        DataType::Boolean => {
-            enc.encode_field(&Some(col.as_any().downcast_ref::<BooleanArray>().unwrap().value(row)))
-        }
+        DataType::Boolean => enc.encode_field(&Some(
+            col.as_any()
+                .downcast_ref::<BooleanArray>()
+                .unwrap()
+                .value(row),
+        )),
         DataType::Utf8 => enc.encode_field(&Some(col.as_string::<i32>().value(row))),
         DataType::LargeUtf8 => enc.encode_field(&Some(col.as_string::<i64>().value(row))),
         DataType::Timestamp(unit, _tz) => {
+            // Each unit has its own Arrow type — `PrimitiveArray<TimestampMicrosecondType>`
+            // is *not* `PrimitiveArray<Int64Type>`, so the downcast must match the unit.
             use arrow_array::temporal_conversions::{
                 timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_s_to_datetime,
                 timestamp_us_to_datetime,
             };
             use arrow_schema::TimeUnit;
-            let raw = col.as_primitive::<Int64Type>().value(row);
-            let dt = match unit {
-                TimeUnit::Second => timestamp_s_to_datetime(raw),
-                TimeUnit::Millisecond => timestamp_ms_to_datetime(raw),
-                TimeUnit::Microsecond => timestamp_us_to_datetime(raw),
-                TimeUnit::Nanosecond => timestamp_ns_to_datetime(raw),
-            }
-            .ok_or_else(|| user_error("22008", format!("timestamp out of range: {raw}")))?;
+            let (raw, dt) = match unit {
+                TimeUnit::Second => {
+                    let v = col.as_primitive::<TimestampSecondType>().value(row);
+                    (v, timestamp_s_to_datetime(v))
+                }
+                TimeUnit::Millisecond => {
+                    let v = col.as_primitive::<TimestampMillisecondType>().value(row);
+                    (v, timestamp_ms_to_datetime(v))
+                }
+                TimeUnit::Microsecond => {
+                    let v = col.as_primitive::<TimestampMicrosecondType>().value(row);
+                    (v, timestamp_us_to_datetime(v))
+                }
+                TimeUnit::Nanosecond => {
+                    let v = col.as_primitive::<TimestampNanosecondType>().value(row);
+                    (v, timestamp_ns_to_datetime(v))
+                }
+            };
+            let dt =
+                dt.ok_or_else(|| user_error("22008", format!("timestamp out of range: {raw}")))?;
             enc.encode_field(&Some(dt))
         }
         DataType::Date32 => {
-            let v = col.as_any().downcast_ref::<Date32Array>().unwrap().value(row);
+            let v = col
+                .as_any()
+                .downcast_ref::<Date32Array>()
+                .unwrap()
+                .value(row);
             let dt = arrow_array::temporal_conversions::date32_to_datetime(v)
                 .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
             enc.encode_field(&Some(dt.date()))
         }
         DataType::Date64 => {
-            let v = col.as_any().downcast_ref::<Date64Array>().unwrap().value(row);
+            let v = col
+                .as_any()
+                .downcast_ref::<Date64Array>()
+                .unwrap()
+                .value(row);
             let dt = arrow_array::temporal_conversions::date64_to_datetime(v)
                 .ok_or_else(|| user_error("22008", format!("DATE out of range: {v}")))?;
             enc.encode_field(&Some(dt.date()))
@@ -673,10 +696,9 @@ impl QueryParser for LaminarQueryParser {
         match stmt {
             StreamingStatement::Subscribe(s) => {
                 let name = s.name.to_string();
-                let (schema, _) =
-                    self.db.lookup_subscription_schema(&name).ok_or_else(|| {
-                        user_error("42P01", format!("SUBSCRIBE '{name}': stream not found"))
-                    })?;
+                let (schema, _) = self.db.lookup_subscription_schema(&name).ok_or_else(|| {
+                    user_error("42P01", format!("SUBSCRIBE '{name}': stream not found"))
+                })?;
                 Ok(LaminarStmt::Subscribe {
                     name,
                     filter_sql: s.filter_sql,
@@ -1864,6 +1886,84 @@ mod integration_tests {
 
         // Don't roll back — the SUBSCRIBE never completes, so let the
         // server-side abort tear it down.
+        handle.abort();
+    }
+
+    /// Regression: binary encoding of `TIMESTAMP` columns must downcast
+    /// the Arrow array as its unit-specific primitive type
+    /// (`PrimitiveArray<TimestampMicrosecondType>`, not
+    /// `PrimitiveArray<Int64Type>`). A bug in this branch would panic on
+    /// the first row.
+    #[tokio::test]
+    async fn extended_query_binary_timestamp() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        // `WATERMARK FOR ts AS ts - INTERVAL '0' SECOND` declares event time
+        // so the streaming pipeline drives progress on the timestamp
+        // column — without it, the MV stays empty.
+        db.execute(
+            "CREATE SOURCE events (ts TIMESTAMP, sym VARCHAR, \
+             WATERMARK FOR ts AS ts - INTERVAL '0' SECOND)",
+        )
+        .await
+        .expect("create source");
+        db.execute("CREATE MATERIALIZED VIEW ev AS SELECT ts, sym FROM events")
+            .await
+            .expect("create mv");
+        db.start().await.expect("db starts");
+
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            None,
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+
+        // Push one row: ts = 2026-05-09T00:00:00Z, sym = AAPL.
+        let ts_us = 1_778_544_000_000_000_i64; // 2026-05-09T00:00:00Z in microseconds
+        let handle_src = db.source_untyped("events").expect("source");
+        let schema = handle_src.schema().clone();
+        let batch = arrow_array::RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow_array::TimestampMicrosecondArray::from(vec![ts_us])),
+                Arc::new(arrow_array::StringArray::from(vec!["AAPL"])),
+            ],
+        )
+        .expect("batch");
+        handle_src.push_arrow(batch).expect("push");
+
+        let mut client = connect(addr).await;
+        let tx = client.transaction().await.expect("BEGIN");
+        let stmt = tx.prepare("SUBSCRIBE ev").await.expect("prepare");
+        let portal = tx.bind(&stmt, &[]).await.expect("bind");
+
+        let rows = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            tx.query_portal(&portal, 1),
+        )
+        .await
+        .expect("row arrives within 2s")
+        .expect("query_portal");
+        assert_eq!(rows.len(), 1);
+
+        // Decoded round-trip via tokio_postgres' chrono mapping
+        // (TIMESTAMP → NaiveDateTime).
+        let ts: chrono::NaiveDateTime = rows[0].get(0);
+        let sym: &str = rows[0].get(1);
+
+        let expected_ts = SystemTime::UNIX_EPOCH + std::time::Duration::from_micros(ts_us as u64);
+        let expected_naive = chrono::DateTime::<chrono::Utc>::from(expected_ts).naive_utc();
+        assert_eq!(ts, expected_naive);
+        assert_eq!(sym, "AAPL");
+
+        let _ = UNIX_EPOCH;
         handle.abort();
     }
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1835,27 +1835,34 @@ mod integration_tests {
         let (db, addr, handle) = spawn_with_data().await;
         let mut client = connect(addr).await;
 
-        // Push two rows BEFORE the SUBSCRIBE so the portal sees them via
-        // replay rather than racing the listener.
-        push_one_trade(&db, "AAPL", 150.5).await;
-        push_one_trade(&db, "GOOG", 2700.25).await;
-
         // tokio_postgres' `bind` + `query_portal` uses the extended-query
-        // protocol with binary format for known column types. This is the
-        // path JDBC and asyncpg take with prepared statements.
+        // protocol with binary format for known column types — the path
+        // JDBC and asyncpg take with prepared statements.
         let tx = client.transaction().await.expect("BEGIN");
         let stmt = tx.prepare("SUBSCRIBE prices").await.expect("prepare");
         let portal = tx.bind(&stmt, &[]).await.expect("bind portal");
 
-        // Pull rows in chunks. `query_portal` returns up to `max_rows` rows
-        // for the current Execute, surfacing `PortalSuspended` as a normal
-        // partial result.
+        // The MV broadcast has no receiver until `Execute` reaches the
+        // server and runs `do_query` → `open_subscription`. We can't push
+        // from this task before query_portal because query_portal blocks
+        // waiting for a row, so spawn the pushes from a sibling task with
+        // a short head start for the receiver to attach. With cap=0
+        // retention, a push that lands before the receiver is dropped.
+        let pusher = {
+            let db = Arc::clone(&db);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                push_one_trade(&db, "AAPL", 150.5).await;
+                push_one_trade(&db, "GOOG", 2700.25).await;
+            })
+        };
+
         let first = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(3),
             tx.query_portal(&portal, 1),
         )
         .await
-        .expect("first chunk arrives within 2s")
+        .expect("first chunk arrives within 3s")
         .expect("query_portal #1");
         assert_eq!(first.len(), 1);
         let symbol: &str = first[0].get(0);
@@ -1864,11 +1871,11 @@ mod integration_tests {
         assert!((price - 150.5).abs() < 1e-9);
 
         let second = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(3),
             tx.query_portal(&portal, 1),
         )
         .await
-        .expect("second chunk arrives within 2s")
+        .expect("second chunk arrives within 3s")
         .expect("query_portal #2");
         assert_eq!(second.len(), 1);
         let symbol: &str = second[0].get(0);
@@ -1876,8 +1883,7 @@ mod integration_tests {
         assert_eq!(symbol, "GOOG");
         assert!((price - 2700.25).abs() < 1e-9);
 
-        // Don't roll back — the SUBSCRIBE never completes, so let the
-        // server-side abort tear it down.
+        pusher.await.expect("push task");
         handle.abort();
     }
 
@@ -1915,34 +1921,44 @@ mod integration_tests {
         .await
         .expect("pgwire serve");
 
+        let mut client = connect(addr).await;
+        let tx = client.transaction().await.expect("BEGIN");
+        let stmt = tx.prepare("SUBSCRIBE ev").await.expect("prepare");
+        let portal = tx.bind(&stmt, &[]).await.expect("bind");
+
         let expected = chrono::NaiveDate::from_ymd_opt(2026, 5, 9)
             .unwrap()
             .and_hms_opt(0, 0, 0)
             .unwrap();
         let ts_us = expected.and_utc().timestamp_micros();
 
-        let src = db.source_untyped("events").expect("source");
-        let batch = arrow_array::RecordBatch::try_new(
-            src.schema().clone(),
-            vec![
-                Arc::new(arrow_array::TimestampMicrosecondArray::from(vec![ts_us])),
-                Arc::new(arrow_array::StringArray::from(vec!["AAPL"])),
-            ],
-        )
-        .expect("batch");
-        src.push_arrow(batch).expect("push");
-
-        let mut client = connect(addr).await;
-        let tx = client.transaction().await.expect("BEGIN");
-        let stmt = tx.prepare("SUBSCRIBE ev").await.expect("prepare");
-        let portal = tx.bind(&stmt, &[]).await.expect("bind");
+        // Push from a sibling task after a short delay so the MV
+        // broadcast receiver (created inside `Execute`) is attached
+        // before send_batch fires. See the matching note in
+        // `extended_query_binary_chunked_subscribe`.
+        let pusher = {
+            let db = Arc::clone(&db);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let src = db.source_untyped("events").expect("source");
+                let batch = arrow_array::RecordBatch::try_new(
+                    src.schema().clone(),
+                    vec![
+                        Arc::new(arrow_array::TimestampMicrosecondArray::from(vec![ts_us])),
+                        Arc::new(arrow_array::StringArray::from(vec!["AAPL"])),
+                    ],
+                )
+                .expect("batch");
+                src.push_arrow(batch).expect("push");
+            })
+        };
 
         let rows = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(3),
             tx.query_portal(&portal, 1),
         )
         .await
-        .expect("row arrives within 2s")
+        .expect("row arrives within 3s")
         .expect("query_portal");
         assert_eq!(rows.len(), 1);
 
@@ -1951,6 +1967,7 @@ mod integration_tests {
         assert_eq!(ts, expected);
         assert_eq!(sym, "AAPL");
 
+        pusher.await.expect("push task");
         handle.abort();
     }
 


### PR DESCRIPTION
## Summary

- Implements the Postgres extended-query protocol (Parse/Bind/Describe/Execute/Sync) for the SUBSCRIBE-over-pgwire listener — the path JDBC `setFetchSize`, asyncpg, psycopg3 and libpq prepared statements take.
- Per-column **binary format** for Int{8,16,32,64}, UInt{8,16,32,64}, Float{32,64}, Bool, Utf8/LargeUtf8, Timestamp, Date32, Date64. Other Arrow types fall back to text via 0A000 if binary is requested.
- Portal-based chunking: clients pull rows in batches via `Execute(max_rows)` with `PortalSuspended` between chunks.

## What changed

- `LaminarStmt` + `LaminarQueryParser` resolve stream schemas at Parse time so `Describe(Statement)` answers without executing.
- `ExtendedQueryHandler` impl on `LaminarPgwireHandler` opens a `SubscriptionPortal` at Execute and threads `Bind.result_column_format` through field encoding. The pgwire crate's default `_on_execute` handles row-limit chunking.
- `on_sync` overridden to drop only the unnamed portal — pgwire 0.39's default `clear_portals()` wipes every named portal, which breaks the `Bind named; Sync; Execute named;` flow that JDBC/asyncpg/psycopg3 use.
- Binary encoders use `arrow_array::temporal_conversions` and `postgres-types::ToSql` (via the `pg-type-chrono` + `pg-type-rust-decimal` feature flags).
- `LaminarDB::lookup_subscription_schema` factored out of `open_subscription` so the parser can resolve schemas without opening a portal.
- DDL on the extended-query path is rejected at Parse (matches the SimpleQuery surface).

## Test plan

- [x] `cargo test -p laminar-server pgwire::` — 32/32 pass (4 new integration tests):
  - `extended_query_describe_subscribe_returns_columns`
  - `extended_query_prepare_unknown_stream_errors`
  - `extended_query_binary_chunked_subscribe` (drives VARCHAR + FLOAT8 binary encoding via `tx.bind` + `tx.query_portal`)
  - `extended_query_ddl_rejected`
- [x] `cargo test -p laminar-db --lib` — 651/651 pass (factored `lookup_subscription_schema` doesn't regress `open_subscription` callers)
- [x] `cargo clippy --workspace --no-default-features -- -D warnings` — clean

## Known limitations

- Binary-format errors on unsupported Arrow types surface mid-row-stream (after `RowDescription`). A stricter implementation would validate at `Bind`. Common types are covered; the error is clear.
- SHOW and driver-SELECT responses always send text bytes regardless of requested format codes. In practice no client requests binary for those tiny single-row outputs.

## Follow-up (not in this PR)

- SQL-level `DECLARE` / `FETCH` / `CLOSE` cursors over SimpleQuery — separable add-on for `psql \set FETCH_COUNT` and classic Postgres tools that don't use extended-query.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Postgres extended-query support for SUBSCRIBE over `pgwire`, with per-column binary encoding and portal-based chunking so JDBC `setFetchSize`, asyncpg, and psycopg3 can stream efficiently. Fixes TIMESTAMP binary encoding to use unit-specific Arrow timestamp arrays.

- **New Features**
  - Implemented Parse/Bind/Describe/Execute/Sync for SUBSCRIBE; Describe returns columns resolved at Parse.
  - Per-column binary encoding for Int{8,16,32,64}, UInt{8,16,32,64}, Float{32,64}, Bool, Utf8/LargeUtf8, Timestamp, Date32/Date64; unsupported types return 0A000. Encoders use `arrow_array` conversions and `postgres-types::ToSql` via `pg-type-chrono` and `pg-type-rust-decimal`.
  - Portal chunking via Execute(max_rows) with PortalSuspended between batches. DDL is rejected at Parse.

- **Bug Fixes**
  - Overrode Sync to drop only the unnamed portal, preserving named portals for chunked fetch flows.
  - Fixed TIMESTAMP binary encoding by downcasting to unit-specific Arrow types (Second/Milli/Micro/Nano); added an integration test to prevent regressions.
  - Stabilized chunked SUBSCRIBE tests by spawning data pushes after Execute attaches the receiver and increasing client timeouts to 3s.

<sup>Written for commit 82f48fb7b6f6b1f1060577087674e5d54f8abebf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended-query protocol support for SUBSCRIBE with per-column text or binary formatting selectable by clients.
  * Improved handling of TIMESTAMP, DATE, and NUMERIC column types in subscription responses.
  * Centralized subscription schema lookup and validation exposed for reuse, improving SUBSCRIBE metadata availability.

* **Tests**
  * Added end-to-end tests covering extended-query SUBSCRIBE prepare/describe, binary encoding, and related regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/375)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/375)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->