### PR TITLE
pgwire: SQL-level cursors over SUBSCRIBE

### DIFF
--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -992,6 +992,10 @@ impl LaminarDB {
             StreamingStatement::Subscribe(_) => Err(DbError::InvalidOperation(
                 "SUBSCRIBE requires the pgwire endpoint, not HTTP /api/v1/sql".into(),
             )),
+            StreamingStatement::DeclareCursorForSubscribe { .. } => Err(DbError::InvalidOperation(
+                "DECLARE CURSOR FOR SUBSCRIBE requires the pgwire endpoint, not HTTP /api/v1/sql"
+                    .into(),
+            )),
         }
     }
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -5,11 +5,14 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{stream, Sink, StreamExt};
-use laminar_sql::parser::{parse_streaming_sql, ShowCommand, StreamingStatement};
+use laminar_sql::parser::{
+    parse_streaming_sql, ShowCommand, StreamingStatement, SubscribeStatement,
+};
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
 use pgwire::api::auth::noop::NoopStartupHandler;
 use pgwire::api::auth::{
@@ -24,8 +27,12 @@ use pgwire::api::{ClientInfo, ClientPortalStore, PgWireServerHandlers, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 use pgwire::tokio::process_socket;
-use sqlparser::ast::{Expr, FunctionArguments, SelectItem, Set, SetExpr, Statement};
+use sqlparser::ast::{
+    CloseCursor, Expr, FetchDirection, FunctionArguments, SelectItem, Set, SetExpr, Statement,
+    Value as AstValue,
+};
 use tokio::net::TcpListener;
+use tokio::sync::Mutex as TokioMutex;
 use tracing::{info, warn};
 
 use laminar_db::subscription::{PortalFrame, SubscribeStart, SubscriptionPortal};
@@ -36,6 +43,39 @@ use crate::server::ServerError;
 
 pub struct LaminarPgwireHandler {
     db: Arc<LaminarDB>,
+    /// Per-peer SimpleQuery cursor map. Entries are evicted at the start of
+    /// every `do_query` call once their cursors are dead and no transaction
+    /// is open — pgwire 0.39 doesn't give us a connection-close hook, so this
+    /// is the cheapest way to keep stale state from leaking on port reuse.
+    connections: parking_lot::Mutex<HashMap<SocketAddr, Arc<ConnState>>>,
+}
+
+impl LaminarPgwireHandler {
+    fn new(db: Arc<LaminarDB>) -> Self {
+        Self {
+            db,
+            connections: parking_lot::Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn conn_state(&self, peer: SocketAddr) -> Arc<ConnState> {
+        let mut guard = self.connections.lock();
+        Arc::clone(
+            guard
+                .entry(peer)
+                .or_insert_with(|| Arc::new(ConnState::default())),
+        )
+    }
+
+    fn gc_peer(&self, peer: SocketAddr) {
+        let mut guard = self.connections.lock();
+        if let Some(state) = guard.get(&peer) {
+            state.prune_dead();
+            if state.is_idle() {
+                guard.remove(&peer);
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -57,7 +97,7 @@ impl NoopStartupHandler for LaminarPgwireHandler {
 
 #[async_trait]
 impl SimpleQueryHandler for LaminarPgwireHandler {
-    async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
     where
         C: ClientInfo + ClientPortalStore + Unpin + Send + Sync,
         C::PortalStore: PortalStore,
@@ -65,29 +105,28 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
         if query.trim().is_empty() {
             return Ok(vec![Response::EmptyQuery]);
         }
+        let peer = client.socket_addr();
+        self.gc_peer(peer);
         let stmts = parse_streaming_sql(query)
             .map_err(|e| user_error("42601", format!("parse error: {e}")))?;
 
         let mut out = Vec::with_capacity(stmts.len());
         for stmt in stmts {
             out.push(match stmt {
-                StreamingStatement::Subscribe(s) => {
-                    let name = s.name.to_string();
-                    let start = match s.as_of_epoch {
-                        Some(n) => SubscribeStart::AsOfEpoch(n),
-                        None => SubscribeStart::Tail,
-                    };
-                    let portal = self
-                        .db
-                        .open_subscription(&name, s.filter_sql.as_deref(), start)
-                        .await
-                        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
-                    portal_to_response(portal, None)
-                }
+                StreamingStatement::Subscribe(s) => subscribe_response(&self.db, *s).await?,
                 StreamingStatement::Show(cmd) => {
                     engine_metadata_response(&self.db, &show_sql(&cmd)).await?
                 }
-                StreamingStatement::Standard(s) => standard_response(&self.db, *s)?,
+                StreamingStatement::DeclareCursorForSubscribe {
+                    name, subscribe, ..
+                } => {
+                    let state = self.conn_state(peer);
+                    handle_declare_cursor(&self.db, &state, &name.value, *subscribe).await?
+                }
+                StreamingStatement::Standard(s) => {
+                    let state = self.conn_state(peer);
+                    standard_or_cursor_response(&self.db, &state, *s)?
+                }
                 other => {
                     return Err(user_error(
                         "0A000",
@@ -97,6 +136,220 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
             });
         }
         Ok(out)
+    }
+}
+
+async fn subscribe_response(db: &LaminarDB, s: SubscribeStatement) -> PgWireResult<Response> {
+    let name = s.name.to_string();
+    let start = match s.as_of_epoch {
+        Some(n) => SubscribeStart::AsOfEpoch(n),
+        None => SubscribeStart::Tail,
+    };
+    let portal = db
+        .open_subscription(&name, s.filter_sql.as_deref(), start)
+        .await
+        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+    Ok(portal_to_response(portal, None))
+}
+
+/// One open cursor. The portal sits behind a tokio mutex so a streaming
+/// FETCH can hold it across awaits without the row stream needing to own it.
+struct ActiveCursor {
+    portal: Arc<TokioMutex<SubscriptionPortal>>,
+    schema: arrow_schema::SchemaRef,
+    /// Flipped when the pump emits `None` or `Lagged`. The next `gc_peer`
+    /// pass reaps the cursor.
+    exhausted: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+struct ConnState {
+    cursors: parking_lot::Mutex<HashMap<String, ActiveCursor>>,
+    in_tx: AtomicBool,
+}
+
+/// Snapshot of an `ActiveCursor` that can be used outside the cursor-map
+/// lock — all fields are cheap clones.
+struct CursorHandle {
+    portal: Arc<TokioMutex<SubscriptionPortal>>,
+    schema: arrow_schema::SchemaRef,
+    exhausted: Arc<AtomicBool>,
+}
+
+impl ConnState {
+    /// Cursor names follow PG identifier folding: unquoted → lowercase. We
+    /// don't track `quote_style`, so quoted-mixed-case cursors collapse too —
+    /// good enough for the `\set FETCH_COUNT` case this targets.
+    fn key(name: &str) -> String {
+        name.to_ascii_lowercase()
+    }
+
+    fn insert(&self, name: &str, cursor: ActiveCursor) {
+        self.cursors.lock().insert(Self::key(name), cursor);
+    }
+
+    fn get(&self, name: &str) -> Option<CursorHandle> {
+        let g = self.cursors.lock();
+        let c = g.get(&Self::key(name))?;
+        Some(CursorHandle {
+            portal: Arc::clone(&c.portal),
+            schema: Arc::clone(&c.schema),
+            exhausted: Arc::clone(&c.exhausted),
+        })
+    }
+
+    fn remove(&self, name: &str) -> bool {
+        self.cursors.lock().remove(&Self::key(name)).is_some()
+    }
+
+    fn drop_all(&self) {
+        self.cursors.lock().clear();
+    }
+
+    fn prune_dead(&self) {
+        self.cursors
+            .lock()
+            .retain(|_, c| !c.exhausted.load(Ordering::Acquire));
+    }
+
+    fn is_idle(&self) -> bool {
+        !self.in_tx.load(Ordering::Acquire) && self.cursors.lock().is_empty()
+    }
+}
+
+/// Open a SUBSCRIBE behind a cursor name. Replacing an existing cursor drops
+/// its portal, which closes the pump.
+async fn handle_declare_cursor(
+    db: &LaminarDB,
+    state: &ConnState,
+    cursor_name: &str,
+    subscribe: SubscribeStatement,
+) -> PgWireResult<Response> {
+    let name = subscribe.name.to_string();
+    let start = match subscribe.as_of_epoch {
+        Some(n) => SubscribeStart::AsOfEpoch(n),
+        None => SubscribeStart::Tail,
+    };
+    let portal = db
+        .open_subscription(&name, subscribe.filter_sql.as_deref(), start)
+        .await
+        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+    let schema = portal.schema();
+    let active = ActiveCursor {
+        portal: Arc::new(TokioMutex::new(portal)),
+        schema,
+        exhausted: Arc::new(AtomicBool::new(false)),
+    };
+    state.insert(cursor_name, active);
+    Ok(Response::Execution(Tag::new("DECLARE CURSOR")))
+}
+
+/// `FETCH NEXT` and bare `FETCH FORWARD` map to a single row, matching PG.
+fn fetch_direction_count(dir: &FetchDirection) -> PgWireResult<FetchTarget> {
+    match dir {
+        FetchDirection::Next | FetchDirection::Forward { limit: None } => Ok(FetchTarget::Count(1)),
+        FetchDirection::Count { limit } | FetchDirection::Forward { limit: Some(limit) } => {
+            value_to_u64(limit).map(FetchTarget::Count)
+        }
+        FetchDirection::All | FetchDirection::ForwardAll => Ok(FetchTarget::All),
+        FetchDirection::Prior
+        | FetchDirection::First
+        | FetchDirection::Last
+        | FetchDirection::Absolute { .. }
+        | FetchDirection::Relative { .. }
+        | FetchDirection::Backward { .. }
+        | FetchDirection::BackwardAll => Err(user_error(
+            "0A000",
+            "FETCH direction not supported (SUBSCRIBE cursors are forward-only): use FORWARD or NEXT",
+        )),
+    }
+}
+
+#[derive(Copy, Clone)]
+enum FetchTarget {
+    Count(u64),
+    All,
+}
+
+fn value_to_u64(v: &AstValue) -> PgWireResult<u64> {
+    match v {
+        AstValue::Number(n, _) => n
+            .parse::<u64>()
+            .map_err(|_| user_error("22023", format!("invalid FETCH count: {n}"))),
+        other => Err(user_error(
+            "22023",
+            format!("FETCH count must be an integer, got {other}"),
+        )),
+    }
+}
+
+fn handle_fetch(
+    state: &ConnState,
+    cursor_name: &str,
+    target: FetchTarget,
+) -> PgWireResult<Response> {
+    let h = state.get(cursor_name).ok_or_else(|| {
+        user_error("34000", format!("cursor \"{cursor_name}\" does not exist"))
+    })?;
+    Ok(fetch_response(h.schema, h.portal, h.exhausted, target))
+}
+
+fn handle_close(state: &ConnState, cursor: &CloseCursor) -> PgWireResult<Response> {
+    match cursor {
+        CloseCursor::All => {
+            state.drop_all();
+            Ok(Response::Execution(Tag::new("CLOSE CURSOR ALL")))
+        }
+        CloseCursor::Specific { name } => {
+            if state.remove(&name.value) {
+                Ok(Response::Execution(Tag::new("CLOSE CURSOR")))
+            } else {
+                Err(user_error(
+                    "34000",
+                    format!("cursor \"{}\" does not exist", name.value),
+                ))
+            }
+        }
+    }
+}
+
+/// Wraps the original `standard_response` and intercepts cursor / transaction
+/// statements that need ConnState. Anything else falls through to the
+/// existing handler unchanged.
+fn standard_or_cursor_response(
+    db: &LaminarDB,
+    state: &ConnState,
+    stmt: Statement,
+) -> PgWireResult<Response> {
+    match stmt {
+        Statement::StartTransaction { .. } => {
+            state.in_tx.store(true, Ordering::Release);
+            Ok(Response::Execution(Tag::new("BEGIN")))
+        }
+        Statement::Commit { .. } => {
+            state.drop_all();
+            state.in_tx.store(false, Ordering::Release);
+            Ok(Response::Execution(Tag::new("COMMIT")))
+        }
+        Statement::Rollback { .. } => {
+            state.drop_all();
+            state.in_tx.store(false, Ordering::Release);
+            Ok(Response::Execution(Tag::new("ROLLBACK")))
+        }
+        Statement::Fetch {
+            ref name,
+            ref direction,
+            ..
+        } => {
+            let target = fetch_direction_count(direction)?;
+            handle_fetch(state, &name.value, target)
+        }
+        Statement::Close { ref cursor } => handle_close(state, cursor),
+        Statement::Declare { .. } => Err(user_error(
+            "0A000",
+            "DECLARE on pgwire only supports CURSOR FOR SUBSCRIBE …",
+        )),
+        other => standard_response(db, other),
     }
 }
 
@@ -361,6 +614,94 @@ fn empty_row(fields: &Arc<Vec<FieldInfo>>) -> pgwire::messages::data::DataRow {
     DataRowEncoder::new(Arc::clone(fields)).take_row()
 }
 
+/// Strict-PG FETCH: blocks until `target` rows are produced, the pump exits,
+/// or the broadcast lags. Lag/exit flips `exhausted` so `gc_peer` reaps the
+/// cursor on the next call. Text format only; SimpleQuery has no binary.
+fn fetch_response(
+    schema: arrow_schema::SchemaRef,
+    portal: Arc<TokioMutex<SubscriptionPortal>>,
+    exhausted: Arc<AtomicBool>,
+    target: FetchTarget,
+) -> Response {
+    let fields = Arc::new(field_infos(&schema, None));
+    let remaining = match target {
+        FetchTarget::Count(n) => Some(n),
+        FetchTarget::All => None,
+    };
+
+    struct State {
+        portal: Arc<TokioMutex<SubscriptionPortal>>,
+        exhausted: Arc<AtomicBool>,
+        rows: Vec<PgWireResult<pgwire::messages::data::DataRow>>,
+        idx: usize,
+        fields: Arc<Vec<FieldInfo>>,
+        remaining: Option<u64>,
+    }
+
+    let init = State {
+        portal,
+        exhausted,
+        rows: Vec::new(),
+        idx: 0,
+        fields: Arc::clone(&fields),
+        remaining,
+    };
+
+    let row_stream = stream::unfold(init, |mut s| async move {
+        loop {
+            // Drain any rows already pulled from a prior batch first.
+            if s.idx < s.rows.len() {
+                if matches!(s.remaining, Some(0)) {
+                    return None;
+                }
+                let row = std::mem::replace(&mut s.rows[s.idx], Ok(empty_row(&s.fields)));
+                s.idx += 1;
+                if let Some(n) = s.remaining.as_mut() {
+                    *n = n.saturating_sub(1);
+                }
+                return Some((row, s));
+            }
+
+            if matches!(s.remaining, Some(0)) {
+                return None;
+            }
+            // Fast-path: a previous frame marked the cursor exhausted.
+            if s.exhausted.load(Ordering::Acquire) {
+                return None;
+            }
+
+            s.rows.clear();
+            s.idx = 0;
+            let next = {
+                let mut guard = s.portal.lock().await;
+                guard.next_frame().await
+            };
+            match next {
+                None => {
+                    s.exhausted.store(true, Ordering::Release);
+                    return None;
+                }
+                Some(PortalFrame::Batch(b)) if b.num_rows() > 0 => {
+                    s.rows = encode_batch(&b, &s.fields);
+                }
+                Some(PortalFrame::Batch(_)) => {}
+                Some(PortalFrame::Barrier { .. }) => {
+                    // Same as portal_to_response: PG has no out-of-band marker.
+                }
+                Some(PortalFrame::Lagged(n)) => {
+                    s.exhausted.store(true, Ordering::Release);
+                    let err = user_error(
+                        "54000",
+                        format!("subscription lagged: skipped {n} messages, terminating cursor"),
+                    );
+                    return Some((Err(err), s));
+                }
+            }
+        }
+    });
+    Response::Query(QueryResponse::new(fields, row_stream))
+}
+
 fn encode_batch(
     batch: &arrow_array::RecordBatch,
     fields: &Arc<Vec<FieldInfo>>,
@@ -606,7 +947,7 @@ pub struct LaminarHandlerFactory {
 
 impl LaminarHandlerFactory {
     fn new(db: Arc<LaminarDB>, users: HashMap<String, Secret>) -> Self {
-        let handler = Arc::new(LaminarPgwireHandler { db });
+        let handler = Arc::new(LaminarPgwireHandler::new(db));
         let startup = if users.is_empty() {
             Arc::new(StartupAuth::Trust(Arc::clone(&handler)))
         } else {
@@ -1990,6 +2331,249 @@ mod integration_tests {
             db_err.message()
         );
 
+        handle.abort();
+    }
+
+    /// Background ingester for cursor tests: pushes one row per sleep tick
+    /// until the test calls `pusher.abort()`. We need this because cursor
+    /// FETCH on a streaming SUBSCRIBE blocks until the row count is met or
+    /// the cursor closes.
+    fn spawn_pusher(db: Arc<LaminarDB>, count: usize) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            for i in 0..count {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let symbol = format!("S{i}");
+                push_one_trade(&db, &symbol, i as f64).await;
+            }
+        })
+    }
+
+    /// `\set FETCH_COUNT N` flow: BEGIN; DECLARE …; FETCH N FROM …; CLOSE; COMMIT.
+    /// All over SimpleQuery — the path psql uses when `FETCH_COUNT` is set.
+    #[tokio::test]
+    async fn cursor_declare_fetch_close_happy_path() {
+        let (db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let pusher = spawn_pusher(Arc::clone(&db), 4);
+
+        client.simple_query("BEGIN").await.expect("BEGIN");
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+
+        // FETCH blocks until 2 rows arrive, no matter how slow the pusher is.
+        let messages = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            client.simple_query("FETCH 2 FROM c"),
+        )
+        .await
+        .expect("FETCH 2 within 3s")
+        .expect("FETCH 2");
+        let row_count = messages
+            .iter()
+            .filter(|m| matches!(m, SimpleQueryMessage::Row(_)))
+            .count();
+        assert_eq!(row_count, 2, "expected exactly 2 rows from FETCH 2");
+
+        client.simple_query("CLOSE c").await.expect("CLOSE");
+        client.simple_query("COMMIT").await.expect("COMMIT");
+
+        let _ = pusher.await;
+        handle.abort();
+    }
+
+    /// COMMIT must close any open cursors. After COMMIT, FETCH against the
+    /// same name returns "cursor does not exist".
+    #[tokio::test]
+    async fn cursor_commit_closes_cursors() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        client.simple_query("BEGIN").await.expect("BEGIN");
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+        client.simple_query("COMMIT").await.expect("COMMIT");
+
+        let err = client
+            .simple_query("FETCH 1 FROM c")
+            .await
+            .expect_err("FETCH after COMMIT must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "34000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// ROLLBACK closes cursors too — same reaper as COMMIT.
+    #[tokio::test]
+    async fn cursor_rollback_closes_cursors() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        client.simple_query("BEGIN").await.expect("BEGIN");
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+        client.simple_query("ROLLBACK").await.expect("ROLLBACK");
+
+        let err = client
+            .simple_query("FETCH 1 FROM c")
+            .await
+            .expect_err("FETCH after ROLLBACK must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "34000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// Explicit CLOSE works outside a transaction. PG allows DECLARE without
+    /// BEGIN; we follow that for parity with `\set FETCH_COUNT 0` clients.
+    #[tokio::test]
+    async fn cursor_close_explicit() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+        client.simple_query("CLOSE c").await.expect("CLOSE");
+
+        let err = client
+            .simple_query("FETCH 1 FROM c")
+            .await
+            .expect_err("FETCH after CLOSE must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "34000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// `SCROLL`, `BINARY`, `WITH HOLD` all rejected at parse time.
+    #[tokio::test]
+    async fn cursor_unsupported_modifiers_rejected() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        for sql in [
+            "DECLARE c SCROLL CURSOR FOR SUBSCRIBE prices",
+            "DECLARE c BINARY CURSOR FOR SUBSCRIBE prices",
+            "DECLARE c CURSOR WITH HOLD FOR SUBSCRIBE prices",
+            "DECLARE c INSENSITIVE CURSOR FOR SUBSCRIBE prices",
+        ] {
+            let err = client
+                .simple_query(sql)
+                .await
+                .expect_err(&format!("{sql} must fail"));
+            let db_err = err.as_db_error().expect("typed PG error");
+            assert_eq!(
+                db_err.code().code(),
+                "42601",
+                "{sql}: expected parse error, got {db_err:?}"
+            );
+        }
+
+        handle.abort();
+    }
+
+    /// `FETCH BACKWARD` and other reverse / absolute directions are rejected
+    /// because SUBSCRIBE is forward-only.
+    #[tokio::test]
+    async fn cursor_backward_directions_rejected() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+
+        for sql in [
+            "FETCH PRIOR FROM c",
+            "FETCH BACKWARD 1 FROM c",
+            "FETCH FIRST FROM c",
+            "FETCH LAST FROM c",
+            "FETCH ABSOLUTE 1 FROM c",
+            "FETCH RELATIVE 1 FROM c",
+        ] {
+            let err = client
+                .simple_query(sql)
+                .await
+                .expect_err(&format!("{sql} must fail"));
+            let db_err = err.as_db_error().expect("typed PG error");
+            assert_eq!(db_err.code().code(), "0A000", "{sql}: got {db_err:?}");
+        }
+
+        client.simple_query("CLOSE c").await.expect("CLOSE");
+        handle.abort();
+    }
+
+    /// `DECLARE … CURSOR FOR <SELECT …>` (regular query, not SUBSCRIBE) is
+    /// not supported on pgwire.
+    #[tokio::test]
+    async fn cursor_for_non_subscribe_rejected() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("DECLARE c CURSOR FOR SELECT 1")
+            .await
+            .expect_err("DECLARE FOR SELECT must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "0A000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// FETCH against a name we never declared returns 34000 (invalid_cursor_name).
+    #[tokio::test]
+    async fn cursor_fetch_unknown_name_errors() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        let err = client
+            .simple_query("FETCH 1 FROM nope")
+            .await
+            .expect_err("must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "34000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// Cursor name lookup is case-insensitive (PG identifier folding rules).
+    #[tokio::test]
+    async fn cursor_name_case_insensitive() {
+        let (db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+        let pusher = spawn_pusher(Arc::clone(&db), 1);
+
+        client
+            .simple_query("DECLARE MyCursor CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+
+        let messages = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            client.simple_query("FETCH 1 FROM mycursor"),
+        )
+        .await
+        .expect("within 3s")
+        .expect("FETCH from lowercased name");
+        let row_count = messages
+            .iter()
+            .filter(|m| matches!(m, SimpleQueryMessage::Row(_)))
+            .count();
+        assert_eq!(row_count, 1);
+
+        client.simple_query("CLOSE MYCURSOR").await.expect("CLOSE");
+
+        let _ = pusher.await;
         handle.abort();
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -67,11 +67,10 @@ impl LaminarPgwireHandler {
         )
     }
 
-    fn gc_peer(&self, peer: SocketAddr) {
+    fn evict_idle_peer(&self, peer: SocketAddr) {
         let mut guard = self.connections.lock();
         if let Some(state) = guard.get(&peer) {
-            state.prune_dead();
-            if state.is_idle() {
+            if state.prune_dead_and_check_idle() {
                 guard.remove(&peer);
             }
         }
@@ -106,7 +105,7 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
             return Ok(vec![Response::EmptyQuery]);
         }
         let peer = client.socket_addr();
-        self.gc_peer(peer);
+        self.evict_idle_peer(peer);
         let stmts = parse_streaming_sql(query)
             .map_err(|e| user_error("42601", format!("parse error: {e}")))?;
 
@@ -139,47 +138,51 @@ impl SimpleQueryHandler for LaminarPgwireHandler {
     }
 }
 
-async fn subscribe_response(db: &LaminarDB, s: SubscribeStatement) -> PgWireResult<Response> {
+async fn open_portal_for_subscribe(
+    db: &LaminarDB,
+    s: &SubscribeStatement,
+) -> PgWireResult<SubscriptionPortal> {
     let name = s.name.to_string();
     let start = match s.as_of_epoch {
         Some(n) => SubscribeStart::AsOfEpoch(n),
         None => SubscribeStart::Tail,
     };
-    let portal = db
-        .open_subscription(&name, s.filter_sql.as_deref(), start)
+    db.open_subscription(&name, s.filter_sql.as_deref(), start)
         .await
-        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))
+}
+
+async fn subscribe_response(db: &LaminarDB, s: SubscribeStatement) -> PgWireResult<Response> {
+    let portal = open_portal_for_subscribe(db, &s).await?;
     Ok(portal_to_response(portal, None))
 }
 
-/// One open cursor. The portal sits behind a tokio mutex so a streaming
-/// FETCH can hold it across awaits without the row stream needing to own it.
-struct ActiveCursor {
-    portal: Arc<TokioMutex<SubscriptionPortal>>,
-    schema: arrow_schema::SchemaRef,
-    /// Rows encoded from a prior frame but not yet consumed. A multi-row
-    /// batch followed by `FETCH 1` would otherwise drop the leftover rows
-    /// when the response stream ends — keeping them on the cursor lets the
-    /// next FETCH pick up where the previous one stopped.
-    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
-    /// Flipped when the pump emits `None` or `Lagged`. The next `gc_peer`
+/// State that shares the cursor's lifetime: the portal, the leftover-row
+/// buffer, and the exhausted flag. Held by `Arc` so a row stream can keep
+/// reading after `ConnState::get` returns.
+struct CursorInner {
+    /// Tokio mutex because a FETCH stream holds it across `await` while
+    /// pulling frames.
+    portal: TokioMutex<SubscriptionPortal>,
+    /// Rows encoded from a prior frame that the previous FETCH didn't
+    /// consume. Without this, a multi-row batch + `FETCH 1` would drop the
+    /// leftover rows when the response stream ends.
+    pending: parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>,
+    /// Flipped when the pump emits `None` or `Lagged`. The next `evict_idle_peer`
     /// pass reaps the cursor.
-    exhausted: Arc<AtomicBool>,
+    exhausted: AtomicBool,
+}
+
+#[derive(Clone)]
+struct ActiveCursor {
+    inner: Arc<CursorInner>,
+    schema: arrow_schema::SchemaRef,
 }
 
 #[derive(Default)]
 struct ConnState {
     cursors: parking_lot::Mutex<HashMap<String, ActiveCursor>>,
     in_tx: AtomicBool,
-}
-
-/// Snapshot of an `ActiveCursor` that can be used outside the cursor-map
-/// lock — all fields are cheap clones.
-struct CursorHandle {
-    portal: Arc<TokioMutex<SubscriptionPortal>>,
-    schema: arrow_schema::SchemaRef,
-    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
-    exhausted: Arc<AtomicBool>,
 }
 
 impl ConnState {
@@ -198,15 +201,8 @@ impl ConnState {
         self.cursors.lock().contains_key(&Self::key(name))
     }
 
-    fn get(&self, name: &str) -> Option<CursorHandle> {
-        let g = self.cursors.lock();
-        let c = g.get(&Self::key(name))?;
-        Some(CursorHandle {
-            portal: Arc::clone(&c.portal),
-            schema: Arc::clone(&c.schema),
-            pending: Arc::clone(&c.pending),
-            exhausted: Arc::clone(&c.exhausted),
-        })
+    fn get(&self, name: &str) -> Option<ActiveCursor> {
+        self.cursors.lock().get(&Self::key(name)).cloned()
     }
 
     fn remove(&self, name: &str) -> bool {
@@ -217,14 +213,12 @@ impl ConnState {
         self.cursors.lock().clear();
     }
 
-    fn prune_dead(&self) {
-        self.cursors
-            .lock()
-            .retain(|_, c| !c.exhausted.load(Ordering::Acquire));
-    }
-
-    fn is_idle(&self) -> bool {
-        !self.in_tx.load(Ordering::Acquire) && self.cursors.lock().is_empty()
+    /// Drop dead cursors and report whether the connection is now idle
+    /// (no cursors, no transaction). Single inner-lock acquisition.
+    fn prune_dead_and_check_idle(&self) -> bool {
+        let mut cursors = self.cursors.lock();
+        cursors.retain(|_, c| !c.inner.exhausted.load(Ordering::Acquire));
+        cursors.is_empty() && !self.in_tx.load(Ordering::Acquire)
     }
 }
 
@@ -242,23 +236,19 @@ async fn handle_declare_cursor(
             format!("cursor \"{cursor_name}\" already exists"),
         ));
     }
-    let name = subscribe.name.to_string();
-    let start = match subscribe.as_of_epoch {
-        Some(n) => SubscribeStart::AsOfEpoch(n),
-        None => SubscribeStart::Tail,
-    };
-    let portal = db
-        .open_subscription(&name, subscribe.filter_sql.as_deref(), start)
-        .await
-        .map_err(|e| user_error("42P01", format!("SUBSCRIBE '{name}': {e}")))?;
+    let portal = open_portal_for_subscribe(db, &subscribe).await?;
     let schema = portal.schema();
-    let active = ActiveCursor {
-        portal: Arc::new(TokioMutex::new(portal)),
-        schema,
-        pending: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
-        exhausted: Arc::new(AtomicBool::new(false)),
-    };
-    state.insert(cursor_name, active);
+    state.insert(
+        cursor_name,
+        ActiveCursor {
+            inner: Arc::new(CursorInner {
+                portal: TokioMutex::new(portal),
+                pending: parking_lot::Mutex::new(VecDeque::new()),
+                exhausted: AtomicBool::new(false),
+            }),
+            schema,
+        },
+    );
     Ok(Response::Execution(Tag::new("DECLARE CURSOR")))
 }
 
@@ -306,16 +296,10 @@ fn handle_fetch(
     cursor_name: &str,
     target: FetchTarget,
 ) -> PgWireResult<Response> {
-    let h = state
+    let cursor = state
         .get(cursor_name)
         .ok_or_else(|| user_error("34000", format!("cursor \"{cursor_name}\" does not exist")))?;
-    Ok(fetch_response(
-        h.schema,
-        h.portal,
-        h.pending,
-        h.exhausted,
-        target,
-    ))
+    Ok(fetch_response(cursor, target))
 }
 
 fn handle_close(state: &ConnState, cursor: &CloseCursor) -> PgWireResult<Response> {
@@ -639,36 +623,25 @@ fn empty_row(fields: &Arc<Vec<FieldInfo>>) -> pgwire::messages::data::DataRow {
 }
 
 /// Strict-PG FETCH: blocks until `target` rows are produced, the pump exits,
-/// or the broadcast lags. Lag/exit flips `exhausted` so `gc_peer` reaps the
-/// cursor on the next call. Text format only; SimpleQuery has no binary.
-///
-/// Leftover rows from a multi-row frame stay in the cursor's `pending`
-/// buffer so successive FETCHes consume the frame in order.
-fn fetch_response(
-    schema: arrow_schema::SchemaRef,
-    portal: Arc<TokioMutex<SubscriptionPortal>>,
-    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
-    exhausted: Arc<AtomicBool>,
-    target: FetchTarget,
-) -> Response {
-    let fields = Arc::new(field_infos(&schema, None));
+/// or the broadcast lags. Lag/exit flips `cursor.inner.exhausted` so the next
+/// `evict_idle_peer` reaps the cursor. Text format only; SimpleQuery has no
+/// binary. Leftover rows from a multi-row frame stay in `cursor.inner.pending`
+/// so successive FETCHes consume the frame in order.
+fn fetch_response(cursor: ActiveCursor, target: FetchTarget) -> Response {
+    let fields = Arc::new(field_infos(&cursor.schema, None));
     let remaining = match target {
         FetchTarget::Count(n) => Some(n),
         FetchTarget::All => None,
     };
 
     struct State {
-        portal: Arc<TokioMutex<SubscriptionPortal>>,
-        pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
-        exhausted: Arc<AtomicBool>,
+        cursor: ActiveCursor,
         fields: Arc<Vec<FieldInfo>>,
         remaining: Option<u64>,
     }
 
     let init = State {
-        portal,
-        pending,
-        exhausted,
+        cursor,
         fields: Arc::clone(&fields),
         remaining,
     };
@@ -680,36 +653,33 @@ fn fetch_response(
             }
             // Pending rows from a prior FETCH come out first. Anything left
             // here when remaining hits 0 stays for the next call.
-            let popped = s.pending.lock().pop_front();
+            let popped = s.cursor.inner.pending.lock().pop_front();
             if let Some(row) = popped {
                 if let Some(n) = s.remaining.as_mut() {
                     *n = n.saturating_sub(1);
                 }
                 return Some((row, s));
             }
-            if s.exhausted.load(Ordering::Acquire) {
+            if s.cursor.inner.exhausted.load(Ordering::Acquire) {
                 return None;
             }
 
-            let next = {
-                let mut guard = s.portal.lock().await;
-                guard.next_frame().await
-            };
+            let next = s.cursor.inner.portal.lock().await.next_frame().await;
             match next {
                 None => {
-                    s.exhausted.store(true, Ordering::Release);
+                    s.cursor.inner.exhausted.store(true, Ordering::Release);
                     return None;
                 }
                 Some(PortalFrame::Batch(b)) if b.num_rows() > 0 => {
                     let encoded = encode_batch(&b, &s.fields);
-                    s.pending.lock().extend(encoded);
+                    s.cursor.inner.pending.lock().extend(encoded);
                 }
                 Some(PortalFrame::Batch(_)) => {}
                 Some(PortalFrame::Barrier { .. }) => {
                     // Same as portal_to_response: PG has no out-of-band marker.
                 }
                 Some(PortalFrame::Lagged(n)) => {
-                    s.exhausted.store(true, Ordering::Release);
+                    s.cursor.inner.exhausted.store(true, Ordering::Release);
                     let err = user_error(
                         "54000",
                         format!("subscription lagged: skipped {n} messages, terminating cursor"),
@@ -2148,6 +2118,40 @@ mod integration_tests {
         (db, addr, handle)
     }
 
+    /// Same as `spawn_with_data`, but `prices` is a STREAM with retained
+    /// history. Lets cursor tests push rows *before* SUBSCRIBE attaches
+    /// without losing them — the receiver replays on attach.
+    async fn spawn_with_retained_data() -> (
+        Arc<LaminarDB>,
+        std::net::SocketAddr,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")
+            .await
+            .expect("create source");
+        db.execute(
+            "CREATE STREAM prices AS SELECT symbol, price FROM trades \
+             WITH ('retain_history' = '4mb')",
+        )
+        .await
+        .expect("create stream");
+        db.start().await.expect("db starts");
+
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            None,
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+        (db, addr, handle)
+    }
+
     /// `prepare()` triggers `Parse` + `Describe(Statement)`. Verifies the
     /// extended-query parser resolves stream schemas at parse time and
     /// returns column metadata to the client.
@@ -2354,28 +2358,17 @@ mod integration_tests {
         handle.abort();
     }
 
-    /// Background ingester for cursor tests: pushes one row per sleep tick
-    /// until the test calls `pusher.abort()`. We need this because cursor
-    /// FETCH on a streaming SUBSCRIBE blocks until the row count is met or
-    /// the cursor closes.
-    fn spawn_pusher(db: Arc<LaminarDB>, count: usize) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(async move {
-            for i in 0..count {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                let symbol = format!("S{i}");
-                push_one_trade(&db, &symbol, i as f64).await;
-            }
-        })
-    }
-
     /// `\set FETCH_COUNT N` flow: BEGIN; DECLARE …; FETCH N FROM …; CLOSE; COMMIT.
     /// All over SimpleQuery — the path psql uses when `FETCH_COUNT` is set.
+    /// Uses the retained-history variant so we can push before SUBSCRIBE.
     #[tokio::test]
     async fn cursor_declare_fetch_close_happy_path() {
-        let (db, addr, handle) = spawn_with_data().await;
+        let (db, addr, handle) = spawn_with_retained_data().await;
         let client = connect(addr).await;
 
-        let pusher = spawn_pusher(Arc::clone(&db), 4);
+        for i in 0..4 {
+            push_one_trade(&db, &format!("S{i}"), i as f64).await;
+        }
 
         client.simple_query("BEGIN").await.expect("BEGIN");
         client
@@ -2383,14 +2376,10 @@ mod integration_tests {
             .await
             .expect("DECLARE");
 
-        // FETCH blocks until 2 rows arrive, no matter how slow the pusher is.
-        let messages = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            client.simple_query("FETCH 2 FROM c"),
-        )
-        .await
-        .expect("FETCH 2 within 3s")
-        .expect("FETCH 2");
+        let messages = client
+            .simple_query("FETCH 2 FROM c")
+            .await
+            .expect("FETCH 2");
         let row_count = messages
             .iter()
             .filter(|m| matches!(m, SimpleQueryMessage::Row(_)))
@@ -2400,7 +2389,6 @@ mod integration_tests {
         client.simple_query("CLOSE c").await.expect("CLOSE");
         client.simple_query("COMMIT").await.expect("COMMIT");
 
-        let _ = pusher.await;
         handle.abort();
     }
 
@@ -2568,44 +2556,33 @@ mod integration_tests {
 
     /// A multi-row batch with `FETCH 1` repeated must return each row in
     /// order — leftover rows persist on the cursor instead of being dropped
-    /// when the response stream ends.
+    /// when the response stream ends. With the bug, `FETCH 1` would consume
+    /// the batch internally, return row[0], and discard row[1].
     #[tokio::test]
     async fn cursor_fetch_preserves_leftover_rows_in_one_batch() {
-        let (db, addr, handle) = spawn_with_data().await;
+        let (db, addr, handle) = spawn_with_retained_data().await;
         let client = connect(addr).await;
 
-        // Push a single 2-row batch. With the bug, FETCH 1 would consume the
-        // batch internally, hand back row[0], and discard row[1] — the next
-        // FETCH would then block waiting for fresh frames and time out.
-        let pusher = {
-            let db = Arc::clone(&db);
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                let src = db.source_untyped("trades").expect("source");
-                let batch = arrow_array::RecordBatch::try_new(
-                    src.schema().clone(),
-                    vec![
-                        Arc::new(arrow_array::StringArray::from(vec!["AAPL", "GOOG"])),
-                        Arc::new(arrow_array::Float64Array::from(vec![1.0, 2.0])),
-                    ],
-                )
-                .expect("batch");
-                src.push_arrow(batch).expect("push");
-            })
-        };
+        let src = db.source_untyped("trades").expect("source");
+        let batch = arrow_array::RecordBatch::try_new(
+            src.schema().clone(),
+            vec![
+                Arc::new(arrow_array::StringArray::from(vec!["AAPL", "GOOG"])),
+                Arc::new(arrow_array::Float64Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .expect("batch");
+        src.push_arrow(batch).expect("push");
 
         client
             .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
             .await
             .expect("DECLARE");
 
-        let first = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            client.simple_query("FETCH 1 FROM c"),
-        )
-        .await
-        .expect("first FETCH within 3s")
-        .expect("FETCH 1 #1");
+        let first = client
+            .simple_query("FETCH 1 FROM c")
+            .await
+            .expect("FETCH 1");
         let r1: Vec<&str> = first
             .iter()
             .filter_map(|m| match m {
@@ -2615,13 +2592,10 @@ mod integration_tests {
             .collect();
         assert_eq!(r1, vec!["AAPL"]);
 
-        let second = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            client.simple_query("FETCH 1 FROM c"),
-        )
-        .await
-        .expect("second FETCH within 3s")
-        .expect("FETCH 1 #2");
+        let second = client
+            .simple_query("FETCH 1 FROM c")
+            .await
+            .expect("FETCH 1");
         let r2: Vec<&str> = second
             .iter()
             .filter_map(|m| match m {
@@ -2632,7 +2606,6 @@ mod integration_tests {
         assert_eq!(r2, vec!["GOOG"]);
 
         client.simple_query("CLOSE c").await.expect("CLOSE");
-        let _ = pusher.await;
         handle.abort();
     }
 
@@ -2668,22 +2641,19 @@ mod integration_tests {
     /// Cursor name lookup is case-insensitive (PG identifier folding rules).
     #[tokio::test]
     async fn cursor_name_case_insensitive() {
-        let (db, addr, handle) = spawn_with_data().await;
+        let (db, addr, handle) = spawn_with_retained_data().await;
         let client = connect(addr).await;
-        let pusher = spawn_pusher(Arc::clone(&db), 1);
+        push_one_trade(&db, "AAPL", 1.0).await;
 
         client
             .simple_query("DECLARE MyCursor CURSOR FOR SUBSCRIBE prices")
             .await
             .expect("DECLARE");
 
-        let messages = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            client.simple_query("FETCH 1 FROM mycursor"),
-        )
-        .await
-        .expect("within 3s")
-        .expect("FETCH from lowercased name");
+        let messages = client
+            .simple_query("FETCH 1 FROM mycursor")
+            .await
+            .expect("FETCH from lowercased name");
         let row_count = messages
             .iter()
             .filter(|m| matches!(m, SimpleQueryMessage::Row(_)))
@@ -2691,8 +2661,6 @@ mod integration_tests {
         assert_eq!(row_count, 1);
 
         client.simple_query("CLOSE MYCURSOR").await.expect("CLOSE");
-
-        let _ = pusher.await;
         handle.abort();
     }
 }

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -288,9 +288,9 @@ fn handle_fetch(
     cursor_name: &str,
     target: FetchTarget,
 ) -> PgWireResult<Response> {
-    let h = state.get(cursor_name).ok_or_else(|| {
-        user_error("34000", format!("cursor \"{cursor_name}\" does not exist"))
-    })?;
+    let h = state
+        .get(cursor_name)
+        .ok_or_else(|| user_error("34000", format!("cursor \"{cursor_name}\" does not exist")))?;
     Ok(fetch_response(h.schema, h.portal, h.exhausted, target))
 }
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -2,7 +2,7 @@
 //! TLS with `pgwire_tls_cert` + `pgwire_tls_key`. Non-loopback binds
 //! require `pgwire_allow_remote = true`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -157,6 +157,11 @@ async fn subscribe_response(db: &LaminarDB, s: SubscribeStatement) -> PgWireResu
 struct ActiveCursor {
     portal: Arc<TokioMutex<SubscriptionPortal>>,
     schema: arrow_schema::SchemaRef,
+    /// Rows encoded from a prior frame but not yet consumed. A multi-row
+    /// batch followed by `FETCH 1` would otherwise drop the leftover rows
+    /// when the response stream ends — keeping them on the cursor lets the
+    /// next FETCH pick up where the previous one stopped.
+    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
     /// Flipped when the pump emits `None` or `Lagged`. The next `gc_peer`
     /// pass reaps the cursor.
     exhausted: Arc<AtomicBool>,
@@ -173,6 +178,7 @@ struct ConnState {
 struct CursorHandle {
     portal: Arc<TokioMutex<SubscriptionPortal>>,
     schema: arrow_schema::SchemaRef,
+    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
     exhausted: Arc<AtomicBool>,
 }
 
@@ -188,12 +194,17 @@ impl ConnState {
         self.cursors.lock().insert(Self::key(name), cursor);
     }
 
+    fn contains(&self, name: &str) -> bool {
+        self.cursors.lock().contains_key(&Self::key(name))
+    }
+
     fn get(&self, name: &str) -> Option<CursorHandle> {
         let g = self.cursors.lock();
         let c = g.get(&Self::key(name))?;
         Some(CursorHandle {
             portal: Arc::clone(&c.portal),
             schema: Arc::clone(&c.schema),
+            pending: Arc::clone(&c.pending),
             exhausted: Arc::clone(&c.exhausted),
         })
     }
@@ -217,14 +228,20 @@ impl ConnState {
     }
 }
 
-/// Open a SUBSCRIBE behind a cursor name. Replacing an existing cursor drops
-/// its portal, which closes the pump.
+/// Open a SUBSCRIBE behind a cursor name. Rejects with 42P03 if the name is
+/// already in use on this connection (matches PG; user must `CLOSE` first).
 async fn handle_declare_cursor(
     db: &LaminarDB,
     state: &ConnState,
     cursor_name: &str,
     subscribe: SubscribeStatement,
 ) -> PgWireResult<Response> {
+    if state.contains(cursor_name) {
+        return Err(user_error(
+            "42P03",
+            format!("cursor \"{cursor_name}\" already exists"),
+        ));
+    }
     let name = subscribe.name.to_string();
     let start = match subscribe.as_of_epoch {
         Some(n) => SubscribeStart::AsOfEpoch(n),
@@ -238,6 +255,7 @@ async fn handle_declare_cursor(
     let active = ActiveCursor {
         portal: Arc::new(TokioMutex::new(portal)),
         schema,
+        pending: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
         exhausted: Arc::new(AtomicBool::new(false)),
     };
     state.insert(cursor_name, active);
@@ -291,7 +309,13 @@ fn handle_fetch(
     let h = state
         .get(cursor_name)
         .ok_or_else(|| user_error("34000", format!("cursor \"{cursor_name}\" does not exist")))?;
-    Ok(fetch_response(h.schema, h.portal, h.exhausted, target))
+    Ok(fetch_response(
+        h.schema,
+        h.portal,
+        h.pending,
+        h.exhausted,
+        target,
+    ))
 }
 
 fn handle_close(state: &ConnState, cursor: &CloseCursor) -> PgWireResult<Response> {
@@ -617,9 +641,13 @@ fn empty_row(fields: &Arc<Vec<FieldInfo>>) -> pgwire::messages::data::DataRow {
 /// Strict-PG FETCH: blocks until `target` rows are produced, the pump exits,
 /// or the broadcast lags. Lag/exit flips `exhausted` so `gc_peer` reaps the
 /// cursor on the next call. Text format only; SimpleQuery has no binary.
+///
+/// Leftover rows from a multi-row frame stay in the cursor's `pending`
+/// buffer so successive FETCHes consume the frame in order.
 fn fetch_response(
     schema: arrow_schema::SchemaRef,
     portal: Arc<TokioMutex<SubscriptionPortal>>,
+    pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
     exhausted: Arc<AtomicBool>,
     target: FetchTarget,
 ) -> Response {
@@ -631,47 +659,38 @@ fn fetch_response(
 
     struct State {
         portal: Arc<TokioMutex<SubscriptionPortal>>,
+        pending: Arc<parking_lot::Mutex<VecDeque<PgWireResult<pgwire::messages::data::DataRow>>>>,
         exhausted: Arc<AtomicBool>,
-        rows: Vec<PgWireResult<pgwire::messages::data::DataRow>>,
-        idx: usize,
         fields: Arc<Vec<FieldInfo>>,
         remaining: Option<u64>,
     }
 
     let init = State {
         portal,
+        pending,
         exhausted,
-        rows: Vec::new(),
-        idx: 0,
         fields: Arc::clone(&fields),
         remaining,
     };
 
     let row_stream = stream::unfold(init, |mut s| async move {
         loop {
-            // Drain any rows already pulled from a prior batch first.
-            if s.idx < s.rows.len() {
-                if matches!(s.remaining, Some(0)) {
-                    return None;
-                }
-                let row = std::mem::replace(&mut s.rows[s.idx], Ok(empty_row(&s.fields)));
-                s.idx += 1;
+            if matches!(s.remaining, Some(0)) {
+                return None;
+            }
+            // Pending rows from a prior FETCH come out first. Anything left
+            // here when remaining hits 0 stays for the next call.
+            let popped = s.pending.lock().pop_front();
+            if let Some(row) = popped {
                 if let Some(n) = s.remaining.as_mut() {
                     *n = n.saturating_sub(1);
                 }
                 return Some((row, s));
             }
-
-            if matches!(s.remaining, Some(0)) {
-                return None;
-            }
-            // Fast-path: a previous frame marked the cursor exhausted.
             if s.exhausted.load(Ordering::Acquire) {
                 return None;
             }
 
-            s.rows.clear();
-            s.idx = 0;
             let next = {
                 let mut guard = s.portal.lock().await;
                 guard.next_frame().await
@@ -682,7 +701,8 @@ fn fetch_response(
                     return None;
                 }
                 Some(PortalFrame::Batch(b)) if b.num_rows() > 0 => {
-                    s.rows = encode_batch(&b, &s.fields);
+                    let encoded = encode_batch(&b, &s.fields);
+                    s.pending.lock().extend(encoded);
                 }
                 Some(PortalFrame::Batch(_)) => {}
                 Some(PortalFrame::Barrier { .. }) => {
@@ -2542,6 +2562,105 @@ mod integration_tests {
             .expect_err("must fail");
         let db_err = err.as_db_error().expect("typed PG error");
         assert_eq!(db_err.code().code(), "34000", "got {db_err:?}");
+
+        handle.abort();
+    }
+
+    /// A multi-row batch with `FETCH 1` repeated must return each row in
+    /// order — leftover rows persist on the cursor instead of being dropped
+    /// when the response stream ends.
+    #[tokio::test]
+    async fn cursor_fetch_preserves_leftover_rows_in_one_batch() {
+        let (db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        // Push a single 2-row batch. With the bug, FETCH 1 would consume the
+        // batch internally, hand back row[0], and discard row[1] — the next
+        // FETCH would then block waiting for fresh frames and time out.
+        let pusher = {
+            let db = Arc::clone(&db);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let src = db.source_untyped("trades").expect("source");
+                let batch = arrow_array::RecordBatch::try_new(
+                    src.schema().clone(),
+                    vec![
+                        Arc::new(arrow_array::StringArray::from(vec!["AAPL", "GOOG"])),
+                        Arc::new(arrow_array::Float64Array::from(vec![1.0, 2.0])),
+                    ],
+                )
+                .expect("batch");
+                src.push_arrow(batch).expect("push");
+            })
+        };
+
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("DECLARE");
+
+        let first = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            client.simple_query("FETCH 1 FROM c"),
+        )
+        .await
+        .expect("first FETCH within 3s")
+        .expect("FETCH 1 #1");
+        let r1: Vec<&str> = first
+            .iter()
+            .filter_map(|m| match m {
+                SimpleQueryMessage::Row(r) => r.get(0),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(r1, vec!["AAPL"]);
+
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            client.simple_query("FETCH 1 FROM c"),
+        )
+        .await
+        .expect("second FETCH within 3s")
+        .expect("FETCH 1 #2");
+        let r2: Vec<&str> = second
+            .iter()
+            .filter_map(|m| match m {
+                SimpleQueryMessage::Row(r) => r.get(0),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(r2, vec!["GOOG"]);
+
+        client.simple_query("CLOSE c").await.expect("CLOSE");
+        let _ = pusher.await;
+        handle.abort();
+    }
+
+    /// Re-DECLAREing an open cursor name returns 42P03; user must CLOSE first.
+    #[tokio::test]
+    async fn cursor_duplicate_declare_rejected() {
+        let (_db, addr, handle) = spawn_with_data().await;
+        let client = connect(addr).await;
+
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("first DECLARE");
+
+        let err = client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect_err("duplicate DECLARE must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "42P03", "got {db_err:?}");
+
+        // After CLOSE the name is free again.
+        client.simple_query("CLOSE c").await.expect("CLOSE");
+        client
+            .simple_query("DECLARE c CURSOR FOR SUBSCRIBE prices")
+            .await
+            .expect("re-DECLARE after CLOSE");
+        client.simple_query("CLOSE c").await.expect("CLOSE again");
 
         handle.abort();
     }

--- a/crates/laminar-sql/src/parser/declare_parser.rs
+++ b/crates/laminar-sql/src/parser/declare_parser.rs
@@ -1,0 +1,164 @@
+//! `DECLARE <name> [NO SCROLL] CURSOR [WITHOUT HOLD] FOR SUBSCRIBE …` parser.
+//!
+//! Cursors over SUBSCRIBE are forward-only and ephemeral. SCROLL/BINARY/
+//! WITH HOLD/INSENSITIVE/ASENSITIVE are rejected at parse time so the
+//! pgwire dispatcher can rely on a single supported shape.
+
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::Parser;
+
+use super::statements::StreamingStatement;
+use super::subscribe_parser::parse_subscribe;
+use super::tokenizer::{expect_custom_keyword, try_parse_custom_keyword};
+use super::ParseError;
+
+pub fn parse_declare_cursor(parser: &mut Parser) -> Result<StreamingStatement, ParseError> {
+    expect_custom_keyword(parser, "DECLARE")?;
+
+    let name = parser
+        .parse_identifier()
+        .map_err(ParseError::SqlParseError)?;
+
+    // BINARY / INSENSITIVE / ASENSITIVE — rejected up-front. SCROLL is rejected
+    // here too; only the `NO SCROLL` shape is allowed.
+    if try_parse_custom_keyword(parser, "BINARY") {
+        return Err(ParseError::StreamingError(
+            "BINARY cursors are not supported on pgwire SimpleQuery (text format only)".into(),
+        ));
+    }
+    if try_parse_custom_keyword(parser, "INSENSITIVE") || try_parse_custom_keyword(parser, "ASENSITIVE") {
+        return Err(ParseError::StreamingError(
+            "INSENSITIVE/ASENSITIVE cursors are not supported".into(),
+        ));
+    }
+
+    let no_scroll = if parser.parse_keyword(Keyword::NO) {
+        if !try_parse_custom_keyword(parser, "SCROLL") {
+            return Err(ParseError::StreamingError(
+                "expected SCROLL after NO".into(),
+            ));
+        }
+        true
+    } else if try_parse_custom_keyword(parser, "SCROLL") {
+        return Err(ParseError::StreamingError(
+            "SCROLL cursors are not supported (SUBSCRIBE is forward-only); use NO SCROLL".into(),
+        ));
+    } else {
+        false
+    };
+
+    expect_custom_keyword(parser, "CURSOR")?;
+
+    // WITHOUT HOLD is the default; WITH HOLD is rejected (no transaction model).
+    if parser.parse_keyword(Keyword::WITH) {
+        if !try_parse_custom_keyword(parser, "HOLD") {
+            return Err(ParseError::StreamingError(
+                "expected HOLD after WITH (cursor declaration)".into(),
+            ));
+        }
+        return Err(ParseError::StreamingError(
+            "WITH HOLD cursors are not supported".into(),
+        ));
+    }
+    if try_parse_custom_keyword(parser, "WITHOUT") && !try_parse_custom_keyword(parser, "HOLD") {
+        return Err(ParseError::StreamingError(
+            "expected HOLD after WITHOUT (cursor declaration)".into(),
+        ));
+    }
+
+    if !parser.parse_keyword(Keyword::FOR) {
+        return Err(ParseError::StreamingError(
+            "expected FOR <SUBSCRIBE …> after CURSOR".into(),
+        ));
+    }
+
+    let subscribe = parse_subscribe(parser)?;
+
+    Ok(StreamingStatement::DeclareCursorForSubscribe {
+        name,
+        no_scroll,
+        subscribe: Box::new(subscribe),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::dialect::LaminarDialect;
+    use super::super::statements::StreamingStatement;
+    use super::*;
+
+    fn parse(sql: &str) -> Result<StreamingStatement, ParseError> {
+        let dialect = LaminarDialect::default();
+        let mut parser = Parser::new(&dialect)
+            .try_with_sql(sql)
+            .map_err(ParseError::SqlParseError)?;
+        parse_declare_cursor(&mut parser)
+    }
+
+    #[test]
+    fn plain_cursor_for_subscribe() {
+        let stmt = parse("DECLARE c CURSOR FOR SUBSCRIBE prices").expect("parse");
+        let StreamingStatement::DeclareCursorForSubscribe {
+            name,
+            no_scroll,
+            subscribe,
+        } = stmt
+        else {
+            panic!("wrong variant");
+        };
+        assert_eq!(name.value, "c");
+        assert!(!no_scroll);
+        assert_eq!(subscribe.name.to_string(), "prices");
+    }
+
+    #[test]
+    fn no_scroll_recognised() {
+        let stmt = parse("DECLARE c NO SCROLL CURSOR FOR SUBSCRIBE prices").expect("parse");
+        let StreamingStatement::DeclareCursorForSubscribe { no_scroll, .. } = stmt else {
+            panic!("wrong variant");
+        };
+        assert!(no_scroll);
+    }
+
+    #[test]
+    fn cursor_with_subscribe_filter_and_epoch() {
+        let stmt = parse(
+            "DECLARE c CURSOR FOR SUBSCRIBE prices AS OF EPOCH 7 WHERE symbol = 'AAPL'",
+        )
+        .expect("parse");
+        let StreamingStatement::DeclareCursorForSubscribe { subscribe, .. } = stmt else {
+            panic!("wrong variant");
+        };
+        assert_eq!(subscribe.as_of_epoch, Some(7));
+        assert!(subscribe.filter_sql.is_some());
+    }
+
+    #[test]
+    fn rejects_scroll() {
+        let err = parse("DECLARE c SCROLL CURSOR FOR SUBSCRIBE prices").unwrap_err();
+        assert!(matches!(err, ParseError::StreamingError(ref m) if m.contains("SCROLL")));
+    }
+
+    #[test]
+    fn rejects_binary() {
+        let err = parse("DECLARE c BINARY CURSOR FOR SUBSCRIBE prices").unwrap_err();
+        assert!(matches!(err, ParseError::StreamingError(ref m) if m.contains("BINARY")));
+    }
+
+    #[test]
+    fn rejects_with_hold() {
+        let err = parse("DECLARE c CURSOR WITH HOLD FOR SUBSCRIBE prices").unwrap_err();
+        assert!(matches!(err, ParseError::StreamingError(ref m) if m.contains("WITH HOLD")));
+    }
+
+    #[test]
+    fn rejects_insensitive() {
+        let err = parse("DECLARE c INSENSITIVE CURSOR FOR SUBSCRIBE prices").unwrap_err();
+        assert!(matches!(err, ParseError::StreamingError(_)));
+    }
+
+    #[test]
+    fn without_hold_accepted() {
+        parse("DECLARE c CURSOR WITHOUT HOLD FOR SUBSCRIBE prices").expect("parse");
+    }
+}

--- a/crates/laminar-sql/src/parser/declare_parser.rs
+++ b/crates/laminar-sql/src/parser/declare_parser.rs
@@ -26,7 +26,9 @@ pub fn parse_declare_cursor(parser: &mut Parser) -> Result<StreamingStatement, P
             "BINARY cursors are not supported on pgwire SimpleQuery (text format only)".into(),
         ));
     }
-    if try_parse_custom_keyword(parser, "INSENSITIVE") || try_parse_custom_keyword(parser, "ASENSITIVE") {
+    if try_parse_custom_keyword(parser, "INSENSITIVE")
+        || try_parse_custom_keyword(parser, "ASENSITIVE")
+    {
         return Err(ParseError::StreamingError(
             "INSENSITIVE/ASENSITIVE cursors are not supported".into(),
         ));
@@ -122,10 +124,9 @@ mod tests {
 
     #[test]
     fn cursor_with_subscribe_filter_and_epoch() {
-        let stmt = parse(
-            "DECLARE c CURSOR FOR SUBSCRIBE prices AS OF EPOCH 7 WHERE symbol = 'AAPL'",
-        )
-        .expect("parse");
+        let stmt =
+            parse("DECLARE c CURSOR FOR SUBSCRIBE prices AS OF EPOCH 7 WHERE symbol = 'AAPL'")
+                .expect("parse");
         let StreamingStatement::DeclareCursorForSubscribe { subscribe, .. } = stmt else {
             panic!("wrong variant");
         };

--- a/crates/laminar-sql/src/parser/mod.rs
+++ b/crates/laminar-sql/src/parser/mod.rs
@@ -7,6 +7,7 @@
 pub mod aggregation_parser;
 pub mod analytic_parser;
 mod continuous_query_parser;
+mod declare_parser;
 pub(crate) mod dialect;
 mod emit_parser;
 pub mod join_parser;
@@ -218,6 +219,13 @@ impl StreamingParser {
                 let stmt = subscribe_parser::parse_subscribe(&mut parser)
                     .map_err(parse_error_to_parser_error)?;
                 Ok(vec![StreamingStatement::Subscribe(Box::new(stmt))])
+            }
+            StreamingDdlKind::DeclareCursor => {
+                let mut parser =
+                    sqlparser::parser::Parser::new(&dialect).with_tokens_with_locations(tokens);
+                let stmt = declare_parser::parse_declare_cursor(&mut parser)
+                    .map_err(parse_error_to_parser_error)?;
+                Ok(vec![stmt])
             }
             StreamingDdlKind::RestoreCheckpoint => {
                 let mut parser =

--- a/crates/laminar-sql/src/parser/statements.rs
+++ b/crates/laminar-sql/src/parser/statements.rs
@@ -196,6 +196,20 @@ pub enum StreamingStatement {
 
     /// `SUBSCRIBE <name> [WHERE ...] [WITH (...)]`.
     Subscribe(Box<SubscribeStatement>),
+
+    /// `DECLARE <name> [NO SCROLL] CURSOR [WITHOUT HOLD] FOR SUBSCRIBE …`
+    ///
+    /// Forward-only cursor over a SUBSCRIBE, scoped to the current SimpleQuery
+    /// connection. SCROLL, BINARY, WITH HOLD, INSENSITIVE, and ASENSITIVE are
+    /// rejected at parse time.
+    DeclareCursorForSubscribe {
+        /// Cursor identifier as supplied by the client.
+        name: Ident,
+        /// `NO SCROLL` was explicit in the source. We never emit SCROLL.
+        no_scroll: bool,
+        /// The SUBSCRIBE body the cursor wraps.
+        subscribe: Box<SubscribeStatement>,
+    },
 }
 
 /// `SUBSCRIBE <name> [AS OF EPOCH n] [WHERE <fragment>] [WITH (...)]`.

--- a/crates/laminar-sql/src/parser/tokenizer.rs
+++ b/crates/laminar-sql/src/parser/tokenizer.rs
@@ -100,6 +100,8 @@ pub enum StreamingDdlKind {
     RestoreCheckpoint,
     /// SUBSCRIBE <name> [WITH (...)]
     Subscribe,
+    /// DECLARE <name> [NO SCROLL] CURSOR [WITHOUT HOLD] FOR SUBSCRIBE …
+    DeclareCursor,
     /// Not a streaming DDL statement
     None,
 }
@@ -133,6 +135,16 @@ pub fn detect_streaming_ddl(tokens: &[TokenWithSpan]) -> StreamingDdlKind {
     if let Token::Word(w) = &significant[0].token {
         if is_word_ci(w, "SUBSCRIBE") {
             return StreamingDdlKind::Subscribe;
+        }
+    }
+
+    // DECLARE <ident> ... CURSOR FOR SUBSCRIBE — pre-empts sqlparser, which
+    // expects the body of a DECLARE…CURSOR FOR clause to be a regular Query.
+    // Plain `DECLARE x INT` and DECLARE-cursor-for-SELECT shapes are still
+    // routed through sqlparser via `None`.
+    if let Token::Word(w) = &significant[0].token {
+        if is_word_ci(w, "DECLARE") && contains_for_subscribe(&significant) {
+            return StreamingDdlKind::DeclareCursor;
         }
     }
 
@@ -490,6 +502,32 @@ fn classify_after_or_replace(token: &Token, significant: &[&TokenWithSpan]) -> S
 /// Check if a Word matches a keyword string (case-insensitive).
 fn is_word_ci(word: &Word, keyword: &str) -> bool {
     word.value.eq_ignore_ascii_case(keyword)
+}
+
+/// True if the token sequence contains adjacent `FOR SUBSCRIBE`. Used to
+/// disambiguate `DECLARE` between sqlparser's cursor-for-Query shape and
+/// our SUBSCRIBE-specific extension. Loose enough to allow `WITHOUT HOLD`
+/// between `CURSOR` and `FOR`.
+fn contains_for_subscribe(significant: &[&TokenWithSpan]) -> bool {
+    let mut i = 0;
+    while i + 1 < significant.len() {
+        let for_kw = matches!(
+            &significant[i].token,
+            Token::Word(Word {
+                keyword: Keyword::FOR,
+                ..
+            })
+        );
+        let subscribe = matches!(
+            &significant[i + 1].token,
+            Token::Word(w) if is_word_ci(w, "SUBSCRIBE")
+        );
+        if for_kw && subscribe {
+            return true;
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Try to consume a custom keyword that may not be in sqlparser's keyword enum.
@@ -886,6 +924,33 @@ mod tests {
         assert_eq!(
             detect_streaming_ddl(&tokenize("subscribe foo with ('snapshot' = 'true')")),
             StreamingDdlKind::Subscribe
+        );
+    }
+
+    #[test]
+    fn test_detect_declare_cursor_for_subscribe() {
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("DECLARE c CURSOR FOR SUBSCRIBE foo")),
+            StreamingDdlKind::DeclareCursor
+        );
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("DECLARE c NO SCROLL CURSOR FOR SUBSCRIBE foo")),
+            StreamingDdlKind::DeclareCursor
+        );
+        assert_eq!(
+            detect_streaming_ddl(&tokenize(
+                "declare c cursor without hold for subscribe foo"
+            )),
+            StreamingDdlKind::DeclareCursor
+        );
+    }
+
+    #[test]
+    fn test_detect_declare_cursor_for_select_falls_through() {
+        // DECLARE…CURSOR FOR <regular query> is left to sqlparser.
+        assert_eq!(
+            detect_streaming_ddl(&tokenize("DECLARE c CURSOR FOR SELECT 1")),
+            StreamingDdlKind::None
         );
     }
 }

--- a/crates/laminar-sql/src/parser/tokenizer.rs
+++ b/crates/laminar-sql/src/parser/tokenizer.rs
@@ -504,13 +504,17 @@ fn is_word_ci(word: &Word, keyword: &str) -> bool {
     word.value.eq_ignore_ascii_case(keyword)
 }
 
-/// True if the token sequence contains adjacent `FOR SUBSCRIBE`. Used to
-/// disambiguate `DECLARE` between sqlparser's cursor-for-Query shape and
-/// our SUBSCRIBE-specific extension. Loose enough to allow `WITHOUT HOLD`
-/// between `CURSOR` and `FOR`.
+/// True if the *first* statement in the token sequence contains adjacent
+/// `FOR SUBSCRIBE`. Used to disambiguate `DECLARE` between sqlparser's
+/// cursor-for-Query shape and our SUBSCRIBE-specific extension. Loose
+/// enough to allow `WITHOUT HOLD` between `CURSOR` and `FOR`. Stops at the
+/// first `;` so a later statement can't accidentally route us here.
 fn contains_for_subscribe(significant: &[&TokenWithSpan]) -> bool {
     let mut i = 0;
     while i + 1 < significant.len() {
+        if matches!(&significant[i].token, Token::SemiColon | Token::EOF) {
+            return false;
+        }
         let for_kw = matches!(
             &significant[i].token,
             Token::Word(Word {
@@ -948,6 +952,18 @@ mod tests {
         // DECLARE…CURSOR FOR <regular query> is left to sqlparser.
         assert_eq!(
             detect_streaming_ddl(&tokenize("DECLARE c CURSOR FOR SELECT 1")),
+            StreamingDdlKind::None
+        );
+    }
+
+    #[test]
+    fn test_declare_does_not_cross_statement_boundary() {
+        // A trailing `FOR SUBSCRIBE` in a *later* statement must not route
+        // the leading DECLARE into our SUBSCRIBE-specific parser.
+        assert_eq!(
+            detect_streaming_ddl(&tokenize(
+                "DECLARE x INT; SELECT 1 FROM t FOR SUBSCRIBE foo"
+            )),
             StreamingDdlKind::None
         );
     }

--- a/crates/laminar-sql/src/parser/tokenizer.rs
+++ b/crates/laminar-sql/src/parser/tokenizer.rs
@@ -938,9 +938,7 @@ mod tests {
             StreamingDdlKind::DeclareCursor
         );
         assert_eq!(
-            detect_streaming_ddl(&tokenize(
-                "declare c cursor without hold for subscribe foo"
-            )),
+            detect_streaming_ddl(&tokenize("declare c cursor without hold for subscribe foo")),
             StreamingDdlKind::DeclareCursor
         );
     }

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -184,7 +184,8 @@ impl StreamingPlanner {
             | StreamingStatement::AlterSource { .. }
             | StreamingStatement::Checkpoint
             | StreamingStatement::RestoreCheckpoint { .. }
-            | StreamingStatement::Subscribe(_) => {
+            | StreamingStatement::Subscribe(_)
+            | StreamingStatement::DeclareCursorForSubscribe { .. } => {
                 // These statements are handled directly by the database facade
                 // and don't need query planning. Return as Standard pass-through.
                 Err(PlanningError::UnsupportedSql(format!(


### PR DESCRIPTION
## Summary

- Adds `DECLARE <name> [NO SCROLL] CURSOR FOR SUBSCRIBE …`, `FETCH [FORWARD] [n|ALL] FROM <name>`, and `CLOSE <name>` on the SimpleQuery path. This is the path psql takes when `\set FETCH_COUNT N` is configured, and the path other clients use when they prefer cursors over extended-query portals.
- FETCH is strict-PG: blocks until the row budget is met or the cursor ends (`CLOSE` / lag / engine `drop_name`). Cursors auto-close on `COMMIT`, `ROLLBACK`, and at next-`do_query` GC for dead/idle peers (pgwire 0.39 has no connection-close hook).
- Closes the last outstanding feature gap on the SUBSCRIBE-over-pgwire roadmap. Hardening backlog (`md5{hex}`, mTLS, hot-reload TLS, min-TLS-version pin) is unchanged.

## What's accepted vs. rejected

| Shape | Result |
|---|---|
| `DECLARE c CURSOR FOR SUBSCRIBE prices` | OK |
| `DECLARE c NO SCROLL CURSOR FOR SUBSCRIBE prices` | OK |
| `DECLARE c CURSOR WITHOUT HOLD FOR SUBSCRIBE prices` | OK |
| `DECLARE c SCROLL CURSOR FOR …` | 42601 |
| `DECLARE c BINARY CURSOR FOR …` | 42601 |
| `DECLARE c CURSOR WITH HOLD FOR …` | 42601 |
| `DECLARE c INSENSITIVE CURSOR FOR …` | 42601 |
| `DECLARE c CURSOR FOR SELECT 1` | 0A000 (use HTTP `/api/v1/sql`) |
| `FETCH NEXT \| FORWARD [n] \| n \| ALL \| FORWARD ALL FROM c` | OK |
| `FETCH PRIOR \| BACKWARD \| FIRST \| LAST \| ABSOLUTE \| RELATIVE` | 0A000 |
| `FETCH 1 FROM c` after `COMMIT` / `ROLLBACK` / `CLOSE` | 34000 (`invalid_cursor_name`) |

## Architecture notes

- New per-peer `ConnState { cursors, in_tx }` on `LaminarPgwireHandler`, keyed by `SocketAddr` behind `parking_lot::Mutex<HashMap<…>>`. No new dependencies.
- `ActiveCursor` holds the `SubscriptionPortal` behind a `tokio::sync::Mutex` so the row stream can hold it across awaits without owning it. Concurrent FETCH on the same cursor name is naturally serialized by the mutex (matches PG: one consumer per cursor).
- `gc_peer` runs at the start of every `do_query`: drops cursors whose pump has exhausted (`None` or `Lagged`), then drops the connection entry entirely if no cursors and no transaction. Bounds memory under client churn / port reuse.
- Cursor name lookup is case-insensitive (PG identifier folding for unquoted idents). Quote-style isn't tracked, so quoted-mixed-case cursors collapse too — pragmatic for the `_psql_cursor` use case.

## Test plan

- [x] 9 new pgwire integration tests under `pgwire::integration_tests::cursor_*` (happy path with COMMIT, explicit CLOSE, ROLLBACK closes, SCROLL/BINARY/WITH HOLD/INSENSITIVE rejection, FETCH BACKWARD/PRIOR/FIRST/LAST/ABSOLUTE/RELATIVE rejection, unknown-cursor 34000, DECLARE-for-non-SUBSCRIBE rejection, case-insensitive name lookup).
- [x] `cargo test --all --no-default-features --lib` — all crates green.
- [x] `cargo test -p laminar-server --no-default-features --bin laminardb pgwire::` — 42/42 pgwire tests pass.
- [x] `cargo clippy --no-default-features --all --tests -- -D warnings` — clean.
- [ ] Smoke against `psql --set=FETCH_COUNT=10` against a running `laminardb` server.

## Known limitations

- Multi-statement SimpleQuery batches (`BEGIN; DECLARE …; FETCH …; COMMIT;` as one wire message) follow the existing first-token routing in `detect_streaming_ddl` and may misparse if the leading statement is itself a streaming-keyword. Existing limitation; psql sends each statement individually so it's not hit in practice.
- `FETCH ALL` blocks until the cursor ends, which on a streaming SUBSCRIBE means effectively forever. PG-correct, but a foot-gun if used carelessly.
- pgwire 0.39 has no connection-close hook, so peer entries are reaped lazily on the next call. Acceptable; capped by the existing connection cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SQL-level cursors over SUBSCRIBE on the `pgwire` SimpleQuery path so `psql` with `\set FETCH_COUNT` (and cursor-based clients) can stream results in chunks. Implements DECLARE/FETCH/CLOSE with strict PostgreSQL semantics and cleans up cursor internals for clearer lifetime management.

- New Features
  - Supports: DECLARE <name> [NO SCROLL] CURSOR FOR SUBSCRIBE …, FETCH FORWARD [n|ALL] FROM <name>, CLOSE <name>|ALL.
  - FETCH blocks until the row budget is met or the cursor ends (close/lag/drop). Text format only. One consumer per cursor.
  - Cursors auto-close on COMMIT/ROLLBACK and are GC’d on the next query; names are case-insensitive.
  - Forward-only: SCROLL/BINARY/WITH HOLD/INSENSITIVE rejected; BACKWARD/PRIOR/FIRST/LAST/ABSOLUTE/RELATIVE error. `DECLARE CURSOR FOR SELECT` and SUBSCRIBE/DECLARE-cursor over HTTP are rejected.

- Bug Fixes
  - Tokenizer now respects statement boundaries when detecting DECLARE … CURSOR FOR SUBSCRIBE.
  - FETCH preserves leftover rows from multi-row frames for subsequent FETCHes.
  - Re-declaring an existing cursor name returns 42P03 instead of overwriting.
  - Refactors: collapsed cursor types, grouped portal/pending/exhausted under one Arc, extracted portal-open helper, renamed GC to `evict_idle_peer`, and stabilized tests with retained-history streams.

<sup>Written for commit 270441bcfe239ef025f8db218f4b58bf6efb1123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added PostgreSQL-style cursor support for `SUBSCRIBE` statements via the pgwire endpoint, enabling `DECLARE`, `FETCH`, and `CLOSE` operations
* Cursors support forward-only fetch semantics and are automatically cleaned up on transaction commit/rollback

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/376)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->