### PR TITLE
docs: refresh public docs for 0.22, tighten tone, drop stale sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Why
 
-<!-- Explain the motivation — link to an issue or describe the problem you're solving. -->
+<!-- Explain the motivation. Link to an issue or describe the problem you're solving. -->
 
 ## How
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,84 @@
 # Changelog
 
+## [0.22.0]
+
+### Added
+
+- **Postgres wire protocol, production hardening**: full TLS path on
+  the SUBSCRIBE listener: `pgwire_tls_min_version` to pin TLS 1.3
+  (`bcab5471`, #12), optional mTLS via `pgwire_tls_client_ca` using
+  `WebPkiClientVerifier` (`88e2af46`, #10), in-place hot reload of the
+  `TlsAcceptor` via a `notify` watcher with debounce (`2cad3d54`, #11),
+  and `pg_authid`-style pre-hashed `md5{32-hex}` passwords in
+  `pgwire_users` so plaintext never has to live in `laminardb.toml`
+  (`a3376408`, #7).
+- **Extended-query + binary format** on the pgwire listener (`95fa8a74`).
+- **SQL-level cursors**: `DECLARE c CURSOR FOR SUBSCRIBE …` +
+  `FETCH n FROM c` for libpq clients with `\set FETCH_COUNT n`
+  (`ab49408e`).
+- **Explicit window-edge columns**: `tumble_end`, `hop_end`,
+  `cumulate_end` UDFs return the window-end timestamp directly
+  (`0a5b862e`).
+
+### Changed
+
+- **`DbState` collapse** (#381): removed the dual representation that
+  carried both the in-flight `LaminarDB` handle and a snapshot of its
+  contents. Trims docs/restated state.
+
+## [0.21.0]
+
+### Added
+
+- **SUBSCRIBE over the Postgres wire protocol** (#369): `psql`, JDBC,
+  asyncpg, and any libpq client can tail a stream or materialized view.
+  Includes the listener itself, MD5 password auth, TLS, and a
+  stream-side schema layer for `WHERE` push-down.
+- **Pgwire hardening** (#371): connection caps, per-client throttling,
+  certificate expiry warnings.
+- **`RETAIN HISTORY` + `AS OF EPOCH`** (#373): `CREATE STREAM … WITH
+  ('retain_history' = '64mb')` keeps a bounded ring of recent committed
+  epochs in memory; `SUBSCRIBE … AS OF EPOCH n` resumes from epoch `n`
+  so a reconnecting client doesn't miss rows produced during the
+  disconnect.
+- **Materialized view result storage and queryability** (#319): MV
+  output is persisted via `mv_store` and exposed through a DataFusion
+  `TableProvider`, so `SELECT * FROM mv_name` works after the pipeline
+  has produced results.
+- **Push-based WebSocket stream subscriptions** (#329): replaces the
+  earlier poll loop on `/ws/{name}`.
+- **Self-join pre-filtering** (#321): predicate analysis on
+  `FROM a JOIN a …` cuts N² buffer growth before the join executes.
+- **OTel demo + connector cleanup** (#317): schema auto-discovery,
+  cleaner connector registration surface.
+- **Production-grade Prometheus metrics** (#339): pipeline counters,
+  cycle duration percentiles, checkpoint telemetry, sink error/timeout
+  counters, per-connector gauges.
+- **Throttled checkpoint barrier retries** (#327): back off rather
+  than spin when a sink times out; clears `sink_timed_out` on success.
+
+### Removed (dead-code waves)
+
+- **#315**: Window operator unification deleted ≈13K LOC of DAG-only
+  window operators.
+- **#316**: Removed ≈23K LOC of dead DAG / checkpoint / storage paths
+  (`core/dag/`, `core/state/`, `storage/checkpoint/`, `incremental/`,
+  `wal.rs`). The single `StreamingCoordinator` tokio task is now the
+  only execution path.
+- **#320 / #326**: Removed ≈5K LOC from `laminar-db`, including the
+  old `StreamExecutor` (4,652 LOC).
+
+These deletions are not backwards-compatible. There were no public
+APIs touched, but checkpoints from 0.20.x cannot be restored on 0.21+.
+
 ## [0.20.2]
 
 ### Added
 
-- **Production-grade Prometheus metrics** (#339) — expanded `/metrics`
+- **Production-grade Prometheus metrics** (#339): expanded `/metrics`
   with pipeline counters, cycle duration percentiles, checkpoint
   telemetry, sink error/timeout counters, and per-connector gauges.
-- **Temporal probe join DDL round-trip** — `CREATE STREAM` and
+- **Temporal probe join DDL round-trip**: `CREATE STREAM` and
   `CREATE MATERIALIZED VIEW` now preserve the raw query text between
   `AS` and `EMIT` via a `query_sql` field on the AST, so custom
   streaming syntax (e.g. `TEMPORAL PROBE JOIN ... LIST (...)`,
@@ -16,47 +87,47 @@
 
 ### Changed / Removed
 
-- **Removed `WatermarkDynamicFilter`** (#338) — the dead dynamic
+- **Removed `WatermarkDynamicFilter`** (#338): the dead dynamic
   filter module was deleted. Watermark-based row filtering now runs
   through the standard streaming scan path.
 - **Moved `examples/microstructure/pipeline.sql`** to use `TIMESTAMP`
   for the event-time column `"T"` (matches the v0.20.1 timestamp
   migration).
-- **Deleted stale planning docs** — `docs/features/INDEX.md` and the
+- **Deleted stale planning docs**: `docs/features/INDEX.md` and the
   `docs/plans/` directory were removed. `docs/ROADMAP.md` is the
   canonical feature tracker.
 
 ### Fixed
 
-- **Watermark fallback wiring** (#337) — `max.out.of.orderness.ms` is
+- **Watermark fallback wiring** (#337): `max.out.of.orderness.ms` is
   now respected when event-time extraction falls back to default
   generators. The attestation gate on the fallback path was removed.
-- **Session window cardinality + CDC / sink shutdown** (#335) —
+- **Session window cardinality + CDC / sink shutdown** (#335):
   session windows cap per-key sessions to prevent unbounded state
   growth; sinks and CDC sources shut down cleanly when the pipeline
   stops.
 
 ## [0.20.1]
 
-### Breaking — Timestamp column migration
+### Breaking: Timestamp column migration
 
 Event-time columns throughout LaminarDB now use Arrow `Timestamp(_)`
 instead of `Int64`-as-epoch-millis. The `interval_rewriter` is gone;
 DataFusion handles `Timestamp ± INTERVAL` arithmetic natively.
 
 **Schema changes in connector-produced columns:**
-- OTel `_laminar_received_at` — `Int64` → `Timestamp(Nanosecond)`
-- Postgres / MySQL CDC `_ts_ms` — `Int64` → `Timestamp(Millisecond)`
-- Kafka metadata `_timestamp` — `Int64` → `Timestamp(Millisecond)`
-- MongoDB CDC `_wall_time_ms` — `Int64` → `Timestamp(Millisecond)`
-- Files `_metadata.file_modification_time` — `Int64` → `Timestamp(Millisecond)`
-- WebSocket `event.time.field` extraction — now reads any `Timestamp(_)`
+- OTel `_laminar_received_at`: `Int64` → `Timestamp(Nanosecond)`
+- Postgres / MySQL CDC `_ts_ms`: `Int64` → `Timestamp(Millisecond)`
+- Kafka metadata `_timestamp`: `Int64` → `Timestamp(Millisecond)`
+- MongoDB CDC `_wall_time_ms`: `Int64` → `Timestamp(Millisecond)`
+- Files `_metadata.file_modification_time`: `Int64` → `Timestamp(Millisecond)`
+- WebSocket `event.time.field` extraction: now reads any `Timestamp(_)`
 
 **User-facing SQL changes:**
 - Event-time DDL must declare `TIMESTAMP`, not `BIGINT`. Hand-written
   sources that used `ts BIGINT, WATERMARK FOR ts` need to switch to
   `ts TIMESTAMP, WATERMARK FOR ts AS ts - INTERVAL 'N' SECOND`.
-- `INTERVAL` arithmetic is now native on `TIMESTAMP` columns —
+- `INTERVAL` arithmetic is now native on `TIMESTAMP` columns.
   `ts BETWEEN t - INTERVAL '10' SECOND AND t + INTERVAL '10' SECOND`
   works. The old `t - 10000` numeric-arithmetic trick is no longer
   required.
@@ -67,12 +138,12 @@ DataFusion handles `Timestamp ± INTERVAL` arithmetic natively.
 **Removed APIs:**
 - `laminar_sql::parser::interval_rewriter` module
 - `laminar_core::time::TimestampFormat` enum
-- `EventTimeExtractor::from_column(name, format)` — now takes only `name`
+- `EventTimeExtractor::from_column(name, format)`: now takes only `name`
 - `laminar_db::db::infer_timestamp_format`
 - `laminar_db::sql_analysis::infer_ts_format_from_batch`
 
 **New APIs:**
-- `laminar_core::time::cast_to_millis_array` — shared helper that
+- `laminar_core::time::cast_to_millis_array`: shared helper that
   normalises any `Timestamp(_)` array to `TimestampMillisecondArray`
   via Arrow's cast kernel. Used by the window UDFs, event-time
   extractor, interval-join key helper, and the WebSocket parser.
@@ -82,7 +153,7 @@ DataFusion handles `Timestamp ± INTERVAL` arithmetic natively.
   errors with "Unsupported timestamp type" at runtime.
 - Interval joins over `Timestamp(Nanosecond)` columns no longer
   error when extracting join keys.
-- OTel `_laminar_received_at` unit-inference bug — windows that
+- OTel `_laminar_received_at` unit-inference bug. Windows that
   used to be silently 1,000,000× smaller than declared (nanos
   treated as millis) now use real wall-clock durations.
 - `WATERMARK FOR` in TOML config composes with connector schema
@@ -90,16 +161,16 @@ DataFusion handles `Timestamp ± INTERVAL` arithmetic natively.
   validated against the discovered schema instead of bailing out.
 
 **Migration notes:**
-- Existing checkpoints from v0.20.0 are **not** compatible — they
+- Existing checkpoints from v0.20.0 are **not** compatible. They
   reference Int64 timestamp columns in serialized operator state.
   Wipe `./data/checkpoints` before starting the server on v0.20.1.
 - Hand-written SQL with `ts BIGINT` needs to change to `ts TIMESTAMP`
   if the column is used in a watermark or window. Plain `BIGINT`
   columns unrelated to event time are unchanged.
 
-## [0.20.0] and earlier — notable additions
+## [0.20.0] and earlier: notable additions
 
-### Added — MongoDB CDC Source & Sink (`mongodb-cdc` feature) — PR #255
+### Added: MongoDB CDC Source & Sink (`mongodb-cdc` feature, PR #255)
 
 Landed in the 0.20.x line via PR #255; the API surface below is what
 the `mongodb-cdc` feature exposes today.
@@ -107,50 +178,50 @@ the `mongodb-cdc` feature exposes today.
 New public API symbols in `laminar_connectors::mongodb`:
 
 **Source Connector**
-- `MongoDbCdcSource` — `SourceConnector` impl for MongoDB change streams
-- `MongoDbSourceConfig` — connection, pipeline, full document mode config
-- `FullDocumentMode` — Delta / UpdateLookup / RequirePostImage / WhenAvailable
-- `mongodb_cdc_envelope_schema()` — Arrow schema for CDC envelope records
+- `MongoDbCdcSource`: `SourceConnector` impl for MongoDB change streams
+- `MongoDbSourceConfig`: connection, pipeline, full document mode config
+- `FullDocumentMode`: Delta / UpdateLookup / RequirePostImage / WhenAvailable
+- `mongodb_cdc_envelope_schema()`: Arrow schema for CDC envelope records
 
 **Sink Connector**
-- `MongoDbSink` — `SinkConnector` impl for MongoDB writes
-- `MongoDbSinkConfig` — connection, batching, write concern config
-- `WriteMode` — Insert / Upsert / Replace / CdcReplay
-- `WriteConcernConfig`, `WriteConcernLevel` — write durability settings
+- `MongoDbSink`: `SinkConnector` impl for MongoDB writes
+- `MongoDbSinkConfig`: connection, batching, write concern config
+- `WriteMode`: Insert / Upsert / Replace / CdcReplay
+- `WriteConcernConfig`, `WriteConcernLevel`: write durability settings
 
 **Change Events**
-- `MongoDbChangeEvent` — typed change stream event
-- `OperationType` — Insert / Update / Replace / Delete / Drop / Rename / Invalidate
-- `UpdateDescription` — delta fields for update events
-- `Namespace` — database + collection pair
-- `TruncatedArray` — truncated array metadata (MongoDB 6.0+)
+- `MongoDbChangeEvent`: typed change stream event
+- `OperationType`: Insert / Update / Replace / Delete / Drop / Rename / Invalidate
+- `UpdateDescription`: delta fields for update events
+- `Namespace`: database + collection pair
+- `TruncatedArray`: truncated array metadata (MongoDB 6.0+)
 
 **Resume Token Persistence**
-- `ResumeTokenStore` trait — pluggable async persistence
-- `ResumeToken` — opaque resume token wrapper
-- `FileResumeTokenStore` — file-based persistence (embedded/test)
-- `MongoResumeTokenStore` — MongoDB-backed persistence (production, feature-gated)
-- `InMemoryResumeTokenStore` — in-memory persistence (testing)
-- `ResumeTokenStoreConfig` — configuration enum (File / Mongo / Memory)
+- `ResumeTokenStore` trait: pluggable async persistence
+- `ResumeToken`: opaque resume token wrapper
+- `FileResumeTokenStore`: file-based persistence (embedded/test)
+- `MongoResumeTokenStore`: MongoDB-backed persistence (production, feature-gated)
+- `InMemoryResumeTokenStore`: in-memory persistence (testing)
+- `ResumeTokenStoreConfig`: configuration enum (File / Mongo / Memory)
 
 **Time Series Support**
-- `CollectionKind` — Standard / TimeSeries
-- `TimeSeriesConfig` — time field, meta field, granularity, TTL
-- `TimeSeriesGranularity` — Seconds / Minutes / Hours / Custom
+- `CollectionKind`: Standard / TimeSeries
+- `TimeSeriesConfig`: time field, meta field, granularity, TTL
+- `TimeSeriesGranularity`: Seconds / Minutes / Hours / Custom
 
 **Large Event Handling**
-- `LargeEventReassembler` — fragment reassembly for split events (MongoDB ≥ 6.0.9)
-- `EventFragment`, `SplitEventInfo` — fragment types
+- `LargeEventReassembler`: fragment reassembly for split events (MongoDB ≥ 6.0.9)
+- `EventFragment`, `SplitEventInfo`: fragment types
 
 **Write Model**
-- `MongoWriteOp` — InsertOne / ReplaceOne / UpdateOne / DeleteOne / Lifecycle
-- `build_update_document()` — $set/$unset update document builder
-- `cdc_replay_op()` — operation type to write op translation
+- `MongoWriteOp`: InsertOne / ReplaceOne / UpdateOne / DeleteOne / Lifecycle
+- `build_update_document()`: $set/$unset update document builder
+- `cdc_replay_op()`: operation type to write op translation
 
 **Metrics**
-- `MongoSourceMetrics` — lock-free source connector metrics
-- `MongoSinkMetrics` — lock-free sink connector metrics
+- `MongoSourceMetrics`: lock-free source connector metrics
+- `MongoSinkMetrics`: lock-free sink connector metrics
 
 **Registry**
-- `register_mongodb_cdc()` — registers source with ConnectorRegistry
-- `register_mongodb_sink()` — registers sink with ConnectorRegistry
+- `register_mongodb_cdc()`: registers source with ConnectorRegistry
+- `register_mongodb_sink()`: registers sink with ConnectorRegistry

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 
 # LaminarDB
 
-A streaming SQL engine for Rust — embed it in your process or run it standalone.
-
-Stream processing today means running a JVM cluster (Flink), paying for a managed service (RisingWave, Confluent), or hand-rolling state machines. LaminarDB brings continuous SQL queries, event-time windowing, and exactly-once checkpointing to a single Rust crate. Rust gives you predictable latency without GC pauses and memory safety without a runtime. No JVM. No cluster. `cargo add laminar-db` and go.
+A streaming SQL engine for Rust. Embed it as a library or run the standalone server. Continuous queries, event-time windows, exactly-once checkpoints. No JVM, no cluster required.
 
 ## Quick Start
 
@@ -17,7 +15,7 @@ Stream processing today means running a JVM cluster (Flink), paying for a manage
 
 ```toml
 [dependencies]
-laminar-db = "0.21"
+laminar-db = "0.22"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -56,7 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-This example compiles and runs against the `laminar-db` v0.21 public API. See [`examples/binance-ws`](examples/binance-ws) for a complete working demo that streams live Binance trades through 18 SQL pipeline stages with a TUI dashboard.
+This example compiles and runs against the `laminar-db` v0.22 public API. See [`examples/binance-ws`](examples/binance-ws) for a complete working demo that streams live Binance trades through 18 SQL pipeline stages with a TUI dashboard.
 
 ### Python
 
@@ -81,19 +79,15 @@ conn.close()
 
 ---
 
-## What It Is
+## Deployment modes
 
-LaminarDB is a streaming SQL engine built on [Apache Arrow](https://arrow.apache.org/) and [DataFusion](https://datafusion.apache.org/). It runs continuous queries over unbounded data streams, manages windowed state, and handles event-time semantics including watermarks and late data.
+| Mode | How |
+|------|-----|
+| Embedded | `cargo add laminar-db`. Runs in-process. |
+| Standalone | `laminardb` binary. TOML config, REST API, Prometheus metrics, hot reload. |
+| Distributed | `--features delta`. Multi-node scaffolding (gossip, Raft, gRPC). Not production-ready. |
 
-Three deployment modes:
-
-| Mode | How | Status |
-|------|-----|--------|
-| **Embedded** | `cargo add laminar-db` — runs inside your Rust process | ✅ Implemented |
-| **Standalone** | `laminardb` binary — TOML config, REST API, Prometheus metrics, hot-reload | ✅ Implemented |
-| **Distributed** | Multi-node via gossip discovery, Raft consensus, gRPC — `--features delta` | 🚧 Scaffolding only (Phase 6c production hardening in progress) |
-
-The embedded mode is the primary deployment target. You get a `LaminarDB` handle, register sources with SQL DDL, push `RecordBatch` data in, subscribe to output streams, and let the engine handle windowing, joins, checkpointing, and exactly-once delivery.
+Built on [Apache Arrow](https://arrow.apache.org/) and [DataFusion](https://datafusion.apache.org/). Embedded is the primary target.
 
 ---
 
@@ -271,7 +265,7 @@ Custom connectors can be built by implementing the `SourceConnector` or `SinkCon
 
 ## Postgres Wire Protocol
 
-The standalone server speaks the Postgres v3 wire protocol, so any libpq-derived client — `psql`, JDBC, asyncpg, `tokio-postgres`, Grafana's Postgres datasource — can connect and tail a stream:
+The standalone server speaks the Postgres v3 wire protocol. Any libpq-derived client (`psql`, JDBC, asyncpg, `tokio-postgres`, Grafana's Postgres datasource) can connect and tail a stream:
 
 ```bash
 psql "host=db.internal port=5433 dbname=laminardb user=alice" \
@@ -288,7 +282,7 @@ Enable the listener by setting `pgwire_bind` in `laminardb.toml`. Auth is trust 
 | `DECLARE c CURSOR FOR SUBSCRIBE …` + `FETCH n FROM c` | Cursored consumption for `\set FETCH_COUNT n` clients |
 | `SELECT version()` / `SELECT 1` / transaction control | The handful of meta-commands clients issue at startup |
 
-DDL (`CREATE SOURCE`, `CREATE STREAM`, etc.) goes through the HTTP API (`POST /api/v1/sql`); the pgwire surface is intentionally narrow — read-side only.
+DDL (`CREATE SOURCE`, `CREATE STREAM`, etc.) goes through the HTTP API (`POST /api/v1/sql`). The pgwire surface is intentionally narrow: read-side only.
 
 ---
 
@@ -332,18 +326,18 @@ DDL (`CREATE SOURCE`, `CREATE STREAM`, etc.) goes through the HTTP API (`POST /a
 └──────────────────────────────────────────────────────────────┘
 ```
 
-- **Streaming coordinator** — Single tokio task on a dedicated single-threaded runtime (the `laminar-compute` thread), isolating CPU-bound event processing from I/O tasks on the main runtime. Source connectors push batches via `tokio::sync::mpsc` channels; the coordinator runs compiled projections / cached logical plans, routes results to sinks, and manages checkpoint barriers. Sub-microsecond for compiled single-source projections; microseconds for incremental aggregations and cached-plan queries; DataFusion fallback for complex queries.
-- **Background I/O** — Source connectors, sink writers, and the checkpoint coordinator all run on the main tokio work-stealing runtime.
-- **Admin** — HTTP REST API (Axum), Prometheus metrics, ad-hoc SQL, hot-reload, checkpoint triggers. Auth is planned (Phase 4).
+- **Streaming coordinator.** Single tokio task on a dedicated single-threaded runtime (the `laminar-compute` thread), isolating CPU-bound event processing from I/O on the main runtime. Source connectors push batches in via `tokio::sync::mpsc`; the coordinator runs compiled projections or cached logical plans, routes results to sinks, and manages checkpoint barriers. Compiled single-source projections are sub-microsecond; incremental aggregations and cached-plan queries are microseconds; complex queries fall back to DataFusion.
+- **Background I/O.** Source connectors, sink writers, and the checkpoint coordinator all run on the main tokio work-stealing runtime.
+- **Admin.** HTTP REST API (Axum), Prometheus metrics, ad-hoc SQL, hot reload, manual checkpoints. No built-in auth on the HTTP API; put it behind a reverse proxy. The Postgres-wire listener has MD5 + TLS + mTLS auth (see above).
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
 
 ### Checkpointing and Recovery
 
-1. **Coordinated Snapshots** — Barrier-based (Chandy-Lamport) checkpoint protocol: the coordinator injects barriers into all sources; operators with multiple inputs align barriers before snapshotting
-2. **Two-Phase Commit** — Exactly-once sinks participate in pre-commit/commit phases, coordinated by `CheckpointCoordinator`
-3. **Atomic Manifest** — Each checkpoint writes a JSON manifest (with operator state and connector offsets) via temp-file-plus-rename to filesystem or object store (S3/GCS/Azure)
-4. **Recovery** — `RecoveryManager` loads the latest manifest, restores operator state, rolls back exactly-once sinks, and resumes connectors from committed offsets
+1. **Coordinated snapshots.** Chandy-Lamport barriers injected at sources; operators with multiple inputs align before snapshotting.
+2. **Two-phase commit.** Exactly-once sinks participate in pre-commit / commit phases coordinated by `CheckpointCoordinator`.
+3. **Atomic manifest.** Each checkpoint writes a JSON manifest (operator state + connector offsets) via temp-file-plus-rename, to filesystem or object store (S3 / GCS / Azure).
+4. **Recovery.** `RecoveryManager` loads the latest manifest, restores operator state, rolls back exactly-once sinks, and resumes connectors from committed offsets.
 
 ```rust
 // Note: StreamCheckpointConfig is from laminar-core (add as a dependency)
@@ -367,80 +361,17 @@ Non-aggregate single-source queries are compiled to `PhysicalExpr` projections o
 
 ## Benchmarks
 
-Benchmark suites live under `crates/laminar-core/benches/`, `crates/laminar-db/benches/`, and `crates/laminar-connectors/benches/` (all using Criterion):
-
-| Metric | Target | Benchmark File |
-|--------|--------|----------------|
-| Streaming throughput | 500K events/sec | `crates/laminar-core/benches/streaming_bench.rs` |
-| Event latency (mean) | < 10us | `crates/laminar-core/benches/latency_bench.rs` |
-| Window operations | -- | `crates/laminar-core/benches/window_bench.rs` |
-| Lookup join | -- | `crates/laminar-core/benches/lookup_join_bench.rs` |
-| foyer cache | -- | `crates/laminar-core/benches/cache_bench.rs` |
-| Stream executor | -- | `crates/laminar-db/benches/stream_executor_bench.rs` |
-| Checkpoint recovery | < 10s | `crates/laminar-db/benches/recovery_bench.rs` |
-| MongoDB throughput | -- | `crates/laminar-connectors/benches/mongodb_throughput.rs` |
-
-Historical mean latencies on an AMD Ryzen AI 7 350 against minimal operator chains: per-event latency 0.55-1.16µs, single-core throughput 1.1-1.46M events/sec on a reactor+window pipeline. Real pipelines with multiple operators, joins, and state lookups show higher latency. p99 under sustained load is not continuously measured in CI. Run `cargo bench` to measure on your own hardware.
+Criterion suites live under `crates/laminar-core/benches/`, `crates/laminar-db/benches/`, and `crates/laminar-connectors/benches/`. Run `cargo bench` to measure on your own hardware. The numbers in the docs are from a developer laptop on minimal operator chains; they are not continuously validated and do not represent p99 under load.
 
 ---
 
 ## Language Bindings
 
-| Language | Package | Status |
-|----------|---------|--------|
-| **Rust** | [`laminar-db`](https://crates.io/crates/laminar-db) | Primary API |
-| **Python** | [`laminardb`](https://pypi.org/project/laminardb/) | Via [`laminardb-python`](https://github.com/laminardb/laminardb-python) (separate repo) |
-| **C/C++** | Via FFI (`--features ffi`) | ✅ Arrow C Data Interface, 50+ exported functions |
-| Java | `laminardb-java` | 📋 Planned |
-| Node.js | `@laminardb/node` | 📋 Planned |
-
----
-
-## Why LaminarDB vs. X?
-
-| | LaminarDB | Apache Flink | Kafka Streams | RisingWave | kdb+ |
-|---|---|---|---|---|---|
-| Deployment | Library or binary | JVM cluster | JVM library | Distributed cluster | Proprietary binary |
-| Language | Rust (+ Python, C FFI) | Java/Scala/Python | Java | Rust/Python/SQL | Q/Python |
-| Embed in your process | Yes | No | Yes (JVM) | No | No |
-| Latency (per-event, microbench) | Sub-microsecond (compiled queries, microbench) | Milliseconds–seconds | Milliseconds | Milliseconds | Microseconds |
-| Operational overhead | None (embedded) or single binary | K8s operator or YARN | Kafka cluster | etcd/K8s/S3 | Vendor support |
-| SQL | Full (DataFusion) | Flink SQL | None (DSL only) | Full (Postgres-compatible) | Q language |
-| Exactly-once | Yes (checkpoint + 2PC) | Yes | Yes | Yes | No |
-| License | Apache-2.0 | Apache-2.0 | Apache-2.0 | Apache-2.0 | Commercial |
-| Maturity | Pre-1.0, active development | Production (10+ years) | Production | Production | Production (25+ years) |
-
-**Where competitors are stronger:**
-- Flink has a decade of production hardening, hundreds of connectors, TB-scale state management (RocksDB backend), and a massive ecosystem.
-- kdb+ has unmatched time-series query performance, handles billions of rows in-memory, and has decades of finance-specific optimization.
-- RisingWave offers managed cloud deployment with zero operational overhead and Postgres wire compatibility.
-- Kafka Streams has been validated across thousands of production deployments for JVM-based event processing at scale.
-
-**Where LaminarDB fits:**
-- You want stream processing without a cluster or JVM dependency.
-- You need sub-millisecond latency and are willing to work with a pre-1.0 project.
-- You want to embed a streaming SQL engine directly in a Rust, C, or Python application.
-
----
-
-## Project Status
-
-**Version 0.21** — active development, pre-1.0. APIs may change between minor versions.
-
-| Phase | Description | Progress |
-|-------|-------------|----------|
-| Phase 1 | Core Engine | ✅ 12/12 |
-| Phase 1.5 | SQL Parser | ✅ 1/1 |
-| Phase 2 | Production Hardening | ✅ 38/38 |
-| Phase 2.5 | JIT Compiler | ❌ Removed (replaced by compiled `PhysicalExpr` projections) |
-| Phase 3 | Connectors & Integration | 🔧 95/100 |
-| Phase 4 | Enterprise Security (Auth, RBAC) | 📋 Planned |
-| Phase 5 | Admin & Observability | 🔧 4/10 |
-| Phase 6a | Partition-Parallel Embedded | ✅ 27/29 |
-| Phase 6b | Delta Foundation | ✅ 14/14 |
-| Phase 6c | Delta Production Hardening | 🔧 8/10 |
-
-Test coverage: ~2,700 tests across the workspace. CI runs on Linux and Windows.
+| Language | Package |
+|----------|---------|
+| Rust | [`laminar-db`](https://crates.io/crates/laminar-db) |
+| Python | [`laminardb`](https://pypi.org/project/laminardb/) (in [`laminardb-python`](https://github.com/laminardb/laminardb-python)) |
+| C / C++ | FFI (`--features ffi`), Arrow C Data Interface |
 
 ---
 
@@ -462,7 +393,7 @@ Test coverage: ~2,700 tests across the workspace. CI runs on Linux and Windows.
 | `otel` | OpenTelemetry OTLP/gRPC source (traces, metrics, logs) |
 | `parquet-lookup` | Parquet lookup source for reference tables |
 | `api` / `ffi` | C FFI layer with Arrow C Data Interface |
-| `delta` | Distributed mode scaffolding (gossip, Raft, gRPC) — not production-ready |
+| `delta` | Distributed mode scaffolding (gossip, Raft, gRPC). Not production-ready. |
 
 ---
 
@@ -509,9 +440,9 @@ examples/
 
 ## Documentation
 
-- [Architecture Guide](docs/ARCHITECTURE.md) — design overview, data flow, state management
-- [SQL Reference](docs/SQL_REFERENCE.md) — streaming SQL dialect, tested patterns
-- [API Reference](https://docs.rs/laminar-db) — rustdoc
+- [Architecture Guide](docs/ARCHITECTURE.md): design overview, data flow, state management.
+- [SQL Reference](docs/SQL_REFERENCE.md): streaming SQL dialect, tested patterns.
+- [API Reference](https://docs.rs/laminar-db): rustdoc.
 
 ## Contributing
 
@@ -519,10 +450,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, Ring 0
 
 ## Support
 
-- [GitHub Issues](https://github.com/laminardb/laminardb/issues) — Bug reports and feature requests
-- [GitHub Discussions](https://github.com/laminardb/laminardb/discussions) — Questions and community help
-- Email: support@laminardb.io
+- [GitHub Issues](https://github.com/laminardb/laminardb/issues) for bug reports and feature requests.
+- [GitHub Discussions](https://github.com/laminardb/laminardb/discussions) for questions.
+- Email: support@laminardb.io.
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
+Pre-1.0, only the latest minor receives fixes.
+
 | Version | Supported |
 |---------|-----------|
-| 0.20.x (latest) | Yes |
-| < 0.20 | No |
+| 0.22.x (latest) | Yes |
+| < 0.22 | No |
 
 ## Reporting a Vulnerability
 
@@ -24,7 +26,9 @@ We will:
 LaminarDB is an embedded database. Security considerations depend on your deployment model:
 
 - **Embedded (library)**: Security is inherited from the host application. LaminarDB does not open network ports unless you use the admin API or server binary.
-- **Server binary**: The standalone server exposes a network interface. Authentication and authorization are planned for a future release.
+- **Server binary**: The standalone server exposes two listeners.
+  - The Postgres-wire listener (`pgwire_bind`) supports MD5 password auth (plaintext or `pg_authid`-style pre-hashed), TLS with `pgwire_tls_min_version` pinning, optional mTLS via `pgwire_tls_client_ca`, and hot certificate reload. Trust auth is restricted to loopback binds; remote binds require `pgwire_allow_remote = true` plus configured users.
+  - The HTTP admin API has no built-in authentication yet. Put it behind a reverse proxy or network policy. SCRAM-SHA-256 and HTTP auth are tracked for a later release.
 - **Connectors**: Kafka, PostgreSQL, MySQL, and MongoDB connectors handle credentials. Connector configurations support TLS and are subject to secret masking in logs.
 
 ## Unsafe Code

--- a/crates/laminar-core/README.md
+++ b/crates/laminar-core/README.md
@@ -1,6 +1,6 @@
 # laminar-core
 
-Core streaming engine for LaminarDB — operators, checkpoint barriers, and streaming infrastructure.
+Core streaming engine for LaminarDB: operators, checkpoint barriers, and streaming infrastructure.
 
 ## Modules
 

--- a/crates/laminar-db/README.md
+++ b/crates/laminar-db/README.md
@@ -104,7 +104,7 @@ laminar-db
 | `files` | File source (AutoLoader) and sink (rolling files) |
 | `parquet-lookup` | Parquet lookup source for reference tables |
 | `otel` | OpenTelemetry OTLP/gRPC source |
-| `delta` | Full distributed mode scaffolding (gRPC, gossip, Raft) — not production-ready |
+| `delta` | Full distributed mode scaffolding (gRPC, gossip, Raft). Not production-ready. |
 | `aws` / `gcs` / `azure` | Object-store checkpoint backends (forwards to laminar-storage) |
 
 ## Internal Architecture

--- a/crates/laminar-derive/README.md
+++ b/crates/laminar-derive/README.md
@@ -1,6 +1,6 @@
 # laminar-derive
 
-Derive macros for LaminarDB — `Record`, `FromRecordBatch`, `FromRow`, and `ConnectorConfig`. Eliminates the boilerplate of writing `to_record_batch()` / `from_batch()` by hand.
+Derive macros for LaminarDB: `Record`, `FromRecordBatch`, `FromRow`, `ConnectorConfig`. Eliminates the boilerplate of writing `to_record_batch()` / `from_batch()` by hand.
 
 ## Macros
 

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -8,9 +8,9 @@ Standalone server binary for LaminarDB. Reads a TOML configuration file, constru
 - **REST API** (Axum) for health checks, pipeline introspection, ad-hoc SQL, and manual checkpoints
 - **Postgres wire protocol** (optional) for `SUBSCRIBE` streaming via `psql` and any libpq client
 - **Prometheus metrics** at `/metrics`
-- **Hot reload** — edit the TOML file and changes are applied automatically (file watcher with debounce), or `POST /api/v1/reload`
-- **Checkpoint validation** — `--validate-checkpoints` flag validates all stored checkpoints and exits
-- **Platform allocators** — jemalloc on Linux, mimalloc on Windows MSVC (see [Tuning the Allocator](#tuning-the-allocator-malloc_conf) for `MALLOC_CONF` recommendations)
+- **Hot reload**: edit the TOML file and changes are applied automatically (file watcher with debounce), or `POST /api/v1/reload`
+- **Checkpoint validation**: `--validate-checkpoints` flag validates all stored checkpoints and exits
+- **Platform allocators**: jemalloc on Linux, mimalloc on Windows MSVC (see [Tuning the Allocator](#tuning-the-allocator-malloc_conf) for `MALLOC_CONF` recommendations)
 - **Docker and Helm** deployment with multi-arch images
 
 ## CLI
@@ -64,7 +64,7 @@ log_level = "info"
 # [server.pgwire_users]
 # alice = "${ALICE_PASSWORD}"
 # bob   = "${BOB_PASSWORD}"
-# Worker thread count is taken from $TOKIO_WORKER_THREADS — defaults to logical CPUs.
+# Worker thread count is taken from $TOKIO_WORKER_THREADS. Defaults to logical CPUs.
 
 [state]
 backend = "memory"          # "memory" or "mmap"
@@ -137,7 +137,7 @@ format = "json"
 
 When `[server].pgwire_bind` is set, the server also listens for Postgres clients and serves a small subset of the SimpleQuery protocol:
 
-- `SUBSCRIBE <name> [WHERE <predicate>]` — streams rows as they're produced. `<name>` may be a materialized view, a source, or a named stream. The query stays open until the client disconnects.
+- `SUBSCRIBE <name> [WHERE <predicate>]`: streams rows as they're produced. `<name>` may be a materialized view, a source, or a named stream. The query stays open until the client disconnects.
 - `SHOW`, `SET <key> = <value>`, and a handful of driver builtins (`SELECT version()`, `current_database()`, etc.) are accepted so standard psql / libpq clients can connect.
 - `INSERT`, `UPDATE`, `DELETE`, and DDL are rejected with a clear error pointing to `POST /api/v1/sql`.
 
@@ -145,7 +145,7 @@ When `[server].pgwire_bind` is set, the server also listens for Postgres clients
 
 ### Authentication
 
-By default the listener uses **trust** auth and rejects non-localhost binds — the assumption is that any caller who can reach the loopback interface is already trusted. To bind to a routable address, configure MD5 password auth and explicitly opt in to remote binds:
+By default the listener uses **trust** auth and rejects non-localhost binds. The assumption is that any caller who can reach the loopback interface is already trusted. To bind to a routable address, configure MD5 password auth and explicitly opt in to remote binds:
 
 ```toml
 pgwire_bind = "0.0.0.0:5433"
@@ -163,14 +163,14 @@ PGPASSWORD=$ALICE_PASSWORD psql "host=db.internal port=5433 dbname=laminardb use
 
 > **MD5 is provided for libpq compatibility, not as a recommended production stance.** Postgres itself deprecated it in PG 14 in favor of SCRAM-SHA-256. Use it for development and short-lived deployments; for production, wait for the SCRAM work in the FIR follow-ups before exposing this listener beyond a trusted network segment.
 
-Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. To avoid plaintext at rest entirely, supply the `pg_authid`-style pre-hashed form: `md5` followed by `md5(password ‖ username)` as 32 lowercase hex characters. The wire protocol is unchanged — clients still send the same plaintext password.
+Plaintext passwords sit in the TOML file. Use `${VAR}` substitution to pull them from environment variables or a secret manager rather than committing them. To avoid plaintext at rest entirely, supply the `pg_authid`-style pre-hashed form: `md5` followed by `md5(password ‖ username)` as 32 lowercase hex characters. The wire protocol is unchanged; clients still send the same plaintext password.
 
 ```bash
 # bash, where pw and user are the plaintext password and username:
 printf '%s' "${pw}${user}" | md5sum | awk '{print "md5"$1}'
 ```
 
-The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes — wire these into your SIEM.
+The listener emits `target: "audit"` events on every connection accepted/closed, including auth-failed outcomes. Wire these into your SIEM.
 
 ### TLS
 
@@ -186,7 +186,7 @@ pgwire_tls_min_version = "1.2"
 pgwire_tls_client_ca = "/etc/laminar/clients-ca.pem"
 ```
 
-Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow — `psql`, JDBC, asyncpg, etc. all just work.
+Postgres clients negotiate TLS via `sslmode=require` (or `verify-ca` / `verify-full` if your cert chain is trusted by the client). The handshake follows the standard `SSLRequest` flow, so `psql`, JDBC, asyncpg, and friends all just work.
 
 The server watches `pgwire_tls_cert`, `pgwire_tls_key`, and `pgwire_tls_client_ca` and reloads the TLS acceptor in place after a 500ms debounce, so cert rotation does not require a restart. In-flight handshakes finish with the cert that was current when the socket was accepted; new accepts pick up the rotated cert. A bad rotation (truncated file, expired cert) is logged as `pgwire.tls_reload outcome=failed` and the previous acceptor is kept. Set `LAMINAR_DISABLE_FILE_WATCH=1` to disable.
 
@@ -205,7 +205,7 @@ Changes to `[server]`, `[state]`, and `[checkpoint]` sections require a restart.
 
 ## Tuning the Allocator (`MALLOC_CONF`)
 
-The server ships with [`jemalloc`](https://jemalloc.net/) on Linux / non-MSVC (via `tikv-jemallocator`) and `mimalloc` on Windows MSVC. These replace the system allocator and materially reduce fragmentation under bursty sink workloads (Delta Lake, Iceberg, Parquet writers). Both are enabled by default — no action needed to turn them on.
+The server ships with [`jemalloc`](https://jemalloc.net/) on Linux / non-MSVC (via `tikv-jemallocator`) and `mimalloc` on Windows MSVC. These replace the system allocator and materially reduce fragmentation under bursty sink workloads (Delta Lake, Iceberg, Parquet writers). Both are enabled by default; no action needed to turn them on.
 
 For long-running deployments, jemalloc's behavior can be tuned at process start via the `MALLOC_CONF` environment variable. The recommended baseline is:
 
@@ -226,7 +226,7 @@ MALLOC_CONF=background_thread:true,metadata_thp:auto,dirty_decay_ms:3000,muzzy_d
 
 ### Settings to avoid
 
-- **Do not set `narenas:N` to a small value.** The jemalloc default is `ncpus * 4`, which gives each reactor / sink thread its own arena and eliminates cross-thread contention on `malloc`/`free`. LaminarDB is thread-per-core — forcing `narenas:4` on an 8-core box means multiple reactors share an arena, and the lock contention shows up directly in the sink commit path. Leave `narenas` unset.
+- **Do not set `narenas:N` to a small value.** The jemalloc default is `ncpus * 4`, which gives each reactor / sink thread its own arena and eliminates cross-thread contention on `malloc`/`free`. LaminarDB is thread-per-core. Forcing `narenas:4` on an 8-core box means multiple reactors share an arena, and the lock contention shows up directly in the sink commit path. Leave `narenas` unset.
 - **Do not set `tcache:false`.** The per-thread small-allocation cache is load-bearing on any sink that churns Arrow/Parquet buffers.
 
 ### How to set it
@@ -236,7 +236,7 @@ MALLOC_CONF=background_thread:true,metadata_thp:auto,dirty_decay_ms:3000,muzzy_d
 - **Kubernetes / Helm**: add to `env:` on the container, or set via the Helm chart's `env` values.
 - **Shell**: `MALLOC_CONF=... laminardb --config laminardb.toml`.
 
-The setting is read by jemalloc at process start; changing it requires a restart. It has no effect on the Windows MSVC build (mimalloc has its own env vars — see the [mimalloc options](https://microsoft.github.io/mimalloc/environment.html) if tuning is needed).
+The setting is read by jemalloc at process start; changing it requires a restart. It has no effect on the Windows MSVC build (mimalloc has its own env vars; see the [mimalloc options](https://microsoft.github.io/mimalloc/environment.html) if tuning is needed).
 
 ### Verifying it took effect
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,8 +314,8 @@ Historical mean-latency measurements (laptop hardware, Criterion microbenchmarks
 
 These are Criterion means from a developer laptop, not continuously
 validated in CI. True p99 under sustained load is not currently
-measured. See [BENCHMARKS.md](BENCHMARKS.md) for the historical
-baseline and caveats.
+measured. Run `cargo bench` on your own hardware to get numbers that
+mean something for your workload.
 
 ## Execution Model
 
@@ -333,7 +333,7 @@ The thread-per-core model described in earlier documentation was removed in PR #
 **Coordinator → Executor relationship:** `StreamingCoordinator` is the
 single tokio task that owns the event loop. It calls `PipelineCallback::execute_cycle()`,
 which delegates to `StreamExecutor::execute_cycle()`. The coordinator drives the
-executor through a callback interface — there is a single execution loop, not
+executor through a callback interface. There is a single execution loop, not
 multiple competing ones.
 
 ### Deployment Model

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -1,6 +1,6 @@
 # SQL Dialect Reference
 
-> Practical guide to LaminarDB's SQL dialect — gotchas, working patterns, and tested examples.
+> Practical guide to LaminarDB's SQL dialect: gotchas, working patterns, tested examples.
 
 LaminarDB uses [Apache DataFusion](https://datafusion.apache.org/) as its SQL engine. While most standard SQL works, streaming-specific operations have differences from other streaming databases (Flink SQL, ksqlDB, etc.). This reference documents patterns that are **confirmed working** in LaminarDB embedded mode.
 
@@ -23,7 +23,7 @@ LaminarDB uses [Apache DataFusion](https://datafusion.apache.org/) as its SQL en
 ## Sources
 
 Create data sources using `CREATE SOURCE`. Event-time columns must be
-declared as `TIMESTAMP` — LaminarDB uses Arrow `Timestamp(_)` internally
+declared as `TIMESTAMP`. LaminarDB uses Arrow `Timestamp(_)` internally
 at any precision and rescales to milliseconds via the Arrow cast kernel.
 
 ```sql
@@ -94,8 +94,8 @@ GROUP BY symbol, tumble(ts, INTERVAL '1' HOUR, INTERVAL '8' HOUR)
 ```
 
 **Key points:**
-- Use lowercase `tumble()` (not `TUMBLE()` — both work, but lowercase is canonical)
-- `tumble()` returns `Timestamp(Millisecond)` directly — there is no `TUMBLE_START()` function
+- Use lowercase `tumble()`. `TUMBLE()` also works, but lowercase is canonical.
+- `tumble()` returns `Timestamp(Millisecond)` directly. There is no `TUMBLE_START()` function.
 - Optional third argument for timezone offset alignment
 - Window closes when watermark passes window end
 
@@ -116,7 +116,7 @@ GROUP BY symbol, HOP(ts, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
 **Key points:**
 - First interval = slide, second interval = window size
 - Each event appears in `size / slide` windows (here: 10/2 = 5)
-- More output rows than TUMBLE — plan downstream capacity accordingly
+- More output rows than TUMBLE. Plan downstream capacity accordingly.
 
 ### SESSION (Gap-based windows)
 
@@ -164,7 +164,7 @@ AND o.ts BETWEEN t.ts - INTERVAL '10' SECOND AND t.ts + INTERVAL '10' SECOND
 
 **Key points:**
 - `INTERVAL` arithmetic on `TIMESTAMP` columns is handled natively by
-  DataFusion — no need for the old `ts - 10000` millisecond tricks
+  DataFusion. No need for the old `ts - 10000` millisecond tricks.
 - Both sources need watermarks advanced for the join to emit
 - Column aliases (`AS trade_price`) are required when both sources have columns with the same name
 
@@ -223,7 +223,7 @@ FROM trades
 GROUP BY account_id, symbol, TUMBLE(ts, INTERVAL '5' SECOND)
 ```
 
-**Key point:** The `ELSE` branch must match the column type. Use `CAST(0 AS BIGINT)` when summing BIGINT columns — `ELSE 0` alone produces INT32, causing a type mismatch.
+**Key point:** The `ELSE` branch must match the column type. Use `CAST(0 AS BIGINT)` when summing BIGINT columns. `ELSE 0` alone produces INT32, causing a type mismatch.
 
 ### Computed columns
 
@@ -247,6 +247,20 @@ GROUP BY symbol, tumble(ts, INTERVAL '5' SECOND)
 | `MIN(col)` / `MAX(col)` | Min/max |
 | `first_value(col)` | First value in window (NOT `FIRST()`) |
 | `last_value(col)` | Last value in window (NOT `LAST()`) |
+
+### Streaming UDFs
+
+| Function | Returns | Use |
+|----------|---------|-----|
+| `tumble(ts, size)` | `Timestamp(Millisecond)` (window start) | `GROUP BY tumble(...)` |
+| `tumble(ts, size, offset)` | `Timestamp(Millisecond)` | Timezone-aligned window boundaries |
+| `tumble_end(ts, size)` | `Timestamp(Millisecond)` | Explicit window-end column in `SELECT` |
+| `hop(ts, slide, size)` / `slide(ts, size, slide)` | `Timestamp(Millisecond)` | Sliding / hopping windows |
+| `hop_end(ts, slide, size)` | `Timestamp(Millisecond)` | Window end for hop |
+| `session(ts, gap)` | `Timestamp(Millisecond)` | Session windows |
+| `cumulate(ts, step, max_size)` | `Timestamp(Millisecond)` | Cumulating windows (parsed; pipeline support pending) |
+| `cumulate_end(ts, step, max_size)` | `Timestamp(Millisecond)` | Cumulating window end |
+| `proctime()` | `Timestamp(Millisecond)` | Processing-time stamp at evaluation |
 
 ---
 
@@ -278,19 +292,49 @@ while let Some(rows) = sub.poll() {
 }
 ```
 
-**Critical:** `FromRow` struct field order must match the SQL `SELECT` column order. Field names don't matter — only position.
+**Critical:** `FromRow` struct field order must match the SQL `SELECT` column order. Field names don't matter, only position does.
 
 ### SUBSCRIBE over the Postgres wire protocol
 
 When the server is started with `pgwire_bind` set, materialized views can be streamed directly to any libpq client (psql, JDBC, asyncpg, etc.):
 
 ```sql
-SUBSCRIBE <mv_name> [WHERE <predicate>]
+SUBSCRIBE <name> [WHERE <predicate>] [AS OF EPOCH <n>]
 ```
 
-- `<mv_name>` may be a materialized view, a source, or a named stream.
+- `<name>` may be a materialized view, a source, or a named stream.
 - The optional `WHERE` clause is compiled by DataFusion against the target's schema and applied per batch before the row reaches the wire. It works on materialized views and sources; named streams reject `WHERE` because their output schema isn't introspectable.
 - The query stays open until the client disconnects; rows arrive as they're produced upstream.
+
+#### Reconnect without gaps: `RETAIN HISTORY` + `AS OF EPOCH`
+
+Create the stream with a bounded history ring:
+
+```sql
+CREATE STREAM trades AS SELECT * FROM raw_trades
+  WITH ('retain_history' = '64mb');
+```
+
+The server keeps recent committed epochs in memory up to that budget. A client that crashed at epoch `42` can reconnect and resume from exactly where it left off:
+
+```sql
+SUBSCRIBE trades AS OF EPOCH 42;
+```
+
+If epoch `42` has already fallen out of the ring the server returns an error instead of silently skipping rows. Pick a larger budget if your clients can disconnect for longer.
+
+#### Cursored consumption: `DECLARE` / `FETCH` / `CLOSE`
+
+For libpq clients that drive flow control via `\set FETCH_COUNT n` (psql, JDBC with `setFetchSize`):
+
+```sql
+DECLARE c CURSOR FOR SUBSCRIBE trades WHERE symbol = 'AAPL';
+FETCH FORWARD 100 FROM c;
+FETCH FORWARD 100 FROM c;
+CLOSE c;
+```
+
+The cursor is forward-only, lives for the duration of the connection, and shares the same `WHERE` and `AS OF EPOCH` semantics as bare `SUBSCRIBE`.
 
 ---
 
@@ -307,7 +351,7 @@ source.watermark(current_ts + 10_000);  // 10s ahead covers HOP(10s) windows
 - Advance watermark on **all** sources (both sides of a join)
 - Watermark should be at least `current_ts + largest_window_size`
 - HOP(10s) needs watermark 10s ahead; SESSION(2s) needs 2s past last event
-- LaminarDB processes in 100ms micro-batch ticks — results appear after next tick
+- LaminarDB processes in 100ms micro-batch ticks. Results appear after the next tick.
 
 ---
 
@@ -393,7 +437,7 @@ SELECT tumble(ts, INTERVAL '5' SECOND), first_value(price), last_value(price)
 ```rust
 // SQL: SELECT symbol, SUM(volume) AS total, AVG(price) AS avg_price
 
-// WRONG — field names don't matter, ORDER matters
+// WRONG: field names don't matter, ORDER matters
 #[derive(FromRow)]
 pub struct Bad {
     pub avg_price: f64,  // This gets the 1st column (symbol), not avg_price!
@@ -401,7 +445,7 @@ pub struct Bad {
     pub total: i64,
 }
 
-// CORRECT — matches SELECT column order
+// CORRECT: matches SELECT column order
 #[derive(FromRow)]
 pub struct Good {
     pub symbol: String,    // 1st column
@@ -413,10 +457,10 @@ pub struct Good {
 ### 5. Both sources need watermarks for joins
 
 ```rust
-// WRONG — join will never emit because orders watermark isn't advancing
+// WRONG: join will never emit because orders watermark isn't advancing
 trade_source.watermark(ts + 10_000);
 
-// CORRECT — advance both
+// CORRECT: advance both
 trade_source.watermark(ts + 10_000);
 order_source.watermark(ts + 10_000);
 ```
@@ -469,9 +513,9 @@ Connector-produced schemas may use other `Timestamp(_)` precisions:
 | `file_modification_time` | `Timestamp(Millisecond)` | Files connector |
 
 Despite the `_ms` / `_ns` suffixes in some historical names, these are
-real Arrow `Timestamp` columns — not `Int64`. `INTERVAL` arithmetic and
+real Arrow `Timestamp` columns, not `Int64`. `INTERVAL` arithmetic and
 window functions compose correctly against any precision.
 
 ---
 
-*This reference is based on LaminarDB v0.20.2 with DataFusion 52.x and Arrow 57.x. Contributions and corrections welcome — please open an issue or PR.*
+*Tracks LaminarDB 0.22 on DataFusion 52.x / Arrow 57.x. Corrections welcome: open an issue or PR.*


### PR DESCRIPTION
## Summary

- Brings every public-facing markdown file up to 0.22 (README, SECURITY, SQL_REFERENCE footer, CHANGELOG).
- Cuts the comparison-with-other-systems table and the phase-tracker "Project Status" section from README; trims the marketing-flavoured intro, the "What It Is" filler, and the speculative Java/Node.js bindings rows. Net `-100` lines on README.
- Adds CHANGELOG entries for the two missing minor releases (0.21.0, 0.22.0) covering the SUBSCRIBE-over-pgwire stack, `RETAIN HISTORY` + `AS OF EPOCH`, SQL-level cursors, MV result storage (#319), push-based WebSocket subs (#329), self-join pre-filter (#321), throttled barrier retries (#327), production Prometheus metrics (#339), the three dead-code waves (#315/#316/#320/#326), DbState collapse (#381), and the new window-edge UDFs.
- Documents the read-side surface in `docs/SQL_REFERENCE.md` (`AS OF EPOCH`, `RETAIN HISTORY`, `DECLARE/FETCH/CLOSE`) and adds a Streaming UDFs table covering `tumble/tumble_end`, `hop/hop_end/slide`, `session`, `cumulate/cumulate_end`, and `proctime()`. Verified names and return types against `crates/laminar-sql/src/datafusion/window_udf.rs` and `proctime_udf.rs`.
- Updates `SECURITY.md` and the README architecture bullet to reflect that pgwire MD5 + TLS + mTLS + TLS-version pinning + hot reload + `pg_authid`-style pre-hashed passwords have shipped. HTTP admin API auth is still listed as pending.
- Fixes a dead link in `docs/ARCHITECTURE.md` pointing to `BENCHMARKS.md` (the file only lives in the private submodule).
- Strips em dashes from every public-facing markdown file. Replacements were chosen per case (colon for `**Topic** — desc` → `**Topic**: desc`, period or comma mid-sentence) rather than a blind global substitution.

## Test plan

- [ ] Render README on GitHub and confirm the cut sections are gone and the new tables read cleanly.
- [ ] Skim CHANGELOG 0.21.0 and 0.22.0 entries against `git log e01cbce6..HEAD` to confirm coverage.
- [ ] Open `docs/SQL_REFERENCE.md` and confirm the new SUBSCRIBE / RETAIN HISTORY / cursor and Streaming UDFs sections render.
- [ ] `grep -r '—' README.md CHANGELOG.md SECURITY.md docs/ crates/*/README.md .github/` returns nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes public docs for 0.22 and tightens tone across READMEs. Adds missing 0.21/0.22 notes, documents pgwire SUBSCRIBE + history/cursors + streaming UDFs, updates security, trims stale README sections, and fixes a dead link.

- **Docs**
  - README: bump quick start to `laminar-db` 0.22; remove comparison and “Project Status” sections; shorten Benchmarks; simplify deployment/language bindings; update pgwire/admin notes; tone/punctuation cleanup.
  - CHANGELOG: add 0.21.0 and 0.22.0 highlights (pgwire SUBSCRIBE incl. extended-query/binary, `RETAIN HISTORY` + `AS OF EPOCH`, SQL cursors, MV result storage, push-based WebSocket subs, production metrics, dead-code removals, `DbState` collapse, window-edge UDFs).
  - SQL Reference: add `RETAIN HISTORY`/`AS OF EPOCH`, `DECLARE`/`FETCH`/`CLOSE` cursor docs, and a Streaming UDFs table (`tumble`/`tumble_end`, `hop`/`hop_end`/`slide`, `session`, `cumulate`/`cumulate_end`, `proctime()`); clarify TIMESTAMP/INTERVAL notes.
  - Security: update supported versions to 0.22.x; document pgwire auth (MD5 or pre-hashed, TLS min version pinning, optional mTLS, hot reload); note HTTP admin API has no built-in auth and should be proxied.
  - Misc: fix dead `BENCHMARKS.md` link in Architecture guide; consistent punctuation across public markdown; minor wording tweaks in crate/server READMEs and PR template.

<sup>Written for commit a84128e73f8ca368f8d5c2f0fd94667fac9cb963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

