### PR TITLE
laminar-db: collapse DbState dual repr, trim restated docs

### DIFF
--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -28,11 +28,7 @@ use crate::sql_utils;
 /// Cloneable async sender for the live-DDL control channel.
 pub(crate) type ControlMsgTx = crossfire::MAsyncTx<crossfire::mpsc::Array<ControlMsg>>;
 
-/// Lifecycle state of a [`LaminarDB`] instance.
-///
-/// Stored as `AtomicU8` on [`LaminarDB::state`] so transitions are
-/// lock-free; the repr is fixed so `as u8` / `TryFrom<u8>` give the
-/// same bytes the atomic sees.
+/// Lifecycle state of a [`LaminarDB`] instance, stored as `AtomicU8`.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DbState {
@@ -44,9 +40,6 @@ pub(crate) enum DbState {
 }
 
 impl DbState {
-    /// Decode a byte previously stored into the atomic. Returns `None`
-    /// if the byte isn't a known variant — always a bug, because only
-    /// `Self::store_into` / `DbState::* as u8` write this atomic.
     pub(crate) fn from_u8(raw: u8) -> Option<Self> {
         Some(match raw {
             0 => Self::Created,
@@ -57,17 +50,15 @@ impl DbState {
             _ => return None,
         })
     }
-}
 
-// Compat aliases — remaining call sites still read/write raw bytes via
-// the atomic. The enum variants and these constants share the same
-// byte values (`#[repr(u8)]` above), so both work until the mechanical
-// rewrite lands.
-pub(crate) const STATE_CREATED: u8 = DbState::Created as u8;
-pub(crate) const STATE_STARTING: u8 = DbState::Starting as u8;
-pub(crate) const STATE_RUNNING: u8 = DbState::Running as u8;
-pub(crate) const STATE_SHUTTING_DOWN: u8 = DbState::ShuttingDown as u8;
-pub(crate) const STATE_STOPPED: u8 = DbState::Stopped as u8;
+    pub(crate) fn load(atomic: &std::sync::atomic::AtomicU8) -> Self {
+        Self::from_u8(atomic.load(std::sync::atomic::Ordering::Acquire)).unwrap_or(Self::Stopped)
+    }
+
+    pub(crate) fn store(self, atomic: &std::sync::atomic::AtomicU8) {
+        atomic.store(self as u8, std::sync::atomic::Ordering::Release);
+    }
+}
 
 fn cache_entries_from_memory(mem: laminar_sql::parser::lookup_table::ByteSize) -> usize {
     (mem.as_bytes() / 256).max(1024) as usize
@@ -85,7 +76,7 @@ pub struct LaminarDB {
     pub(crate) config: LaminarConfig,
     pub(crate) config_vars: Arc<HashMap<String, String>>,
     pub(crate) shutdown: std::sync::atomic::AtomicBool,
-    /// Unified checkpoint coordinator (populated by `start()`).
+    /// Populated by `start()`.
     pub(crate) coordinator:
         Arc<tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>>,
     pub(crate) connector_manager: parking_lot::Mutex<crate::connector_manager::ConnectorManager>,
@@ -93,105 +84,68 @@ pub struct LaminarDB {
     pub(crate) mv_registry: parking_lot::Mutex<laminar_core::mv::MvRegistry>,
     pub(crate) table_store: Arc<parking_lot::RwLock<crate::table_store::TableStore>>,
     pub(crate) state: Arc<std::sync::atomic::AtomicU8>,
-    /// Handle to the background processing task (if running).
     pub(crate) runtime_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
-    /// Signal to stop the processing loop.
     pub(crate) shutdown_signal: Arc<tokio::sync::Notify>,
-    /// Prometheus engine metrics. `None` until `set_engine_metrics()` is called.
     pub(crate) engine_metrics:
         parking_lot::Mutex<Option<Arc<crate::engine_metrics::EngineMetrics>>>,
-    /// Shared Prometheus registry. `None` until `set_prometheus_registry()` is called.
     pub(crate) prometheus_registry: parking_lot::Mutex<Option<Arc<prometheus::Registry>>>,
-    /// Instant when the database was created, for uptime calculation.
     pub(crate) start_time: std::time::Instant,
-    /// Session properties set via `SET key = value`.
     pub(crate) session_properties: parking_lot::Mutex<HashMap<String, String>>,
-    /// Global pipeline watermark (min of all source watermarks).
+    /// Min of all source watermarks.
     pub(crate) pipeline_watermark: Arc<std::sync::atomic::AtomicI64>,
-    /// Shared lookup table registry for physical planning of lookup joins.
     pub(crate) lookup_registry: Arc<laminar_sql::datafusion::LookupTableRegistry>,
-    /// Control channel sender for live DDL to the running coordinator.
-    /// `None` before `start()` or after `shutdown()`.
+    /// Live-DDL channel to the running coordinator. `None` outside `start..shutdown`.
     pub(crate) control_tx: parking_lot::Mutex<Option<ControlMsgTx>>,
-    /// Materialized view result store (shared with compute thread and query threads).
     pub(crate) mv_store: Arc<parking_lot::RwLock<crate::mv_store::MvStore>>,
-    /// Cluster control facade, installed by `LaminarDbBuilder::cluster_controller`.
-    /// `None` in embedded / single-instance mode; `Some` activates the
-    /// leader / follower checkpoint flow when the coordinator starts.
+    /// Activates leader/follower checkpoint flow when set. `None` in embedded mode.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) cluster_controller:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::ClusterController>>>,
-    /// State backend for durability-gate participation. Installed by
-    /// `LaminarDbBuilder::state_backend`. When paired with a
-    /// `vnode_registry` the coordinator writes per-vnode markers each
-    /// checkpoint and the gate runs.
+    /// Pair with `vnode_registry`; the coordinator writes per-vnode durability
+    /// markers each checkpoint and runs the gate when both are installed.
     pub(crate) state_backend:
         parking_lot::Mutex<Option<Arc<dyn laminar_core::state::StateBackend>>>,
-    /// Vnode topology + assignment. Installed by
-    /// `LaminarDbBuilder::vnode_registry`. Needed for the coordinator to
-    /// know which vnodes this instance owns.
     pub(crate) vnode_registry: parking_lot::Mutex<Option<Arc<laminar_core::state::VnodeRegistry>>>,
-    /// Extra physical optimizer rules from the builder, applied to both
-    /// `self.ctx` and the pipeline-side `OperatorGraph` context.
+    /// Applied to both `self.ctx` and the pipeline-side `OperatorGraph` context.
     pub(crate) physical_optimizer_rules:
         Arc<[Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>]>,
-    /// `target_partitions` override from the builder, mirrored into the
-    /// pipeline-side `SessionContext`.
+    /// `target_partitions` override; cluster mode sets this to `vnode_count`.
     pub(crate) pipeline_target_partitions: Option<usize>,
-    /// Outbound shuffle handle. Installed via `LaminarDbBuilder::shuffle_sender`;
-    /// used by `SqlQueryOperator` to row-shuffle pre-aggregate batches to vnode
-    /// owners.
+    /// Used by `SqlQueryOperator` to row-shuffle pre-aggregate batches to owners.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) shuffle_sender:
         parking_lot::Mutex<Option<Arc<laminar_core::shuffle::ShuffleSender>>>,
-    /// Inbound shuffle handle. Installed via `LaminarDbBuilder::shuffle_receiver`.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) shuffle_receiver:
         parking_lot::Mutex<Option<Arc<laminar_core::shuffle::ShuffleReceiver>>>,
-    /// Shared commit-marker store. Installed via the builder.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) decision_store:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::CheckpointDecisionStore>>>,
-    /// Shared vnode-assignment snapshot store. Installed via the
-    /// builder; the rebalance tasks (spawned by the caller) watch it.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) assignment_snapshot_store:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::AssignmentSnapshotStore>>>,
-    /// Forwards `db.checkpoint()` requests to the running pipeline so
-    /// the callback captures operator state before the manifest is
-    /// packed. `None` before `start()` or after `shutdown()`; when
-    /// `None`, `db.checkpoint()` falls back to the direct coordinator
-    /// path (only valid when the engine has no stateful operators).
+    /// Hands `db.checkpoint()` requests to the pipeline callback so it can capture
+    /// operator state before the manifest is packed. When `None`, falls back to
+    /// the direct coordinator path — only valid for stateless engines.
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
-    /// SUBSCRIBE fan-out registry, shared with the pipeline callback.
     pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
-    /// Stream output schemas resolved at `start()`; SUBSCRIBE WHERE reads this.
+    /// Stream output schemas resolved at `start()`; consulted by SUBSCRIBE WHERE.
     pub(crate) stream_schemas:
         parking_lot::RwLock<std::collections::HashMap<String, arrow_schema::SchemaRef>>,
 }
 
-/// Oneshot reply carrying the full `CheckpointResult` back to the
-/// caller of `db.checkpoint()`. Created per-request.
-///
-/// Uses crossfire's oneshot (matches `sink_task`) rather than
-/// `tokio::sync::oneshot` so the whole checkpoint plumbing uses a
-/// consistent primitive family.
+/// Reply channel for a single `db.checkpoint()` request.
 pub(crate) type ForceCheckpointReply =
     crossfire::oneshot::TxOneshot<Result<crate::checkpoint_coordinator::CheckpointResult, DbError>>;
 
-/// Channel used by `db.checkpoint()` to hand a reply sender to the
-/// running pipeline callback. Bounded at 64 — cold path (one item per
-/// manual `db.checkpoint()` call); the cap is generous enough that the
-/// caller is never expected to wait.
+/// `db.checkpoint()` → pipeline callback request channel. Cold path; the cap
+/// is generous enough that callers never wait.
 pub(crate) type ForceCheckpointTx =
     crossfire::MAsyncTx<crossfire::mpsc::Array<ForceCheckpointReply>>;
 
-/// Paired receive-side of [`ForceCheckpointTx`], held by
-/// `ConnectorPipelineCallback`.
 pub(crate) type ForceCheckpointRx =
     crossfire::AsyncRx<crossfire::mpsc::Array<ForceCheckpointReply>>;
 
-/// Capacity of the force-checkpoint request channel.
 pub(crate) const FORCE_CHECKPOINT_CHANNEL_CAPACITY: usize = 64;
 
 pub(crate) struct SourceWatermarkState {
@@ -321,7 +275,7 @@ impl LaminarDB {
             table_store: Arc::new(parking_lot::RwLock::new(
                 crate::table_store::TableStore::new(),
             )),
-            state: Arc::new(std::sync::atomic::AtomicU8::new(STATE_CREATED)),
+            state: Arc::new(std::sync::atomic::AtomicU8::new(DbState::Created as u8)),
             runtime_handle: parking_lot::Mutex::new(None),
             shutdown_signal: Arc::new(tokio::sync::Notify::new()),
             engine_metrics: parking_lot::Mutex::new(None),
@@ -352,17 +306,11 @@ impl LaminarDB {
         })
     }
 
-    /// Install the outbound shuffle handle used by cluster-mode streaming
-    /// aggregates to route pre-aggregate rows to vnode owners. Called by
-    /// [`LaminarDbBuilder::shuffle_sender`]. Must be set before `start()`
-    /// to take effect.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) fn set_shuffle_sender(&self, sender: Arc<laminar_core::shuffle::ShuffleSender>) {
         *self.shuffle_sender.lock() = Some(sender);
     }
 
-    /// Install the inbound shuffle handle. Pair with
-    /// [`Self::set_shuffle_sender`]; neither alone is a no-op.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) fn set_shuffle_receiver(
         &self,
@@ -371,7 +319,6 @@ impl LaminarDB {
         *self.shuffle_receiver.lock() = Some(receiver);
     }
 
-    /// Install the commit-marker store. Must be called before `start()`.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) fn set_decision_store(
         &self,
@@ -380,7 +327,6 @@ impl LaminarDB {
         *self.decision_store.lock() = Some(store);
     }
 
-    /// Install the assignment snapshot store. Must be called before `start()`.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) fn set_assignment_snapshot_store(
         &self,
@@ -389,10 +335,9 @@ impl LaminarDB {
         *self.assignment_snapshot_store.lock() = Some(store);
     }
 
-    /// Adopt a new assignment snapshot: update the registry, backend
-    /// fence, and coordinator under the coordinator mutex so the
-    /// change lands strictly between checkpoints. Idempotent for
-    /// versions at or below the current registry version.
+    /// Adopt a new vnode assignment snapshot atomically across the registry,
+    /// state-backend fence, and coordinator. Idempotent for versions ≤ the
+    /// current registry version.
     #[cfg(feature = "cluster-unstable")]
     pub async fn adopt_assignment_snapshot(
         &self,
@@ -408,8 +353,7 @@ impl LaminarDB {
         let new_assignment: Arc<[laminar_core::state::NodeId]> =
             snapshot.to_vnode_vec(vnode_count).into();
 
-        // Hold the coord mutex so the registry and fence update land
-        // between epochs from the coordinator's perspective.
+        // Hold the coord mutex so registry + fence updates land between epochs.
         let mut guard = self.coordinator.lock().await;
         registry.set_assignment_and_version(new_assignment, snapshot.version);
         if let Some(backend) = self.state_backend.lock().clone() {
@@ -432,10 +376,6 @@ impl LaminarDB {
         tracing::info!(version = snapshot.version, "adopted assignment snapshot",);
     }
 
-    /// Install the cluster control facade. Called by
-    /// [`LaminarDbBuilder::cluster_controller`](crate::LaminarDbBuilder::cluster_controller)
-    /// before the pipeline starts; the `CheckpointCoordinator` picks
-    /// it up when constructed in `pipeline_lifecycle`.
     #[cfg(feature = "cluster-unstable")]
     pub(crate) fn set_cluster_controller(
         &self,
@@ -444,29 +384,21 @@ impl LaminarDB {
         *self.cluster_controller.lock() = Some(controller);
     }
 
-    /// Install a state backend so the checkpoint coordinator publishes
-    /// per-vnode durability markers and the gate runs. Pair with
-    /// [`Self::set_vnode_registry`]; either alone is a no-op.
     pub(crate) fn set_state_backend(&self, backend: Arc<dyn laminar_core::state::StateBackend>) {
         *self.state_backend.lock() = Some(backend);
     }
 
-    /// Install a vnode registry so the checkpoint coordinator knows
-    /// which vnodes this instance owns. Pair with
-    /// [`Self::set_state_backend`]; either alone is a no-op.
     pub(crate) fn set_vnode_registry(&self, registry: Arc<laminar_core::state::VnodeRegistry>) {
         *self.vnode_registry.lock() = Some(registry);
     }
 
-    /// Underlying `DataFusion` `SessionContext`. Primarily for tests
-    /// that need to compile SQL through the same session the engine
-    /// uses.
+    /// The underlying `DataFusion` `SessionContext`.
     #[must_use]
     pub fn session_context(&self) -> &SessionContext {
         &self.ctx
     }
 
-    /// Get a fluent builder for constructing a `LaminarDB`.
+    /// Returns a fluent builder for constructing a [`LaminarDB`].
     #[must_use]
     pub fn builder() -> LaminarDbBuilder {
         LaminarDbBuilder::new()

--- a/crates/laminar-db/src/metrics_api.rs
+++ b/crates/laminar-db/src/metrics_api.rs
@@ -36,14 +36,12 @@ impl LaminarDB {
 
     /// Get the current pipeline state as a string.
     pub fn pipeline_state(&self) -> &'static str {
-        let raw = self.state.load(std::sync::atomic::Ordering::Acquire);
-        match DbState::from_u8(raw) {
-            Some(DbState::Created) => "Created",
-            Some(DbState::Starting) => "Starting",
-            Some(DbState::Running) => "Running",
-            Some(DbState::ShuttingDown) => "ShuttingDown",
-            Some(DbState::Stopped) => "Stopped",
-            None => "Unknown",
+        match DbState::load(&self.state) {
+            DbState::Created => "Created",
+            DbState::Starting => "Starting",
+            DbState::Running => "Running",
+            DbState::ShuttingDown => "ShuttingDown",
+            DbState::Stopped => "Stopped",
         }
     }
 
@@ -167,15 +165,13 @@ impl LaminarDB {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    /// Convert the internal `AtomicU8` state to a `PipelineState` enum.
     pub(crate) fn pipeline_state_enum(&self) -> crate::metrics::PipelineState {
-        let raw = self.state.load(std::sync::atomic::Ordering::Acquire);
-        match DbState::from_u8(raw) {
-            Some(DbState::Created) => crate::metrics::PipelineState::Created,
-            Some(DbState::Starting) => crate::metrics::PipelineState::Starting,
-            Some(DbState::Running) => crate::metrics::PipelineState::Running,
-            Some(DbState::ShuttingDown) => crate::metrics::PipelineState::ShuttingDown,
-            Some(DbState::Stopped) | None => crate::metrics::PipelineState::Stopped,
+        match DbState::load(&self.state) {
+            DbState::Created => crate::metrics::PipelineState::Created,
+            DbState::Starting => crate::metrics::PipelineState::Starting,
+            DbState::Running => crate::metrics::PipelineState::Running,
+            DbState::ShuttingDown => crate::metrics::PipelineState::ShuttingDown,
+            DbState::Stopped => crate::metrics::PipelineState::Stopped,
         }
     }
 

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -8,10 +8,7 @@ use arrow_array::RecordBatch;
 use laminar_core::streaming;
 use rustc_hash::FxHashMap;
 
-use crate::db::{
-    LaminarDB, SourceWatermarkState, STATE_CREATED, STATE_RUNNING, STATE_SHUTTING_DOWN,
-    STATE_STARTING, STATE_STOPPED,
-};
+use crate::db::{DbState, LaminarDB, SourceWatermarkState};
 use crate::error::DbError;
 
 /// Resolves each `CREATE STREAM`'s output Arrow schema by planning its SQL.
@@ -130,40 +127,33 @@ impl LaminarDB {
     }
 
     pub(crate) fn is_pipeline_running(&self) -> bool {
-        let s = self.state.load(std::sync::atomic::Ordering::Acquire);
-        s == STATE_RUNNING || s == STATE_STARTING || s == STATE_SHUTTING_DOWN
+        matches!(
+            DbState::load(&self.state),
+            DbState::Running | DbState::Starting | DbState::ShuttingDown
+        )
     }
 
-    /// Start the streaming pipeline.
+    /// Start the streaming pipeline. Idempotent if already running.
     ///
-    /// Activates all registered connectors and begins processing.
-    /// This is a no-op if the pipeline is already running.
-    ///
-    /// When the `kafka` feature is enabled and Kafka sources/sinks are
-    /// registered, this builds `KafkaSource`/`KafkaSink` instances and
-    /// spawns a background task that polls sources, executes stream queries
-    /// via `DataFusion`, and writes results to sinks.
-    ///
-    /// In embedded (in-memory) mode, this simply transitions to `Running`.
+    /// Activates registered connectors and spawns the background processing
+    /// task. On failure the instance is unwound back to `Created` so the
+    /// caller can retry after fixing the offending config.
     ///
     /// # Errors
     ///
-    /// Returns an error if the pipeline cannot be started. On failure, the
-    /// instance is unwound back to `STATE_CREATED` so the caller can retry
-    /// after fixing the offending config.
+    /// Returns an error if the pipeline cannot be started.
     pub async fn start(&self) -> Result<(), DbError> {
-        let current = self.state.load(std::sync::atomic::Ordering::Acquire);
-        if current == STATE_RUNNING || current == STATE_STARTING {
-            return Ok(());
-        }
-        if current == STATE_STOPPED {
-            return Err(DbError::InvalidOperation(
-                "Cannot start a stopped pipeline. Create a new LaminarDB instance.".into(),
-            ));
+        match DbState::load(&self.state) {
+            DbState::Running | DbState::Starting => return Ok(()),
+            DbState::Stopped => {
+                return Err(DbError::InvalidOperation(
+                    "Cannot start a stopped pipeline. Create a new LaminarDB instance.".into(),
+                ));
+            }
+            DbState::Created | DbState::ShuttingDown => {}
         }
 
-        self.state
-            .store(STATE_STARTING, std::sync::atomic::Ordering::Release);
+        DbState::Starting.store(&self.state);
 
         // Fallback for embedded use without a server.
         {
@@ -177,24 +167,18 @@ impl LaminarDB {
 
         match self.start_inner().await {
             Ok(()) => {
-                self.state
-                    .store(STATE_RUNNING, std::sync::atomic::Ordering::Release);
+                DbState::Running.store(&self.state);
                 Ok(())
             }
             Err(e) => {
-                // Any failure between STATE_STARTING and STATE_RUNNING must
-                // unwind — otherwise the instance is wedged and a retry from
-                // the caller silently succeeds without actually starting.
-                self.state
-                    .store(STATE_CREATED, std::sync::atomic::Ordering::Release);
+                // Unwind so a retry actually re-runs startup instead of
+                // silently succeeding against a wedged Starting state.
+                DbState::Created.store(&self.state);
                 Err(e)
             }
         }
     }
 
-    /// Runs the actual startup sequence. Called exclusively by
-    /// [`LaminarDB::start`], which handles the `STATE_STARTING` ↔
-    /// `STATE_RUNNING` / `STATE_CREATED` transitions around it.
     #[allow(clippy::too_many_lines)]
     async fn start_inner(&self) -> Result<(), DbError> {
         // Snapshot connector registrations under the lock
@@ -1505,7 +1489,7 @@ impl LaminarDB {
             let handle = tokio::spawn(async move {
                 if done_rx.await.is_err() {
                     tracing::error!("laminar-compute thread exited unexpectedly");
-                    watcher_state.store(STATE_STOPPED, std::sync::atomic::Ordering::Release);
+                    DbState::Stopped.store(&watcher_state);
                     watcher_shutdown.notify_one();
                 }
             });
@@ -1515,51 +1499,37 @@ impl LaminarDB {
         Ok(())
     }
 
-    /// Shut down the streaming pipeline gracefully.
-    ///
-    /// Signals the processing loop to stop, waits for it to complete
-    /// (with a timeout), then transitions to `Stopped`.
-    /// This is idempotent -- calling it multiple times is safe.
+    /// Shut down the streaming pipeline gracefully. Idempotent.
     ///
     /// # Errors
     ///
     /// Returns an error if shutdown encounters an error.
     pub async fn shutdown(&self) -> Result<(), DbError> {
-        let current = self.state.load(std::sync::atomic::Ordering::Acquire);
-        if current == STATE_STOPPED || current == STATE_SHUTTING_DOWN {
+        if matches!(
+            DbState::load(&self.state),
+            DbState::Stopped | DbState::ShuttingDown
+        ) {
             return Ok(());
         }
 
-        self.state
-            .store(STATE_SHUTTING_DOWN, std::sync::atomic::Ordering::Release);
+        DbState::ShuttingDown.store(&self.state);
 
-        // Drop the force-checkpoint sender before signalling shutdown.
-        // Any subsequent `db.checkpoint()` call falls through to the
-        // (now-defunct) coordinator path, which errors cleanly instead
-        // of hanging on a oneshot that will never be answered.
+        // Drop the force-checkpoint sender first so any later db.checkpoint()
+        // errors cleanly instead of waiting on a oneshot that will never reply.
         *self.force_ckpt_tx.lock() = None;
 
-        // Signal the runtime loop to stop
         self.shutdown_signal.notify_one();
 
-        // Await the runtime handle (with timeout)
         let handle = self.runtime_handle.lock().take();
         if let Some(handle) = handle {
             match tokio::time::timeout(std::time::Duration::from_secs(10), handle).await {
-                Ok(Ok(())) => {
-                    tracing::info!("Pipeline shut down cleanly");
-                }
-                Ok(Err(e)) => {
-                    tracing::warn!(error = %e, "Pipeline task panicked during shutdown");
-                }
-                Err(_) => {
-                    tracing::warn!("Pipeline shutdown timed out after 10s");
-                }
+                Ok(Ok(())) => tracing::info!("Pipeline shut down cleanly"),
+                Ok(Err(e)) => tracing::warn!(error = %e, "Pipeline task panicked during shutdown"),
+                Err(_) => tracing::warn!("Pipeline shutdown timed out after 10s"),
             }
         }
 
-        self.state
-            .store(STATE_STOPPED, std::sync::atomic::Ordering::Release);
+        DbState::Stopped.store(&self.state);
         self.close();
         Ok(())
     }

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -460,7 +460,7 @@ impl<'a> RecoveryManager<'a> {
             );
         }
 
-        // Step 3: Restore source offsets
+        // Restore source offsets.
         for source in sources {
             if !source.supports_replay {
                 info!(
@@ -502,7 +502,7 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Step 4: Restore table source offsets
+        // Restore table source offsets.
         for table_source in table_sources {
             if let Some(cp) = manifest.table_offsets.get(&table_source.name) {
                 let source_cp = connector_to_source_checkpoint(cp);
@@ -521,10 +521,8 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Step 5: Rollback sinks for exactly-once semantics.
-        // Only roll back sinks that did NOT successfully commit (Pending or Failed).
-        // Sinks with SinkCommitStatus::Committed already completed their commit
-        // and should not be rolled back.
+        // Roll back exactly-once sinks that did NOT commit (Pending or Failed).
+        // Already-Committed sinks are left alone.
         for sink in sinks {
             if sink.exactly_once {
                 // Check per-sink commit status — if the sink committed, skip rollback.


### PR DESCRIPTION
## Summary

Senior-engineer cleanup pass on `laminar-db`. Removes transitional cruft and restated documentation; no behavior change.

- **Collapse the `DbState` dual representation.** The five `STATE_*: u8` constants in `db.rs` were marked *"compat aliases ... until the mechanical rewrite lands"* — that rewrite is overdue. Add `DbState::load(&atomic)` / `state.store(&atomic)` helpers on the enum and rewrite call sites in `pipeline_lifecycle.rs` and `metrics_api.rs` to use the variants directly via `matches!`.
- **Trim restated docs on internal `pub(crate)` setters.** `set_shuffle_sender` / `set_decision_store` / `set_state_backend` / etc. carried paragraph-long explainers that just duplicated the field comment one screen above. Public `adopt_assignment_snapshot` keeps its substantive doc.
- **Trim restated `LaminarDB` field docs and `ForceCheckpoint*` type aliases.** Drop docs that just rename the type (`/// Handle to the background processing task`, `/// Signal to stop the processing loop`); keep the ones that carry real contracts (pairing requirements, lifetime, what consults this field).
- **Drop `// Step N:` prefixes** in `recovery_manager.rs` inline markers; keep the descriptive part.

Net: `-104 LOC` across 4 files.

## Test plan

- [x] `cargo check -p laminar-db --no-default-features`
- [x] `cargo check -p laminar-db --no-default-features --features cluster-unstable`
- [x] `cargo clippy -p laminar-db -- -D warnings` (both feature sets)
- [x] `cargo test -p laminar-db --lib` — 651 passed, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified `laminar-db` state handling by removing the dual `DbState` representation and cleaning up redundant docs. No behavior change.

- **Refactors**
  - Removed `STATE_*: u8` constants; added `DbState::load` and `DbState::store`, and switched call sites to the enum (`pipeline_lifecycle.rs`, `metrics_api.rs`).
  - Trimmed duplicated docs on internal setters, `LaminarDB` fields, and `ForceCheckpoint*` aliases; kept substantive docs (e.g., `adopt_assignment_snapshot`).
  - Dropped "Step N:" prefixes in `recovery_manager.rs` comments. Net: -104 LOC.

<sup>Written for commit 45d1f96a71ed9a9a17c37cf15bbf001e3bac32ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal database state management system for improved consistency across pipeline lifecycle operations.
  * Streamlined state handling and synchronization mechanisms.

* **Documentation**
  * Clarified recovery process documentation for better understanding of database restoration operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/381)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->