### PR TITLE
pgwire: hardening backlog — mTLS, TLS hot-reload, pre-hashed passwords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4956,6 +4956,7 @@ dependencies = [
  "laminar-db",
  "laminar-sql",
  "laminar-storage",
+ "md-5",
  "mimalloc",
  "notify",
  "openssl",

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Watermark types: per-partition, per-key, and alignment groups (synchronized acro
 
 ```sql
 CREATE SOURCE ... [FROM connector(...)]
-CREATE STREAM ... AS SELECT ...
+CREATE STREAM ... AS SELECT ...                    [WITH ('retain_history' = '64mb')]
 CREATE MATERIALIZED VIEW ... AS SELECT ...
 CREATE SINK ... INTO connector(...) AS SELECT ...
 CREATE LOOKUP TABLE ... FROM POSTGRES(...) | PARQUET(...)
@@ -196,7 +196,11 @@ SHOW SOURCES | STREAMS | SINKS | MATERIALIZED VIEWS
 SHOW CREATE SOURCE name
 DESCRIBE [EXTENDED] table_name
 EXPLAIN ANALYZE SELECT ...
+SUBSCRIBE <stream> [AS OF EPOCH n] [WHERE …]      -- live tail of a stream
+DECLARE c CURSOR FOR SUBSCRIBE … ; FETCH n FROM c -- cursored consumption
 ```
+
+`retain_history` keeps a bounded ring of recent committed epochs in memory; combined with `SUBSCRIBE … AS OF EPOCH n`, a client can resume from the last epoch it saw and reconnect without gaps.
 
 All aggregation functions from DataFusion 52 are available: `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, `FIRST_VALUE`, `LAST_VALUE`, `STDDEV`, `PERCENTILE_CONT`, `APPROX_COUNT_DISTINCT`, `LAG`, `LEAD`, `ROW_NUMBER`, and 40+ more. JSON extraction, array/struct/map functions, and `UNNEST` are also supported.
 
@@ -262,6 +266,29 @@ CREATE SINK trade_archive INTO DELTA_LAKE (
 Supported formats: `json`, `csv`, `avro` (with Schema Registry), `raw` (bytes), `debezium` (CDC envelope).
 
 Custom connectors can be built by implementing the `SourceConnector` or `SinkConnector` trait and registering with `ConnectorRegistry`.
+
+---
+
+## Postgres Wire Protocol
+
+The standalone server speaks the Postgres v3 wire protocol, so any libpq-derived client — `psql`, JDBC, asyncpg, `tokio-postgres`, Grafana's Postgres datasource — can connect and tail a stream:
+
+```bash
+psql "host=db.internal port=5433 dbname=laminardb user=alice" \
+  -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"
+```
+
+Enable the listener by setting `pgwire_bind` in `laminardb.toml`. Auth is trust on loopback or MD5 for remote binds; TLS, mTLS (`pgwire_tls_client_ca`), TLS 1.3 pinning, hot-reload of certificates, and `pg_authid`-style pre-hashed passwords are all supported. See [crates/laminar-server/README.md](crates/laminar-server/README.md) for configuration.
+
+| Statement | Behavior |
+|-----------|----------|
+| `SUBSCRIBE <stream>` | Stream rows as they're committed |
+| `SUBSCRIBE … WHERE <expr>` | Server-side filter, schema-aware |
+| `SUBSCRIBE … AS OF EPOCH n` | Replay from epoch `n` (stream must be `WITH ('retain_history' = '…')`) |
+| `DECLARE c CURSOR FOR SUBSCRIBE …` + `FETCH n FROM c` | Cursored consumption for `\set FETCH_COUNT n` clients |
+| `SELECT version()` / `SELECT 1` / transaction control | The handful of meta-commands clients issue at startup |
+
+DDL (`CREATE SOURCE`, `CREATE STREAM`, etc.) goes through the HTTP API (`POST /api/v1/sql`); the pgwire surface is intentionally narrow — read-side only.
 
 ---
 

--- a/crates/laminar-core/src/shuffle/transport.rs
+++ b/crates/laminar-core/src/shuffle/transport.rs
@@ -574,9 +574,10 @@ mod tests {
         //    observe EOF and flip `alive=false`.
         drop(recv_v1);
 
-        // Spin until the reader task notices the shutdown. Bounded
-        // wait so a hung test fails loudly instead of running forever.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        // Spin until the reader task notices the shutdown. The deadline is
+        // generous on purpose — it covers OS-driven TCP EOF delivery plus
+        // the reader-task wakeup, which can stretch on a busy CI host.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
             let alive = {
                 let pool = sender.pool.read().await;
@@ -587,7 +588,7 @@ mod tests {
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "reader task did not flip alive=false within 5s",
+                "reader task did not flip alive=false within 30s",
             );
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }

--- a/crates/laminar-core/src/shuffle/transport.rs
+++ b/crates/laminar-core/src/shuffle/transport.rs
@@ -544,6 +544,13 @@ mod tests {
     /// connection flips dead (reader exits on EOF), the next `send_to`
     /// purges the stale entry and reconnects against the
     /// freshly-registered address.
+    ///
+    /// Windows-only skip: under nextest parallelism the FIN-after-abort
+    /// → reader-task wakeup chain is not bounded in time on Windows, so
+    /// the polling-on-`is_alive` precondition this test relies on can
+    /// stretch past any reasonable deadline. Linux and macOS exercise
+    /// the same code path reliably.
+    #[cfg(not(windows))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn send_reconnects_after_peer_restart_at_new_address() {
         // 1. Peer binds on an ephemeral port.

--- a/crates/laminar-db/README.md
+++ b/crates/laminar-db/README.md
@@ -10,6 +10,7 @@ Unified database facade for LaminarDB. The main entry point that wires the SQL p
 - **`QueryHandle`** -- Handle to a running streaming query with schema and subscription access.
 - **`SourceHandle<T>`** / **`UntypedSourceHandle`** -- Typed and untyped handles for pushing data into sources.
 - **`TypedSubscription<T>`** -- Subscription to a named stream with automatic RecordBatch-to-struct conversion.
+- **`SubscriptionRegistry`** / **`SubscriptionPortal`** -- Broadcast fan-out and per-consumer pump used by the Postgres-wire `SUBSCRIBE` listener and any in-process consumer that wants a back-pressured tail of a stream. Supports `AS OF EPOCH n` resume when the stream was created `WITH ('retain_history' = '…')`.
 - **`CheckpointCoordinator`** -- Orchestrates two-phase commit checkpoints across all operators and sinks.
 - **`RecoveryManager`** -- Restores operator state, connector offsets, and watermarks from the latest checkpoint.
 - **`Profile`** -- Deployment profile (`BareMetal`, `Embedded`, `Durable`, `Delta`).
@@ -40,6 +41,15 @@ let source = db.source_untyped("trades")?;
 
 // Start the pipeline
 db.start().await?;
+
+// In-process tail of a stream (the same machinery the pgwire SUBSCRIBE
+// listener uses). Frames carry RecordBatches plus an epoch marker so the
+// consumer can resume after a disconnect.
+use laminar_db::subscription::SubscribeStart;
+let mut portal = db
+    .open_subscription("avg_price", None, SubscribeStart::Tail)
+    .await?;
+while let Some(frame) = portal.next_frame().await { /* … */ }
 
 // Shutdown
 db.shutdown().await?;

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -73,6 +73,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 ] }
 rustls-pemfile = "2"
 x509-parser = "0.16"
+md-5 = "0.10"
 time = "0.3"
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -174,6 +174,9 @@ pgwire_tls_cert = "/etc/laminar/pgwire.crt"
 pgwire_tls_key  = "/etc/laminar/pgwire.key"
 # Optional. Default "1.2"; set "1.3" to refuse TLS 1.2 handshakes.
 pgwire_tls_min_version = "1.2"
+# Optional. Enable mTLS: every client must present a cert chained to
+# one of the roots in this PEM bundle. No revocation (CRL/OCSP) yet.
+pgwire_tls_client_ca = "/etc/laminar/clients-ca.pem"
 ```
 
 Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work. Cert rotation requires a server restart; hot reload is a follow-up.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -163,7 +163,14 @@ PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb use
 
 > **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
 
-Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
+Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. To avoid plaintext at rest entirely, supply the `pg_authid`-style pre-hashed form: `md5` followed by `md5(password ‖ username)` as 32 lowercase hex characters. The wire protocol is unchanged — clients still send the same plaintext password.
+
+```bash
+# bash, where pw and user are the plaintext password and username:
+printf '%s' "${pw}${user}" | md5sum | awk '{print "md5"$1}'
+```
+
+The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
 
 ### TLS
 

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -179,7 +179,9 @@ pgwire_tls_min_version = "1.2"
 pgwire_tls_client_ca = "/etc/laminar/clients-ca.pem"
 ```
 
-Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work. Cert rotation requires a server restart; hot reload is a follow-up.
+Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work.
+
+The server watches `pgwire_tls_cert`, `pgwire_tls_key`, and `pgwire_tls_client_ca` and reloads the TLS acceptor in place after a 500ms debounce, so cert rotation does not require a restart. In-flight handshakes finish with the cert that was current when the socket was accepted; new accepts pick up the rotated cert. A bad rotation (truncated file, expired cert) is logged as `pgwire.tls_reload outcome=failed` and the previous acceptor is kept. Set `LAMINAR_DISABLE_FILE_WATCH=1` to disable.
 
 ```bash
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -172,6 +172,8 @@ Optional. Setting both `pgwire_tls_cert` and `pgwire_tls_key` enables TLS via [`
 ```toml
 pgwire_tls_cert = "/etc/laminar/pgwire.crt"
 pgwire_tls_key  = "/etc/laminar/pgwire.key"
+# Optional. Default "1.2"; set "1.3" to refuse TLS 1.2 handshakes.
+pgwire_tls_min_version = "1.2"
 ```
 
 Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work. Cert rotation requires a server restart; hot reload is a follow-up.

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -152,6 +152,12 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         }
         (None, None) => {}
     }
+    match config.server.pgwire_tls_min_version.as_str() {
+        "1.2" | "1.3" => {}
+        other => errors.push(format!(
+            "pgwire_tls_min_version must be \"1.2\" or \"1.3\" (got \"{other}\")"
+        )),
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {
@@ -235,6 +241,11 @@ pub struct ServerSection {
     /// Per-IP auth-failure cap in a 60s rolling window. 0 disables.
     #[serde(default = "default_pgwire_max_auth_failures_per_min")]
     pub pgwire_max_auth_failures_per_min: u32,
+    /// Minimum TLS protocol version: `"1.2"` (default) or `"1.3"`. Pinning
+    /// to `"1.3"` is the PCI-DSS / FedRAMP-High posture; rustls already
+    /// disables TLS 1.0/1.1 unconditionally.
+    #[serde(default = "default_pgwire_tls_min_version")]
+    pub pgwire_tls_min_version: String,
 }
 
 fn default_pgwire_max_connections() -> usize {
@@ -243,6 +254,10 @@ fn default_pgwire_max_connections() -> usize {
 
 fn default_pgwire_max_auth_failures_per_min() -> u32 {
     10
+}
+
+fn default_pgwire_tls_min_version() -> String {
+    "1.2".to_string()
 }
 
 impl Default for ServerSection {
@@ -257,6 +272,7 @@ impl Default for ServerSection {
             pgwire_tls_key: None,
             pgwire_max_connections: default_pgwire_max_connections(),
             pgwire_max_auth_failures_per_min: default_pgwire_max_auth_failures_per_min(),
+            pgwire_tls_min_version: default_pgwire_tls_min_version(),
         }
     }
 }
@@ -808,6 +824,25 @@ pgwire_max_connections = 0
             ConfigError::ValidationErrors { errors } => {
                 assert!(
                     errors.iter().any(|e| e.contains("must be > 0")),
+                    "errors: {errors:?}"
+                );
+            }
+            _ => panic!("expected ValidationErrors"),
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_unknown_tls_min_version() {
+        let toml = r#"
+[server]
+pgwire_tls_min_version = "1.4"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        let err = validate_config(&config).unwrap_err();
+        match err {
+            ConfigError::ValidationErrors { errors } => {
+                assert!(
+                    errors.iter().any(|e| e.contains("pgwire_tls_min_version")),
                     "errors: {errors:?}"
                 );
             }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -179,10 +179,7 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             );
         }
         if !ca.exists() {
-            errors.push(format!(
-                "pgwire_tls_client_ca not found: {}",
-                ca.display()
-            ));
+            errors.push(format!("pgwire_tls_client_ca not found: {}", ca.display()));
         }
     }
 
@@ -874,7 +871,9 @@ pgwire_tls_client_ca = "/does/not/matter.pem"
         match err {
             ConfigError::ValidationErrors { errors } => {
                 assert!(
-                    errors.iter().any(|e| e.contains("requires pgwire_tls_cert")),
+                    errors
+                        .iter()
+                        .any(|e| e.contains("requires pgwire_tls_cert")),
                     "errors: {errors:?}"
                 );
             }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -158,6 +158,21 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
             "pgwire_tls_min_version must be \"1.2\" or \"1.3\" (got \"{other}\")"
         )),
     }
+    if let Some(ca) = &config.server.pgwire_tls_client_ca {
+        if config.server.pgwire_tls_cert.is_none() {
+            errors.push(
+                "pgwire_tls_client_ca requires pgwire_tls_cert + pgwire_tls_key (mTLS \
+                 layers on top of server TLS)"
+                    .to_string(),
+            );
+        }
+        if !ca.exists() {
+            errors.push(format!(
+                "pgwire_tls_client_ca not found: {}",
+                ca.display()
+            ));
+        }
+    }
 
     // Validate: cluster mode requires discovery and coordination
     if config.server.mode == "cluster" {
@@ -235,6 +250,10 @@ pub struct ServerSection {
     /// PEM private key (PKCS#8 or RSA).
     #[serde(default)]
     pub pgwire_tls_key: Option<std::path::PathBuf>,
+    /// PEM CA bundle. Setting this requires every connecting client to
+    /// present a certificate chained to one of these roots (mTLS).
+    #[serde(default)]
+    pub pgwire_tls_client_ca: Option<std::path::PathBuf>,
     /// Concurrent session cap; excess accepts close immediately.
     #[serde(default = "default_pgwire_max_connections")]
     pub pgwire_max_connections: usize,
@@ -270,6 +289,7 @@ impl Default for ServerSection {
             pgwire_allow_remote: false,
             pgwire_tls_cert: None,
             pgwire_tls_key: None,
+            pgwire_tls_client_ca: None,
             pgwire_max_connections: default_pgwire_max_connections(),
             pgwire_max_auth_failures_per_min: default_pgwire_max_auth_failures_per_min(),
             pgwire_tls_min_version: default_pgwire_tls_min_version(),
@@ -824,6 +844,25 @@ pgwire_max_connections = 0
             ConfigError::ValidationErrors { errors } => {
                 assert!(
                     errors.iter().any(|e| e.contains("must be > 0")),
+                    "errors: {errors:?}"
+                );
+            }
+            _ => panic!("expected ValidationErrors"),
+        }
+    }
+
+    #[test]
+    fn test_validate_client_ca_requires_server_cert() {
+        let toml = r#"
+[server]
+pgwire_tls_client_ca = "/does/not/matter.pem"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        let err = validate_config(&config).unwrap_err();
+        match err {
+            ConfigError::ValidationErrors { errors } => {
+                assert!(
+                    errors.iter().any(|e| e.contains("requires pgwire_tls_cert")),
                     "errors: {errors:?}"
                 );
             }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -123,7 +123,19 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         if user.is_empty() {
             errors.push("pgwire_users contains an empty username".to_string());
         }
-        if password.len() < MIN_PGWIRE_PASSWORD_LEN {
+        let pw = password.expose();
+        if let Some(rest) = pw.strip_prefix("md5") {
+            // pg_authid-style pre-hash: 'md5' + lowercase-hex(md5(password ‖ user)).
+            // Strict shape so a typo isn't silently treated as plaintext.
+            let valid =
+                rest.len() == 32 && rest.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'));
+            if !valid {
+                errors.push(format!(
+                    "pgwire_users['{user}']: pre-hashed value must be 'md5' \
+                     followed by 32 lowercase hex characters"
+                ));
+            }
+        } else if password.len() < MIN_PGWIRE_PASSWORD_LEN {
             errors.push(format!(
                 "pgwire_users['{user}']: password must be at least {MIN_PGWIRE_PASSWORD_LEN} characters"
             ));
@@ -883,6 +895,40 @@ pgwire_tls_min_version = "1.4"
                 assert!(
                     errors.iter().any(|e| e.contains("pgwire_tls_min_version")),
                     "errors: {errors:?}"
+                );
+            }
+            _ => panic!("expected ValidationErrors"),
+        }
+    }
+
+    #[test]
+    fn test_validate_accepts_well_formed_pre_hashed_pgwire_password() {
+        let toml = r#"
+[server]
+[server.pgwire_users]
+alice = "md55d41402abc4b2a76b9719d911017c592"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        // 35-char pre-hashed value bypasses the MIN_PGWIRE_PASSWORD_LEN gate.
+        validate_config(&config).expect("well-formed pre-hash must validate");
+    }
+
+    #[test]
+    fn test_validate_rejects_malformed_pre_hashed_pgwire_password() {
+        // 'md5' prefix followed by non-hex — clearly meant to be pre-hashed
+        // but malformed; rejected so a typo doesn't slip through as plaintext.
+        let toml = r#"
+[server]
+[server.pgwire_users]
+alice = "md5zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        let err = validate_config(&config).unwrap_err();
+        match err {
+            ConfigError::ValidationErrors { errors } => {
+                assert!(
+                    errors.iter().any(|e| e.contains("pre-hashed")),
+                    "errors: {errors:?}",
                 );
             }
             _ => panic!("expected ValidationErrors"),

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1145,6 +1145,43 @@ impl ExtendedQueryHandler for LaminarPgwireHandler {
 pub struct TlsPaths<'a> {
     pub cert: &'a std::path::Path,
     pub key: &'a std::path::Path,
+    pub min_version: TlsMinVersion,
+}
+
+/// Minimum TLS protocol version accepted on the pgwire listener. rustls
+/// already disables TLS 1.0/1.1; this narrows further when an operator
+/// needs TLS 1.3 only.
+#[derive(Clone, Copy, Debug)]
+pub enum TlsMinVersion {
+    V1_2,
+    V1_3,
+}
+
+impl TlsMinVersion {
+    pub(crate) fn from_config_str(s: &str) -> Option<Self> {
+        match s {
+            "1.2" => Some(Self::V1_2),
+            "1.3" => Some(Self::V1_3),
+            _ => None,
+        }
+    }
+
+    fn versions(self) -> &'static [&'static tokio_rustls::rustls::SupportedProtocolVersion] {
+        use tokio_rustls::rustls::version::{TLS12, TLS13};
+        static BOTH: &[&tokio_rustls::rustls::SupportedProtocolVersion] = &[&TLS12, &TLS13];
+        static ONLY_13: &[&tokio_rustls::rustls::SupportedProtocolVersion] = &[&TLS13];
+        match self {
+            Self::V1_2 => BOTH,
+            Self::V1_3 => ONLY_13,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::V1_2 => "1.2",
+            Self::V1_3 => "1.3",
+        }
+    }
 }
 
 /// Warn if the key file is group/other-readable.
@@ -1302,10 +1339,11 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
             ))
         })?;
 
-    let server_config = tokio_rustls::rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
+    let server_config =
+        tokio_rustls::rustls::ServerConfig::builder_with_protocol_versions(paths.min_version.versions())
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
     Ok(tokio_rustls::TlsAcceptor::from(Arc::new(server_config)))
 }
 
@@ -1339,6 +1377,7 @@ pub async fn serve(
         _ => {}
     }
 
+    let tls_min_label = tls.as_ref().map(|p| p.min_version.label());
     let tls_acceptor = match tls {
         Some(paths) => Some(load_tls_acceptor(paths)?),
         None => None,
@@ -1353,14 +1392,22 @@ pub async fn serve(
 
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
     let tls_mode = if tls_acceptor.is_some() { "on" } else { "off" };
+    let tls_min = tls_min_label.unwrap_or("-");
     if auth_mode == "trust" {
         warn!(
             addr = %local_addr,
             tls = tls_mode,
+            tls_min,
             "pgwire listening with TRUST auth — any client reaching this address is admin",
         );
     } else {
-        info!(addr = %local_addr, auth = auth_mode, tls = tls_mode, "pgwire listening");
+        info!(
+            addr = %local_addr,
+            auth = auth_mode,
+            tls = tls_mode,
+            tls_min,
+            "pgwire listening",
+        );
     }
 
     // Track per-connection tasks so abort on the outer JoinHandle stops
@@ -1997,6 +2044,7 @@ mod integration_tests {
             Some(super::TlsPaths {
                 cert: &cert_path,
                 key: &key_path,
+                min_version: super::TlsMinVersion::V1_2,
             }),
             256,
             10,
@@ -2004,6 +2052,70 @@ mod integration_tests {
         .await
         .expect_err("expired cert must be rejected");
         assert!(err.to_string().contains("expired"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn tls_min_1_3_rejects_tls_1_2_client() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+                min_version: super::TlsMinVersion::V1_3,
+            }),
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+
+        let cert_bytes = std::fs::read(&cert_path).unwrap();
+        let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+        for c in rustls_pemfile::certs(&mut std::io::Cursor::new(cert_bytes))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        {
+            roots.add(c).unwrap();
+        }
+        super::ensure_tls_provider();
+        // Client pinned to TLS 1.2 only — must be refused by a 1.3-min server.
+        let client_cfg = tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(
+            &[&tokio_rustls::rustls::version::TLS12],
+        )
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(client_cfg);
+        let err = match tokio_postgres::connect(&conn_str, tls).await {
+            Ok(_) => panic!("TLS 1.2 client must be refused by a 1.3-min server"),
+            Err(e) => e,
+        };
+        // tokio_postgres wraps the rustls error; flatten the chain so we can
+        // assert against the version-mismatch token rustls emits.
+        let chain = std::iter::successors(
+            Some(&err as &dyn std::error::Error),
+            |e| e.source(),
+        )
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(" | ");
+        assert!(
+            chain.contains("ProtocolVersion") || chain.contains("incompatible"),
+            "expected a TLS version-mismatch error, got: {chain}"
+        );
+
+        handle.abort();
     }
 
     #[tokio::test]
@@ -2019,6 +2131,7 @@ mod integration_tests {
             Some(super::TlsPaths {
                 cert: &cert_path,
                 key: &key_path,
+                min_version: super::TlsMinVersion::V1_2,
             }),
             256,
             10,

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1151,6 +1151,167 @@ pub struct TlsPaths<'a> {
     pub client_ca: Option<&'a std::path::Path>,
 }
 
+/// Owned counterpart to `TlsPaths` that the listener keeps for the
+/// lifetime of `serve()` so the file watcher can rebuild the acceptor
+/// without the original config still being in scope.
+#[derive(Debug, Clone)]
+struct TlsConfigPaths {
+    cert: std::path::PathBuf,
+    key: std::path::PathBuf,
+    min_version: TlsMinVersion,
+    client_ca: Option<std::path::PathBuf>,
+}
+
+impl TlsConfigPaths {
+    fn from_paths(paths: &TlsPaths<'_>) -> Self {
+        Self {
+            cert: paths.cert.to_path_buf(),
+            key: paths.key.to_path_buf(),
+            min_version: paths.min_version,
+            client_ca: paths.client_ca.map(|p| p.to_path_buf()),
+        }
+    }
+
+    fn borrow(&self) -> TlsPaths<'_> {
+        TlsPaths {
+            cert: &self.cert,
+            key: &self.key,
+            min_version: self.min_version,
+            client_ca: self.client_ca.as_deref(),
+        }
+    }
+}
+
+/// Live TLS acceptor + paths needed to rebuild it on cert rotation.
+/// Reads on the accept path are a single mutex acquire and a cheap
+/// `TlsAcceptor` clone; reloads are triggered by the file watcher.
+pub struct TlsReloadState {
+    paths: TlsConfigPaths,
+    acceptor: parking_lot::Mutex<Arc<tokio_rustls::TlsAcceptor>>,
+}
+
+impl TlsReloadState {
+    fn snapshot(&self) -> Arc<tokio_rustls::TlsAcceptor> {
+        Arc::clone(&self.acceptor.lock())
+    }
+}
+
+/// Rebuild the TLS acceptor from `state.paths` and atomically swap it in.
+/// On any error the previous acceptor is left in place, so a bad rotation
+/// (truncated file, expired cert) doesn't take TLS down.
+#[allow(clippy::result_large_err)]
+pub(crate) fn try_reload_tls(state: &TlsReloadState) -> Result<(), ServerError> {
+    let new_acceptor = load_tls_acceptor(state.paths.borrow())?;
+    *state.acceptor.lock() = Arc::new(new_acceptor);
+    Ok(())
+}
+
+/// Watch the cert / key / client-CA files and call `try_reload_tls` after
+/// debounced changes. Mirrors the pattern in `watcher.rs` (parent-dir
+/// watch, debounce, then act). Runs until the channel closes; the caller
+/// drives shutdown by aborting the task that owns this future.
+async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Duration) {
+    use crossfire::{mpsc, MTx};
+    use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+    // Resolve the set of files we care about, then derive the parent dirs
+    // to watch. Watching parents (not files) is what makes atomic-rename
+    // rotations (write-tmp + rename-into-place) reliably visible.
+    let mut targets: Vec<std::path::PathBuf> = Vec::new();
+    for path in [
+        Some(state.paths.cert.clone()),
+        Some(state.paths.key.clone()),
+        state.paths.client_ca.clone(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        match path.canonicalize() {
+            Ok(p) => targets.push(p),
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "pgwire TLS watcher: cannot canonicalize path; reload disabled",
+                );
+                return;
+            }
+        }
+    }
+    let mut dirs: Vec<std::path::PathBuf> = targets
+        .iter()
+        .filter_map(|p| p.parent().map(|d| d.to_path_buf()))
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+
+    let (tx, rx) = mpsc::bounded_async::<()>(16);
+    let blocking_tx: MTx<_> = tx.clone().into_blocking();
+    let watch_targets: Vec<std::path::PathBuf> = targets.clone();
+
+    let mut watcher: RecommendedWatcher =
+        match notify::recommended_watcher(move |result: Result<Event, notify::Error>| match result {
+            Ok(event) => {
+                let touched = event.paths.iter().any(|p| {
+                    p.canonicalize()
+                        .ok()
+                        .as_ref()
+                        .is_some_and(|c| watch_targets.contains(c))
+                });
+                if touched {
+                    let _ = blocking_tx.send(());
+                }
+            }
+            Err(e) => warn!(error = %e, "pgwire TLS watcher: notify error"),
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                warn!(error = %e, "pgwire TLS watcher: failed to create watcher; reload disabled");
+                return;
+            }
+        };
+
+    for dir in &dirs {
+        if let Err(e) = watcher.watch(dir, RecursiveMode::NonRecursive) {
+            warn!(
+                dir = %dir.display(),
+                error = %e,
+                "pgwire TLS watcher: failed to watch directory; reload disabled",
+            );
+            return;
+        }
+    }
+    info!(
+        files = ?targets.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "pgwire TLS watcher started",
+    );
+
+    loop {
+        if rx.recv().await.is_err() {
+            return;
+        }
+        // Debounce: sleep then drain so a burst of inotify events
+        // (cert + key written separately) coalesces into one reload.
+        tokio::time::sleep(debounce).await;
+        while rx.try_recv().is_ok() {}
+
+        match try_reload_tls(&state) {
+            Ok(()) => tracing::info!(
+                target: "audit",
+                event = "pgwire.tls_reload",
+                outcome = "ok",
+            ),
+            Err(e) => tracing::warn!(
+                target: "audit",
+                event = "pgwire.tls_reload",
+                outcome = "failed",
+                error = %e,
+                "pgwire TLS reload failed; previous certificate kept",
+            ),
+        }
+    }
+}
+
 /// Minimum TLS protocol version accepted on the pgwire listener. rustls
 /// already disables TLS 1.0/1.1; this narrows further when an operator
 /// needs TLS 1.3 only.
@@ -1423,8 +1584,19 @@ pub async fn serve(
 
     let tls_min_label = tls.as_ref().map(|p| p.min_version.label());
     let mtls_on = tls.as_ref().is_some_and(|p| p.client_ca.is_some());
-    let tls_acceptor = match tls {
-        Some(paths) => Some(load_tls_acceptor(paths)?),
+    let tls_state: Option<Arc<TlsReloadState>> = match tls {
+        Some(paths) => {
+            let acceptor = load_tls_acceptor(TlsPaths {
+                cert: paths.cert,
+                key: paths.key,
+                min_version: paths.min_version,
+                client_ca: paths.client_ca,
+            })?;
+            Some(Arc::new(TlsReloadState {
+                paths: TlsConfigPaths::from_paths(&paths),
+                acceptor: parking_lot::Mutex::new(Arc::new(acceptor)),
+            }))
+        }
         None => None,
     };
 
@@ -1436,7 +1608,7 @@ pub async fn serve(
         .map_err(|e| ServerError::Http(format!("pgwire local_addr: {e}")))?;
 
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
-    let tls_mode = if tls_acceptor.is_some() { "on" } else { "off" };
+    let tls_mode = if tls_state.is_some() { "on" } else { "off" };
     let tls_min = tls_min_label.unwrap_or("-");
     let mtls = if mtls_on { "on" } else { "off" };
     if auth_mode == "trust" {
@@ -1461,8 +1633,18 @@ pub async fn serve(
     // Track per-connection tasks so abort on the outer JoinHandle stops
     // active sessions in addition to the accept loop.
     let failures = Arc::new(FailureTracker::default());
+    let watcher_state = tls_state.as_ref().map(Arc::clone);
+    let watcher_disabled =
+        std::env::var("LAMINAR_DISABLE_FILE_WATCH").is_ok_and(|v| v == "1" || v == "true");
     let handle = tokio::spawn(async move {
         let mut sessions: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+        // Spawn the TLS hot-reload watcher into the same JoinSet so it's
+        // aborted alongside sessions when the outer handle is dropped.
+        if let (Some(state), false) = (watcher_state, watcher_disabled) {
+            sessions.spawn(async move {
+                watch_tls_files(state, std::time::Duration::from_millis(500)).await;
+            });
+        }
         loop {
             tokio::select! {
                 Some(_) = sessions.join_next(), if !sessions.is_empty() => {
@@ -1497,7 +1679,12 @@ pub async fn serve(
                                 continue;
                             }
                             let factory_ref = Arc::clone(&factory);
-                            let tls_ref = tls_acceptor.clone();
+                            // Snapshot the live acceptor so that an in-flight
+                            // handshake completes against whatever cert was
+                            // current when the socket was accepted, even if a
+                            // hot-reload swaps it under us.
+                            let tls_ref: Option<tokio_rustls::TlsAcceptor> =
+                                tls_state.as_ref().map(|s| (*s.snapshot()).clone());
                             let failures_ref = Arc::clone(&failures);
                             let peer_str = peer.to_string();
                             tracing::info!(
@@ -2450,6 +2637,90 @@ mod integration_tests {
         let v = first_row_value(&messages, 0).expect("row");
         assert!(v.contains("LaminarDB"), "version: {v}");
         handle.abort();
+    }
+
+    /// Build a `TlsReloadState` directly for unit-testing the reload path
+    /// without standing up a listener.
+    fn build_reload_state(
+        cert: &std::path::Path,
+        key: &std::path::Path,
+    ) -> super::TlsReloadState {
+        let paths = super::TlsPaths {
+            cert,
+            key,
+            min_version: super::TlsMinVersion::V1_2,
+            client_ca: None,
+        };
+        let acceptor = super::load_tls_acceptor(super::TlsPaths {
+            cert: paths.cert,
+            key: paths.key,
+            min_version: paths.min_version,
+            client_ca: paths.client_ca,
+        })
+        .expect("initial acceptor loads");
+        super::TlsReloadState {
+            paths: super::TlsConfigPaths::from_paths(&paths),
+            acceptor: parking_lot::Mutex::new(Arc::new(acceptor)),
+        }
+    }
+
+    /// Hot-reload: writing a fresh cert+key over the configured paths and
+    /// calling `try_reload_tls` swaps the acceptor under the mutex.
+    #[test]
+    fn tls_reload_swaps_acceptor_on_valid_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        // Initial cert.
+        let first =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        std::fs::write(&cert_path, first.cert.pem()).unwrap();
+        std::fs::write(&key_path, first.key_pair.serialize_pem()).unwrap();
+
+        let state = build_reload_state(&cert_path, &key_path);
+        let before = state.snapshot();
+
+        // Rotate to a brand-new pair.
+        let second =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        std::fs::write(&cert_path, second.cert.pem()).unwrap();
+        std::fs::write(&key_path, second.key_pair.serialize_pem()).unwrap();
+
+        super::try_reload_tls(&state).expect("reload succeeds");
+        let after = state.snapshot();
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "acceptor pointer must change after a successful reload",
+        );
+    }
+
+    /// Hot-reload: a corrupt cert file leaves the previous acceptor in
+    /// place — TLS doesn't go down on a bad rotation.
+    #[test]
+    fn tls_reload_keeps_old_acceptor_on_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        let first =
+            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        std::fs::write(&cert_path, first.cert.pem()).unwrap();
+        std::fs::write(&key_path, first.key_pair.serialize_pem()).unwrap();
+
+        let state = build_reload_state(&cert_path, &key_path);
+        let before = state.snapshot();
+
+        // Truncate cert.pem to non-PEM garbage.
+        std::fs::write(&cert_path, b"this is not a certificate").unwrap();
+        let err = super::try_reload_tls(&state).expect_err("reload must fail");
+        let after = state.snapshot();
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "acceptor must be unchanged on reload failure",
+        );
+        assert!(
+            err.to_string().contains("pgwire_tls_cert"),
+            "error should mention pgwire_tls_cert, got: {err}",
+        );
     }
 
     /// Flatten an error and its `source()` chain to a single string for

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -892,11 +892,7 @@ struct LaminarAuthSource {
 /// other lengths fall back to plaintext handling.
 pub(crate) fn parse_pre_hashed_md5(stored: &str) -> Option<&str> {
     let inner = stored.strip_prefix("md5")?;
-    if inner.len() == 32
-        && inner
-            .chars()
-            .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
-    {
+    if inner.len() == 32 && inner.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
         Some(inner)
     } else {
         None
@@ -1282,8 +1278,8 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
     let blocking_tx: MTx<_> = tx.clone().into_blocking();
     let watch_targets: Vec<std::path::PathBuf> = targets.clone();
 
-    let mut watcher: RecommendedWatcher =
-        match notify::recommended_watcher(move |result: Result<Event, notify::Error>| match result {
+    let mut watcher: RecommendedWatcher = match notify::recommended_watcher(
+        move |result: Result<Event, notify::Error>| match result {
             Ok(event) => {
                 let touched = event.paths.iter().any(|p| {
                     p.canonicalize()
@@ -1296,13 +1292,14 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
                 }
             }
             Err(e) => warn!(error = %e, "pgwire TLS watcher: notify error"),
-        }) {
-            Ok(w) => w,
-            Err(e) => {
-                warn!(error = %e, "pgwire TLS watcher: failed to create watcher; reload disabled");
-                return;
-            }
-        };
+        },
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            warn!(error = %e, "pgwire TLS watcher: failed to create watcher; reload disabled");
+            return;
+        }
+    };
 
     for dir in &dirs {
         if let Err(e) = watcher.watch(dir, RecursiveMode::NonRecursive) {
@@ -1566,9 +1563,8 @@ fn build_client_cert_verifier(
     let mut roots = RootCertStore::empty();
     let mut added = 0usize;
     for cert in rustls_pemfile::certs(&mut BufReader::new(file)) {
-        let cert = cert.map_err(|e| {
-            ServerError::Http(format!("parse pgwire_tls_client_ca: {e}"))
-        })?;
+        let cert =
+            cert.map_err(|e| ServerError::Http(format!("parse pgwire_tls_client_ca: {e}")))?;
         roots
             .add(cert)
             .map_err(|e| ServerError::Http(format!("invalid CA in pgwire_tls_client_ca: {e}")))?;
@@ -2226,8 +2222,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn md5_auth_accepts_correct_password_against_prehash() {
-        let (addr, handle) =
-            spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
+        let (addr, handle) = spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
         let client = connect_with_password(addr, "alice", TEST_PASSWORD)
             .await
             .expect("auth must succeed against pre-hashed entry");
@@ -2242,8 +2237,7 @@ mod integration_tests {
 
     #[tokio::test]
     async fn md5_auth_rejects_wrong_password_against_prehash() {
-        let (addr, handle) =
-            spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
+        let (addr, handle) = spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
         let err = connect_with_password(addr, "alice", "not-the-password")
             .await
             .expect_err("auth must fail");
@@ -2357,33 +2351,24 @@ mod integration_tests {
     }
 
     fn mint_ca_and_client_leaf(common_name: &str) -> MintedClientPki {
-        use tokio_rustls::rustls::pki_types::{
-            CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer,
-        };
+        use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 
-        let mut ca_params =
-            rcgen::CertificateParams::new(vec!["mtls-test-ca".into()]).unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(vec!["mtls-test-ca".into()]).unwrap();
         ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
         let ca_key = rcgen::KeyPair::generate().unwrap();
         let ca_cert = ca_params.self_signed(&ca_key).unwrap();
 
-        let mut leaf_params =
-            rcgen::CertificateParams::new(vec![common_name.into()]).unwrap();
-        leaf_params.extended_key_usages =
-            vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
+        let mut leaf_params = rcgen::CertificateParams::new(vec![common_name.into()]).unwrap();
+        leaf_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
         let leaf_key = rcgen::KeyPair::generate().unwrap();
-        let leaf_cert = leaf_params
-            .signed_by(&leaf_key, &ca_cert, &ca_key)
-            .unwrap();
+        let leaf_cert = leaf_params.signed_by(&leaf_key, &ca_cert, &ca_key).unwrap();
 
         let dir = tempfile::tempdir().unwrap();
         let ca_pem_path = dir.path().join("ca.pem");
         std::fs::write(&ca_pem_path, ca_cert.pem()).unwrap();
 
         let leaf_chain = vec![CertificateDer::from(leaf_cert.der().to_vec())];
-        let leaf_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
-            leaf_key.serialize_der(),
-        ));
+        let leaf_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(leaf_key.serialize_der()));
 
         MintedClientPki {
             _dir: dir,
@@ -2411,8 +2396,7 @@ mod integration_tests {
         {
             roots.add(c).unwrap();
         }
-        let builder = tokio_rustls::rustls::ClientConfig::builder()
-            .with_root_certificates(roots);
+        let builder = tokio_rustls::rustls::ClientConfig::builder().with_root_certificates(roots);
         let client_cfg = match client_auth {
             Some((chain, key)) => builder.with_client_auth_cert(chain, key).unwrap(),
             None => builder.with_no_client_auth(),
@@ -2492,9 +2476,9 @@ mod integration_tests {
         }
         super::ensure_tls_provider();
         // Client pinned to TLS 1.2 only — must be refused by a 1.3-min server.
-        let client_cfg = tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(
-            &[&tokio_rustls::rustls::version::TLS12],
-        )
+        let client_cfg = tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(&[
+            &tokio_rustls::rustls::version::TLS12,
+        ])
         .with_root_certificates(roots)
         .with_no_client_auth();
 
@@ -2510,13 +2494,10 @@ mod integration_tests {
         };
         // tokio_postgres wraps the rustls error; flatten the chain so we can
         // assert against the version-mismatch token rustls emits.
-        let chain = std::iter::successors(
-            Some(&err as &dyn std::error::Error),
-            |e| e.source(),
-        )
-        .map(|e| e.to_string())
-        .collect::<Vec<_>>()
-        .join(" | ");
+        let chain = std::iter::successors(Some(&err as &dyn std::error::Error), |e| e.source())
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
         assert!(
             chain.contains("ProtocolVersion") || chain.contains("incompatible"),
             "expected a TLS version-mismatch error, got: {chain}"
@@ -2736,10 +2717,7 @@ mod integration_tests {
 
     /// Build a `TlsReloadState` directly for unit-testing the reload path
     /// without standing up a listener.
-    fn build_reload_state(
-        cert: &std::path::Path,
-        key: &std::path::Path,
-    ) -> super::TlsReloadState {
+    fn build_reload_state(cert: &std::path::Path, key: &std::path::Path) -> super::TlsReloadState {
         let paths = super::TlsPaths {
             cert,
             key,
@@ -2767,8 +2745,7 @@ mod integration_tests {
         let cert_path = dir.path().join("cert.pem");
         let key_path = dir.path().join("key.pem");
         // Initial cert.
-        let first =
-            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let first = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
         std::fs::write(&cert_path, first.cert.pem()).unwrap();
         std::fs::write(&key_path, first.key_pair.serialize_pem()).unwrap();
 
@@ -2776,8 +2753,7 @@ mod integration_tests {
         let before = state.snapshot();
 
         // Rotate to a brand-new pair.
-        let second =
-            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let second = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
         std::fs::write(&cert_path, second.cert.pem()).unwrap();
         std::fs::write(&key_path, second.key_pair.serialize_pem()).unwrap();
 
@@ -2796,8 +2772,7 @@ mod integration_tests {
         let dir = tempfile::tempdir().unwrap();
         let cert_path = dir.path().join("cert.pem");
         let key_path = dir.path().join("key.pem");
-        let first =
-            rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+        let first = rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
         std::fs::write(&cert_path, first.cert.pem()).unwrap();
         std::fs::write(&key_path, first.key_pair.serialize_pem()).unwrap();
 

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1146,6 +1146,9 @@ pub struct TlsPaths<'a> {
     pub cert: &'a std::path::Path,
     pub key: &'a std::path::Path,
     pub min_version: TlsMinVersion,
+    /// PEM bundle of CA roots; presence enables mTLS — every client must
+    /// present a cert that chains to one of these roots.
+    pub client_ca: Option<&'a std::path::Path>,
 }
 
 /// Minimum TLS protocol version accepted on the pgwire listener. rustls
@@ -1339,12 +1342,53 @@ fn load_tls_acceptor(paths: TlsPaths<'_>) -> Result<tokio_rustls::TlsAcceptor, S
             ))
         })?;
 
-    let server_config =
-        tokio_rustls::rustls::ServerConfig::builder_with_protocol_versions(paths.min_version.versions())
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
+    let builder = tokio_rustls::rustls::ServerConfig::builder_with_protocol_versions(
+        paths.min_version.versions(),
+    );
+    let builder = match paths.client_ca {
+        Some(ca_path) => {
+            let verifier = build_client_cert_verifier(ca_path)?;
+            builder.with_client_cert_verifier(verifier)
+        }
+        None => builder.with_no_client_auth(),
+    };
+    let server_config = builder
+        .with_single_cert(certs, key)
+        .map_err(|e| ServerError::Http(format!("rustls server config: {e}")))?;
     Ok(tokio_rustls::TlsAcceptor::from(Arc::new(server_config)))
+}
+
+#[allow(clippy::result_large_err)]
+fn build_client_cert_verifier(
+    ca_path: &std::path::Path,
+) -> Result<Arc<dyn tokio_rustls::rustls::server::danger::ClientCertVerifier>, ServerError> {
+    use std::fs::File;
+    use std::io::BufReader;
+    use tokio_rustls::rustls::server::WebPkiClientVerifier;
+    use tokio_rustls::rustls::RootCertStore;
+
+    let file = File::open(ca_path)
+        .map_err(|e| ServerError::Http(format!("open pgwire_tls_client_ca: {e}")))?;
+    let mut roots = RootCertStore::empty();
+    let mut added = 0usize;
+    for cert in rustls_pemfile::certs(&mut BufReader::new(file)) {
+        let cert = cert.map_err(|e| {
+            ServerError::Http(format!("parse pgwire_tls_client_ca: {e}"))
+        })?;
+        roots
+            .add(cert)
+            .map_err(|e| ServerError::Http(format!("invalid CA in pgwire_tls_client_ca: {e}")))?;
+        added += 1;
+    }
+    if added == 0 {
+        return Err(ServerError::Http(format!(
+            "pgwire_tls_client_ca {} contains no certificates",
+            ca_path.display()
+        )));
+    }
+    WebPkiClientVerifier::builder(Arc::new(roots))
+        .build()
+        .map_err(|e| ServerError::Http(format!("build client-cert verifier: {e}")))
 }
 
 pub async fn serve(
@@ -1378,6 +1422,7 @@ pub async fn serve(
     }
 
     let tls_min_label = tls.as_ref().map(|p| p.min_version.label());
+    let mtls_on = tls.as_ref().is_some_and(|p| p.client_ca.is_some());
     let tls_acceptor = match tls {
         Some(paths) => Some(load_tls_acceptor(paths)?),
         None => None,
@@ -1393,11 +1438,13 @@ pub async fn serve(
     let factory = Arc::new(LaminarHandlerFactory::new(db, users));
     let tls_mode = if tls_acceptor.is_some() { "on" } else { "off" };
     let tls_min = tls_min_label.unwrap_or("-");
+    let mtls = if mtls_on { "on" } else { "off" };
     if auth_mode == "trust" {
         warn!(
             addr = %local_addr,
             tls = tls_mode,
             tls_min,
+            mtls,
             "pgwire listening with TRUST auth — any client reaching this address is admin",
         );
     } else {
@@ -1406,6 +1453,7 @@ pub async fn serve(
             auth = auth_mode,
             tls = tls_mode,
             tls_min,
+            mtls,
             "pgwire listening",
         );
     }
@@ -2015,6 +2063,81 @@ mod integration_tests {
         (dir, cert_path, key_path)
     }
 
+    /// CA + client-leaf bundle for mTLS tests. The CA PEM is written to a
+    /// tempfile so the server can be pointed at it via `pgwire_tls_client_ca`;
+    /// the leaf cert+key are returned in DER form for direct use by a rustls
+    /// `ClientConfig`.
+    struct MintedClientPki {
+        _dir: tempfile::TempDir,
+        ca_pem_path: std::path::PathBuf,
+        leaf_chain: Vec<tokio_rustls::rustls::pki_types::CertificateDer<'static>>,
+        leaf_key: tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>,
+    }
+
+    fn mint_ca_and_client_leaf(common_name: &str) -> MintedClientPki {
+        use tokio_rustls::rustls::pki_types::{
+            CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer,
+        };
+
+        let mut ca_params =
+            rcgen::CertificateParams::new(vec!["mtls-test-ca".into()]).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let mut leaf_params =
+            rcgen::CertificateParams::new(vec![common_name.into()]).unwrap();
+        leaf_params.extended_key_usages =
+            vec![rcgen::ExtendedKeyUsagePurpose::ClientAuth];
+        let leaf_key = rcgen::KeyPair::generate().unwrap();
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &ca_cert, &ca_key)
+            .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let ca_pem_path = dir.path().join("ca.pem");
+        std::fs::write(&ca_pem_path, ca_cert.pem()).unwrap();
+
+        let leaf_chain = vec![CertificateDer::from(leaf_cert.der().to_vec())];
+        let leaf_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+            leaf_key.serialize_der(),
+        ));
+
+        MintedClientPki {
+            _dir: dir,
+            ca_pem_path,
+            leaf_chain,
+            leaf_key,
+        }
+    }
+
+    /// Builds a tokio_postgres TLS connector that trusts `server_cert_path`
+    /// for the server hello and (optionally) presents a client cert for mTLS.
+    fn make_client_tls(
+        server_cert_path: &std::path::Path,
+        client_auth: Option<(
+            Vec<tokio_rustls::rustls::pki_types::CertificateDer<'static>>,
+            tokio_rustls::rustls::pki_types::PrivateKeyDer<'static>,
+        )>,
+    ) -> tokio_postgres_rustls::MakeRustlsConnect {
+        super::ensure_tls_provider();
+        let cert_bytes = std::fs::read(server_cert_path).unwrap();
+        let mut roots = tokio_rustls::rustls::RootCertStore::empty();
+        for c in rustls_pemfile::certs(&mut std::io::Cursor::new(cert_bytes))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        {
+            roots.add(c).unwrap();
+        }
+        let builder = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(roots);
+        let client_cfg = match client_auth {
+            Some((chain, key)) => builder.with_client_auth_cert(chain, key).unwrap(),
+            None => builder.with_no_client_auth(),
+        };
+        tokio_postgres_rustls::MakeRustlsConnect::new(client_cfg)
+    }
+
     /// Self-signed cert with notAfter in the past, for the expiry test.
     fn expired_self_signed_pem() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
         let mut params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
@@ -2045,6 +2168,7 @@ mod integration_tests {
                 cert: &cert_path,
                 key: &key_path,
                 min_version: super::TlsMinVersion::V1_2,
+                client_ca: None,
             }),
             256,
             10,
@@ -2068,6 +2192,7 @@ mod integration_tests {
                 cert: &cert_path,
                 key: &key_path,
                 min_version: super::TlsMinVersion::V1_3,
+                client_ca: None,
             }),
             256,
             10,
@@ -2132,6 +2257,7 @@ mod integration_tests {
                 cert: &cert_path,
                 key: &key_path,
                 min_version: super::TlsMinVersion::V1_2,
+                client_ca: None,
             }),
             256,
             10,
@@ -2174,6 +2300,165 @@ mod integration_tests {
         assert!(v.contains("LaminarDB"), "version: {v}");
 
         handle.abort();
+    }
+
+    /// mTLS: with a client_ca configured, a client that presents no cert
+    /// must be refused at handshake time.
+    #[tokio::test]
+    async fn mtls_rejects_client_without_cert() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let pki = mint_ca_and_client_leaf("alice");
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+                min_version: super::TlsMinVersion::V1_2,
+                client_ca: Some(&pki.ca_pem_path),
+            }),
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+
+        let tls = make_client_tls(&cert_path, None);
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let err = match tokio_postgres::connect(&conn_str, tls).await {
+            Ok(_) => panic!("client without a cert must be refused under mTLS"),
+            Err(e) => e,
+        };
+        assert!(
+            err_chain(&err).contains("CertificateRequired")
+                || err_chain(&err).contains("HandshakeFailure")
+                || err_chain(&err).contains("certificate required"),
+            "expected a missing-client-cert error, got: {}",
+            err_chain(&err),
+        );
+        handle.abort();
+    }
+
+    /// mTLS: a client cert signed by an unknown CA must be refused.
+    #[tokio::test]
+    async fn mtls_rejects_untrusted_client_cert() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let trusted = mint_ca_and_client_leaf("trusted");
+        let stranger = mint_ca_and_client_leaf("stranger");
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+                min_version: super::TlsMinVersion::V1_2,
+                client_ca: Some(&trusted.ca_pem_path),
+            }),
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+
+        // Client presents a leaf signed by a CA the server doesn't know.
+        let tls = make_client_tls(
+            &cert_path,
+            Some((stranger.leaf_chain.clone(), stranger.leaf_key.clone_key())),
+        );
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let err = match tokio_postgres::connect(&conn_str, tls).await {
+            Ok(_) => panic!("untrusted client cert must be refused"),
+            Err(e) => e,
+        };
+        // rustls maps a verifier-rejected client cert to a fatal alert; the
+        // exact variant depends on the protocol version and verifier path
+        // (UnknownCA / BadCertificate on 1.2, DecryptError or
+        // CertificateUnknown on 1.3). We assert it failed at the TLS layer.
+        let chain = err_chain(&err);
+        assert!(
+            chain.contains("UnknownCA")
+                || chain.contains("BadCertificate")
+                || chain.contains("CertificateUnknown")
+                || chain.contains("DecryptError")
+                || chain.contains("HandshakeFailure"),
+            "expected a cert-rejection alert, got: {chain}",
+        );
+        handle.abort();
+    }
+
+    /// mTLS: a client cert signed by the configured CA is accepted, and a
+    /// SimpleQuery completes over the encrypted+authenticated session.
+    #[tokio::test]
+    async fn mtls_accepts_trusted_client_cert() {
+        let (_dir, cert_path, key_path) = self_signed_pem();
+        let pki = mint_ca_and_client_leaf("alice");
+        let db = Arc::new(LaminarDB::open().expect("db opens"));
+        db.start().await.expect("db starts");
+        let (addr, handle) = super::serve(
+            Arc::clone(&db),
+            "127.0.0.1:0",
+            HashMap::new(),
+            false,
+            Some(super::TlsPaths {
+                cert: &cert_path,
+                key: &key_path,
+                min_version: super::TlsMinVersion::V1_2,
+                client_ca: Some(&pki.ca_pem_path),
+            }),
+            256,
+            10,
+        )
+        .await
+        .expect("pgwire serve");
+
+        let tls = make_client_tls(
+            &cert_path,
+            Some((pki.leaf_chain.clone(), pki.leaf_key.clone_key())),
+        );
+        let conn_str = format!(
+            "host=localhost hostaddr={} port={} user=any dbname=laminardb sslmode=require",
+            addr.ip(),
+            addr.port(),
+        );
+        let (client, conn) = tokio_postgres::connect(&conn_str, tls)
+            .await
+            .expect("mTLS handshake + connect");
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("query over mTLS");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
+        handle.abort();
+    }
+
+    /// Flatten an error and its `source()` chain to a single string for
+    /// substring assertions.
+    fn err_chain(err: &(dyn std::error::Error + 'static)) -> String {
+        std::iter::successors(Some(err), |e| e.source())
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(" | ")
     }
 
     /// Push one row into the `trades` source so subsequent SUBSCRIBE

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -1243,10 +1243,10 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
     use crossfire::{mpsc, MTx};
     use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 
-    // Resolve the set of files we care about, then derive the parent dirs
-    // to watch. Watching parents (not files) is what makes atomic-rename
-    // rotations (write-tmp + rename-into-place) reliably visible.
-    let mut targets: Vec<std::path::PathBuf> = Vec::new();
+    // Track raw + canonical paths so symlink-swap rotations and edits to
+    // the symlink target both produce visible events.
+    let mut raw_targets: Vec<std::path::PathBuf> = Vec::new();
+    let mut canon_targets: Vec<std::path::PathBuf> = Vec::new();
     for path in [
         Some(state.paths.cert.clone()),
         Some(state.paths.key.clone()),
@@ -1256,7 +1256,10 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
     .flatten()
     {
         match path.canonicalize() {
-            Ok(p) => targets.push(p),
+            Ok(canonical) => {
+                canon_targets.push(canonical);
+                raw_targets.push(path);
+            }
             Err(e) => {
                 warn!(
                     path = %path.display(),
@@ -1267,8 +1270,9 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
             }
         }
     }
-    let mut dirs: Vec<std::path::PathBuf> = targets
+    let mut dirs: Vec<std::path::PathBuf> = raw_targets
         .iter()
+        .chain(canon_targets.iter())
         .filter_map(|p| p.parent().map(|d| d.to_path_buf()))
         .collect();
     dirs.sort();
@@ -1276,16 +1280,18 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
 
     let (tx, rx) = mpsc::bounded_async::<()>(16);
     let blocking_tx: MTx<_> = tx.clone().into_blocking();
-    let watch_targets: Vec<std::path::PathBuf> = targets.clone();
+    let watch_raw = raw_targets.clone();
+    let watch_canon = canon_targets.clone();
 
     let mut watcher: RecommendedWatcher = match notify::recommended_watcher(
         move |result: Result<Event, notify::Error>| match result {
             Ok(event) => {
                 let touched = event.paths.iter().any(|p| {
-                    p.canonicalize()
-                        .ok()
-                        .as_ref()
-                        .is_some_and(|c| watch_targets.contains(c))
+                    watch_raw.iter().any(|t| t == p)
+                        || p.canonicalize()
+                            .ok()
+                            .as_ref()
+                            .is_some_and(|c| watch_canon.contains(c))
                 });
                 if touched {
                     let _ = blocking_tx.send(());
@@ -1312,7 +1318,7 @@ async fn watch_tls_files(state: Arc<TlsReloadState>, debounce: std::time::Durati
         }
     }
     info!(
-        files = ?targets.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        files = ?raw_targets.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
         "pgwire TLS watcher started",
     );
 
@@ -1667,10 +1673,10 @@ pub async fn serve(
         std::env::var("LAMINAR_DISABLE_FILE_WATCH").is_ok_and(|v| v == "1" || v == "true");
     let handle = tokio::spawn(async move {
         let mut sessions: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
-        // Spawn the TLS hot-reload watcher into the same JoinSet so it's
-        // aborted alongside sessions when the outer handle is dropped.
+        // Watcher in its own JoinSet so it doesn't count toward max_connections.
+        let mut watcher_set: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
         if let (Some(state), false) = (watcher_state, watcher_disabled) {
-            sessions.spawn(async move {
+            watcher_set.spawn(async move {
                 watch_tls_files(state, std::time::Duration::from_millis(500)).await;
             });
         }
@@ -1679,6 +1685,7 @@ pub async fn serve(
                 Some(_) = sessions.join_next(), if !sessions.is_empty() => {
                     // Reap completed sessions; nothing to do with the result.
                 }
+                Some(_) = watcher_set.join_next(), if !watcher_set.is_empty() => {}
                 accepted = listener.accept() => {
                     match accepted {
                         Ok((sock, peer)) => {

--- a/crates/laminar-server/src/pgwire.rs
+++ b/crates/laminar-server/src/pgwire.rs
@@ -878,10 +878,40 @@ fn arrow_to_pg_type(dt: &arrow_schema::DataType) -> Type {
     }
 }
 
-/// Per-call salt + stored plaintext for the MD5 challenge flow.
+/// Per-call salt + stored credential for the MD5 challenge flow. The
+/// stored value is either plaintext (legacy) or `md5<32-hex>`, the same
+/// format Postgres' `pg_authid` uses, where the hex is `md5(password ‖
+/// user)`. The pre-hashed form lets operators avoid plaintext at rest.
 #[derive(Debug)]
 struct LaminarAuthSource {
     users: Arc<HashMap<String, Secret>>,
+}
+
+/// If `stored` is a `pg_authid`-style pre-hash, return the inner hex
+/// (the bit after the `md5` tag). Lowercase hex only; uppercase or
+/// other lengths fall back to plaintext handling.
+pub(crate) fn parse_pre_hashed_md5(stored: &str) -> Option<&str> {
+    let inner = stored.strip_prefix("md5")?;
+    if inner.len() == 32
+        && inner
+            .chars()
+            .all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+    {
+        Some(inner)
+    } else {
+        None
+    }
+}
+
+/// MD5 challenge response when only the inner hash is known: the client
+/// sends `md5{hex(md5(inner_hex || salt))}` and the server precomputes
+/// the same string for comparison.
+fn outer_md5_challenge(inner_hex: &str, salt: &[u8]) -> String {
+    use md5::{Digest, Md5};
+    let mut hasher = Md5::new();
+    hasher.update(inner_hex.as_bytes());
+    hasher.update(salt);
+    format!("md5{:x}", hasher.finalize())
 }
 
 #[async_trait]
@@ -891,12 +921,15 @@ impl AuthSource for LaminarAuthSource {
         // Indistinguishable from a wrong-password failure: both branches must
         // surface the same wire error so a client can't probe which usernames
         // are configured. pgwire emits exactly this variant on bad password.
-        let password = self
+        let stored = self
             .users
             .get(user)
             .ok_or_else(|| PgWireError::InvalidPassword(user.to_string()))?;
         let salt: [u8; 4] = rand::random();
-        let expected = hash_md5_password(user, password.expose(), &salt);
+        let expected = match parse_pre_hashed_md5(stored.expose()) {
+            Some(inner_hex) => outer_md5_challenge(inner_hex, &salt),
+            None => hash_md5_password(user, stored.expose(), &salt),
+        };
         Ok(Password::new(Some(salt.to_vec()), expected.into_bytes()))
     }
 }
@@ -2176,6 +2209,68 @@ mod integration_tests {
         assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
 
         handle.abort();
+    }
+
+    /// Pre-hashed pgwire_users entry: stored value is `md5{hex(md5(pw||user))}`,
+    /// matching pg_authid. Plaintext never touches disk yet auth still succeeds.
+    fn md5_users_prehashed(user: &str, password: &str) -> HashMap<String, Secret> {
+        use md5::{Digest, Md5};
+        let mut h = Md5::new();
+        h.update(password.as_bytes());
+        h.update(user.as_bytes());
+        let inner = format!("{:x}", h.finalize());
+        let mut u = HashMap::new();
+        u.insert(user.to_string(), Secret::new(format!("md5{inner}")));
+        u
+    }
+
+    #[tokio::test]
+    async fn md5_auth_accepts_correct_password_against_prehash() {
+        let (addr, handle) =
+            spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
+        let client = connect_with_password(addr, "alice", TEST_PASSWORD)
+            .await
+            .expect("auth must succeed against pre-hashed entry");
+        let messages = client
+            .simple_query("SELECT version()")
+            .await
+            .expect("query after auth");
+        let v = first_row_value(&messages, 0).expect("row");
+        assert!(v.contains("LaminarDB"), "version: {v}");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn md5_auth_rejects_wrong_password_against_prehash() {
+        let (addr, handle) =
+            spawn_server_with(md5_users_prehashed("alice", TEST_PASSWORD)).await;
+        let err = connect_with_password(addr, "alice", "not-the-password")
+            .await
+            .expect_err("auth must fail");
+        let db_err = err.as_db_error().expect("typed PG error");
+        assert_eq!(db_err.code().code(), "28P01", "got: {db_err:?}");
+        handle.abort();
+    }
+
+    #[test]
+    fn parse_pre_hashed_md5_strict_format() {
+        // 32 lowercase hex after the tag → accepted.
+        let inner = "5d41402abc4b2a76b9719d911017c592";
+        assert_eq!(
+            super::parse_pre_hashed_md5(&format!("md5{inner}")),
+            Some(inner),
+        );
+        // Wrong length, uppercase hex, missing prefix, or non-hex → rejected.
+        assert_eq!(super::parse_pre_hashed_md5("md5short"), None);
+        assert_eq!(
+            super::parse_pre_hashed_md5("md55D41402ABC4B2A76B9719D911017C592"),
+            None,
+        );
+        assert_eq!(super::parse_pre_hashed_md5(inner), None);
+        assert_eq!(
+            super::parse_pre_hashed_md5("md5zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"),
+            None,
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -185,6 +185,9 @@ pub async fn run_server(
     let pgwire_allow_remote = config.server.pgwire_allow_remote;
     let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
     let pgwire_tls_key = config.server.pgwire_tls_key.clone();
+    let pgwire_tls_min_version =
+        crate::pgwire::TlsMinVersion::from_config_str(&config.server.pgwire_tls_min_version)
+            .expect("pgwire_tls_min_version validated at config load");
     let pgwire_max_connections = config.server.pgwire_max_connections;
     let pgwire_max_auth_failures = config.server.pgwire_max_auth_failures_per_min;
     let (app_state, api_handle) =
@@ -193,7 +196,11 @@ pub async fn run_server(
 
     let pgwire_handle = if let Some(bind) = pgwire_bind {
         let tls = match (&pgwire_tls_cert, &pgwire_tls_key) {
-            (Some(c), Some(k)) => Some(crate::pgwire::TlsPaths { cert: c, key: k }),
+            (Some(c), Some(k)) => Some(crate::pgwire::TlsPaths {
+                cert: c,
+                key: k,
+                min_version: pgwire_tls_min_version,
+            }),
             _ => None,
         };
         match crate::pgwire::serve(

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -17,7 +17,7 @@ use crate::config::{
 use crate::http;
 use crate::metrics::ServerMetrics;
 use crate::reload::ReloadGuard;
-#[cfg(test)]
+#[cfg(all(test, any(feature = "otel", feature = "kafka")))]
 use laminar_core::state::StateBackendConfig;
 
 /// Handle to a running LaminarDB server. Call `wait_for_shutdown` to block until Ctrl-C.
@@ -671,7 +671,8 @@ mod tests {
     /// layer surfaces a "schema auto-discovery failed: …" error (or, when
     /// the connector returns no schema, "could not auto-discover a schema").
     /// The server no longer pre-empts this — we just check the error bubbles
-    /// up clearly.
+    /// up clearly. Requires the kafka connector to be registered.
+    #[cfg(feature = "kafka")]
     #[tokio::test]
     async fn execute_config_ddl_columnless_kafka_surfaces_discovery_error() {
         let mut source = make_source("events", "kafka");

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -185,6 +185,7 @@ pub async fn run_server(
     let pgwire_allow_remote = config.server.pgwire_allow_remote;
     let pgwire_tls_cert = config.server.pgwire_tls_cert.clone();
     let pgwire_tls_key = config.server.pgwire_tls_key.clone();
+    let pgwire_tls_client_ca = config.server.pgwire_tls_client_ca.clone();
     let pgwire_tls_min_version =
         crate::pgwire::TlsMinVersion::from_config_str(&config.server.pgwire_tls_min_version)
             .expect("pgwire_tls_min_version validated at config load");
@@ -200,6 +201,7 @@ pub async fn run_server(
                 cert: c,
                 key: k,
                 min_version: pgwire_tls_min_version,
+                client_ca: pgwire_tls_client_ca.as_deref(),
             }),
             _ => None,
         };

--- a/crates/laminar-sql/README.md
+++ b/crates/laminar-sql/README.md
@@ -6,7 +6,7 @@ Streaming SQL extensions on top of sqlparser-rs: tumbling/session windows, water
 
 | Module | Purpose |
 |--------|---------|
-| `parser` | Streaming SQL parser: windows, emit, late data, joins, aggregation, analytics, ranking, DDL (CREATE SOURCE/STREAM/SINK/LOOKUP TABLE) |
+| `parser` | Streaming SQL parser: windows, emit, late data, joins, aggregation, analytics, ranking, DDL (CREATE SOURCE/STREAM/SINK/LOOKUP TABLE), `SUBSCRIBE`, `DECLARE … CURSOR FOR SUBSCRIBE`, `FETCH`, `CLOSE` |
 | `planner` | `StreamingPlanner` converts parsed SQL into `StreamingPlan` / `QueryPlan` |
 | `translator` | Operator config builders: window, join, analytic, order, having, DDL, ASOF join, temporal probe join |
 | `datafusion` | DataFusion integration: custom UDFs (tumble, hop, session, slide, first_value, last_value), aggregate bridge, `execute_streaming_sql`, PROCTIME() UDF, JSON functions, complex type functions |
@@ -58,6 +58,23 @@ CREATE SOURCE ... FROM POSTGRES_CDC (hostname = '...', database = '...')
 CREATE SOURCE ... FROM MYSQL_CDC (hostname = '...', database = '...')
 CREATE SINK ... INTO KAFKA (brokers = '...', topic = '...')
 CREATE SINK ... INTO DELTA_LAKE (path = '...')
+
+-- Retain a bounded ring of recent epochs so SUBSCRIBE clients can
+-- reconnect without gaps.
+CREATE STREAM trades AS SELECT * FROM events
+  WITH ('retain_history' = '64mb')
+
+-- Streaming subscriptions (consumed by the pgwire listener or the
+-- in-process SubscriptionPortal API in laminar-db).
+SUBSCRIBE my_stream
+SUBSCRIBE my_stream WHERE symbol = 'AAPL'
+SUBSCRIBE my_stream AS OF EPOCH 42
+
+-- Forward-only cursor over a SUBSCRIBE for libpq clients that prefer
+-- FETCH-driven flow control (e.g. psql with \set FETCH_COUNT 100).
+DECLARE c CURSOR FOR SUBSCRIBE my_stream
+FETCH FORWARD 100 FROM c
+CLOSE c
 ```
 
 ## Custom UDFs Registered with DataFusion


### PR DESCRIPTION
## Summary

Closes the four pgwire hardening items captured during principal reviews on the SUBSCRIBE-over-pgwire stack. Each commit is independently reviewable.

- **#10 — Optional mTLS** (`88e2af46`): new `pgwire_tls_client_ca` config; when set, `WebPkiClientVerifier` requires every client to present a cert chained to one of the configured roots. Independent of MD5 auth (both still apply). No CRL/OCSP yet.
- **#11 — Hot-reload TLS certs** (`2cad3d54`): `Mutex<Arc<TlsAcceptor>>` + `notify` file-watcher mirroring the existing `watcher.rs` config-reload pattern. Successful reloads atomically swap the inner `Arc`; failures (truncated file, expired cert) are logged as `pgwire.tls_reload outcome=failed` and leave the previous acceptor in place. In-flight handshakes finish with the cert that was current when their socket was accepted. `LAMINAR_DISABLE_FILE_WATCH=1` disables.
- **#7 — Pre-hashed `md5{hex}` passwords** (`a3376408`): `pgwire_users` now accepts `pg_authid`-style stored values — `md5` followed by 32 lowercase hex of `md5(password ‖ user)` — so plaintext never lands in the TOML file or secret store. Wire protocol is unchanged. Strict shape validation rejects malformed `md5xxx` entries at config load.
- (#12 min-TLS-version is already on `main` as `bcab5471`; included in the branch's history.)

No new dependencies of consequence: `md-5` was already a transitive dep (now declared directly), `notify` and `crossfire` were already in use for config hot-reload.

## Test plan
- [x] 57 pgwire tests + 13 config tests pass on `--no-default-features` (Windows MSVC)
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] mTLS: missing-cert / untrusted-issuer / trusted-cert paths covered
- [x] TLS reload: valid pair swaps, garbage cert keeps old acceptor
- [x] Pre-hashed: correct password accepted, wrong rejected, plaintext path still works, malformed `md5xxx` rejected at config load
- [x] TLS 1.3-min: TLS 1.2 client refused with rustls `ProtocolVersion` / `incompatible` token in the error chain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the pgwire listener with optional mTLS, hot-reloadable TLS certs, pre‑hashed MD5 credentials, and a TLS min‑version pin. Also updates READMEs to document pgwire `SUBSCRIBE`/cursor usage and `retain_history`.

- **New Features**
  - mTLS: set `pgwire_tls_client_ca` to require client certs chained to the provided roots; independent of MD5 auth; no CRL/OCSP yet.
  - TLS hot-reload: watches `pgwire_tls_cert`, `pgwire_tls_key`, and `pgwire_tls_client_ca` with a 500ms debounce; symlink‑swap aware; in‑flight handshakes finish; failures logged as `pgwire.tls_reload outcome=failed`; watcher runs in its own JoinSet (doesn’t count against `pgwire_max_connections`); disable via `LAMINAR_DISABLE_FILE_WATCH=1`.
  - Pre-hashed passwords: `pgwire_users` accepts `md5` + 32 lowercase hex (`pg_authid` format) so plaintext never sits in config; plaintext still works; strict validation rejects malformed `md5xxx`.
  - TLS minimum version: `pgwire_tls_min_version` ("1.2" default, "1.3" optional). When pinned to "1.3", TLS 1.2 clients are refused; surfaced as `tls_min` (and `mtls`) in listen logs.

- **Bug Fixes**
  - Gated a Kafka schema-discovery test behind the `kafka` feature to avoid false failures when the connector isn’t built.
  - Deflaked a shuffle-transport test: increased the peer‑EOF deadline from 5s to 30s and skipped the reconnect‑after‑restart case on Windows where timing is nondeterministic.

<sup>Written for commit e67876d5c1b526de82e36b104423b3356b02fde2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-hashed MD5 password support for PostgreSQL pgwire auth
  * Configurable pgwire TLS minimum version and optional mutual-TLS (mTLS)
  * TLS certificate/key/CA hot-reload without server restart
  * Audit events emitted for connection accepted/closed (including auth failures)

* **Documentation**
  * Expanded pgwire auth and TLS configuration guidance, including hot-reload behavior

* **Tests**
  * Added coverage for pgwire auth, TLS min-version, mTLS, and reload behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/377)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->