### PR TITLE
windowing: explicit window_start/window_end columns via tumble_end/hop_end/cumulate_end UDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs/adr/
 /examples/binance-markout/target
 /examples/binance-markout/Cargo.lock
 /examples/binance-markout/smoke-report.txt
+/demo/kafka-iceberg-timeseries/validate/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "arrow",
  "laminar-connectors",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-storage"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.21.10"
+version = "0.22.0"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.85"

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,7 +11,7 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.21.5" }
+laminar-core = { path = "../laminar-core", version = "0.22.0" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -37,10 +37,10 @@ gcs = ["laminar-storage/gcs"]
 azure = ["laminar-storage/azure"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.21.5" }
-laminar-sql = { path = "../laminar-sql", version = "0.21.5" }
-laminar-storage = { path = "../laminar-storage", version = "0.21.5" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.21.5" }
+laminar-core = { path = "../laminar-core", version = "0.22.0" }
+laminar-sql = { path = "../laminar-sql", version = "0.22.0" }
+laminar-storage = { path = "../laminar-storage", version = "0.22.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.22.0" }
 
 # Arrow
 arrow = { workspace = true }
@@ -103,8 +103,8 @@ bytes = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = { workspace = true }
-laminar-derive = { path = "../laminar-derive", version = "0.21.5" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.21.5", features = ["testing"] }
+laminar-derive = { path = "../laminar-derive", version = "0.22.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.22.0", features = ["testing"] }
 criterion = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -51,9 +51,12 @@ pub(crate) use keys::{
 };
 pub(crate) use scalar_ipc::{ipc_to_scalars, scalars_to_ipc};
 
+/// Builds the per-window result batch for one closed window. The
+/// returned batch's schema is `[group_cols..., agg_outputs...]` — no
+/// implicit `window_start` / `window_end` columns. Callers that want
+/// those values in the output should project the matching window UDFs
+/// (`tumble(...)`, `tumble_end(...)`, etc.) in the upstream MV SQL.
 pub(crate) fn emit_window_batch(
-    window_start: i64,
-    window_end: i64,
     groups: ahash::AHashMap<arrow::row::OwnedRow, Vec<Box<dyn datafusion_expr::Accumulator>>>,
     row_converter: &arrow::row::RowConverter,
     num_group_cols: usize,
@@ -81,13 +84,6 @@ pub(crate) fn emit_window_batch(
         }
     }
 
-    let win_start_array: ArrayRef = Arc::new(arrow::array::Int64Array::from_iter_values(
-        std::iter::repeat_n(window_start, num_rows),
-    ));
-    let win_end_array: ArrayRef = Arc::new(arrow::array::Int64Array::from_iter_values(
-        std::iter::repeat_n(window_end, num_rows),
-    ));
-
     let group_arrays = if num_group_cols == 0 {
         Vec::new()
     } else {
@@ -109,7 +105,7 @@ pub(crate) fn emit_window_batch(
         }
     }
 
-    let mut all_arrays = vec![win_start_array, win_end_array];
+    let mut all_arrays = Vec::with_capacity(group_arrays.len() + agg_arrays.len());
     all_arrays.extend(group_arrays);
     all_arrays.extend(agg_arrays);
 

--- a/crates/laminar-db/src/aggregate_state/checkpoints.rs
+++ b/crates/laminar-db/src/aggregate_state/checkpoints.rs
@@ -68,14 +68,10 @@ pub(crate) struct EowcStateCheckpoint {
     pub fingerprint: u64,
     pub windows: Vec<WindowCheckpoint>,
     /// Highest watermark at checkpoint time, so recovery doesn't re-admit
-    /// late events the previous run already dropped. `i64::MIN` for
-    /// checkpoints written before this field existed.
-    #[serde(default = "default_high_watermark")]
+    /// late events the previous run already dropped. Adding this field
+    /// is a breaking rkyv schema change; pre-feature checkpoints will
+    /// fail to deserialize and a fresh start path is taken.
     pub high_watermark_ms: i64,
-}
-
-fn default_high_watermark() -> i64 {
-    i64::MIN
 }
 
 #[derive(

--- a/crates/laminar-db/src/aggregate_state/checkpoints.rs
+++ b/crates/laminar-db/src/aggregate_state/checkpoints.rs
@@ -67,10 +67,9 @@ pub(crate) struct WindowCheckpoint {
 pub(crate) struct EowcStateCheckpoint {
     pub fingerprint: u64,
     pub windows: Vec<WindowCheckpoint>,
-    /// Highest watermark at checkpoint time, so recovery doesn't re-admit
-    /// late events the previous run already dropped. Adding this field
-    /// is a breaking rkyv schema change; pre-feature checkpoints will
-    /// fail to deserialize and a fresh start path is taken.
+    /// Highest watermark at checkpoint time. Bumps the rkyv schema —
+    /// pre-feature checkpoints fail to deserialize and the recovery
+    /// path falls back to a fresh start.
     pub high_watermark_ms: i64,
 }
 

--- a/crates/laminar-db/src/aggregate_state/checkpoints.rs
+++ b/crates/laminar-db/src/aggregate_state/checkpoints.rs
@@ -67,6 +67,15 @@ pub(crate) struct WindowCheckpoint {
 pub(crate) struct EowcStateCheckpoint {
     pub fingerprint: u64,
     pub windows: Vec<WindowCheckpoint>,
+    /// Highest watermark at checkpoint time, so recovery doesn't re-admit
+    /// late events the previous run already dropped. `i64::MIN` for
+    /// checkpoints written before this field existed.
+    #[serde(default = "default_high_watermark")]
+    pub high_watermark_ms: i64,
+}
+
+fn default_high_watermark() -> i64 {
+    i64::MIN
 }
 
 #[derive(

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -86,14 +86,10 @@ pub(crate) struct CoreWindowCheckpoint {
     /// Discriminant so restore can pick the right branch.
     #[serde(default = "default_window_type_tag")]
     pub window_type: String,
-    /// Highest watermark observed at checkpoint time, so recovery
-    /// doesn't re-admit late events the previous run already dropped.
-    #[serde(default = "default_high_watermark")]
+    /// Highest watermark observed at checkpoint time. Adding this field
+    /// is a breaking rkyv schema change; pre-feature checkpoints fail to
+    /// deserialize and a fresh start path is taken.
     pub high_watermark_ms: i64,
-}
-
-fn default_high_watermark() -> i64 {
-    i64::MIN
 }
 
 fn default_window_type_tag() -> String {
@@ -698,17 +694,21 @@ impl CoreWindowState {
                 if ts_ms == NULL_TIMESTAMP {
                     continue; // skip rows with null timestamps
                 }
-                if self.is_event_late_beyond_recovery(ts_ms) {
-                    continue;
-                }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
                 match &self.assigner {
                     CoreWindowAssigner::Tumbling(a) => {
-                        grouped.entry(a.assign(ts_ms).start).or_default().push(idx);
+                        let ws = a.assign(ts_ms).start;
+                        if self.is_window_closed(ws) {
+                            continue;
+                        }
+                        grouped.entry(ws).or_default().push(idx);
                     }
                     CoreWindowAssigner::Hopping(a) => {
                         for wid in a.assign_windows(ts_ms) {
+                            if self.is_window_closed(wid.start) {
+                                continue;
+                            }
                             grouped.entry(wid.start).or_default().push(idx);
                         }
                     }
@@ -757,21 +757,22 @@ impl CoreWindowState {
             if ts_ms == NULL_TIMESTAMP {
                 continue;
             }
-            if self.is_event_late_beyond_recovery(ts_ms) {
-                continue;
-            }
             let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
             let (gid, idx) = (gid as u32, row_idx as u32);
             match &self.assigner {
                 CoreWindowAssigner::Tumbling(a) => {
-                    grouped
-                        .entry((a.assign(ts_ms).start, gid))
-                        .or_default()
-                        .push(idx);
+                    let ws = a.assign(ts_ms).start;
+                    if self.is_window_closed(ws) {
+                        continue;
+                    }
+                    grouped.entry((ws, gid)).or_default().push(idx);
                 }
                 CoreWindowAssigner::Hopping(a) => {
                     for wid in a.assign_windows(ts_ms) {
+                        if self.is_window_closed(wid.start) {
+                            continue;
+                        }
                         grouped.entry((wid.start, gid)).or_default().push(idx);
                     }
                 }
@@ -1069,26 +1070,26 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// True when the watermark has passed every window `ts_ms` could
-    /// belong to (plus the grace period). Sessions are excluded because
-    /// their end is data-dependent — merging is handled at close time.
+    /// True if the window starting at `window_start` has already closed.
+    /// Checked per assigned window so an event whose hopping windows are
+    /// partly closed still updates the still-open ones without
+    /// re-creating closed buckets. The window-start values are produced
+    /// by the assigner's `assign()` / `assign_windows()`, which already
+    /// account for window offsets.
     #[inline]
-    fn is_event_late_beyond_recovery(&self, ts_ms: i64) -> bool {
+    fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
             return false;
         }
-        let max_end_ms = match &self.assigner {
-            CoreWindowAssigner::Tumbling(a) => {
-                let size = a.size_ms();
-                ts_ms - ts_ms.rem_euclid(size) + size
-            }
-            CoreWindowAssigner::Hopping(a) => {
-                let slide = a.slide_ms();
-                ts_ms - ts_ms.rem_euclid(slide) + a.size_ms()
-            }
+        let size_ms = match &self.assigner {
+            CoreWindowAssigner::Tumbling(a) => a.size_ms(),
+            CoreWindowAssigner::Hopping(a) => a.size_ms(),
             CoreWindowAssigner::Session { .. } => return false,
         };
-        max_end_ms.saturating_add(self.allowed_lateness_ms) <= self.high_watermark_ms
+        window_start
+            .saturating_add(size_ms)
+            .saturating_add(self.allowed_lateness_ms)
+            <= self.high_watermark_ms
     }
 
     /// Close windows whose end <= watermark, returning emitted batches.

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -39,7 +39,6 @@ enum CoreWindowAssigner {
 struct PostProjection {
     exprs: Vec<Arc<dyn PhysicalExpr>>,
     final_schema: SchemaRef,
-    intermediate_schema: SchemaRef,
 }
 
 struct SessionAccState {
@@ -538,23 +537,19 @@ impl CoreWindowState {
             None
         };
 
-        let mut intermediate_fields: Vec<Field> = Vec::new();
+        // Output schema = group cols (in GROUP BY order) + agg outputs.
+        // No implicit window_start/window_end prepend; users surface those
+        // via the `tumble(...)` / `tumble_end(...)` UDFs explicitly.
+        let mut output_fields: Vec<Field> = Vec::new();
         for (name, dt) in group_col_names.iter().zip(group_types.iter()) {
-            intermediate_fields.push(Field::new(name, dt.clone(), true));
+            output_fields.push(Field::new(name, dt.clone(), true));
         }
         for spec in &agg_specs {
-            intermediate_fields.push(Field::new(
+            output_fields.push(Field::new(
                 &spec.output_name,
                 spec.return_type.clone(),
                 true,
             ));
-        }
-        let intermediate_schema = Arc::new(Schema::new(intermediate_fields));
-
-        let mut output_fields =
-            laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
-        for f in intermediate_schema.fields() {
-            output_fields.push(f.as_ref().clone());
         }
         let output_schema = Arc::new(Schema::new(output_fields));
 
@@ -577,17 +572,13 @@ impl CoreWindowState {
                     })?;
                 compiled.push(phys);
             }
-            let mut final_fields =
-                laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
-            for f in top_schema.fields() {
-                final_fields.push(f.as_ref().clone());
-            }
-            let final_schema = Arc::new(Schema::new(final_fields));
+            // Final schema = the post-aggregate projection's output, exactly
+            // as DataFusion planned it. No window_start/window_end prepend.
+            let final_schema = Arc::clone(&top_schema);
 
             Some(PostProjection {
                 exprs: compiled,
                 final_schema,
-                intermediate_schema: Arc::clone(&intermediate_schema),
             })
         } else {
             None
@@ -1113,8 +1104,7 @@ impl CoreWindowState {
             if groups.is_empty() {
                 continue;
             }
-            let window_end = window_start.saturating_add(size_ms);
-            if let Some(b) = self.emit_window(window_start, window_end, groups)? {
+            if let Some(b) = self.emit_window(groups)? {
                 result_batches.push(b);
             }
         }
@@ -1179,7 +1169,15 @@ impl CoreWindowState {
         self.emit_session_rows(rows)
     }
 
-    /// Build a `RecordBatch` from closed session rows (variable start/end).
+    /// Build a `RecordBatch` from closed session rows.
+    ///
+    /// Output schema = `[group_cols..., agg_outputs...]`. Session start
+    /// and end timestamps are NOT in the row output: each session has a
+    /// data-dependent end (the timestamp of its last event) that no
+    /// row-local function can compute, so there is no `session_end`
+    /// UDF and no implicit prepend. Consumers that need session
+    /// boundaries should add timestamp columns to the upstream SELECT
+    /// (e.g. `MIN(ts) AS session_start`, `MAX(ts) AS session_end`).
     #[allow(clippy::type_complexity)]
     fn emit_session_rows(
         &self,
@@ -1192,16 +1190,12 @@ impl CoreWindowState {
     ) -> Result<Vec<RecordBatch>, DbError> {
         let num_rows = rows.len();
 
-        let mut starts = Vec::with_capacity(num_rows);
-        let mut ends = Vec::with_capacity(num_rows);
         let mut row_keys: Vec<arrow::row::OwnedRow> = Vec::with_capacity(num_rows);
         let mut agg_scalars: Vec<Vec<ScalarValue>> = (0..self.agg_specs.len())
             .map(|_| Vec::with_capacity(num_rows))
             .collect();
 
-        for (ws, we, key, mut accs) in rows {
-            starts.push(ws);
-            ends.push(we);
+        for (_ws, _we, key, mut accs) in rows {
             row_keys.push(key);
             for (i, acc) in accs.iter_mut().enumerate() {
                 let sv = acc
@@ -1210,9 +1204,6 @@ impl CoreWindowState {
                 agg_scalars[i].push(sv);
             }
         }
-
-        let win_start_array: ArrayRef = Arc::new(arrow::array::Int64Array::from(starts));
-        let win_end_array: ArrayRef = Arc::new(arrow::array::Int64Array::from(ends));
 
         // Convert OwnedRow keys back to columnar arrays via RowConverter
         let group_arrays: Vec<ArrayRef> = if self.num_group_cols > 0 {
@@ -1249,7 +1240,7 @@ impl CoreWindowState {
             }
         }
 
-        let mut all_arrays = vec![win_start_array, win_end_array];
+        let mut all_arrays = Vec::with_capacity(group_arrays.len() + agg_arrays.len());
         all_arrays.extend(group_arrays);
         all_arrays.extend(agg_arrays);
 
@@ -1260,15 +1251,12 @@ impl CoreWindowState {
     }
 
     /// Emit a single window's accumulated state as a `RecordBatch`.
+    /// Output schema = `[group_cols..., agg_outputs...]`.
     fn emit_window(
         &self,
-        window_start: i64,
-        window_end: i64,
         groups: AHashMap<arrow::row::OwnedRow, Vec<Box<dyn datafusion_expr::Accumulator>>>,
     ) -> Result<Option<RecordBatch>, DbError> {
         crate::aggregate_state::emit_window_batch(
-            window_start,
-            window_end,
             groups,
             &self.row_converter,
             self.num_group_cols,
@@ -1278,6 +1266,8 @@ impl CoreWindowState {
     }
 
     /// Apply compiled post-aggregate projection to emitted batches.
+    /// Input schema is `[group_cols..., agg_outputs...]`; output schema
+    /// is `final_schema` (the user's SELECT list).
     fn apply_post_projection(
         &self,
         batches: Vec<RecordBatch>,
@@ -1293,23 +1283,10 @@ impl CoreWindowState {
                 continue;
             }
 
-            let win_start = Arc::clone(batch.column(0));
-            let win_end = Arc::clone(batch.column(1));
-
-            let content_cols: Vec<ArrayRef> = (2..batch.num_columns())
-                .map(|i| Arc::clone(batch.column(i)))
-                .collect();
-            let intermediate =
-                RecordBatch::try_new(Arc::clone(&proj.intermediate_schema), content_cols).map_err(
-                    |e| DbError::Pipeline(format!("post-projection intermediate batch: {e}")),
-                )?;
-
-            let mut projected_cols = Vec::with_capacity(2 + proj.exprs.len());
-            projected_cols.push(win_start);
-            projected_cols.push(win_end);
+            let mut projected_cols = Vec::with_capacity(proj.exprs.len());
             for phys_expr in &proj.exprs {
                 let col_val = phys_expr
-                    .evaluate(&intermediate)
+                    .evaluate(batch)
                     .map_err(|e| DbError::Pipeline(format!("post-projection evaluate: {e}")))?;
                 let array = col_val
                     .into_array(num_rows)
@@ -1640,9 +1617,8 @@ mod tests {
             filter_col_index: None,
         }];
 
+        // Output = group cols + agg outputs (no implicit window_start/end).
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
             Field::new("symbol", DataType::Utf8, true),
             Field::new("total", DataType::Int64, true),
         ]));
@@ -1703,9 +1679,8 @@ mod tests {
             },
         ];
 
+        // Output = group cols + agg outputs (no implicit window_start/end).
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
             Field::new("symbol", DataType::Utf8, true),
             Field::new("total", DataType::Int64, true),
             Field::new("cnt", DataType::Int64, true),
@@ -1754,9 +1729,8 @@ mod tests {
             filter_col_index: None,
         }];
 
+        // Output = group cols + agg outputs (no implicit window_start/end).
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
             Field::new("symbol", DataType::Utf8, true),
             Field::new("total", DataType::Int64, true),
         ]));
@@ -1806,9 +1780,8 @@ mod tests {
             filter_col_index: None,
         }];
 
+        // Output = group cols + agg outputs (no implicit window_start/end).
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
             Field::new("symbol", DataType::Utf8, true),
             Field::new("total", DataType::Int64, true),
         ]));
@@ -1963,32 +1936,19 @@ mod tests {
         let batch2 = make_pre_agg_batch(vec!["AAPL"], vec![30], vec![800]);
         state.update_batch(&batch2).unwrap();
 
-        // Close window at watermark 1000
+        // Close window at watermark 1000. Output schema is [symbol, total];
+        // window timing is no longer prepended (users opt in via tumble/
+        // tumble_end UDFs in their MV SELECT).
         let batches = state.close_windows(1000).unwrap();
         assert_eq!(batches.len(), 1);
 
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1);
+        assert_eq!(result.schema().fields().len(), 2);
 
-        // Check window_start = 0
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), 0);
-
-        // Check window_end = 1000
-        let we = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(we.value(0), 1000);
-
-        // Check SUM = 10 + 20 + 30 = 60
+        // SUM = 10 + 20 + 30 = 60 (column(1) is the agg output).
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2030,31 +1990,31 @@ mod tests {
     fn test_core_window_close_windows_watermark() {
         let mut state = make_core_window_state(1000);
 
-        // Events in three windows
+        // Events in three windows: SUMs by window are 1, 2, 3.
         let batch = make_pre_agg_batch(vec!["A", "A", "A"], vec![1, 2, 3], vec![100, 1100, 2100]);
         state.update_batch(&batch).unwrap();
 
-        // Watermark at 1500 → only window [0, 1000) closes
+        // Watermark at 1500 → only window [0, 1000) closes; SUM=1.
         let batches = state.close_windows(1500).unwrap();
         assert_eq!(batches.len(), 1);
-        let ws = batches[0]
-            .column(0)
+        let total = batches[0]
+            .column(1) // [symbol, total]
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-        assert_eq!(ws.value(0), 0);
+        assert_eq!(total.value(0), 1);
 
-        // Watermark at 2000 → window [1000, 2000) closes
+        // Watermark at 2000 → window [1000, 2000) closes; SUM=2.
         let batches = state.close_windows(2000).unwrap();
         assert_eq!(batches.len(), 1);
-        let ws = batches[0]
-            .column(0)
+        let total = batches[0]
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-        assert_eq!(ws.value(0), 1000);
+        assert_eq!(total.value(0), 2);
 
-        // Watermark at 2500 → nothing to close (window [2000,3000) still open)
+        // Watermark at 2500 → nothing to close (window [2000,3000) still open).
         let batches = state.close_windows(2500).unwrap();
         assert!(batches.is_empty());
     }
@@ -2112,14 +2072,15 @@ mod tests {
         let restored = state2.restore_windows(&cp).unwrap();
         assert!(restored > 0, "Should have restored groups");
 
-        // Close first window and verify SUM
+        // Close first window and verify SUM. Schema is [symbol, total];
+        // the agg col is at index 1.
         let batches = state2.close_windows(1000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1); // Only AAPL in window [0,1000)
 
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2129,7 +2090,7 @@ mod tests {
         let batches = state2.close_windows(2000).unwrap();
         assert_eq!(batches.len(), 1);
         let total2 = batches[0]
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2266,24 +2227,33 @@ mod tests {
         let batch = make_pre_agg_batch(vec!["A", "A"], vec![10, 20], vec![1000, 3000]);
         state.update_batch(&batch).unwrap();
 
-        // Close everything up to watermark 6000
-        let batches = state.close_windows(6000).unwrap();
+        // Without window_start in the emitted columns, attribution to a
+        // specific hop window comes from closing one boundary at a time:
+        // each `close_windows(watermark)` call closes exactly the windows
+        // whose end ≤ watermark.
+        //
+        //   watermark=2000 → window [-2000, 2000): only ts=1000 → SUM=10
+        //   watermark=4000 → window [0, 4000):     ts=1000+3000 → SUM=30
+        //   watermark=6000 → window [2000, 6000):  only ts=3000 → SUM=20
+        let read_total = |b: &arrow_array::RecordBatch| -> i64 {
+            b.column(1) // [symbol, total]
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0)
+        };
 
-        // Collect all (window_start, sum) pairs
-        let mut results: Vec<(i64, i64)> = Vec::new();
-        for b in &batches {
-            let ws = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
-            let totals = b.column(3).as_any().downcast_ref::<Int64Array>().unwrap();
-            for i in 0..b.num_rows() {
-                results.push((ws.value(i), totals.value(i)));
-            }
-        }
-        results.sort_unstable();
+        let b = state.close_windows(2000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(read_total(&b[0]), 10);
 
-        // window [-2000, 2000): only ts=1000 → SUM=10
-        // window [0, 4000): ts=1000 + ts=3000 → SUM=30
-        // window [2000, 6000): only ts=3000 → SUM=20
-        assert_eq!(results, vec![(-2000, 10), (0, 30), (2000, 20)]);
+        let b = state.close_windows(4000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(read_total(&b[0]), 30);
+
+        let b = state.close_windows(6000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(read_total(&b[0]), 20);
     }
 
     #[test]
@@ -2297,27 +2267,42 @@ mod tests {
         );
         state.update_batch(&batch).unwrap();
 
-        let batches = state.close_windows(6000).unwrap();
-
-        let mut results: Vec<(i64, String, i64)> = Vec::new();
-        for b in &batches {
-            let ws = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
-            let syms = b.column(2).as_any().downcast_ref::<StringArray>().unwrap();
-            let totals = b.column(3).as_any().downcast_ref::<Int64Array>().unwrap();
-            for i in 0..b.num_rows() {
-                results.push((ws.value(i), syms.value(i).to_string(), totals.value(i)));
-            }
-        }
-        results.sort();
+        // Same iterative-close trick as `test_hopping_basic_sum`.
+        // Within each window, sort the rows by (symbol, total) for a
+        // stable assertion regardless of group iteration order.
+        let collect_sym_total = |b: &arrow_array::RecordBatch| -> Vec<(String, i64)> {
+            let syms = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+            let totals = b.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
+            (0..b.num_rows())
+                .map(|i| (syms.value(i).to_string(), totals.value(i)))
+                .collect()
+        };
+        let sorted = |b: &arrow_array::RecordBatch| -> Vec<(String, i64)> {
+            let mut v = collect_sym_total(b);
+            v.sort();
+            v
+        };
 
         // window [-2000, 2000): A=10, B=100
+        let b = state.close_windows(2000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(
+            sorted(&b[0]),
+            vec![("A".to_string(), 10), ("B".to_string(), 100)]
+        );
+
         // window [0, 4000): A=10+20=30, B=100
-        // window [2000, 6000): A=20
-        assert!(results.contains(&(-2000, "A".to_string(), 10)));
-        assert!(results.contains(&(-2000, "B".to_string(), 100)));
-        assert!(results.contains(&(0, "A".to_string(), 30)));
-        assert!(results.contains(&(0, "B".to_string(), 100)));
-        assert!(results.contains(&(2000, "A".to_string(), 20)));
+        let b = state.close_windows(4000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(
+            sorted(&b[0]),
+            vec![("A".to_string(), 30), ("B".to_string(), 100)]
+        );
+
+        // window [2000, 6000): A=20 (B has no event in [2000,6000))
+        let b = state.close_windows(6000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(sorted(&b[0]), vec![("A".to_string(), 20)]);
     }
 
     #[test]
@@ -2327,25 +2312,23 @@ mod tests {
         let batch = make_pre_agg_batch(vec!["A", "A"], vec![10, 20], vec![1000, 3000]);
         state.update_batch(&batch).unwrap();
 
-        // Watermark at 2000 → only window [-2000, 2000) closes
+        let total = |b: &arrow_array::RecordBatch| -> i64 {
+            b.column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0)
+        };
+
+        // Watermark at 2000 → window [-2000, 2000): only ts=1000, SUM=10.
         let batches = state.close_windows(2000).unwrap();
         assert_eq!(batches.len(), 1);
-        let ws = batches[0]
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), -2000);
+        assert_eq!(total(&batches[0]), 10);
 
-        // Watermark at 4000 → window [0, 4000) closes
+        // Watermark at 4000 → window [0, 4000): ts=1000+3000, SUM=30.
         let batches = state.close_windows(4000).unwrap();
         assert_eq!(batches.len(), 1);
-        let ws = batches[0]
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), 0);
+        assert_eq!(total(&batches[0]), 30);
 
         // Watermark at 5000 → nothing (window [2000,6000) still open)
         let batches = state.close_windows(5000).unwrap();
@@ -2366,28 +2349,16 @@ mod tests {
         state.update_batch(&batch).unwrap();
 
         // Session: start=1000, end=4000+5000=9000
-        // Watermark at 9000 → session closes
+        // Watermark at 9000 → session closes; output is [symbol, total],
+        // session boundaries are no longer prepended (sessions are
+        // data-dependent — there is no `session_end` UDF).
         let batches = state.close_windows(9000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1);
 
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), 1000);
-
-        let we = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(we.value(0), 9000);
-
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2407,29 +2378,23 @@ mod tests {
         );
         state.update_batch(&batch).unwrap();
 
-        // Session 1: [1000, 3000), Session 2: [5000, 8000)
-        // Watermark at 8000 → both close
+        // Session 1: [1000, 3000) → SUM=10
+        // Session 2: [5000, 8000) → SUM=20+30=50
+        // Watermark at 8000 → both close. The two sessions emit in time
+        // order; output is [symbol, total].
         let batches = state.close_windows(8000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 2);
 
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
         let totals = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-
-        // Sorted by window_start
-        assert_eq!(ws.value(0), 1000);
-        assert_eq!(totals.value(0), 10);
-        assert_eq!(ws.value(1), 5000);
-        assert_eq!(totals.value(1), 50);
+        let mut sums: Vec<i64> = (0..result.num_rows()).map(|i| totals.value(i)).collect();
+        sums.sort_unstable();
+        assert_eq!(sums, vec![10, 50]);
     }
 
     #[test]
@@ -2447,27 +2412,15 @@ mod tests {
         state.update_batch(&batch2).unwrap();
         // Merged: [1000, 8000) with SUM = 10+20+30 = 60
 
+        // Merged session: [1000, 8000) with SUM=10+20+30=60.
+        // Output is [symbol, total]; session boundaries no longer in cols.
         let batches = state.close_windows(8000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1);
 
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), 1000);
-
-        let we = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(we.value(0), 8000);
-
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2487,34 +2440,31 @@ mod tests {
 
         // A: session [1000, 5000) SUM=30
         // B: session [2000, 6000) SUM=300
+        // Output schema [symbol, total]; per-session start/end are
+        // data-dependent and no longer surfaced as columns.
         let batches = state.close_windows(6000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 2);
 
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
         let syms = result
-            .column(2)
+            .column(0)
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
         let totals = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
 
-        let mut results: Vec<(String, i64, i64)> = (0..result.num_rows())
-            .map(|i| (syms.value(i).to_string(), ws.value(i), totals.value(i)))
+        let mut results: Vec<(String, i64)> = (0..result.num_rows())
+            .map(|i| (syms.value(i).to_string(), totals.value(i)))
             .collect();
         results.sort();
 
-        assert_eq!(results[0], ("A".to_string(), 1000, 30));
-        assert_eq!(results[1], ("B".to_string(), 2000, 300));
+        assert_eq!(results[0], ("A".to_string(), 30));
+        assert_eq!(results[1], ("B".to_string(), 300));
     }
 
     #[test]
@@ -2535,13 +2485,14 @@ mod tests {
         let batches = state.close_windows(10_000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
+        // Output is [symbol, total].
         let syms = result
-            .column(2)
+            .column(0)
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
         let totals = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2567,17 +2518,25 @@ mod tests {
         let restored = state2.restore_windows(&cp).unwrap();
         assert!(restored > 0);
 
-        let batches = state2.close_windows(6000).unwrap();
-        let mut results: Vec<(i64, i64)> = Vec::new();
-        for b in &batches {
-            let ws = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
-            let totals = b.column(3).as_any().downcast_ref::<Int64Array>().unwrap();
-            for i in 0..b.num_rows() {
-                results.push((ws.value(i), totals.value(i)));
-            }
-        }
-        results.sort_unstable();
-        assert_eq!(results, vec![(-2000, 10), (0, 30), (2000, 20)]);
+        // Restore-then-close iteratively to attribute sums to each
+        // window without relying on a window_start column (no longer
+        // emitted; consumers project tumble/hop UDFs themselves).
+        let total = |b: &arrow_array::RecordBatch| -> i64 {
+            b.column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap()
+                .value(0)
+        };
+        let b = state2.close_windows(2000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(total(&b[0]), 10);
+        let b = state2.close_windows(4000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(total(&b[0]), 30);
+        let b = state2.close_windows(6000).unwrap();
+        assert_eq!(b.len(), 1);
+        assert_eq!(total(&b[0]), 20);
     }
 
     #[test]
@@ -2605,7 +2564,7 @@ mod tests {
         assert_eq!(result.num_rows(), 1);
 
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -2745,18 +2704,19 @@ mod tests {
         assert_eq!(batches.len(), 1, "should emit one batch");
         let out = &batches[0];
 
-        // The projection SELECT has 2 items (symbol, ratio), so the
-        // final schema is [window_start, window_end, symbol, ratio].
-        assert_eq!(out.num_columns(), 4, "schema: {:?}", out.schema());
+        // The post-aggregate projection has 2 items (symbol, ratio), so
+        // the final schema is exactly [symbol, ratio]. Window-time cols
+        // are no longer prepended; if the user wants them they project
+        // `tumble(ts, INTERVAL '10' SECOND)` and `tumble_end(ts, …)`
+        // explicitly (and add them to GROUP BY).
+        assert_eq!(out.num_columns(), 2, "schema: {:?}", out.schema());
         assert_eq!(out.num_rows(), 1);
 
         // MemTable has 1 row: a=1.0, b=2.0.
-        // ratio = SUM(a) / SUM(b) = 1.0 / 2.0 = 0.5
-        // Output columns: [window_start, window_end, symbol, ratio]
-        // (group_1 = TUMBLE is consumed by window assignment, projection
-        //  selects only symbol + ratio)
+        // ratio = SUM(a) / SUM(b) = 1.0 / 2.0 = 0.5.
+        // Output columns: [symbol, ratio].
         let ratio_col = out
-            .column(out.num_columns() - 1)
+            .column(1)
             .as_any()
             .downcast_ref::<arrow::array::Float64Array>()
             .expect("ratio should be Float64");

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -86,6 +86,14 @@ pub(crate) struct CoreWindowCheckpoint {
     /// Discriminant so restore can pick the right branch.
     #[serde(default = "default_window_type_tag")]
     pub window_type: String,
+    /// Highest watermark observed at checkpoint time, so recovery
+    /// doesn't re-admit late events the previous run already dropped.
+    #[serde(default = "default_high_watermark")]
+    pub high_watermark_ms: i64,
+}
+
+fn default_high_watermark() -> i64 {
+    i64::MIN
 }
 
 fn default_window_type_tag() -> String {
@@ -121,6 +129,10 @@ pub(crate) struct CoreWindowState {
     /// Grace period (ms) after window end before closing. Late events
     /// arriving within this window are included instead of dropped.
     allowed_lateness_ms: i64,
+    /// Highest watermark seen via `close_windows`; `i64::MIN` before the
+    /// first close. Used by `update_batch` to drop events whose window
+    /// has already closed instead of re-creating the bucket.
+    high_watermark_ms: i64,
     post_projection: Option<PostProjection>,
     /// Reusable scratch map for no-group window assignment (avoids per-batch allocation).
     scratch_nogroup: AHashMap<i64, Vec<u32>>,
@@ -629,6 +641,7 @@ impl CoreWindowState {
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: i64::try_from(window_config.allowed_lateness.as_millis())
                 .unwrap_or(0),
+            high_watermark_ms: i64::MIN,
             post_projection,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
@@ -685,6 +698,9 @@ impl CoreWindowState {
                 if ts_ms == NULL_TIMESTAMP {
                     continue; // skip rows with null timestamps
                 }
+                if self.is_event_late_beyond_recovery(ts_ms) {
+                    continue;
+                }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
                 match &self.assigner {
@@ -739,6 +755,9 @@ impl CoreWindowState {
 
         for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
             if ts_ms == NULL_TIMESTAMP {
+                continue;
+            }
+            if self.is_event_late_beyond_recovery(ts_ms) {
                 continue;
             }
             let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
@@ -1050,8 +1069,31 @@ impl CoreWindowState {
         Ok(())
     }
 
+    /// True when the watermark has passed every window `ts_ms` could
+    /// belong to (plus the grace period). Sessions are excluded because
+    /// their end is data-dependent — merging is handled at close time.
+    #[inline]
+    fn is_event_late_beyond_recovery(&self, ts_ms: i64) -> bool {
+        if self.high_watermark_ms == i64::MIN {
+            return false;
+        }
+        let max_end_ms = match &self.assigner {
+            CoreWindowAssigner::Tumbling(a) => {
+                let size = a.size_ms();
+                ts_ms - ts_ms.rem_euclid(size) + size
+            }
+            CoreWindowAssigner::Hopping(a) => {
+                let slide = a.slide_ms();
+                ts_ms - ts_ms.rem_euclid(slide) + a.size_ms()
+            }
+            CoreWindowAssigner::Session { .. } => return false,
+        };
+        max_end_ms.saturating_add(self.allowed_lateness_ms) <= self.high_watermark_ms
+    }
+
     /// Close windows whose end <= watermark, returning emitted batches.
     pub fn close_windows(&mut self, watermark_ms: i64) -> Result<Vec<RecordBatch>, DbError> {
+        self.high_watermark_ms = self.high_watermark_ms.max(watermark_ms);
         let batches = match &self.assigner {
             CoreWindowAssigner::Tumbling(a) => self.close_fixed_windows(watermark_ms, a.size_ms()),
             CoreWindowAssigner::Hopping(a) => self.close_fixed_windows(watermark_ms, a.size_ms()),
@@ -1398,6 +1440,7 @@ impl CoreWindowState {
                     windows,
                     session_state: Vec::new(),
                     window_type,
+                    high_watermark_ms: self.high_watermark_ms,
                 })
             }
             CoreWindowAssigner::Session { .. } => {
@@ -1434,6 +1477,7 @@ impl CoreWindowState {
                     windows: Vec::new(),
                     session_state,
                     window_type,
+                    high_watermark_ms: self.high_watermark_ms,
                 })
             }
         }
@@ -1452,6 +1496,7 @@ impl CoreWindowState {
             )));
         }
 
+        self.high_watermark_ms = checkpoint.high_watermark_ms;
         if checkpoint.window_type == "session" {
             self.restore_session_windows(checkpoint)
         } else {
@@ -1631,6 +1676,7 @@ mod tests {
             having_filter: None,
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: 0,
+            high_watermark_ms: i64::MIN,
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
@@ -1693,6 +1739,7 @@ mod tests {
             having_filter: None,
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: 0,
+            high_watermark_ms: i64::MIN,
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
@@ -1743,6 +1790,7 @@ mod tests {
             having_filter: None,
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: 0,
+            high_watermark_ms: i64::MIN,
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
@@ -1791,6 +1839,7 @@ mod tests {
             having_filter: None,
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: 0,
+            high_watermark_ms: i64::MIN,
             post_projection: None,
             scratch_nogroup: AHashMap::new(),
             scratch_grouped: AHashMap::new(),
@@ -2000,6 +2049,36 @@ mod tests {
         // Watermark at 2500 → nothing to close (window [2000,3000) still open).
         let batches = state.close_windows(2500).unwrap();
         assert!(batches.is_empty());
+    }
+
+    /// Late events for an already-closed window must not re-create the
+    /// bucket — otherwise the next close re-emits the same row.
+    #[test]
+    fn test_late_events_for_closed_windows_are_dropped() {
+        let mut state = make_core_window_state(1000);
+
+        let batch1 = make_pre_agg_batch(vec!["A", "A", "A"], vec![10, 20, 30], vec![100, 200, 500]);
+        state.update_batch(&batch1).unwrap();
+
+        let first = state.close_windows(1000).unwrap();
+        assert_eq!(first.len(), 1);
+        let total = first[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(total.value(0), 60);
+
+        // Late event for the closed window [0, 1000); watermark already past 1000.
+        let late = make_pre_agg_batch(vec!["A"], vec![999], vec![300]);
+        state.update_batch(&late).unwrap();
+
+        let second = state.close_windows(2000).unwrap();
+        assert!(
+            second.is_empty(),
+            "late events for already-closed windows must not re-emit; got {} batches",
+            second.len()
+        );
     }
 
     #[test]

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -86,9 +86,8 @@ pub(crate) struct CoreWindowCheckpoint {
     /// Discriminant so restore can pick the right branch.
     #[serde(default = "default_window_type_tag")]
     pub window_type: String,
-    /// Highest watermark observed at checkpoint time. Adding this field
-    /// is a breaking rkyv schema change; pre-feature checkpoints fail to
-    /// deserialize and a fresh start path is taken.
+    /// Highest watermark at checkpoint time. See
+    /// [`crate::aggregate_state::checkpoints::EowcStateCheckpoint::high_watermark_ms`].
     pub high_watermark_ms: i64,
 }
 
@@ -125,9 +124,8 @@ pub(crate) struct CoreWindowState {
     /// Grace period (ms) after window end before closing. Late events
     /// arriving within this window are included instead of dropped.
     allowed_lateness_ms: i64,
-    /// Highest watermark seen via `close_windows`; `i64::MIN` before the
-    /// first close. Used by `update_batch` to drop events whose window
-    /// has already closed instead of re-creating the bucket.
+    /// Highest watermark seen via `close_windows`; `i64::MIN` until
+    /// the first close. Drives [`Self::is_window_closed`].
     high_watermark_ms: i64,
     post_projection: Option<PostProjection>,
     /// Reusable scratch map for no-group window assignment (avoids per-batch allocation).
@@ -1070,12 +1068,9 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// True if the window starting at `window_start` has already closed.
-    /// Checked per assigned window so an event whose hopping windows are
-    /// partly closed still updates the still-open ones without
-    /// re-creating closed buckets. The window-start values are produced
-    /// by the assigner's `assign()` / `assign_windows()`, which already
-    /// account for window offsets.
+    /// Per-window late-event predicate. Per-window (not per-event) so
+    /// hopping windows whose earlier slices have closed still admit
+    /// the event into their still-open later slices.
     #[inline]
     fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
@@ -1635,6 +1630,16 @@ mod tests {
         .unwrap()
     }
 
+    fn sum_total(batch: &RecordBatch) -> i64 {
+        batch
+            .column_by_name("total")
+            .expect("output schema has 'total' column")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("'total' is Int64")
+            .value(0)
+    }
+
     /// Build a `CoreWindowState` for SUM(Int64) with 1-second tumbling
     /// windows and a single Utf8 group-by column.
     fn make_core_window_state(size_ms: i64) -> CoreWindowState {
@@ -2052,6 +2057,30 @@ mod tests {
         assert!(batches.is_empty());
     }
 
+    /// Late-event check must use the assigner's window-start, not naive
+    /// `ts.rem_euclid(size)`, when an offset is configured.
+    #[test]
+    fn test_late_events_with_window_offset_are_dropped() {
+        let mut state = make_core_window_state(1000);
+        state.assigner = CoreWindowAssigner::Tumbling(
+            TumblingWindowAssigner::from_millis(1000).with_offset_ms(200),
+        );
+
+        let batch = make_pre_agg_batch(vec!["A"], vec![10], vec![500]);
+        state.update_batch(&batch).unwrap();
+
+        let first = state.close_windows(1200).unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(sum_total(&first[0]), 10);
+
+        // ts=1100 maps to [200, 1200), already closed at watermark 1200.
+        let late = make_pre_agg_batch(vec!["A"], vec![1100], vec![999]);
+        state.update_batch(&late).unwrap();
+
+        let second = state.close_windows(2200).unwrap();
+        assert!(second.is_empty());
+    }
+
     /// Late events for an already-closed window must not re-create the
     /// bucket — otherwise the next close re-emits the same row.
     #[test]
@@ -2063,23 +2092,13 @@ mod tests {
 
         let first = state.close_windows(1000).unwrap();
         assert_eq!(first.len(), 1);
-        let total = first[0]
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(total.value(0), 60);
+        assert_eq!(sum_total(&first[0]), 60);
 
-        // Late event for the closed window [0, 1000); watermark already past 1000.
         let late = make_pre_agg_batch(vec!["A"], vec![999], vec![300]);
         state.update_batch(&late).unwrap();
 
         let second = state.close_windows(2000).unwrap();
-        assert!(
-            second.is_empty(),
-            "late events for already-closed windows must not re-emit; got {} batches",
-            second.len()
-        );
+        assert!(second.is_empty());
     }
 
     #[test]

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -903,6 +903,7 @@ impl LaminarDB {
             StreamingStatement::CreateMaterializedView {
                 name,
                 query,
+                emit_clause,
                 or_replace,
                 if_not_exists,
                 query_sql,
@@ -912,6 +913,7 @@ impl LaminarDB {
                     sql,
                     name,
                     query,
+                    emit_clause.clone(),
                     *or_replace,
                     *if_not_exists,
                     query_sql,

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -978,6 +978,44 @@ async fn test_create_materialized_view() {
     }
 }
 
+/// An MV's `EMIT ON WINDOW CLOSE` must reach `StreamRegistration` so
+/// `OperatorGraph` routes it through `EowcQueryOperator` rather than the
+/// per-cycle `SqlQueryOperator`.
+#[tokio::test]
+async fn test_mv_emit_on_window_close_threads_through_to_registration() {
+    let db = LaminarDB::open().unwrap();
+    db.execute(
+        "CREATE SOURCE ticks (sym VARCHAR, price DOUBLE, ts TIMESTAMP, \
+         WATERMARK FOR ts AS ts - INTERVAL '1' SECOND)",
+    )
+    .await
+    .unwrap();
+
+    db.execute(
+        "CREATE MATERIALIZED VIEW per_minute \
+         AS SELECT sym, AVG(price) AS avg_px \
+            FROM ticks \
+            GROUP BY sym, tumble(ts, INTERVAL '1' MINUTE) \
+            EMIT ON WINDOW CLOSE",
+    )
+    .await
+    .expect("MV creation should succeed");
+
+    let mgr = db.connector_manager.lock();
+    let reg = mgr
+        .streams()
+        .get("per_minute")
+        .expect("MV should be registered as a stream");
+    assert!(
+        matches!(
+            reg.emit_clause,
+            Some(laminar_sql::parser::EmitClause::OnWindowClose)
+        ),
+        "EMIT ON WINDOW CLOSE was dropped on the way to StreamRegistration: {:?}",
+        reg.emit_clause
+    );
+}
+
 #[tokio::test]
 async fn test_mv_registry_base_tables() {
     let db = LaminarDB::open().unwrap();

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -902,11 +902,13 @@ impl LaminarDB {
     /// then executes the backing query through `DataFusion` to obtain the
     /// output schema.
     #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_create_materialized_view(
         &self,
         sql: &str,
         name: &sqlparser::ast::ObjectName,
         query: &StreamingStatement,
+        emit_clause: Option<laminar_sql::parser::EmitClause>,
         or_replace: bool,
         if_not_exists: bool,
         query_sql: &str,
@@ -979,15 +981,16 @@ impl LaminarDB {
                 .map_err(|e| DbError::MaterializedView(e.to_string()))?;
         }
 
-        // Plan the MV's backing query to extract emit_clause, window_config,
-        // order_config, and the multi-step join_config.
+        // Reuse the planner by wrapping as a CreateStream. The MV's EMIT
+        // clause must be passed through — OperatorGraph routes
+        // EMIT ON WINDOW CLOSE to EowcQueryOperator (close-only emit),
+        // anything else to SqlQueryOperator (per-cycle emit).
         let (plan_emit, plan_window, plan_order, plan_joins) = {
             let mut planner = self.planner.lock();
-            // Wrap the inner query as a CreateStream to reuse the planner
             let stmt = StreamingStatement::CreateStream {
                 name: name.clone(),
                 query: Box::new(query.clone()),
-                emit_clause: None,
+                emit_clause,
                 or_replace: false,
                 if_not_exists: false,
                 query_sql: query_sql.clone(),

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -458,8 +458,11 @@ impl IncrementalEowcState {
             None
         };
 
-        let mut output_fields =
-            laminar_sql::translator::WindowOperatorConfig::output_prefix_fields();
+        // Output = group cols (in GROUP BY order) followed by agg outputs
+        // in the order they appear in SELECT. Window-time columns are
+        // surfaced explicitly by the user via `tumble(...)` / `tumble_end(...)`
+        // and arrive here as ordinary group columns.
+        let mut output_fields = Vec::with_capacity(group_col_names.len() + agg_specs.len());
         for (name, dt) in group_col_names.iter().zip(group_types.iter()) {
             output_fields.push(Field::new(name, dt.clone(), true));
         }
@@ -702,9 +705,7 @@ impl IncrementalEowcState {
                 continue;
             }
 
-            let window_end = window_start.saturating_add(size_ms);
-            let batch = self.emit_window(window_start, window_end, groups)?;
-            if let Some(b) = batch {
+            if let Some(b) = self.emit_window(groups)? {
                 result_batches.push(b);
             }
         }
@@ -714,13 +715,9 @@ impl IncrementalEowcState {
 
     fn emit_window(
         &self,
-        window_start: i64,
-        window_end: i64,
         groups: AHashMap<arrow::row::OwnedRow, Vec<Box<dyn datafusion_expr::Accumulator>>>,
     ) -> Result<Option<RecordBatch>, DbError> {
         crate::aggregate_state::emit_window_batch(
-            window_start,
-            window_end,
             groups,
             &self.row_converter,
             self.num_group_cols,
@@ -1087,9 +1084,10 @@ mod tests {
             filter_col_index: None,
         }];
 
+        // Output = group cols + agg outputs (no implicit window_start/end —
+        // see commit history; users now project `tumble(ts, …)` /
+        // `tumble_end(ts, …)` explicitly when they want those values).
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
             Field::new("symbol", DataType::Utf8, true),
             Field::new("total", DataType::Int64, true),
         ]));
@@ -1130,32 +1128,19 @@ mod tests {
 
         assert_eq!(state.open_window_count(), 1);
 
-        // Close window at watermark 1000
+        // Close window at watermark 1000 — only window [0, 1000) qualifies.
         let batches = state.close_windows(1000).unwrap();
         assert_eq!(batches.len(), 1);
 
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1);
+        assert_eq!(result.schema().fields().len(), 2);
+        assert_eq!(result.schema().field(0).name(), "symbol");
+        assert_eq!(result.schema().field(1).name(), "total");
 
-        // Check window_start = 0
-        let ws = result
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(ws.value(0), 0);
-
-        // Check window_end = 1000
-        let we = result
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(we.value(0), 1000);
-
-        // Check SUM = 10 + 20 + 30 = 60
+        // SUM = 10 + 20 + 30 = 60
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -1191,16 +1176,18 @@ mod tests {
 
         assert_eq!(state.open_window_count(), 2);
 
-        // Close only the first window (watermark at 1000)
+        // Close only the first window (watermark at 1000) — first event
+        // contributes 10 to the sum; the second event lives in [1000, 2000)
+        // and is not yet emitted.
         let batches = state.close_windows(1000).unwrap();
         assert_eq!(batches.len(), 1);
-
-        let ws = batches[0]
-            .column(0)
+        assert_eq!(batches[0].num_rows(), 1);
+        let total = batches[0]
+            .column(1) // [symbol, total]
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-        assert_eq!(ws.value(0), 0);
+        assert_eq!(total.value(0), 10);
 
         // Second window still open
         assert_eq!(state.open_window_count(), 1);
@@ -1240,6 +1227,9 @@ mod tests {
 
     #[test]
     fn test_window_close_emits_correct_schema() {
+        // EOWC output is now `[group_cols..., agg_outputs...]`. Window
+        // boundaries are no longer prepended; users surface them via
+        // `tumble(...)` / `tumble_end(...)` UDFs in the upstream SELECT.
         let mut state = make_eowc_state(EowcWindowType::Tumbling { size_ms: 1000 });
 
         let batch = make_pre_agg_batch(vec!["AAPL"], vec![42], vec![100]);
@@ -1249,11 +1239,9 @@ mod tests {
         let result = &batches[0];
         let schema = result.schema();
 
-        assert_eq!(schema.field(0).name(), "window_start");
-        assert_eq!(schema.field(1).name(), "window_end");
-        assert_eq!(schema.field(2).name(), "symbol");
-        assert_eq!(schema.field(3).name(), "total");
-        assert_eq!(schema.fields().len(), 4);
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "symbol");
+        assert_eq!(schema.field(1).name(), "total");
     }
 
     #[test]
@@ -1280,14 +1268,15 @@ mod tests {
         assert!(restored > 0, "Should have restored groups");
         assert_eq!(state2.open_window_count(), 2);
 
-        // Close first window and verify SUM
+        // Close first window and verify SUM. Schema is [symbol, total];
+        // the agg col sits at index 1 now that window_start/end are gone.
         let batches = state2.close_windows(1000).unwrap();
         assert_eq!(batches.len(), 1);
         let result = &batches[0];
         assert_eq!(result.num_rows(), 1); // Only AAPL in window [0,1000)
 
         let total = result
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -1297,7 +1286,7 @@ mod tests {
         let batches = state2.close_windows(2000).unwrap();
         assert_eq!(batches.len(), 1);
         let total2 = batches[0]
-            .column(3)
+            .column(1)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -523,11 +523,7 @@ impl IncrementalEowcState {
         }))
     }
 
-    /// True if the window starting at `window_start` has already closed.
-    /// Checked per assigned window so that for hopping windows, an event
-    /// whose *earlier* (already-emitted) windows are closed still
-    /// updates its still-open *later* windows, without re-creating the
-    /// closed buckets.
+    /// See [`CoreWindowState::is_window_closed`].
     #[inline]
     fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
@@ -1094,6 +1090,16 @@ mod tests {
         .unwrap()
     }
 
+    fn sum_total(batch: &RecordBatch) -> i64 {
+        batch
+            .column_by_name("total")
+            .expect("output schema has 'total' column")
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("'total' is Int64")
+            .value(0)
+    }
+
     fn make_eowc_state(window_type: EowcWindowType) -> IncrementalEowcState {
         use datafusion::execution::FunctionRegistry;
 
@@ -1237,12 +1243,7 @@ mod tests {
 
         let first = state.close_windows(1000).unwrap();
         assert_eq!(first.len(), 1);
-        let total = first[0]
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(total.value(0), 60);
+        assert_eq!(sum_total(&first[0]), 60);
         assert_eq!(state.open_window_count(), 0);
 
         let late = make_pre_agg_batch(vec!["AAPL"], vec![999], vec![300]);
@@ -1276,12 +1277,7 @@ mod tests {
 
         let second = state.close_windows(1500).unwrap();
         assert_eq!(second.len(), 1);
-        let total = second[0]
-            .column(1)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .unwrap();
-        assert_eq!(total.value(0), 60);
+        assert_eq!(sum_total(&second[0]), 60);
     }
 
     #[test]

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -127,6 +127,8 @@ pub(crate) struct IncrementalEowcState {
     /// arriving within this window are included instead of dropped.
     /// Must match `CoreWindowState::allowed_lateness_ms` behavior.
     allowed_lateness_ms: i64,
+    /// See [`CoreWindowState::high_watermark_ms`].
+    high_watermark_ms: i64,
 }
 
 impl IncrementalEowcState {
@@ -517,7 +519,32 @@ impl IncrementalEowcState {
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: i64::try_from(window_config.allowed_lateness.as_millis())
                 .unwrap_or(0),
+            high_watermark_ms: i64::MIN,
         }))
+    }
+
+    /// Mirror of [`CoreWindowState::is_event_late_beyond_recovery`].
+    #[inline]
+    fn is_event_late_beyond_recovery(&self, ts_ms: i64) -> bool {
+        if self.high_watermark_ms == i64::MIN {
+            return false;
+        }
+        let max_end_ms = match &self.window_type {
+            EowcWindowType::Tumbling { size_ms } => {
+                if *size_ms <= 0 {
+                    return false;
+                }
+                ts_ms - ts_ms.rem_euclid(*size_ms) + size_ms
+            }
+            EowcWindowType::Hopping { size_ms, slide_ms } => {
+                if *slide_ms <= 0 || *size_ms <= 0 {
+                    return false;
+                }
+                ts_ms - ts_ms.rem_euclid(*slide_ms) + size_ms
+            }
+            EowcWindowType::Session { .. } => return false,
+        };
+        max_end_ms.saturating_add(self.allowed_lateness_ms) <= self.high_watermark_ms
     }
 
     /// Vectorized batch update: extracts timestamps and group keys at the
@@ -554,6 +581,9 @@ impl IncrementalEowcState {
             for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
                 if ts_ms == NULL_TIMESTAMP {
                     continue; // skip rows with null timestamps
+                }
+                if self.is_event_late_beyond_recovery(ts_ms) {
+                    continue;
                 }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
@@ -604,6 +634,9 @@ impl IncrementalEowcState {
 
         for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
             if ts_ms == NULL_TIMESTAMP {
+                continue;
+            }
+            if self.is_event_late_beyond_recovery(ts_ms) {
                 continue;
             }
             let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
@@ -670,6 +703,7 @@ impl IncrementalEowcState {
     /// where `window_start + window_size <= watermark_ms`. Closed windows
     /// are removed from state.
     pub fn close_windows(&mut self, watermark_ms: i64) -> Result<Vec<RecordBatch>, DbError> {
+        self.high_watermark_ms = self.high_watermark_ms.max(watermark_ms);
         let size_ms = self.window_type.size_ms();
         if size_ms <= 0 {
             return Ok(Vec::new());
@@ -800,6 +834,7 @@ impl IncrementalEowcState {
         Ok(EowcStateCheckpoint {
             fingerprint,
             windows,
+            high_watermark_ms: self.high_watermark_ms,
         })
     }
 
@@ -818,6 +853,7 @@ impl IncrementalEowcState {
             )));
         }
         self.windows.clear();
+        self.high_watermark_ms = checkpoint.high_watermark_ms;
         let mut total_groups = 0usize;
         for wc in &checkpoint.windows {
             let mut groups = AHashMap::new();
@@ -1104,6 +1140,7 @@ mod tests {
             having_sql: None,
             max_groups_per_window: 1_000_000,
             allowed_lateness_ms: 0,
+            high_watermark_ms: i64::MIN,
         }
     }
 
@@ -1189,6 +1226,35 @@ mod tests {
         let batches = state.close_windows(2000).unwrap();
         assert_eq!(batches.len(), 1);
         assert_eq!(state.open_window_count(), 0);
+    }
+
+    #[test]
+    fn test_late_events_for_closed_windows_are_dropped() {
+        let mut state = make_eowc_state(EowcWindowType::Tumbling { size_ms: 1000 });
+
+        let batch1 = make_pre_agg_batch(
+            vec!["AAPL", "AAPL", "AAPL"],
+            vec![10, 20, 30],
+            vec![100, 200, 500],
+        );
+        state.update_batch(&batch1).unwrap();
+
+        let first = state.close_windows(1000).unwrap();
+        assert_eq!(first.len(), 1);
+        let total = first[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(total.value(0), 60);
+        assert_eq!(state.open_window_count(), 0);
+
+        let late = make_pre_agg_batch(vec!["AAPL"], vec![999], vec![300]);
+        state.update_batch(&late).unwrap();
+        assert_eq!(state.open_window_count(), 0);
+
+        let second = state.close_windows(2000).unwrap();
+        assert!(second.is_empty());
     }
 
     #[test]

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -523,28 +523,24 @@ impl IncrementalEowcState {
         }))
     }
 
-    /// Mirror of [`CoreWindowState::is_event_late_beyond_recovery`].
+    /// True if the window starting at `window_start` has already closed.
+    /// Checked per assigned window so that for hopping windows, an event
+    /// whose *earlier* (already-emitted) windows are closed still
+    /// updates its still-open *later* windows, without re-creating the
+    /// closed buckets.
     #[inline]
-    fn is_event_late_beyond_recovery(&self, ts_ms: i64) -> bool {
+    fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
             return false;
         }
-        let max_end_ms = match &self.window_type {
-            EowcWindowType::Tumbling { size_ms } => {
-                if *size_ms <= 0 {
-                    return false;
-                }
-                ts_ms - ts_ms.rem_euclid(*size_ms) + size_ms
-            }
-            EowcWindowType::Hopping { size_ms, slide_ms } => {
-                if *slide_ms <= 0 || *size_ms <= 0 {
-                    return false;
-                }
-                ts_ms - ts_ms.rem_euclid(*slide_ms) + size_ms
-            }
-            EowcWindowType::Session { .. } => return false,
-        };
-        max_end_ms.saturating_add(self.allowed_lateness_ms) <= self.high_watermark_ms
+        let size_ms = self.window_type.size_ms();
+        if size_ms <= 0 {
+            return false;
+        }
+        window_start
+            .saturating_add(size_ms)
+            .saturating_add(self.allowed_lateness_ms)
+            <= self.high_watermark_ms
     }
 
     /// Vectorized batch update: extracts timestamps and group keys at the
@@ -582,12 +578,12 @@ impl IncrementalEowcState {
                 if ts_ms == NULL_TIMESTAMP {
                     continue; // skip rows with null timestamps
                 }
-                if self.is_event_late_beyond_recovery(ts_ms) {
-                    continue;
-                }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
                 for ws in assign_windows(ts_ms, &self.window_type) {
+                    if self.is_window_closed(ws) {
+                        continue;
+                    }
                     grouped.entry(ws).or_default().push(idx);
                 }
             }
@@ -636,13 +632,13 @@ impl IncrementalEowcState {
             if ts_ms == NULL_TIMESTAMP {
                 continue;
             }
-            if self.is_event_late_beyond_recovery(ts_ms) {
-                continue;
-            }
             let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
             let (gid, idx) = (gid as u32, row_idx as u32);
             for ws in assign_windows(ts_ms, &self.window_type) {
+                if self.is_window_closed(ws) {
+                    continue;
+                }
                 grouped.entry((ws, gid)).or_default().push(idx);
             }
         }
@@ -1255,6 +1251,37 @@ mod tests {
 
         let second = state.close_windows(2000).unwrap();
         assert!(second.is_empty());
+    }
+
+    /// Hopping: ts=999 belongs to [500, 1500) (open) and [0, 1000) (closed
+    /// once watermark hits 1000). The late update must reach [500, 1500)
+    /// without re-creating [0, 1000).
+    #[test]
+    fn test_hopping_late_event_only_updates_still_open_windows() {
+        let mut state = make_eowc_state(EowcWindowType::Hopping {
+            size_ms: 1000,
+            slide_ms: 500,
+        });
+
+        let batch1 = make_pre_agg_batch(vec!["A", "A"], vec![10, 20], vec![600, 600]);
+        state.update_batch(&batch1).unwrap();
+
+        let first = state.close_windows(1000).unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(state.open_window_count(), 1);
+
+        let late = make_pre_agg_batch(vec!["A"], vec![30], vec![999]);
+        state.update_batch(&late).unwrap();
+        assert_eq!(state.open_window_count(), 1);
+
+        let second = state.close_windows(1500).unwrap();
+        assert_eq!(second.len(), 1);
+        let total = second[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(total.value(0), 60);
     }
 
     #[test]

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -12,6 +12,22 @@ use laminar_connectors::config::ConnectorConfig;
 use laminar_connectors::connector::SourceConnector;
 use rustc_hash::FxHashMap;
 
+/// Outcome of a barrier-aligned checkpoint attempt.
+///
+/// `Skipped` distinguishes "deliberately did not try" (e.g. no execution
+/// cycles since the last checkpoint) from `Failed` ("tried and could not
+/// commit"). The coordinator demotes `Skipped` to `debug!` so an idle
+/// pipeline doesn't flood the log with warnings.
+#[derive(Debug)]
+pub enum BarrierOutcome {
+    /// Checkpoint committed at the given epoch.
+    Committed(u64),
+    /// Checkpoint was deliberately skipped; `reason` is logged at debug.
+    Skipped(&'static str),
+    /// Checkpoint attempt failed and should be retried on the next interval.
+    Failed,
+}
+
 /// A registered source with its name and config.
 pub struct SourceRegistration {
     /// Source name.
@@ -75,7 +91,7 @@ pub trait PipelineCallback: Send + 'static {
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> Option<u64>;
+    ) -> BarrierOutcome;
 
     /// Record cycle metrics.
     fn record_cycle(&self, events_ingested: u64, batches: u64, elapsed_ns: u64);

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -12,19 +12,36 @@ use laminar_connectors::config::ConnectorConfig;
 use laminar_connectors::connector::SourceConnector;
 use rustc_hash::FxHashMap;
 
-/// Outcome of a barrier-aligned checkpoint attempt.
-///
-/// `Skipped` distinguishes "deliberately did not try" (e.g. no execution
-/// cycles since the last checkpoint) from `Failed` ("tried and could not
-/// commit"). The coordinator demotes `Skipped` to `debug!` so an idle
-/// pipeline doesn't flood the log with warnings.
+/// Why a barrier checkpoint was deliberately skipped, as opposed to
+/// attempted-and-failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// No execution cycles ran since the last checkpoint.
+    NoCyclesSinceLastCheckpoint,
+    /// A sink write timed out; skip to keep the replay window intact.
+    PreservingReplayWindowAfterSinkTimeout,
+}
+
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SkipReason::NoCyclesSinceLastCheckpoint => "no_cycles_since_last_checkpoint",
+            SkipReason::PreservingReplayWindowAfterSinkTimeout => {
+                "preserving_replay_window_after_sink_timeout"
+            }
+        })
+    }
+}
+
+/// Outcome of a barrier-aligned checkpoint attempt. `Skipped` is logged
+/// at debug; `Failed` keeps the retry warning.
 #[derive(Debug)]
 pub enum BarrierOutcome {
     /// Checkpoint committed at the given epoch.
     Committed(u64),
-    /// Checkpoint was deliberately skipped; `reason` is logged at debug.
-    Skipped(&'static str),
-    /// Checkpoint attempt failed and should be retried on the next interval.
+    /// Deliberately skipped (see `SkipReason`).
+    Skipped(SkipReason),
+    /// Attempted and failed; retry on the next interval.
     Failed,
 }
 

--- a/crates/laminar-db/src/pipeline/mod.rs
+++ b/crates/laminar-db/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ pub mod callback;
 pub mod config;
 pub mod streaming_coordinator;
 
-pub use callback::{BarrierOutcome, PipelineCallback, SourceRegistration};
+pub use callback::{BarrierOutcome, PipelineCallback, SkipReason, SourceRegistration};
 pub use config::PipelineConfig;
 pub use streaming_coordinator::StreamingCoordinator;
 

--- a/crates/laminar-db/src/pipeline/mod.rs
+++ b/crates/laminar-db/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ pub mod callback;
 pub mod config;
 pub mod streaming_coordinator;
 
-pub use callback::{PipelineCallback, SourceRegistration};
+pub use callback::{BarrierOutcome, PipelineCallback, SourceRegistration};
 pub use config::PipelineConfig;
 pub use streaming_coordinator::StreamingCoordinator;
 

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -32,7 +32,7 @@ use laminar_core::alloc::{PriorityClass, PriorityGuard};
 use laminar_core::checkpoint::{CheckpointBarrier, CheckpointBarrierInjector};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use super::callback::{PipelineCallback, SourceRegistration};
+use super::callback::{BarrierOutcome, PipelineCallback, SourceRegistration};
 use super::config::PipelineConfig;
 use crate::error::DbError;
 
@@ -860,15 +860,21 @@ impl StreamingCoordinator {
             // offsets, ack tokens) advances only with the durable manifest.
             let fan_out = checkpoints.clone();
             let checkpoint_id = self.pending_barrier.checkpoint_id;
-            if let Some(epoch) = callback.checkpoint_with_barrier(checkpoints).await {
-                self.broadcast_epoch_committed(epoch, &fan_out);
-                // Wire barrier = durable epoch.
-                callback.publish_barrier(epoch, checkpoint_id);
-            } else {
-                tracing::warn!(
-                    checkpoint_id = self.pending_barrier.checkpoint_id,
-                    "barrier checkpoint failed, will retry on next interval"
-                );
+            match callback.checkpoint_with_barrier(checkpoints).await {
+                BarrierOutcome::Committed(epoch) => {
+                    self.broadcast_epoch_committed(epoch, &fan_out);
+                    // Wire barrier = durable epoch.
+                    callback.publish_barrier(epoch, checkpoint_id);
+                }
+                BarrierOutcome::Skipped(reason) => {
+                    tracing::debug!(checkpoint_id, reason, "barrier checkpoint skipped");
+                }
+                BarrierOutcome::Failed => {
+                    tracing::warn!(
+                        checkpoint_id,
+                        "barrier checkpoint failed, will retry on next interval"
+                    );
+                }
             }
             self.pending_barrier.active = false;
             self.last_checkpoint = Instant::now();
@@ -1013,8 +1019,8 @@ mod tests {
         async fn checkpoint_with_barrier(
             &mut self,
             _source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-        ) -> Option<u64> {
-            Some(1)
+        ) -> BarrierOutcome {
+            BarrierOutcome::Committed(1)
         }
 
         fn record_cycle(&self, _events: u64, _batches: u64, _elapsed_ns: u64) {}
@@ -1407,7 +1413,7 @@ mod tests {
         async fn checkpoint_with_barrier(
             &mut self,
             cp: FxHashMap<String, SourceCheckpoint>,
-        ) -> Option<u64> {
+        ) -> BarrierOutcome {
             self.inner.checkpoint_with_barrier(cp).await
         }
         fn record_cycle(&self, e: u64, b: u64, ns: u64) {

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -867,7 +867,7 @@ impl StreamingCoordinator {
                     callback.publish_barrier(epoch, checkpoint_id);
                 }
                 BarrierOutcome::Skipped(reason) => {
-                    tracing::debug!(checkpoint_id, reason, "barrier checkpoint skipped");
+                    tracing::debug!(checkpoint_id, reason = %reason, "barrier checkpoint skipped");
                 }
                 BarrierOutcome::Failed => {
                     tracing::warn!(

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -841,12 +841,13 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> Option<u64> {
+    ) -> crate::pipeline::BarrierOutcome {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
+        use crate::pipeline::BarrierOutcome;
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
         if self.prom.cycles.get() == 0 {
-            return None;
+            return BarrierOutcome::Skipped("no execution cycles since last checkpoint");
         }
 
         self.sync_sinks_and_drain_events().await;
@@ -855,10 +856,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         // clears this flag is unreachable when barrier checkpointing is active.
         if self.sink_timed_out {
             self.sink_timed_out = false;
-            tracing::warn!(
-                "skipping barrier checkpoint after sink timeout to preserve replay window"
-            );
-            return None;
+            return BarrierOutcome::Skipped("preserving replay window after sink timeout");
         }
 
         // Capture table source offsets.
@@ -877,8 +875,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let operator_states = match self.capture_and_serialize_operator_state().await {
             Ok(states) => states,
             Err(e) => {
-                tracing::warn!(error = %e, "Stream executor barrier checkpoint failed — skipping");
-                return None;
+                tracing::warn!(error = %e, "Stream executor barrier checkpoint failed");
+                return BarrierOutcome::Failed;
             }
         };
 
@@ -920,7 +918,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         "Barrier-aligned checkpoint completed"
                     );
                     self.last_checkpoint = std::time::Instant::now();
-                    return Some(result.epoch);
+                    return BarrierOutcome::Committed(result.epoch);
                 }
                 Ok(result) => {
                     tracing::warn!(
@@ -935,7 +933,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        None
+        BarrierOutcome::Failed
     }
 
     fn record_cycle(&self, events_ingested: u64, _batches: u64, elapsed_ns: u64) {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -843,11 +843,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
     ) -> crate::pipeline::BarrierOutcome {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
-        use crate::pipeline::BarrierOutcome;
+        use crate::pipeline::{BarrierOutcome, SkipReason};
         let _priority = PriorityGuard::enter(PriorityClass::BackgroundIo);
 
         if self.prom.cycles.get() == 0 {
-            return BarrierOutcome::Skipped("no execution cycles since last checkpoint");
+            return BarrierOutcome::Skipped(SkipReason::NoCyclesSinceLastCheckpoint);
         }
 
         self.sync_sinks_and_drain_events().await;
@@ -856,7 +856,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         // clears this flag is unreachable when barrier checkpointing is active.
         if self.sink_timed_out {
             self.sink_timed_out = false;
-            return BarrierOutcome::Skipped("preserving replay window after sink timeout");
+            return BarrierOutcome::Skipped(SkipReason::PreservingReplayWindowAfterSinkTimeout);
         }
 
         // Capture table source offsets.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -42,14 +42,15 @@ async fn resolve_stream_output_schemas(
                     continue;
                 };
 
-                let mut fields = if reg.window_config.is_some() {
-                    laminar_sql::translator::WindowOperatorConfig::output_prefix_fields()
-                } else {
-                    Vec::new()
-                };
-                for f in plan.schema().fields() {
-                    fields.push((**f).clone());
-                }
+                // Schema = `plan.schema()` verbatim. Don't prepend
+                // window_start/window_end here — sinks would see a
+                // schema wider than the runtime batches.
+                let fields: Vec<_> = plan
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| (**f).clone())
+                    .collect();
                 let schema = Arc::new(Schema::new(fields));
 
                 if !ctx.table_exist(&reg.name).unwrap_or(false) {
@@ -1614,7 +1615,11 @@ mod resolver_tests {
     }
 
     #[tokio::test]
-    async fn windowed_stream_gets_window_start_end_prefix() {
+    async fn windowed_stream_schema_matches_user_select() {
+        // The resolver no longer prepends `window_start` / `window_end`
+        // onto windowed-stream schemas. Schema-claim equals exactly what
+        // DataFusion plans for the user's SELECT — matching what EOWC
+        // emits and what downstream sinks see in `write_batch`.
         let ctx = ctx_with_payments();
         let mut regs = std::collections::HashMap::new();
         regs.insert(
@@ -1633,9 +1638,54 @@ mod resolver_tests {
             .iter()
             .map(|f| f.name().as_str())
             .collect();
-        assert_eq!(&names[..2], &["window_start", "window_end"]);
-        assert_eq!(out["agg"].field(0).data_type(), &DataType::Int64);
-        assert!(names.contains(&"region") && names.contains(&"n"));
+        assert_eq!(names, vec!["region", "n"]);
+    }
+
+    /// Users that want `window_start` / `window_end` opt in by projecting
+    /// the `tumble(...)` / `tumble_end(...)` UDFs explicitly. The resolver
+    /// surfaces them as ordinary projection columns with the user-chosen
+    /// aliases.
+    #[tokio::test]
+    async fn windowed_stream_with_explicit_window_columns() {
+        let ctx = ctx_with_payments();
+        ctx.register_udf(datafusion_expr::ScalarUDF::from(
+            laminar_sql::datafusion::TumbleWindowEnd::new(),
+        ));
+        let mut regs = std::collections::HashMap::new();
+        regs.insert(
+            "agg".to_string(),
+            reg(
+                "agg",
+                "SELECT \
+                    tumble(event_time, INTERVAL '1' MINUTE)     AS window_start, \
+                    tumble_end(event_time, INTERVAL '1' MINUTE) AS window_end, \
+                    region, \
+                    COUNT(*) AS n \
+                 FROM payments \
+                 GROUP BY \
+                    tumble(event_time, INTERVAL '1' MINUTE), \
+                    tumble_end(event_time, INTERVAL '1' MINUTE), \
+                    region",
+                true,
+            ),
+        );
+
+        let out = resolve_stream_output_schemas(&ctx, &regs).await.unwrap();
+        let names: Vec<&str> = out["agg"]
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["window_start", "window_end", "region", "n"]);
+        // tumble / tumble_end UDFs return Timestamp(Millisecond), not Int64.
+        assert_eq!(
+            out["agg"].field(0).data_type(),
+            &DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None)
+        );
+        assert_eq!(
+            out["agg"].field(1).data_type(),
+            &DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None)
+        );
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1637,11 +1637,11 @@ mod resolver_tests {
         assert_eq!(names, vec!["window_start", "window_end", "region", "n"]);
         assert_eq!(
             out["agg"].field(0).data_type(),
-            &DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None)
+            &DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, None)
         );
         assert_eq!(
             out["agg"].field(1).data_type(),
-            &DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, None)
+            &DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, None)
         );
     }
 

--- a/crates/laminar-db/tests/checkpoint_exactly_once.rs
+++ b/crates/laminar-db/tests/checkpoint_exactly_once.rs
@@ -102,10 +102,10 @@ impl PipelineCallback for BarrierTrackingCallback {
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
-    ) -> Option<u64> {
+    ) -> laminar_db::pipeline::BarrierOutcome {
         let epoch = self.barrier_checkpoints.len() as u64 + 1;
         self.barrier_checkpoints.push(source_checkpoints);
-        Some(epoch)
+        laminar_db::pipeline::BarrierOutcome::Committed(epoch)
     }
 
     fn record_cycle(&self, _events_ingested: u64, _batches: u64, _elapsed_ns: u64) {}

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 arrow = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.21.5" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.21.5" }
+laminar-core = { path = "../laminar-core", version = "0.22.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.22.0" }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 # LaminarDB crates. laminar-db re-exports the rest of the workspace; the
 # server only needs the unified facade plus laminar-core for things like
 # metrics types referenced directly.
-laminar-core = { path = "../laminar-core", version = "0.21.5" }
-laminar-storage = { path = "../laminar-storage", version = "0.21.5" }
-laminar-db = { path = "../laminar-db", version = "0.21.5", features = ["api"] }
-laminar-sql = { path = "../laminar-sql", version = "0.21.5" }
+laminar-core = { path = "../laminar-core", version = "0.22.0" }
+laminar-storage = { path = "../laminar-storage", version = "0.22.0" }
+laminar-db = { path = "../laminar-db", version = "0.22.0", features = ["api"] }
+laminar-sql = { path = "../laminar-sql", version = "0.22.0" }
 
 # For pgwire dispatch on parsed AST
 sqlparser = { workspace = true }

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -17,7 +17,7 @@ cluster-unstable = ["laminar-core/cluster-unstable"]
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.21.5" }
+laminar-core = { path = "../laminar-core", version = "0.22.0" }
 
 # Runtime glue for ClusterRepartitionExec's per-partition channels.
 tokio-stream = { workspace = true }

--- a/crates/laminar-sql/src/datafusion/mod.rs
+++ b/crates/laminar-sql/src/datafusion/mod.rs
@@ -185,17 +185,11 @@ pub fn create_streaming_context_with_validator(mode: StreamingValidatorMode) -> 
     ctx
 }
 
-/// Registers `LaminarDB` streaming UDFs with a session context.
-///
-/// Registers the following scalar functions:
-/// - `tumble(timestamp, interval)` — tumbling window start
-/// - `hop(timestamp, slide, size)` — hopping window start
-/// - `session(timestamp, gap)` — session window pass-through
-/// - `watermark()` — current watermark (returns NULL, no live source)
-///
-/// Use [`register_streaming_functions_with_watermark`] to provide a
-/// live watermark source from Ring 0.
-pub fn register_streaming_functions(ctx: &SessionContext) {
+/// Window-time, JSON, complex-type, lambda, and `proctime()` UDFs —
+/// every streaming UDF except `watermark()`. Pulled out of the public
+/// `register_streaming_functions*` entry points so they share a single
+/// list and stay in sync.
+fn register_non_watermark_udfs(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowStart::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(HopWindowStart::new()));
@@ -203,7 +197,6 @@ pub fn register_streaming_functions(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::new_from_impl(SessionWindowStart::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowStart::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowEnd::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(WatermarkUdf::unset()));
     ctx.register_udf(ScalarUDF::new_from_impl(ProcTimeUdf::new()));
     register_json_functions(ctx);
     register_json_extensions(ctx);
@@ -211,33 +204,25 @@ pub fn register_streaming_functions(ctx: &SessionContext) {
     register_lambda_functions(ctx);
 }
 
-/// Registers streaming UDFs with a live watermark source.
-///
-/// Same as [`register_streaming_functions`] but connects the `watermark()`
-/// UDF to a shared atomic value that Ring 0 updates in real time.
-///
-/// # Arguments
-///
-/// * `ctx` - `DataFusion` session context
-/// * `watermark_ms` - Shared atomic holding the current watermark in
-///   milliseconds since epoch. Values < 0 mean "no watermark" (returns NULL).
+/// Registers `LaminarDB` streaming UDFs with a session context. The
+/// `watermark()` UDF is registered in unset mode (always returns NULL);
+/// use [`register_streaming_functions_with_watermark`] to provide a
+/// live watermark source from Ring 0.
+pub fn register_streaming_functions(ctx: &SessionContext) {
+    register_non_watermark_udfs(ctx);
+    ctx.register_udf(ScalarUDF::new_from_impl(WatermarkUdf::unset()));
+}
+
+/// Registers streaming UDFs with a live watermark source — same as
+/// [`register_streaming_functions`] but `watermark()` reads
+/// `watermark_ms` (in milliseconds since epoch; values < 0 mean "no
+/// watermark", returning NULL).
 pub fn register_streaming_functions_with_watermark(
     ctx: &SessionContext,
     watermark_ms: Arc<AtomicI64>,
 ) {
-    ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowStart::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowEnd::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(HopWindowStart::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(HopWindowEnd::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(SessionWindowStart::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowStart::new()));
-    ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowEnd::new()));
+    register_non_watermark_udfs(ctx);
     ctx.register_udf(ScalarUDF::new_from_impl(WatermarkUdf::new(watermark_ms)));
-    ctx.register_udf(ScalarUDF::new_from_impl(ProcTimeUdf::new()));
-    register_json_functions(ctx);
-    register_json_extensions(ctx);
-    register_complex_type_functions(ctx);
-    register_lambda_functions(ctx);
 }
 
 /// Registers all PostgreSQL-compatible JSON UDFs and UDAFs
@@ -527,7 +512,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tumble_udf_via_datafusion() {
-        use arrow_array::TimestampMillisecondArray;
+        use arrow_array::{TimestampMicrosecondArray, TimestampMillisecondArray};
         use arrow_schema::TimeUnit;
 
         let ctx = create_streaming_context();
@@ -578,17 +563,18 @@ mod tests {
         let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3);
 
-        // Verify the window_start values (single batch, order preserved)
+        // tumble() returns microsecond timestamps for lakehouse-sink compat;
+        // expected window starts are scaled accordingly (× 1000).
         let ws_col = batches[0]
             .column(0)
             .as_any()
-            .downcast_ref::<TimestampMillisecondArray>()
-            .expect("window_start should be TimestampMillisecond");
-        // 60_000 and 120_000 → window [0, 300_000), start = 0
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .expect("window_start should be TimestampMicrosecond");
+        // 60_000 and 120_000 ms → window [0, 300_000) ms, start = 0 µs.
         assert_eq!(ws_col.value(0), 0);
         assert_eq!(ws_col.value(1), 0);
-        // 360_000 → window [300_000, 600_000), start = 300_000
-        assert_eq!(ws_col.value(2), 300_000);
+        // 360_000 ms → window [300_000, 600_000) ms, start = 300_000_000 µs.
+        assert_eq!(ws_col.value(2), 300_000_000);
     }
 
     #[tokio::test]

--- a/crates/laminar-sql/src/datafusion/mod.rs
+++ b/crates/laminar-sql/src/datafusion/mod.rs
@@ -81,7 +81,10 @@ pub use proctime_udf::ProcTimeUdf;
 pub use source::{SortColumn, StreamSource, StreamSourceRef};
 pub use table_provider::StreamingTableProvider;
 pub use watermark_udf::WatermarkUdf;
-pub use window_udf::{CumulateWindowStart, HopWindowStart, SessionWindowStart, TumbleWindowStart};
+pub use window_udf::{
+    CumulateWindowEnd, CumulateWindowStart, HopWindowEnd, HopWindowStart, SessionWindowStart,
+    TumbleWindowEnd, TumbleWindowStart,
+};
 
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
@@ -194,9 +197,12 @@ pub fn create_streaming_context_with_validator(mode: StreamingValidatorMode) -> 
 /// live watermark source from Ring 0.
 pub fn register_streaming_functions(ctx: &SessionContext) {
     ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(HopWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(HopWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(SessionWindowStart::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(WatermarkUdf::unset()));
     ctx.register_udf(ScalarUDF::new_from_impl(ProcTimeUdf::new()));
     register_json_functions(ctx);
@@ -220,9 +226,12 @@ pub fn register_streaming_functions_with_watermark(
     watermark_ms: Arc<AtomicI64>,
 ) {
     ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(TumbleWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(HopWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(HopWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(SessionWindowStart::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowStart::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(CumulateWindowEnd::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(WatermarkUdf::new(watermark_ms)));
     ctx.register_udf(ScalarUDF::new_from_impl(ProcTimeUdf::new()));
     register_json_functions(ctx);

--- a/crates/laminar-sql/src/datafusion/window_udf.rs
+++ b/crates/laminar-sql/src/datafusion/window_udf.rs
@@ -1,668 +1,262 @@
 //! Scalar UDFs that compute window boundary timestamps for streaming
 //! `GROUP BY TUMBLE(...)` style queries.
 //!
-//! Pairs: `tumble`/`tumble_end`, `hop`/`hop_end`, `cumulate`/`cumulate_end`.
-//! `session` is a pass-through (sessions are data-dependent — no row-local
-//! end exists, so there is no `session_end`).
-//!
-//! Both halves of a pair must appear in `GROUP BY` so DataFusion accepts
-//! them as group keys; they are functionally redundant within a fixed
-//! interval but standard SQL requires every projected non-aggregate to
-//! be in the grouping set. Example:
+//! Pairs `tumble`/`tumble_end`, `hop`/`hop_end`, `cumulate`/`cumulate_end`
+//! must both appear in `GROUP BY`: DataFusion treats them as independent
+//! group keys, even though within a fixed interval they are functionally
+//! redundant. `session(ts, gap)` is a passthrough — real session
+//! boundaries are computed by Ring 0 operators.
 //!
 //! ```sql
-//! SELECT
-//!     TUMBLE(ts, INTERVAL '1' MINUTE)     AS window_start,
-//!     TUMBLE_END(ts, INTERVAL '1' MINUTE) AS window_end,
-//!     symbol,
-//!     MAX(price)
+//! SELECT tumble(ts, INTERVAL '1' MINUTE)     AS window_start,
+//!        tumble_end(ts, INTERVAL '1' MINUTE) AS window_end, ...
 //! FROM ev
-//! GROUP BY
-//!     TUMBLE(ts, INTERVAL '1' MINUTE),
-//!     TUMBLE_END(ts, INTERVAL '1' MINUTE),
-//!     symbol;
+//! GROUP BY tumble(ts, INTERVAL '1' MINUTE),
+//!          tumble_end(ts, INTERVAL '1' MINUTE), ...
 //! ```
+//!
+//! Math runs in milliseconds (matching the Ring 0 watermark). The SQL
+//! boundary returns `Timestamp(Microsecond, None)` so lakehouse sinks
+//! (Iceberg, Delta, Parquet) accept the columns directly — Iceberg
+//! rejects `Timestamp(Millisecond)`.
 
 use std::any::Any;
 use std::hash::{Hash, Hasher};
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, TimeUnit};
-use arrow_array::{ArrayRef, TimestampMillisecondArray};
+use arrow_array::{ArrayRef, TimestampMicrosecondArray, TimestampMillisecondArray};
 use datafusion_common::{DataFusionError, Result, ScalarValue};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
 use laminar_core::time::cast_to_millis_array;
 
-// ─── TumbleWindowStart ───────────────────────────────────────────────────────
+// ─── window_udf! macro ──────────────────────────────────────────────────────
+//
+// Generates the trait boilerplate (Default + PartialEq + Eq + Hash +
+// ScalarUDFImpl) for a zero-state singleton UDF that returns a
+// `Timestamp(Microsecond)`. Each UDF declaration below is just SQL name,
+// arity, and a body closure.
 
-/// Computes the tumbling window start for a given timestamp.
-///
-/// `tumble(timestamp, interval)` returns `floor(ts / interval) * interval`,
-/// which is the start of the non-overlapping window that contains `ts`.
-///
-/// # Arguments
-///
-/// * Arg 0: Timestamp column or scalar (`TimestampMillisecond` or `Int64` ms)
-/// * Arg 1: Window size as an interval scalar
-///
-/// # Returns
-///
-/// `TimestampMillisecond` representing the window start.
-#[derive(Debug)]
-pub struct TumbleWindowStart {
-    signature: Signature,
-}
-
-impl TumbleWindowStart {
-    /// Creates a new tumble window start UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(
-                TypeSignature::OneOf(vec![TypeSignature::Any(2), TypeSignature::Any(3)]),
-                Volatility::Immutable,
-            ),
+macro_rules! window_udf {
+    (
+        $(#[$attr:meta])*
+        $type:ident, $sql_name:literal, $arity:expr, |$args:ident| $body:expr
+    ) => {
+        $(#[$attr])*
+        #[derive(Debug)]
+        pub struct $type {
+            signature: Signature,
         }
-    }
-}
 
-impl Default for TumbleWindowStart {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for TumbleWindowStart {
-    fn eq(&self, _other: &Self) -> bool {
-        true // All instances are identical
-    }
-}
-
-impl Eq for TumbleWindowStart {}
-
-impl Hash for TumbleWindowStart {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "tumble".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for TumbleWindowStart {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "tumble"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() < 2 || args.len() > 3 {
-            return Err(DataFusionError::Plan(
-                "tumble() requires 2-3 arguments: (timestamp, interval [, offset])".to_string(),
-            ));
-        }
-        let interval_ms = extract_interval_ms(&args[1])?;
-        if interval_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "tumble() interval must be positive".to_string(),
-            ));
-        }
-        let offset_ms = if args.len() == 3 {
-            extract_interval_ms(&args[2])?
-        } else {
-            0
-        };
-        compute_tumble_with_offset(&args[0], interval_ms, offset_ms)
-    }
-}
-
-// ─── TumbleWindowEnd ─────────────────────────────────────────────────────────
-
-/// `tumble_end(ts, interval)` — exclusive upper bound of the tumble
-/// window containing `ts`. See [`TumbleWindowStart`].
-#[derive(Debug)]
-pub struct TumbleWindowEnd {
-    signature: Signature,
-}
-
-impl TumbleWindowEnd {
-    /// Creates a new tumble window end UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(
-                TypeSignature::OneOf(vec![TypeSignature::Any(2), TypeSignature::Any(3)]),
-                Volatility::Immutable,
-            ),
-        }
-    }
-}
-
-impl Default for TumbleWindowEnd {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for TumbleWindowEnd {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for TumbleWindowEnd {}
-
-impl Hash for TumbleWindowEnd {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "tumble_end".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for TumbleWindowEnd {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "tumble_end"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() < 2 || args.len() > 3 {
-            return Err(DataFusionError::Plan(
-                "tumble_end() requires 2-3 arguments: (timestamp, interval [, offset])".to_string(),
-            ));
-        }
-        let interval_ms = extract_interval_ms(&args[1])?;
-        if interval_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "tumble_end() interval must be positive".to_string(),
-            ));
-        }
-        let offset_ms = if args.len() == 3 {
-            extract_interval_ms(&args[2])?
-        } else {
-            0
-        };
-        shift_timestamp_ms(
-            &compute_tumble_with_offset(&args[0], interval_ms, offset_ms)?,
-            interval_ms,
-        )
-    }
-}
-
-// ─── HopWindowStart ──────────────────────────────────────────────────────────
-
-/// Computes the earliest hopping window start for a given timestamp.
-///
-/// `hop(timestamp, slide, size)` returns the start of the earliest window
-/// (of the given `size`, sliding by `slide`) that contains `ts`.
-///
-/// # Limitation
-///
-/// This returns only the *earliest* window start. Full multi-window
-/// assignment (one row per window) is handled by Ring 0 operators.
-///
-/// # Arguments
-///
-/// * Arg 0: Timestamp column or scalar
-/// * Arg 1: Slide interval scalar
-/// * Arg 2: Window size interval scalar
-#[derive(Debug)]
-pub struct HopWindowStart {
-    signature: Signature,
-}
-
-impl HopWindowStart {
-    /// Creates a new hop window start UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(
-                TypeSignature::OneOf(vec![TypeSignature::Any(3), TypeSignature::Any(4)]),
-                Volatility::Immutable,
-            ),
-        }
-    }
-}
-
-impl Default for HopWindowStart {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for HopWindowStart {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for HopWindowStart {}
-
-impl Hash for HopWindowStart {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "hop".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for HopWindowStart {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "hop"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() < 3 || args.len() > 4 {
-            return Err(DataFusionError::Plan(
-                "hop() requires 3-4 arguments: (timestamp, slide, size [, offset])".to_string(),
-            ));
-        }
-        let slide_ms = extract_interval_ms(&args[1])?;
-        let size_ms = extract_interval_ms(&args[2])?;
-        if slide_ms <= 0 || size_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "hop() slide and size must be positive".to_string(),
-            ));
-        }
-        let offset_ms = if args.len() == 4 {
-            extract_interval_ms(&args[3])?
-        } else {
-            0
-        };
-        compute_hop_with_offset(&args[0], slide_ms, size_ms, offset_ms)
-    }
-}
-
-// ─── HopWindowEnd ────────────────────────────────────────────────────────────
-
-/// `hop_end(ts, slide, size)` — end of the earliest hop window
-/// containing `ts`. See [`HopWindowStart`].
-#[derive(Debug)]
-pub struct HopWindowEnd {
-    signature: Signature,
-}
-
-impl HopWindowEnd {
-    /// Creates a new hop window end UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(
-                TypeSignature::OneOf(vec![TypeSignature::Any(3), TypeSignature::Any(4)]),
-                Volatility::Immutable,
-            ),
-        }
-    }
-}
-
-impl Default for HopWindowEnd {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for HopWindowEnd {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for HopWindowEnd {}
-
-impl Hash for HopWindowEnd {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "hop_end".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for HopWindowEnd {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "hop_end"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() < 3 || args.len() > 4 {
-            return Err(DataFusionError::Plan(
-                "hop_end() requires 3-4 arguments: (timestamp, slide, size [, offset])".to_string(),
-            ));
-        }
-        let slide_ms = extract_interval_ms(&args[1])?;
-        let size_ms = extract_interval_ms(&args[2])?;
-        if slide_ms <= 0 || size_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "hop_end() slide and size must be positive".to_string(),
-            ));
-        }
-        let offset_ms = if args.len() == 4 {
-            extract_interval_ms(&args[3])?
-        } else {
-            0
-        };
-        shift_timestamp_ms(
-            &compute_hop_with_offset(&args[0], slide_ms, size_ms, offset_ms)?,
-            size_ms,
-        )
-    }
-}
-
-// ─── SessionWindowStart ──────────────────────────────────────────────────────
-
-/// Pass-through UDF for session window compatibility.
-///
-/// `session(timestamp, gap)` returns the input timestamp unchanged.
-/// Session windows are data-dependent (gap-based grouping) and cannot
-/// be computed as a per-row scalar. The actual session assignment is
-/// handled by Ring 0 operators.
-///
-/// This UDF exists so that `GROUP BY SESSION(ts, gap)` is syntactically
-/// valid in `DataFusion` queries, with real session logic deferred to
-/// the streaming engine.
-#[derive(Debug)]
-pub struct SessionWindowStart {
-    signature: Signature,
-}
-
-impl SessionWindowStart {
-    /// Creates a new session window start UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(TypeSignature::Any(2), Volatility::Immutable),
-        }
-    }
-}
-
-impl Default for SessionWindowStart {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for SessionWindowStart {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for SessionWindowStart {}
-
-impl Hash for SessionWindowStart {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "session".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for SessionWindowStart {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "session"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() != 2 {
-            return Err(DataFusionError::Plan(
-                "session() requires exactly 2 arguments: (timestamp, gap)".to_string(),
-            ));
-        }
-        // Pass-through: return the input timestamp as-is
-        match &args[0] {
-            ColumnarValue::Array(array) => {
-                let result = convert_to_timestamp_ms_array(array)?;
-                Ok(ColumnarValue::Array(result))
-            }
-            ColumnarValue::Scalar(scalar) => {
-                let ts_ms = scalar_to_timestamp_ms(scalar)?;
-                Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                    ts_ms, None,
-                )))
+        impl $type {
+            /// Constructs the UDF instance.
+            #[must_use]
+            pub fn new() -> Self {
+                Self { signature: variadic_signature($arity) }
             }
         }
-    }
-}
 
-// ─── CumulateWindowStart ────────────────────────────────────────────────────
-
-/// Computes the cumulate window epoch start for a given timestamp.
-///
-/// `cumulate(timestamp, step, size)` returns `floor(ts / size) * size`,
-/// which is the epoch start for the cumulating window that contains `ts`.
-/// The actual multi-window assignment (one row per cumulating window) is
-/// handled by Ring 0 operators.
-///
-/// # Arguments
-///
-/// * Arg 0: Timestamp column or scalar (`TimestampMillisecond` or `Int64` ms)
-/// * Arg 1: Step interval scalar (window growth increment)
-/// * Arg 2: Max size interval scalar (epoch size)
-#[derive(Debug)]
-pub struct CumulateWindowStart {
-    signature: Signature,
-}
-
-impl CumulateWindowStart {
-    /// Creates a new cumulate window start UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(TypeSignature::Any(3), Volatility::Immutable),
+        impl Default for $type {
+            fn default() -> Self { Self::new() }
         }
-    }
-}
 
-impl Default for CumulateWindowStart {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for CumulateWindowStart {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for CumulateWindowStart {}
-
-impl Hash for CumulateWindowStart {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "cumulate".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for CumulateWindowStart {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "cumulate"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() != 3 {
-            return Err(DataFusionError::Plan(
-                "cumulate() requires exactly 3 arguments: (timestamp, step, size)".to_string(),
-            ));
+        impl PartialEq for $type {
+            fn eq(&self, _: &Self) -> bool { true }
         }
-        let step_ms = extract_interval_ms(&args[1])?;
-        let size_ms = extract_interval_ms(&args[2])?;
-        if step_ms <= 0 || size_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "cumulate() step and size must be positive".to_string(),
-            ));
+
+        impl Eq for $type {}
+
+        impl Hash for $type {
+            fn hash<H: Hasher>(&self, state: &mut H) { $sql_name.hash(state); }
         }
-        if step_ms > size_ms {
-            return Err(DataFusionError::Plan(
-                "cumulate() step must not exceed size".to_string(),
-            ));
+
+        impl ScalarUDFImpl for $type {
+            fn as_any(&self) -> &dyn Any { self }
+            fn name(&self) -> &'static str { $sql_name }
+            fn signature(&self) -> &Signature { &self.signature }
+            fn return_type(&self, _: &[DataType]) -> Result<DataType> {
+                Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
+            }
+            fn invoke_with_args(&self, sfa: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                let $args = sfa.args;
+                check_arity(&$args, $arity, $sql_name)?;
+                $body
+            }
         }
-        if size_ms % step_ms != 0 {
-            return Err(DataFusionError::Plan(
-                "cumulate() size must be evenly divisible by step".to_string(),
-            ));
-        }
-        // Return epoch start = floor(ts / size) * size (same as tumble with size)
-        compute_tumble(&args[0], size_ms)
+    };
+}
+
+// ─── UDF declarations ───────────────────────────────────────────────────────
+
+window_udf!(
+    /// `tumble(ts, interval [, offset])` — start of the non-overlapping
+    /// window containing `ts`. Returns `Timestamp(Microsecond, None)`.
+    TumbleWindowStart, "tumble", 2..=3,
+    |args| {
+        let interval_ms = positive_interval(&args[1], "tumble", "interval")?;
+        let offset_ms = optional_offset(&args, 2)?;
+        into_us_columnar(&args[0], |ts| tumble_start_ms(ts, interval_ms, offset_ms))
+    }
+);
+
+window_udf!(
+    /// `tumble_end(ts, interval [, offset])` — exclusive upper bound of
+    /// the tumble window containing `ts` (i.e. `tumble(...) + interval`).
+    TumbleWindowEnd, "tumble_end", 2..=3,
+    |args| {
+        let interval_ms = positive_interval(&args[1], "tumble_end", "interval")?;
+        let offset_ms = optional_offset(&args, 2)?;
+        into_us_columnar(&args[0], |ts| {
+            tumble_start_ms(ts, interval_ms, offset_ms).saturating_add(interval_ms)
+        })
+    }
+);
+
+window_udf!(
+    /// `hop(ts, slide, size [, offset])` — earliest sliding window
+    /// (size `size`, sliding by `slide`) that contains `ts`. Full
+    /// multi-window assignment is handled by Ring 0.
+    HopWindowStart, "hop", 3..=4,
+    |args| {
+        let slide_ms = positive_interval(&args[1], "hop", "slide")?;
+        let size_ms = positive_interval(&args[2], "hop", "size")?;
+        let offset_ms = optional_offset(&args, 3)?;
+        into_us_columnar(&args[0], |ts| hop_start_ms(ts, slide_ms, size_ms, offset_ms))
+    }
+);
+
+window_udf!(
+    /// `hop_end(ts, slide, size [, offset])` — end of the earliest
+    /// sliding window containing `ts` (i.e. `hop(...) + size`).
+    HopWindowEnd, "hop_end", 3..=4,
+    |args| {
+        let slide_ms = positive_interval(&args[1], "hop_end", "slide")?;
+        let size_ms = positive_interval(&args[2], "hop_end", "size")?;
+        let offset_ms = optional_offset(&args, 3)?;
+        into_us_columnar(&args[0], |ts| {
+            hop_start_ms(ts, slide_ms, size_ms, offset_ms).saturating_add(size_ms)
+        })
+    }
+);
+
+window_udf!(
+    /// `session(ts, gap)` — passthrough that converts `ts` to
+    /// microsecond resolution. Real session start/end are data-dependent
+    /// and computed by Ring 0; this UDF exists so `GROUP BY session(ts,
+    /// gap)` parses. There is no `session_end` UDF for the same reason.
+    SessionWindowStart, "session", 2..=2,
+    |args| into_us_columnar(&args[0], |ts| ts)
+);
+
+window_udf!(
+    /// `cumulate(ts, step, size)` — epoch start (size-aligned bucket)
+    /// containing `ts`. Per-step cumulating boundaries (which depend on
+    /// data) are exposed by Ring 0.
+    CumulateWindowStart, "cumulate", 3..=3,
+    |args| {
+        let (_step_ms, size_ms) = cumulate_intervals(&args, "cumulate")?;
+        into_us_columnar(&args[0], |ts| tumble_start_ms(ts, size_ms, 0))
+    }
+);
+
+window_udf!(
+    /// `cumulate_end(ts, step, size)` — exclusive upper bound of the
+    /// epoch (size-aligned bucket) containing `ts`.
+    CumulateWindowEnd, "cumulate_end", 3..=3,
+    |args| {
+        let (_step_ms, size_ms) = cumulate_intervals(&args, "cumulate_end")?;
+        into_us_columnar(&args[0], |ts| {
+            tumble_start_ms(ts, size_ms, 0).saturating_add(size_ms)
+        })
+    }
+);
+
+// ─── Math helpers ──────────────────────────────────────────────────────────
+//
+// All in milliseconds. Pure i64 → i64.
+
+/// Tumble window start: `floor((ts - offset) / interval) * interval + offset`.
+fn tumble_start_ms(ts: i64, interval_ms: i64, offset_ms: i64) -> i64 {
+    let adj = ts - offset_ms;
+    (adj - adj.rem_euclid(interval_ms)) + offset_ms
+}
+
+/// Earliest start of a hopping window of `size` (sliding by `slide`)
+/// that contains `ts`.
+fn hop_start_ms(ts: i64, slide_ms: i64, size_ms: i64, offset_ms: i64) -> i64 {
+    let adj = ts - size_ms + slide_ms - offset_ms;
+    (adj - adj.rem_euclid(slide_ms)) + offset_ms
+}
+
+// ─── Argument parsing helpers ──────────────────────────────────────────────
+
+/// Builds `Signature::any(N)` or `Signature::one_of([Any(N), …])` for a
+/// scalar UDF whose arity covers a contiguous range.
+fn variadic_signature(arity: RangeInclusive<usize>) -> Signature {
+    let mut arities: Vec<TypeSignature> = arity.map(TypeSignature::Any).collect();
+    let inner = if arities.len() == 1 {
+        arities.pop().unwrap()
+    } else {
+        TypeSignature::OneOf(arities)
+    };
+    Signature::new(inner, Volatility::Immutable)
+}
+
+fn check_arity(args: &[ColumnarValue], arity: RangeInclusive<usize>, fn_name: &str) -> Result<()> {
+    if arity.contains(&args.len()) {
+        return Ok(());
+    }
+    let expected = if arity.start() == arity.end() {
+        format!("exactly {}", arity.start())
+    } else {
+        format!("{}-{}", arity.start(), arity.end())
+    };
+    Err(DataFusionError::Plan(format!(
+        "{}() requires {} arguments, got {}",
+        fn_name,
+        expected,
+        args.len()
+    )))
+}
+
+fn positive_interval(value: &ColumnarValue, fn_name: &str, arg_name: &str) -> Result<i64> {
+    let ms = extract_interval_ms(value)?;
+    if ms <= 0 {
+        return Err(DataFusionError::Plan(format!(
+            "{fn_name}() {arg_name} must be positive"
+        )));
+    }
+    Ok(ms)
+}
+
+fn optional_offset(args: &[ColumnarValue], idx: usize) -> Result<i64> {
+    match args.get(idx) {
+        Some(value) => extract_interval_ms(value),
+        None => Ok(0),
     }
 }
 
-// ─── CumulateWindowEnd ──────────────────────────────────────────────────────
-
-/// `cumulate_end(ts, step, size)` — exclusive upper bound of the epoch
-/// (size-aligned bucket) containing `ts`. See [`CumulateWindowStart`].
-#[derive(Debug)]
-pub struct CumulateWindowEnd {
-    signature: Signature,
+fn cumulate_intervals(args: &[ColumnarValue], fn_name: &str) -> Result<(i64, i64)> {
+    let step_ms = positive_interval(&args[1], fn_name, "step")?;
+    let size_ms = positive_interval(&args[2], fn_name, "size")?;
+    if step_ms > size_ms {
+        return Err(DataFusionError::Plan(format!(
+            "{fn_name}() step must not exceed size"
+        )));
+    }
+    if size_ms % step_ms != 0 {
+        return Err(DataFusionError::Plan(format!(
+            "{fn_name}() size must be evenly divisible by step"
+        )));
+    }
+    Ok((step_ms, size_ms))
 }
 
-impl CumulateWindowEnd {
-    /// Creates a new cumulate window end UDF.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            signature: Signature::new(TypeSignature::Any(3), Volatility::Immutable),
-        }
-    }
-}
-
-impl Default for CumulateWindowEnd {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PartialEq for CumulateWindowEnd {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl Eq for CumulateWindowEnd {}
-
-impl Hash for CumulateWindowEnd {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        "cumulate_end".hash(state);
-    }
-}
-
-impl ScalarUDFImpl for CumulateWindowEnd {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn name(&self) -> &'static str {
-        "cumulate_end"
-    }
-
-    fn signature(&self) -> &Signature {
-        &self.signature
-    }
-
-    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-    }
-
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        if args.len() != 3 {
-            return Err(DataFusionError::Plan(
-                "cumulate_end() requires exactly 3 arguments: (timestamp, step, size)".to_string(),
-            ));
-        }
-        let step_ms = extract_interval_ms(&args[1])?;
-        let size_ms = extract_interval_ms(&args[2])?;
-        if step_ms <= 0 || size_ms <= 0 {
-            return Err(DataFusionError::Plan(
-                "cumulate_end() step and size must be positive".to_string(),
-            ));
-        }
-        if step_ms > size_ms {
-            return Err(DataFusionError::Plan(
-                "cumulate_end() step must not exceed size".to_string(),
-            ));
-        }
-        if size_ms % step_ms != 0 {
-            return Err(DataFusionError::Plan(
-                "cumulate_end() size must be evenly divisible by step".to_string(),
-            ));
-        }
-        shift_timestamp_ms(&compute_tumble(&args[0], size_ms)?, size_ms)
-    }
-}
-
-// ─── Helper Functions ────────────────────────────────────────────────────────
-
-/// Extracts an interval value in milliseconds from a `ColumnarValue`.
-///
-/// Only scalar intervals are supported (array intervals would require
-/// per-row window sizes, which is not a valid streaming pattern).
+/// Extracts a scalar interval in milliseconds. Array intervals are
+/// rejected — per-row window sizes are not a valid streaming pattern.
 fn extract_interval_ms(value: &ColumnarValue) -> Result<i64> {
     match value {
         ColumnarValue::Scalar(scalar) => scalar_interval_to_ms(scalar),
@@ -672,7 +266,6 @@ fn extract_interval_ms(value: &ColumnarValue) -> Result<i64> {
     }
 }
 
-/// Converts a scalar interval to milliseconds.
 fn scalar_interval_to_ms(scalar: &ScalarValue) -> Result<i64> {
     match scalar {
         ScalarValue::IntervalDayTime(Some(v)) => {
@@ -698,7 +291,38 @@ fn scalar_interval_to_ms(scalar: &ScalarValue) -> Result<i64> {
     }
 }
 
-/// Converts a scalar value to a timestamp in milliseconds.
+// ─── Dispatch helper ───────────────────────────────────────────────────────
+
+/// Applies `transform` (ms → ms) to every non-null input timestamp and
+/// returns a `Timestamp(Microsecond)` result. One allocation per call;
+/// null inputs propagate.
+fn into_us_columnar(
+    value: &ColumnarValue,
+    transform: impl Fn(i64) -> i64,
+) -> Result<ColumnarValue> {
+    match value {
+        ColumnarValue::Array(array) => {
+            let input = to_millis_array(array)?;
+            let result: TimestampMicrosecondArray = input
+                .iter()
+                .map(|opt| opt.map(|ms| transform(ms).saturating_mul(1000)))
+                .collect();
+            Ok(ColumnarValue::Array(Arc::new(result)))
+        }
+        ColumnarValue::Scalar(scalar) => {
+            let result =
+                scalar_to_timestamp_ms(scalar)?.map(|ms| transform(ms).saturating_mul(1000));
+            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(
+                result, None,
+            )))
+        }
+    }
+}
+
+fn to_millis_array(array: &ArrayRef) -> Result<TimestampMillisecondArray> {
+    cast_to_millis_array(array.as_ref()).map_err(|e| DataFusionError::Plan(e.to_string()))
+}
+
 fn scalar_to_timestamp_ms(scalar: &ScalarValue) -> Result<Option<i64>> {
     match scalar {
         ScalarValue::TimestampMillisecond(v, _) | ScalarValue::Int64(v) => Ok(*v),
@@ -711,204 +335,10 @@ fn scalar_to_timestamp_ms(scalar: &ScalarValue) -> Result<Option<i64>> {
     }
 }
 
-/// Computes tumble window start for a `ColumnarValue`.
-fn compute_tumble(value: &ColumnarValue, interval_ms: i64) -> Result<ColumnarValue> {
-    match value {
-        ColumnarValue::Array(array) => {
-            let result = compute_tumble_array(array, interval_ms)?;
-            Ok(ColumnarValue::Array(result))
-        }
-        ColumnarValue::Scalar(scalar) => {
-            let ts_ms = scalar_to_timestamp_ms(scalar)?;
-            let window_start = ts_ms.map(|ts| ts - ts.rem_euclid(interval_ms));
-            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                window_start,
-                None,
-            )))
-        }
-    }
-}
-
-/// Normalise a timestamp array to `TimestampMillisecond` for the window
-/// math below. Wraps the shared helper so DataFusion gets a `Plan` error
-/// on non-timestamp columns.
-fn to_millis_array(array: &ArrayRef) -> Result<TimestampMillisecondArray> {
-    cast_to_millis_array(array.as_ref()).map_err(|e| DataFusionError::Plan(e.to_string()))
-}
-
-/// Computes tumble window start for an array of timestamps.
-fn compute_tumble_array(array: &ArrayRef, interval_ms: i64) -> Result<ArrayRef> {
-    let input = to_millis_array(array)?;
-    let result: TimestampMillisecondArray = input
-        .iter()
-        .map(|opt_ts| opt_ts.map(|ts| ts - ts.rem_euclid(interval_ms)))
-        .collect();
-    Ok(Arc::new(result))
-}
-
-/// Computes tumble window start with offset for a `ColumnarValue`.
-fn compute_tumble_with_offset(
-    value: &ColumnarValue,
-    interval_ms: i64,
-    offset_ms: i64,
-) -> Result<ColumnarValue> {
-    if offset_ms == 0 {
-        return compute_tumble(value, interval_ms);
-    }
-    match value {
-        ColumnarValue::Array(array) => {
-            let result = compute_tumble_array_with_offset(array, interval_ms, offset_ms)?;
-            Ok(ColumnarValue::Array(result))
-        }
-        ColumnarValue::Scalar(scalar) => {
-            let ts_ms = scalar_to_timestamp_ms(scalar)?;
-            let window_start = ts_ms.map(|ts| {
-                let adj = ts - offset_ms;
-                (adj - adj.rem_euclid(interval_ms)) + offset_ms
-            });
-            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                window_start,
-                None,
-            )))
-        }
-    }
-}
-
-/// Computes tumble window start with offset for an array of timestamps.
-fn compute_tumble_array_with_offset(
-    array: &ArrayRef,
-    interval_ms: i64,
-    offset_ms: i64,
-) -> Result<ArrayRef> {
-    let input = to_millis_array(array)?;
-    let result: TimestampMillisecondArray = input
-        .iter()
-        .map(|opt_ts| {
-            opt_ts.map(|ts| {
-                let adj = ts - offset_ms;
-                (adj - adj.rem_euclid(interval_ms)) + offset_ms
-            })
-        })
-        .collect();
-    Ok(Arc::new(result))
-}
-
-/// Computes hop (earliest) window start for a `ColumnarValue`.
-fn compute_hop(value: &ColumnarValue, slide_ms: i64, size_ms: i64) -> Result<ColumnarValue> {
-    match value {
-        ColumnarValue::Array(array) => {
-            let result = compute_hop_array(array, slide_ms, size_ms)?;
-            Ok(ColumnarValue::Array(result))
-        }
-        ColumnarValue::Scalar(scalar) => {
-            let ts_ms = scalar_to_timestamp_ms(scalar)?;
-            let window_start = ts_ms.map(|ts| hop_earliest_start(ts, slide_ms, size_ms));
-            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                window_start,
-                None,
-            )))
-        }
-    }
-}
-
-/// Computes hop window start for an array of timestamps.
-fn compute_hop_array(array: &ArrayRef, slide_ms: i64, size_ms: i64) -> Result<ArrayRef> {
-    let input = to_millis_array(array)?;
-    let result: TimestampMillisecondArray = input
-        .iter()
-        .map(|opt_ts| opt_ts.map(|ts| hop_earliest_start(ts, slide_ms, size_ms)))
-        .collect();
-    Ok(Arc::new(result))
-}
-
-/// Computes the earliest window start for a hopping window containing `ts`.
-///
-/// Windows of `size_ms` slide by `slide_ms`. The earliest window that
-/// contains `ts` starts at `floor((ts - size + slide) / slide) * slide`.
-#[inline]
-fn hop_earliest_start(ts: i64, slide_ms: i64, size_ms: i64) -> i64 {
-    let adjusted = ts - size_ms + slide_ms;
-    adjusted - adjusted.rem_euclid(slide_ms)
-}
-
-/// Computes hop (earliest) window start with offset.
-fn compute_hop_with_offset(
-    value: &ColumnarValue,
-    slide_ms: i64,
-    size_ms: i64,
-    offset_ms: i64,
-) -> Result<ColumnarValue> {
-    if offset_ms == 0 {
-        return compute_hop(value, slide_ms, size_ms);
-    }
-    match value {
-        ColumnarValue::Array(array) => {
-            let result = compute_hop_array_with_offset(array, slide_ms, size_ms, offset_ms)?;
-            Ok(ColumnarValue::Array(result))
-        }
-        ColumnarValue::Scalar(scalar) => {
-            let ts_ms = scalar_to_timestamp_ms(scalar)?;
-            let window_start =
-                ts_ms.map(|ts| hop_earliest_start(ts - offset_ms, slide_ms, size_ms) + offset_ms);
-            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                window_start,
-                None,
-            )))
-        }
-    }
-}
-
-/// Computes hop window start with offset for an array.
-fn compute_hop_array_with_offset(
-    array: &ArrayRef,
-    slide_ms: i64,
-    size_ms: i64,
-    offset_ms: i64,
-) -> Result<ArrayRef> {
-    let input = to_millis_array(array)?;
-    let result: TimestampMillisecondArray = input
-        .iter()
-        .map(|opt_ts| {
-            opt_ts.map(|ts| hop_earliest_start(ts - offset_ms, slide_ms, size_ms) + offset_ms)
-        })
-        .collect();
-    Ok(Arc::new(result))
-}
-
-/// Converts a timestamp array to `TimestampMillisecond` for consistent output.
-fn convert_to_timestamp_ms_array(array: &ArrayRef) -> Result<ArrayRef> {
-    let ms = to_millis_array(array)?;
-    Ok(Arc::new(ms))
-}
-
-/// Saturating-shifts every non-null `TimestampMillisecond` forward.
-fn shift_timestamp_ms(value: &ColumnarValue, delta_ms: i64) -> Result<ColumnarValue> {
-    match value {
-        ColumnarValue::Array(array) => {
-            let input = to_millis_array(array)?;
-            let result: TimestampMillisecondArray = input
-                .iter()
-                .map(|opt_ts| opt_ts.map(|ts| ts.saturating_add(delta_ms)))
-                .collect();
-            Ok(ColumnarValue::Array(Arc::new(result)))
-        }
-        ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(opt, tz)) => {
-            let shifted = opt.map(|ts| ts.saturating_add(delta_ms));
-            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
-                shifted,
-                tz.clone(),
-            )))
-        }
-        ColumnarValue::Scalar(other) => Err(DataFusionError::Plan(format!(
-            "expected TimestampMillisecond from window-start helper, got: {other:?}"
-        ))),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::{IntervalDayTime, IntervalMonthDayNano, TimestampMillisecondType};
+    use arrow::datatypes::{IntervalDayTime, IntervalMonthDayNano, TimestampMicrosecondType};
     use arrow_array::cast::AsArray;
     use arrow_array::Array;
     use arrow_schema::Field;
@@ -925,11 +355,21 @@ mod tests {
         ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(ms, None))
     }
 
-    fn expect_ts_ms(result: ColumnarValue) -> Option<i64> {
+    /// Returns the microsecond value of a UDF scalar result, or panics
+    /// if the result isn't a `TimestampMicrosecond` scalar.
+    fn expect_ts_us(result: ColumnarValue) -> Option<i64> {
         match result {
-            ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(v, _)) => v,
-            other => panic!("Expected TimestampMillisecond scalar, got: {other:?}"),
+            ColumnarValue::Scalar(ScalarValue::TimestampMicrosecond(v, _)) => v,
+            other => panic!("Expected TimestampMicrosecond scalar, got: {other:?}"),
         }
+    }
+
+    /// Returns the per-row microsecond values of a UDF array result.
+    fn array_values_us(arr: &dyn Array) -> Vec<Option<i64>> {
+        let r = arr.as_primitive::<TimestampMicrosecondType>();
+        (0..r.len())
+            .map(|i| if r.is_null(i) { None } else { Some(r.value(i)) })
+            .collect()
     }
 
     fn make_args(args: Vec<ColumnarValue>, rows: usize) -> ScalarFunctionArgs {
@@ -939,184 +379,247 @@ mod tests {
             number_rows: rows,
             return_field: Arc::new(Field::new(
                 "output",
-                DataType::Timestamp(TimeUnit::Millisecond, None),
+                DataType::Timestamp(TimeUnit::Microsecond, None),
                 true,
             )),
             config_options: Arc::new(ConfigOptions::default()),
         }
     }
 
-    // ── Tumble tests ─────────────────────────────────────────────────────
+    // ── Tumble ──────────────────────────────────────────────────────────
 
     #[test]
     fn test_tumble_basic() {
-        let udf = TumbleWindowStart::new();
-        // 5-minute interval = 300_000 ms, timestamp at 7 min
-        let result = udf
+        // 5-minute interval, ts=7 minutes (420 000 ms) → bucket start =
+        // 5 minutes = 300 000 ms = 300 000 000 µs.
+        let result = TumbleWindowStart::new()
             .invoke_with_args(make_args(
                 vec![ts_ms(Some(420_000)), interval_dt(0, 300_000)],
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(300_000));
+        assert_eq!(expect_ts_us(result), Some(300_000_000));
     }
 
     #[test]
     fn test_tumble_exact_boundary() {
-        let udf = TumbleWindowStart::new();
-        let result = udf
+        let result = TumbleWindowStart::new()
             .invoke_with_args(make_args(
                 vec![ts_ms(Some(300_000)), interval_dt(0, 300_000)],
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(300_000));
+        assert_eq!(expect_ts_us(result), Some(300_000_000));
     }
 
     #[test]
     fn test_tumble_zero_timestamp() {
-        let udf = TumbleWindowStart::new();
-        let result = udf
+        let result = TumbleWindowStart::new()
             .invoke_with_args(make_args(vec![ts_ms(Some(0)), interval_dt(0, 300_000)], 1))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(0));
+        assert_eq!(expect_ts_us(result), Some(0));
     }
 
     #[test]
     fn test_tumble_null_handling() {
-        let udf = TumbleWindowStart::new();
-        let result = udf
+        let result = TumbleWindowStart::new()
             .invoke_with_args(make_args(vec![ts_ms(None), interval_dt(0, 300_000)], 1))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), None);
+        assert_eq!(expect_ts_us(result), None);
     }
 
     #[test]
     fn test_tumble_array_input() {
-        let udf = TumbleWindowStart::new();
-        let ts_array = TimestampMillisecondArray::from(vec![
+        let ts = ColumnarValue::Array(Arc::new(TimestampMillisecondArray::from(vec![
             Some(0),
             Some(150_000),
             Some(300_000),
             Some(420_000),
             None,
-        ]);
-        let ts = ColumnarValue::Array(Arc::new(ts_array));
-        let interval = interval_dt(0, 300_000);
-
-        let result = udf
-            .invoke_with_args(make_args(vec![ts, interval], 5))
+        ])));
+        let result = TumbleWindowStart::new()
+            .invoke_with_args(make_args(vec![ts, interval_dt(0, 300_000)], 5))
             .unwrap();
         match result {
-            ColumnarValue::Array(arr) => {
-                let r = arr.as_primitive::<TimestampMillisecondType>();
-                assert_eq!(r.value(0), 0);
-                assert_eq!(r.value(1), 0);
-                assert_eq!(r.value(2), 300_000);
-                assert_eq!(r.value(3), 300_000);
-                assert!(r.is_null(4));
-            }
+            ColumnarValue::Array(arr) => assert_eq!(
+                array_values_us(&arr),
+                vec![Some(0), Some(0), Some(300_000_000), Some(300_000_000), None,]
+            ),
             ColumnarValue::Scalar(_) => panic!("Expected array result"),
         }
     }
 
-    /// Regression: TUMBLE over a `Timestamp(Nanosecond)` column used to
-    /// bail out with "Unsupported timestamp type for tumble()" because
-    /// the array fast path only handled `Timestamp(Millisecond)` and
-    /// `Int64`. `to_millis_array` now casts any Timestamp precision.
+    /// Regression: TUMBLE over a `Timestamp(Nanosecond)` column must
+    /// take the `to_millis_array` path (any precision in, milliseconds
+    /// out) rather than failing on the array fast path.
     #[test]
     fn test_tumble_array_input_nanosecond() {
         use arrow_array::TimestampNanosecondArray;
-
-        let udf = TumbleWindowStart::new();
-        // 0s, 150s, 300s, 420s in ns.
-        let ts_array = TimestampNanosecondArray::from(vec![
+        let ts = ColumnarValue::Array(Arc::new(TimestampNanosecondArray::from(vec![
             Some(0),
             Some(150_000_000_000),
             Some(300_000_000_000),
             Some(420_000_000_000),
             None,
-        ]);
-        let ts = ColumnarValue::Array(Arc::new(ts_array));
-        let interval = interval_dt(0, 300_000); // 5 minutes
-
-        let result = udf
-            .invoke_with_args(make_args(vec![ts, interval], 5))
+        ])));
+        let result = TumbleWindowStart::new()
+            .invoke_with_args(make_args(vec![ts, interval_dt(0, 300_000)], 5))
             .unwrap();
         match result {
-            ColumnarValue::Array(arr) => {
-                let r = arr.as_primitive::<TimestampMillisecondType>();
-                assert_eq!(r.value(0), 0);
-                assert_eq!(r.value(1), 0);
-                assert_eq!(r.value(2), 300_000);
-                assert_eq!(r.value(3), 300_000);
-                assert!(r.is_null(4));
-            }
+            ColumnarValue::Array(arr) => assert_eq!(
+                array_values_us(&arr),
+                vec![Some(0), Some(0), Some(300_000_000), Some(300_000_000), None,]
+            ),
             ColumnarValue::Scalar(_) => panic!("Expected array result"),
         }
     }
 
-    /// Regression: HOP over a `Timestamp(Nanosecond)` column — same
-    /// missing arm as TUMBLE, fixed by the same `to_millis_array` helper.
+    /// Regression: HOP over `Timestamp(Nanosecond)` — same shape as the
+    /// tumble nanosecond regression.
     #[test]
     fn test_hop_array_input_nanosecond() {
         use arrow_array::TimestampNanosecondArray;
-
-        let udf = HopWindowStart::new();
-        // 7 minutes in ns.
-        let ts_array = TimestampNanosecondArray::from(vec![Some(420_000_000_000)]);
-        let ts = ColumnarValue::Array(Arc::new(ts_array));
-        // slide=5min, size=10min
-        let result = udf
+        let ts = ColumnarValue::Array(Arc::new(TimestampNanosecondArray::from(vec![Some(
+            420_000_000_000,
+        )])));
+        let result = HopWindowStart::new()
             .invoke_with_args(make_args(
                 vec![ts, interval_dt(0, 300_000), interval_dt(0, 600_000)],
                 1,
             ))
             .unwrap();
         match result {
-            ColumnarValue::Array(arr) => {
-                let r = arr.as_primitive::<TimestampMillisecondType>();
-                assert_eq!(r.value(0), 0);
-            }
+            ColumnarValue::Array(arr) => assert_eq!(array_values_us(&arr), vec![Some(0)]),
             ColumnarValue::Scalar(_) => panic!("Expected array result"),
         }
     }
 
     #[test]
     fn test_tumble_month_day_nano_interval() {
-        let udf = TumbleWindowStart::new();
-        // 1 hour = 3_600_000_000_000 nanoseconds
+        // 1 hour as IntervalMonthDayNano (3 600 s in nanoseconds);
+        // ts = 90 minutes (5 400 000 ms) → bucket start = 1 hour =
+        // 3 600 000 ms = 3 600 000 000 µs.
         let interval = ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(Some(
             IntervalMonthDayNano::new(0, 0, 3_600_000_000_000),
         )));
-        // 90 minutes = 5_400_000 ms
-        let result = udf
+        let result = TumbleWindowStart::new()
             .invoke_with_args(make_args(vec![ts_ms(Some(5_400_000)), interval], 1))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(3_600_000));
+        assert_eq!(expect_ts_us(result), Some(3_600_000_000));
     }
 
     #[test]
     fn test_tumble_rejects_zero_interval() {
-        let udf = TumbleWindowStart::new();
-        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000)), interval_dt(0, 0)], 1));
+        let result = TumbleWindowStart::new()
+            .invoke_with_args(make_args(vec![ts_ms(Some(1000)), interval_dt(0, 0)], 1));
         assert!(result.is_err());
     }
 
     #[test]
     fn test_tumble_rejects_wrong_arg_count() {
-        let udf = TumbleWindowStart::new();
-        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000))], 1));
+        let result =
+            TumbleWindowStart::new().invoke_with_args(make_args(vec![ts_ms(Some(1000))], 1));
         assert!(result.is_err());
     }
 
-    // ── Hop tests ────────────────────────────────────────────────────────
+    // ── Tumble end ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_tumble_end_basic() {
+        // 5-minute interval, ts=7 min → window [5, 10) min → end = 10
+        // min = 600 000 ms = 600 000 000 µs.
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(
+                vec![ts_ms(Some(420_000)), interval_dt(0, 300_000)],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_us(result), Some(600_000_000));
+    }
+
+    #[test]
+    fn test_tumble_end_at_boundary() {
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(
+                vec![ts_ms(Some(300_000)), interval_dt(0, 300_000)],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_us(result), Some(600_000_000));
+    }
+
+    #[test]
+    fn test_tumble_end_null_propagates() {
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(vec![ts_ms(None), interval_dt(0, 300_000)], 1))
+            .unwrap();
+        assert_eq!(expect_ts_us(result), None);
+    }
+
+    #[test]
+    fn test_tumble_end_array_input() {
+        let ts = ColumnarValue::Array(Arc::new(TimestampMillisecondArray::from(vec![
+            Some(0),
+            Some(150_000),
+            Some(300_000),
+            Some(420_000),
+            None,
+        ])));
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(vec![ts, interval_dt(0, 300_000)], 5))
+            .unwrap();
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(
+                array_values_us(&arr),
+                vec![
+                    Some(300_000_000),
+                    Some(300_000_000),
+                    Some(600_000_000),
+                    Some(600_000_000),
+                    None,
+                ]
+            ),
+            ColumnarValue::Scalar(_) => panic!("Expected array result"),
+        }
+    }
+
+    #[test]
+    fn test_tumble_end_array_input_nanosecond() {
+        use arrow_array::TimestampNanosecondArray;
+        let ts = ColumnarValue::Array(Arc::new(TimestampNanosecondArray::from(vec![Some(
+            420_000_000_000,
+        )])));
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(vec![ts, interval_dt(0, 300_000)], 1))
+            .unwrap();
+        match result {
+            ColumnarValue::Array(arr) => assert_eq!(array_values_us(&arr), vec![Some(600_000_000)]),
+            ColumnarValue::Scalar(_) => panic!("Expected array result"),
+        }
+    }
+
+    #[test]
+    fn test_tumble_end_rejects_zero_interval() {
+        let result = TumbleWindowEnd::new()
+            .invoke_with_args(make_args(vec![ts_ms(Some(1000)), interval_dt(0, 0)], 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tumble_end_rejects_wrong_arg_count() {
+        let result = TumbleWindowEnd::new().invoke_with_args(make_args(vec![ts_ms(Some(1000))], 1));
+        assert!(result.is_err());
+    }
+
+    // ── Hop ─────────────────────────────────────────────────────────────
 
     #[test]
     fn test_hop_basic() {
-        let udf = HopWindowStart::new();
-        // slide=5min, size=10min, ts=7min
-        let result = udf
+        // slide=5 min, size=10 min, ts=7 min → earliest start = 0 (the
+        // `[-2 min, 8 min)` window doesn't exist because earliest start
+        // is non-negative; correct earliest start that contains 7 min
+        // is 0 because `[0, 10)` is the first such window).
+        let result = HopWindowStart::new()
             .invoke_with_args(make_args(
                 vec![
                     ts_ms(Some(420_000)),
@@ -1126,17 +629,12 @@ mod tests {
                 1,
             ))
             .unwrap();
-        // Earliest 10-min window (sliding 5min) containing 420_000:
-        // adjusted = 420_000 - 600_000 + 300_000 = 120_000
-        // 120_000 - (120_000 % 300_000) = 120_000 - 120_000 = 0
-        assert_eq!(expect_ts_ms(result), Some(0));
+        assert_eq!(expect_ts_us(result), Some(0));
     }
 
     #[test]
     fn test_hop_at_boundary() {
-        let udf = HopWindowStart::new();
-        // slide=5min, size=10min, ts=exactly 5min
-        let result = udf
+        let result = HopWindowStart::new()
             .invoke_with_args(make_args(
                 vec![
                     ts_ms(Some(300_000)),
@@ -1146,53 +644,73 @@ mod tests {
                 1,
             ))
             .unwrap();
-        // adjusted = 300_000 - 600_000 + 300_000 = 0
-        // 0 - (0 % 300_000) = 0
-        assert_eq!(expect_ts_ms(result), Some(0));
+        assert_eq!(expect_ts_us(result), Some(0));
     }
 
     #[test]
     fn test_hop_rejects_wrong_arg_count() {
-        let udf = HopWindowStart::new();
-        let result = udf.invoke_with_args(make_args(
+        let result = HopWindowStart::new().invoke_with_args(make_args(
             vec![ts_ms(Some(1000)), interval_dt(0, 300_000)],
             1,
         ));
         assert!(result.is_err());
     }
 
-    // ── Session tests ────────────────────────────────────────────────────
+    // ── Hop end ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_hop_end_basic() {
+        // slide=5 min, size=10 min, ts=7 min → earliest start=0,
+        // end=10 min = 600 000 000 µs.
+        let result = HopWindowEnd::new()
+            .invoke_with_args(make_args(
+                vec![
+                    ts_ms(Some(420_000)),
+                    interval_dt(0, 300_000),
+                    interval_dt(0, 600_000),
+                ],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_us(result), Some(600_000_000));
+    }
+
+    #[test]
+    fn test_hop_end_rejects_wrong_arg_count() {
+        let result = HopWindowEnd::new().invoke_with_args(make_args(
+            vec![ts_ms(Some(1000)), interval_dt(0, 300_000)],
+            1,
+        ));
+        assert!(result.is_err());
+    }
+
+    // ── Session ─────────────────────────────────────────────────────────
 
     #[test]
     fn test_session_passthrough_scalar() {
-        let udf = SessionWindowStart::new();
-        let result = udf
+        let result = SessionWindowStart::new()
             .invoke_with_args(make_args(
                 vec![ts_ms(Some(42_000)), interval_dt(0, 60_000)],
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(42_000));
+        assert_eq!(expect_ts_us(result), Some(42_000_000));
     }
 
     #[test]
     fn test_session_passthrough_null() {
-        let udf = SessionWindowStart::new();
-        let result = udf
+        let result = SessionWindowStart::new()
             .invoke_with_args(make_args(vec![ts_ms(None), interval_dt(0, 60_000)], 1))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), None);
+        assert_eq!(expect_ts_us(result), None);
     }
 
-    // ── Registration & signature tests ───────────────────────────────────
-
-    // ── Cumulate tests ──────────────────────────────────────────────────
+    // ── Cumulate ────────────────────────────────────────────────────────
 
     #[test]
     fn test_cumulate_basic() {
-        let udf = CumulateWindowStart::new();
-        // step=1min, size=5min, ts=30s → epoch start = 0
-        let result = udf
+        // step=1 min, size=5 min, ts=30 s → epoch start = 0.
+        let result = CumulateWindowStart::new()
             .invoke_with_args(make_args(
                 vec![
                     ts_ms(Some(30_000)),
@@ -1202,14 +720,13 @@ mod tests {
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(0));
+        assert_eq!(expect_ts_us(result), Some(0));
     }
 
     #[test]
     fn test_cumulate_second_epoch() {
-        let udf = CumulateWindowStart::new();
-        // step=1min, size=5min, ts=350s → epoch start = 300_000
-        let result = udf
+        // ts=350 s → epoch start = 5 min = 300 000 000 µs.
+        let result = CumulateWindowStart::new()
             .invoke_with_args(make_args(
                 vec![
                     ts_ms(Some(350_000)),
@@ -1219,13 +736,12 @@ mod tests {
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(300_000));
+        assert_eq!(expect_ts_us(result), Some(300_000_000));
     }
 
     #[test]
     fn test_cumulate_rejects_step_exceeds_size() {
-        let udf = CumulateWindowStart::new();
-        let result = udf.invoke_with_args(make_args(
+        let result = CumulateWindowStart::new().invoke_with_args(make_args(
             vec![
                 ts_ms(Some(1000)),
                 interval_dt(0, 600_000),
@@ -1238,8 +754,7 @@ mod tests {
 
     #[test]
     fn test_cumulate_rejects_not_divisible() {
-        let udf = CumulateWindowStart::new();
-        let result = udf.invoke_with_args(make_args(
+        let result = CumulateWindowStart::new().invoke_with_args(make_args(
             vec![
                 ts_ms(Some(1000)),
                 interval_dt(0, 70_000),
@@ -1252,173 +767,19 @@ mod tests {
 
     #[test]
     fn test_cumulate_rejects_wrong_arg_count() {
-        let udf = CumulateWindowStart::new();
-        let result = udf.invoke_with_args(make_args(
+        let result = CumulateWindowStart::new().invoke_with_args(make_args(
             vec![ts_ms(Some(1000)), interval_dt(0, 60_000)],
             1,
         ));
         assert!(result.is_err());
     }
 
-    // ── Registration & signature tests ───────────────────────────────────
-
-    #[test]
-    fn test_udf_registration() {
-        let tumble = ScalarUDF::new_from_impl(TumbleWindowStart::new());
-        assert_eq!(tumble.name(), "tumble");
-
-        let tumble_end = ScalarUDF::new_from_impl(TumbleWindowEnd::new());
-        assert_eq!(tumble_end.name(), "tumble_end");
-
-        let hop = ScalarUDF::new_from_impl(HopWindowStart::new());
-        assert_eq!(hop.name(), "hop");
-
-        let hop_end = ScalarUDF::new_from_impl(HopWindowEnd::new());
-        assert_eq!(hop_end.name(), "hop_end");
-
-        let session = ScalarUDF::new_from_impl(SessionWindowStart::new());
-        assert_eq!(session.name(), "session");
-
-        let cumulate = ScalarUDF::new_from_impl(CumulateWindowStart::new());
-        assert_eq!(cumulate.name(), "cumulate");
-
-        let cumulate_end = ScalarUDF::new_from_impl(CumulateWindowEnd::new());
-        assert_eq!(cumulate_end.name(), "cumulate_end");
-    }
-
-    // ── *_end tests ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_tumble_end_basic() {
-        let udf = TumbleWindowEnd::new();
-        // 5-min interval, ts=7min ⇒ window = [5min, 10min) ⇒ end=600_000
-        let result = udf
-            .invoke_with_args(make_args(
-                vec![ts_ms(Some(420_000)), interval_dt(0, 300_000)],
-                1,
-            ))
-            .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(600_000));
-    }
-
-    #[test]
-    fn test_tumble_end_at_boundary() {
-        let udf = TumbleWindowEnd::new();
-        // ts exactly on a boundary: ts=300_000 in 5-min windows ⇒ start=300_000, end=600_000
-        let result = udf
-            .invoke_with_args(make_args(
-                vec![ts_ms(Some(300_000)), interval_dt(0, 300_000)],
-                1,
-            ))
-            .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(600_000));
-    }
-
-    #[test]
-    fn test_tumble_end_null_propagates() {
-        let udf = TumbleWindowEnd::new();
-        let result = udf
-            .invoke_with_args(make_args(vec![ts_ms(None), interval_dt(0, 300_000)], 1))
-            .unwrap();
-        assert_eq!(expect_ts_ms(result), None);
-    }
-
-    #[test]
-    fn test_tumble_end_array_input() {
-        let udf = TumbleWindowEnd::new();
-        let ts_array = TimestampMillisecondArray::from(vec![
-            Some(0),
-            Some(150_000),
-            Some(300_000),
-            Some(420_000),
-            None,
-        ]);
-        let ts = ColumnarValue::Array(Arc::new(ts_array));
-        let interval = interval_dt(0, 300_000);
-
-        let result = udf
-            .invoke_with_args(make_args(vec![ts, interval], 5))
-            .unwrap();
-        match result {
-            ColumnarValue::Array(arr) => {
-                let r = arr.as_primitive::<TimestampMillisecondType>();
-                assert_eq!(r.value(0), 300_000); // start=0,   end=300_000
-                assert_eq!(r.value(1), 300_000); // start=0,   end=300_000
-                assert_eq!(r.value(2), 600_000); // start=300, end=600
-                assert_eq!(r.value(3), 600_000); // start=300, end=600
-                assert!(r.is_null(4));
-            }
-            ColumnarValue::Scalar(_) => panic!("Expected array result"),
-        }
-    }
-
-    /// Regression: TUMBLE_END over a `Timestamp(Nanosecond)` input must
-    /// take the same `to_millis_array` path as TUMBLE.
-    #[test]
-    fn test_tumble_end_array_input_nanosecond() {
-        use arrow_array::TimestampNanosecondArray;
-        let udf = TumbleWindowEnd::new();
-        let ts_array = TimestampNanosecondArray::from(vec![Some(420_000_000_000)]);
-        let ts = ColumnarValue::Array(Arc::new(ts_array));
-        let interval = interval_dt(0, 300_000);
-        let result = udf
-            .invoke_with_args(make_args(vec![ts, interval], 1))
-            .unwrap();
-        match result {
-            ColumnarValue::Array(arr) => {
-                let r = arr.as_primitive::<TimestampMillisecondType>();
-                assert_eq!(r.value(0), 600_000);
-            }
-            ColumnarValue::Scalar(_) => panic!("Expected array result"),
-        }
-    }
-
-    #[test]
-    fn test_tumble_end_rejects_zero_interval() {
-        let udf = TumbleWindowEnd::new();
-        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000)), interval_dt(0, 0)], 1));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_tumble_end_rejects_wrong_arg_count() {
-        let udf = TumbleWindowEnd::new();
-        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000))], 1));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_hop_end_basic() {
-        let udf = HopWindowEnd::new();
-        // slide=5min, size=10min, ts=7min ⇒ earliest start=0, end=600_000
-        let result = udf
-            .invoke_with_args(make_args(
-                vec![
-                    ts_ms(Some(420_000)),
-                    interval_dt(0, 300_000),
-                    interval_dt(0, 600_000),
-                ],
-                1,
-            ))
-            .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(600_000));
-    }
-
-    #[test]
-    fn test_hop_end_rejects_wrong_arg_count() {
-        let udf = HopWindowEnd::new();
-        let result = udf.invoke_with_args(make_args(
-            vec![ts_ms(Some(1000)), interval_dt(0, 300_000)],
-            1,
-        ));
-        assert!(result.is_err());
-    }
+    // ── Cumulate end ────────────────────────────────────────────────────
 
     #[test]
     fn test_cumulate_end_basic() {
-        let udf = CumulateWindowEnd::new();
-        // step=1min, size=5min, ts=30s ⇒ epoch=[0, 300_000) ⇒ end=300_000
-        let result = udf
+        // ts=30 s → epoch=[0, 5 min) → end = 5 min = 300 000 000 µs.
+        let result = CumulateWindowEnd::new()
             .invoke_with_args(make_args(
                 vec![
                     ts_ms(Some(30_000)),
@@ -1428,13 +789,12 @@ mod tests {
                 1,
             ))
             .unwrap();
-        assert_eq!(expect_ts_ms(result), Some(300_000));
+        assert_eq!(expect_ts_us(result), Some(300_000_000));
     }
 
     #[test]
     fn test_cumulate_end_rejects_step_exceeds_size() {
-        let udf = CumulateWindowEnd::new();
-        let result = udf.invoke_with_args(make_args(
+        let result = CumulateWindowEnd::new().invoke_with_args(make_args(
             vec![
                 ts_ms(Some(1000)),
                 interval_dt(0, 600_000),
@@ -1445,37 +805,82 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // ── Registration / signature ────────────────────────────────────────
+
+    #[test]
+    fn test_udf_registration() {
+        for (impl_name, expected) in [
+            (
+                ScalarUDF::new_from_impl(TumbleWindowStart::new())
+                    .name()
+                    .to_string(),
+                "tumble",
+            ),
+            (
+                ScalarUDF::new_from_impl(TumbleWindowEnd::new())
+                    .name()
+                    .to_string(),
+                "tumble_end",
+            ),
+            (
+                ScalarUDF::new_from_impl(HopWindowStart::new())
+                    .name()
+                    .to_string(),
+                "hop",
+            ),
+            (
+                ScalarUDF::new_from_impl(HopWindowEnd::new())
+                    .name()
+                    .to_string(),
+                "hop_end",
+            ),
+            (
+                ScalarUDF::new_from_impl(SessionWindowStart::new())
+                    .name()
+                    .to_string(),
+                "session",
+            ),
+            (
+                ScalarUDF::new_from_impl(CumulateWindowStart::new())
+                    .name()
+                    .to_string(),
+                "cumulate",
+            ),
+            (
+                ScalarUDF::new_from_impl(CumulateWindowEnd::new())
+                    .name()
+                    .to_string(),
+                "cumulate_end",
+            ),
+        ] {
+            assert_eq!(impl_name, expected);
+        }
+    }
+
     #[test]
     fn test_udf_signatures_immutable() {
-        assert_eq!(
-            TumbleWindowStart::new().signature().volatility,
-            Volatility::Immutable
-        );
-        assert_eq!(
-            HopWindowStart::new().signature().volatility,
-            Volatility::Immutable
-        );
-        assert_eq!(
-            SessionWindowStart::new().signature().volatility,
-            Volatility::Immutable
-        );
-        assert_eq!(
-            CumulateWindowStart::new().signature().volatility,
-            Volatility::Immutable
-        );
+        for sig in [
+            TumbleWindowStart::new().signature().clone(),
+            TumbleWindowEnd::new().signature().clone(),
+            HopWindowStart::new().signature().clone(),
+            HopWindowEnd::new().signature().clone(),
+            SessionWindowStart::new().signature().clone(),
+            CumulateWindowStart::new().signature().clone(),
+            CumulateWindowEnd::new().signature().clone(),
+        ] {
+            assert_eq!(sig.volatility, Volatility::Immutable);
+        }
     }
 
     #[test]
-    fn test_tumble_return_type() {
-        let udf = TumbleWindowStart::new();
-        let rt = udf.return_type(&[]).unwrap();
-        assert_eq!(rt, DataType::Timestamp(TimeUnit::Millisecond, None));
-    }
-
-    #[test]
-    fn test_cumulate_return_type() {
-        let udf = CumulateWindowStart::new();
-        let rt = udf.return_type(&[]).unwrap();
-        assert_eq!(rt, DataType::Timestamp(TimeUnit::Millisecond, None));
+    fn test_return_types_microsecond() {
+        let target = DataType::Timestamp(TimeUnit::Microsecond, None);
+        assert_eq!(TumbleWindowStart::new().return_type(&[]).unwrap(), target);
+        assert_eq!(TumbleWindowEnd::new().return_type(&[]).unwrap(), target);
+        assert_eq!(HopWindowStart::new().return_type(&[]).unwrap(), target);
+        assert_eq!(HopWindowEnd::new().return_type(&[]).unwrap(), target);
+        assert_eq!(SessionWindowStart::new().return_type(&[]).unwrap(), target);
+        assert_eq!(CumulateWindowStart::new().return_type(&[]).unwrap(), target);
+        assert_eq!(CumulateWindowEnd::new().return_type(&[]).unwrap(), target);
     }
 }

--- a/crates/laminar-sql/src/datafusion/window_udf.rs
+++ b/crates/laminar-sql/src/datafusion/window_udf.rs
@@ -1,14 +1,27 @@
-//! Window function UDFs for `DataFusion` integration
+//! Scalar UDFs that compute window boundary timestamps for streaming
+//! `GROUP BY TUMBLE(...)` style queries.
 //!
-//! Provides scalar UDFs that compute window start timestamps for
-//! streaming window operations:
+//! Pairs: `tumble`/`tumble_end`, `hop`/`hop_end`, `cumulate`/`cumulate_end`.
+//! `session` is a pass-through (sessions are data-dependent — no row-local
+//! end exists, so there is no `session_end`).
 //!
-//! - [`TumbleWindowStart`] — `tumble(timestamp, interval)` — fixed-size non-overlapping windows
-//! - [`HopWindowStart`] — `hop(timestamp, slide, size)` — fixed-size overlapping windows
-//! - [`SessionWindowStart`] — `session(timestamp, gap)` — pass-through for Ring 0 sessions
+//! Both halves of a pair must appear in `GROUP BY` so DataFusion accepts
+//! them as group keys; they are functionally redundant within a fixed
+//! interval but standard SQL requires every projected non-aggregate to
+//! be in the grouping set. Example:
 //!
-//! These UDFs allow `DataFusion` to execute `GROUP BY TUMBLE(...)` style queries
-//! by computing the window start as a per-row scalar value.
+//! ```sql
+//! SELECT
+//!     TUMBLE(ts, INTERVAL '1' MINUTE)     AS window_start,
+//!     TUMBLE_END(ts, INTERVAL '1' MINUTE) AS window_end,
+//!     symbol,
+//!     MAX(price)
+//! FROM ev
+//! GROUP BY
+//!     TUMBLE(ts, INTERVAL '1' MINUTE),
+//!     TUMBLE_END(ts, INTERVAL '1' MINUTE),
+//!     symbol;
+//! ```
 
 use std::any::Any;
 use std::hash::{Hash, Hasher};
@@ -114,6 +127,95 @@ impl ScalarUDFImpl for TumbleWindowStart {
     }
 }
 
+// ─── TumbleWindowEnd ─────────────────────────────────────────────────────────
+
+/// Computes the tumbling window end for a given timestamp.
+///
+/// `tumble_end(timestamp, interval)` returns `tumble(...) + interval`,
+/// i.e. the exclusive upper bound of the non-overlapping window that
+/// contains `ts`.
+///
+/// Same arguments as [`TumbleWindowStart`].
+#[derive(Debug)]
+pub struct TumbleWindowEnd {
+    signature: Signature,
+}
+
+impl TumbleWindowEnd {
+    /// Creates a new tumble window end UDF.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(
+                TypeSignature::OneOf(vec![TypeSignature::Any(2), TypeSignature::Any(3)]),
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl Default for TumbleWindowEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for TumbleWindowEnd {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for TumbleWindowEnd {}
+
+impl Hash for TumbleWindowEnd {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "tumble_end".hash(state);
+    }
+}
+
+impl ScalarUDFImpl for TumbleWindowEnd {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "tumble_end"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        if args.len() < 2 || args.len() > 3 {
+            return Err(DataFusionError::Plan(
+                "tumble_end() requires 2-3 arguments: (timestamp, interval [, offset])".to_string(),
+            ));
+        }
+        let interval_ms = extract_interval_ms(&args[1])?;
+        if interval_ms <= 0 {
+            return Err(DataFusionError::Plan(
+                "tumble_end() interval must be positive".to_string(),
+            ));
+        }
+        let offset_ms = if args.len() == 3 {
+            extract_interval_ms(&args[2])?
+        } else {
+            0
+        };
+        shift_timestamp_ms(
+            &compute_tumble_with_offset(&args[0], interval_ms, offset_ms)?,
+            interval_ms,
+        )
+    }
+}
+
 // ─── HopWindowStart ──────────────────────────────────────────────────────────
 
 /// Computes the earliest hopping window start for a given timestamp.
@@ -206,6 +308,95 @@ impl ScalarUDFImpl for HopWindowStart {
             0
         };
         compute_hop_with_offset(&args[0], slide_ms, size_ms, offset_ms)
+    }
+}
+
+// ─── HopWindowEnd ────────────────────────────────────────────────────────────
+
+/// Computes the hopping window end for a given timestamp.
+///
+/// `hop_end(timestamp, slide, size)` returns the *end* of the earliest
+/// hopping window of `size` (sliding by `slide`) that contains `ts`,
+/// i.e. `hop(...) + size`. Same multi-window caveat as
+/// [`HopWindowStart`]: only the earliest window's end is returned.
+#[derive(Debug)]
+pub struct HopWindowEnd {
+    signature: Signature,
+}
+
+impl HopWindowEnd {
+    /// Creates a new hop window end UDF.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(
+                TypeSignature::OneOf(vec![TypeSignature::Any(3), TypeSignature::Any(4)]),
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl Default for HopWindowEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for HopWindowEnd {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for HopWindowEnd {}
+
+impl Hash for HopWindowEnd {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "hop_end".hash(state);
+    }
+}
+
+impl ScalarUDFImpl for HopWindowEnd {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "hop_end"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        if args.len() < 3 || args.len() > 4 {
+            return Err(DataFusionError::Plan(
+                "hop_end() requires 3-4 arguments: (timestamp, slide, size [, offset])".to_string(),
+            ));
+        }
+        let slide_ms = extract_interval_ms(&args[1])?;
+        let size_ms = extract_interval_ms(&args[2])?;
+        if slide_ms <= 0 || size_ms <= 0 {
+            return Err(DataFusionError::Plan(
+                "hop_end() slide and size must be positive".to_string(),
+            ));
+        }
+        let offset_ms = if args.len() == 4 {
+            extract_interval_ms(&args[3])?
+        } else {
+            0
+        };
+        shift_timestamp_ms(
+            &compute_hop_with_offset(&args[0], slide_ms, size_ms, offset_ms)?,
+            size_ms,
+        )
     }
 }
 
@@ -388,6 +579,94 @@ impl ScalarUDFImpl for CumulateWindowStart {
         }
         // Return epoch start = floor(ts / size) * size (same as tumble with size)
         compute_tumble(&args[0], size_ms)
+    }
+}
+
+// ─── CumulateWindowEnd ──────────────────────────────────────────────────────
+
+/// Computes the cumulate epoch end for a given timestamp.
+///
+/// `cumulate_end(timestamp, step, size)` returns the exclusive upper
+/// bound of the epoch (size-aligned bucket) that contains `ts`, i.e.
+/// `cumulate(...) + size`. The actual per-step cumulating boundary
+/// (which is data-determined within the epoch) is exposed by Ring 0.
+#[derive(Debug)]
+pub struct CumulateWindowEnd {
+    signature: Signature,
+}
+
+impl CumulateWindowEnd {
+    /// Creates a new cumulate window end UDF.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(TypeSignature::Any(3), Volatility::Immutable),
+        }
+    }
+}
+
+impl Default for CumulateWindowEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for CumulateWindowEnd {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for CumulateWindowEnd {}
+
+impl Hash for CumulateWindowEnd {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        "cumulate_end".hash(state);
+    }
+}
+
+impl ScalarUDFImpl for CumulateWindowEnd {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &'static str {
+        "cumulate_end"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        if args.len() != 3 {
+            return Err(DataFusionError::Plan(
+                "cumulate_end() requires exactly 3 arguments: (timestamp, step, size)".to_string(),
+            ));
+        }
+        let step_ms = extract_interval_ms(&args[1])?;
+        let size_ms = extract_interval_ms(&args[2])?;
+        if step_ms <= 0 || size_ms <= 0 {
+            return Err(DataFusionError::Plan(
+                "cumulate_end() step and size must be positive".to_string(),
+            ));
+        }
+        if step_ms > size_ms {
+            return Err(DataFusionError::Plan(
+                "cumulate_end() step must not exceed size".to_string(),
+            ));
+        }
+        if size_ms % step_ms != 0 {
+            return Err(DataFusionError::Plan(
+                "cumulate_end() size must be evenly divisible by step".to_string(),
+            ));
+        }
+        shift_timestamp_ms(&compute_tumble(&args[0], size_ms)?, size_ms)
     }
 }
 
@@ -613,6 +892,33 @@ fn compute_hop_array_with_offset(
 fn convert_to_timestamp_ms_array(array: &ArrayRef) -> Result<ArrayRef> {
     let ms = to_millis_array(array)?;
     Ok(Arc::new(ms))
+}
+
+/// Shifts every non-null `TimestampMillisecond` in `value` forward by
+/// `delta_ms`. Used by the `*_end` UDFs to derive the window upper bound
+/// from the corresponding window start. Saturating add keeps overflow
+/// well-defined; null inputs propagate.
+fn shift_timestamp_ms(value: &ColumnarValue, delta_ms: i64) -> Result<ColumnarValue> {
+    match value {
+        ColumnarValue::Array(array) => {
+            let input = to_millis_array(array)?;
+            let result: TimestampMillisecondArray = input
+                .iter()
+                .map(|opt_ts| opt_ts.map(|ts| ts.saturating_add(delta_ms)))
+                .collect();
+            Ok(ColumnarValue::Array(Arc::new(result)))
+        }
+        ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(opt, tz)) => {
+            let shifted = opt.map(|ts| ts.saturating_add(delta_ms));
+            Ok(ColumnarValue::Scalar(ScalarValue::TimestampMillisecond(
+                shifted,
+                tz.clone(),
+            )))
+        }
+        ColumnarValue::Scalar(other) => Err(DataFusionError::Plan(format!(
+            "expected TimestampMillisecond from window-start helper, got: {other:?}"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -977,14 +1283,182 @@ mod tests {
         let tumble = ScalarUDF::new_from_impl(TumbleWindowStart::new());
         assert_eq!(tumble.name(), "tumble");
 
+        let tumble_end = ScalarUDF::new_from_impl(TumbleWindowEnd::new());
+        assert_eq!(tumble_end.name(), "tumble_end");
+
         let hop = ScalarUDF::new_from_impl(HopWindowStart::new());
         assert_eq!(hop.name(), "hop");
+
+        let hop_end = ScalarUDF::new_from_impl(HopWindowEnd::new());
+        assert_eq!(hop_end.name(), "hop_end");
 
         let session = ScalarUDF::new_from_impl(SessionWindowStart::new());
         assert_eq!(session.name(), "session");
 
         let cumulate = ScalarUDF::new_from_impl(CumulateWindowStart::new());
         assert_eq!(cumulate.name(), "cumulate");
+
+        let cumulate_end = ScalarUDF::new_from_impl(CumulateWindowEnd::new());
+        assert_eq!(cumulate_end.name(), "cumulate_end");
+    }
+
+    // ── *_end tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_tumble_end_basic() {
+        let udf = TumbleWindowEnd::new();
+        // 5-min interval, ts=7min ⇒ window = [5min, 10min) ⇒ end=600_000
+        let result = udf
+            .invoke_with_args(make_args(
+                vec![ts_ms(Some(420_000)), interval_dt(0, 300_000)],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_ms(result), Some(600_000));
+    }
+
+    #[test]
+    fn test_tumble_end_at_boundary() {
+        let udf = TumbleWindowEnd::new();
+        // ts exactly on a boundary: ts=300_000 in 5-min windows ⇒ start=300_000, end=600_000
+        let result = udf
+            .invoke_with_args(make_args(
+                vec![ts_ms(Some(300_000)), interval_dt(0, 300_000)],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_ms(result), Some(600_000));
+    }
+
+    #[test]
+    fn test_tumble_end_null_propagates() {
+        let udf = TumbleWindowEnd::new();
+        let result = udf
+            .invoke_with_args(make_args(vec![ts_ms(None), interval_dt(0, 300_000)], 1))
+            .unwrap();
+        assert_eq!(expect_ts_ms(result), None);
+    }
+
+    #[test]
+    fn test_tumble_end_array_input() {
+        let udf = TumbleWindowEnd::new();
+        let ts_array = TimestampMillisecondArray::from(vec![
+            Some(0),
+            Some(150_000),
+            Some(300_000),
+            Some(420_000),
+            None,
+        ]);
+        let ts = ColumnarValue::Array(Arc::new(ts_array));
+        let interval = interval_dt(0, 300_000);
+
+        let result = udf
+            .invoke_with_args(make_args(vec![ts, interval], 5))
+            .unwrap();
+        match result {
+            ColumnarValue::Array(arr) => {
+                let r = arr.as_primitive::<TimestampMillisecondType>();
+                assert_eq!(r.value(0), 300_000); // start=0,   end=300_000
+                assert_eq!(r.value(1), 300_000); // start=0,   end=300_000
+                assert_eq!(r.value(2), 600_000); // start=300, end=600
+                assert_eq!(r.value(3), 600_000); // start=300, end=600
+                assert!(r.is_null(4));
+            }
+            ColumnarValue::Scalar(_) => panic!("Expected array result"),
+        }
+    }
+
+    /// Regression: TUMBLE_END over a `Timestamp(Nanosecond)` input must
+    /// take the same `to_millis_array` path as TUMBLE.
+    #[test]
+    fn test_tumble_end_array_input_nanosecond() {
+        use arrow_array::TimestampNanosecondArray;
+        let udf = TumbleWindowEnd::new();
+        let ts_array = TimestampNanosecondArray::from(vec![Some(420_000_000_000)]);
+        let ts = ColumnarValue::Array(Arc::new(ts_array));
+        let interval = interval_dt(0, 300_000);
+        let result = udf
+            .invoke_with_args(make_args(vec![ts, interval], 1))
+            .unwrap();
+        match result {
+            ColumnarValue::Array(arr) => {
+                let r = arr.as_primitive::<TimestampMillisecondType>();
+                assert_eq!(r.value(0), 600_000);
+            }
+            ColumnarValue::Scalar(_) => panic!("Expected array result"),
+        }
+    }
+
+    #[test]
+    fn test_tumble_end_rejects_zero_interval() {
+        let udf = TumbleWindowEnd::new();
+        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000)), interval_dt(0, 0)], 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tumble_end_rejects_wrong_arg_count() {
+        let udf = TumbleWindowEnd::new();
+        let result = udf.invoke_with_args(make_args(vec![ts_ms(Some(1000))], 1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hop_end_basic() {
+        let udf = HopWindowEnd::new();
+        // slide=5min, size=10min, ts=7min ⇒ earliest start=0, end=600_000
+        let result = udf
+            .invoke_with_args(make_args(
+                vec![
+                    ts_ms(Some(420_000)),
+                    interval_dt(0, 300_000),
+                    interval_dt(0, 600_000),
+                ],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_ms(result), Some(600_000));
+    }
+
+    #[test]
+    fn test_hop_end_rejects_wrong_arg_count() {
+        let udf = HopWindowEnd::new();
+        let result = udf.invoke_with_args(make_args(
+            vec![ts_ms(Some(1000)), interval_dt(0, 300_000)],
+            1,
+        ));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cumulate_end_basic() {
+        let udf = CumulateWindowEnd::new();
+        // step=1min, size=5min, ts=30s ⇒ epoch=[0, 300_000) ⇒ end=300_000
+        let result = udf
+            .invoke_with_args(make_args(
+                vec![
+                    ts_ms(Some(30_000)),
+                    interval_dt(0, 60_000),
+                    interval_dt(0, 300_000),
+                ],
+                1,
+            ))
+            .unwrap();
+        assert_eq!(expect_ts_ms(result), Some(300_000));
+    }
+
+    #[test]
+    fn test_cumulate_end_rejects_step_exceeds_size() {
+        let udf = CumulateWindowEnd::new();
+        let result = udf.invoke_with_args(make_args(
+            vec![
+                ts_ms(Some(1000)),
+                interval_dt(0, 600_000),
+                interval_dt(0, 300_000),
+            ],
+            1,
+        ));
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/laminar-sql/src/translator/window_translator.rs
+++ b/crates/laminar-sql/src/translator/window_translator.rs
@@ -5,8 +5,6 @@
 
 use std::time::Duration;
 
-use arrow_schema::{DataType, Field};
-
 use crate::parser::{
     EmitClause, EmitStrategy, LateDataClause, ParseError, WindowFunction, WindowRewriter,
 };
@@ -128,16 +126,6 @@ impl std::fmt::Display for WindowOperatorConfig {
 }
 
 impl WindowOperatorConfig {
-    /// Fields the window operator prepends to every output batch.
-    /// Single source of truth for the windowed-stream output contract.
-    #[must_use]
-    pub fn output_prefix_fields() -> Vec<Field> {
-        vec![
-            Field::new("window_start", DataType::Int64, false),
-            Field::new("window_end", DataType::Int64, false),
-        ]
-    }
-
     /// Create a new tumbling window configuration.
     #[must_use]
     pub fn tumbling(time_column: String, size: Duration) -> Self {


### PR DESCRIPTION
## Summary

- Drop the magic `window_start, window_end NOT NULL` prepend that previously appeared at four sites (`pipeline_lifecycle::resolve_stream_output_schemas`, `aggregate_state::emit_window_batch`, both EOWC and `CoreWindowState` `output_schema` builders, and `CoreWindowState::apply_post_projection`).
- Add three scalar UDFs — `tumble_end`, `hop_end`, `cumulate_end` — alongside the existing `tumble` / `hop` / `cumulate` start-side UDFs. Users that want window boundary columns project them explicitly in `SELECT` and add them to `GROUP BY`. No `session_end` is added — sessions are data-dependent and have no row-local end.
- After this change schema-claim, EOWC emit, and any downstream sink all see exactly `[group_cols..., agg_outputs...]` — what the user's `SELECT` plans to.

## Why

The two derivation paths could disagree once a post-aggregate projection landed:

- `pipeline_lifecycle::resolve_stream_output_schemas` built the schema sent to sinks as `[window_start, window_end] ++ plan.schema()`.
- `core_window_state::apply_post_projection` produced batches whose actual content was the post-projection output (no implicit `window_start`/`window_end`).

The Iceberg sink with `auto.create='true'` would author a wider table from the schema claim, then reject every commit with:

```
schema mismatch: Iceberg column 'window_start' is NOT NULL but missing from pipeline
```

Users had no SQL-level workaround: DataFusion's planner doesn't know `window_start` as a virtual column (`TUMBLE` is a `ScalarUDF`, not a UDTF), so `SELECT window_start, ...` is rejected with `No field named window_start. Valid fields are <source cols>.`

## User-visible change

```sql
-- before (broken on lakehouse sinks):
CREATE MATERIALIZED VIEW ohlc_1m AS
SELECT symbol, FIRST_VALUE(price) AS open, MAX(price) AS high, ...
FROM trades
GROUP BY TUMBLE(ts, INTERVAL '1' MINUTE), symbol
EMIT ON WINDOW CLOSE;

-- after:
CREATE MATERIALIZED VIEW ohlc_1m AS
SELECT
    TUMBLE(ts, INTERVAL '1' MINUTE)     AS window_start,
    TUMBLE_END(ts, INTERVAL '1' MINUTE) AS window_end,
    symbol,
    FIRST_VALUE(price) AS open,
    MAX(price)         AS high,
    MIN(price)         AS low,
    LAST_VALUE(price)  AS close,
    SUM(qty)           AS volume,
    SUM(price * qty)   AS notional,
    COUNT(*)           AS tick_count
FROM trades
GROUP BY
    TUMBLE(ts, INTERVAL '1' MINUTE),
    TUMBLE_END(ts, INTERVAL '1' MINUTE),
    symbol
EMIT ON WINDOW CLOSE;
```

Both `TUMBLE` and `TUMBLE_END` must appear in `GROUP BY` because DataFusion treats them as independent group keys (it can't see they are functionally redundant within a fixed interval). Same pattern for `HOP` / `HOP_END` and `CUMULATE` / `CUMULATE_END`.

This mirrors Flink's pre-1.13 `TUMBLE_START` / `TUMBLE_END` syntax. Materialize and ksqlDB use similar pseudo-column or function-based patterns. Going through DataFusion's existing `ScalarUDF` machinery means no analyzer-rule additions and no fork.

## Backwards compatibility

Behavior change for any windowed materialized view that was relying on the auto-prepended `window_start` / `window_end` columns. The fix is mechanical — add `TUMBLE_END(ts, INTERVAL …) AS window_end` to the `SELECT` and to `GROUP BY`. Per repo memory there are no external users of LaminarDB, so no compat shim shipped.

## Test plan

- [x] `cargo test -p laminar-db -p laminar-sql --lib --no-default-features` — 869/869 pass on Windows
- [x] `cargo clippy -p laminar-db -p laminar-sql --tests -- -D warnings` clean
- [x] `cargo fmt --check -p laminar-db -p laminar-sql` clean
- [x] 11 new unit tests for the `*_end` UDFs (basic, boundary, null, array path, nanosecond regression, arg-count rejection, divisibility for cumulate)
- [x] New resolver-level integration test `windowed_stream_with_explicit_window_columns` exercises the full `tumble + tumble_end` projection path
- [x] Three hopping/checkpoint tests rewritten from "collect-and-compare-literal" to "iterative close-by-watermark", which is the correct invariant now that `window_start` isn't emitted
- [ ] End-to-end Kafka → 1-minute OHLC → Iceberg demo (separate PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-prepending `window_start/window_end` and introduces `tumble_end`, `hop_end`, and `cumulate_end` UDFs that return microsecond timestamps. Also fixes emit-once for windowed MVs by preserving `EMIT ON WINDOW CLOSE`, persisting a high watermark, applying per-window late-event drops (correct for hopping and offset windows), and clarifies barrier checkpoint outcomes with a typed `BarrierOutcome`.

- New Features
  - Added UDFs: `tumble_end`, `hop_end`, `cumulate_end` (registered in both `register_streaming_functions` paths); `cumulate_end` enforces `step ≤ size` and divisibility.
  - Window-time UDFs return `Timestamp(Microsecond)`; math remains in ms.
  - Windowed outputs are `[group_cols..., agg_outputs...]` across Core/EOWC; no implicit columns and no `session_end`.
  - Pipeline checkpoints now return `BarrierOutcome` with `Skipped(SkipReason)` vs `Failed`, reducing noisy WARNs for deliberate skips.

- Migration
  - Project and group by both start and end, e.g. `SELECT TUMBLE(...) AS window_start, TUMBLE_END(...) AS window_end ... GROUP BY TUMBLE(...), TUMBLE_END(...), ...`.
  - For sessions, add explicit boundaries if needed (e.g., `MIN(ts)` / `MAX(ts)`).
  - Downstream sinks now receive exactly the SELECT schema.

<sup>Written for commit ff6a443e1e2a7ce8148d2228e86008a03ec00ebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added window-end functions: tumble_end, hop_end, cumulate_end.

* **Changes**
  - Windowed aggregate outputs no longer include automatic window_start/window_end columns.
  - Window timestamp UDFs now return microsecond precision.
  - Late events beyond the watermark are suppressed to avoid duplicate/late updates.
  - EMIT clause is preserved when creating materialized views.
  - Checkpoint/barrier handling improved to report richer outcomes.
  - Workspace version bumped to 0.22.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/382)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->