### PR TITLE
fix(core,db): bound event-time watermark against future-dated timestamps + surface late drops

### DIFF
--- a/crates/laminar-core/src/time/mod.rs
+++ b/crates/laminar-core/src/time/mod.rs
@@ -9,7 +9,7 @@ pub use cast::{cast_to_millis_array, CastError};
 pub use duration_str::parse_duration_str;
 pub use event_time::{EventTimeError, EventTimeExtractor, ExtractionMode, TimestampField};
 
-pub use filter::{filter_batch_by_timestamp, ThresholdOp};
+pub use filter::{filter_batch_by_timestamp, FilterError, ThresholdOp};
 
 pub use watermark::{
     AscendingTimestampsGenerator, BoundedOutOfOrdernessGenerator, PeriodicGenerator,

--- a/crates/laminar-core/src/time/mod.rs
+++ b/crates/laminar-core/src/time/mod.rs
@@ -14,7 +14,7 @@ pub use filter::{filter_batch_by_timestamp, ThresholdOp};
 pub use watermark::{
     AscendingTimestampsGenerator, BoundedOutOfOrdernessGenerator, PeriodicGenerator,
     ProcessingTimeGenerator, PunctuatedGenerator, SourceProvidedGenerator, WatermarkGenerator,
-    WatermarkTracker,
+    WatermarkTracker, DEFAULT_MAX_FUTURE_SKEW_MS,
 };
 
 use smallvec::SmallVec;

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -36,11 +36,10 @@ pub trait WatermarkGenerator: Send {
 pub const DEFAULT_MAX_FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
 
 /// Wall clock in epoch millis; `0` if unreadable (callers fail open).
-#[allow(clippy::cast_possible_truncation)]
 fn now_unix_millis() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| d.as_millis() as i64)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
 }
 
 /// Watermark = `max_timestamp_seen - max_out_of_orderness`. `on_event`

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -32,13 +32,10 @@ pub trait WatermarkGenerator: Send {
     fn advance_watermark(&mut self, timestamp: i64) -> Option<Watermark>;
 }
 
-/// Default ceiling on how far a single event timestamp may exceed wall
-/// clock before it is treated as a corrupt clock rather than time
-/// progress (5 minutes). See [ADR-002].
+/// Default `max_future_skew_ms` (5 min). See ADR-002.
 pub const DEFAULT_MAX_FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
 
-/// Wall clock in Unix epoch millis; `0` if the clock is unreadable
-/// (pre-1970 / failure), on which callers fail open.
+/// Wall clock in epoch millis; `0` if unreadable (callers fail open).
 #[allow(clippy::cast_possible_truncation)]
 fn now_unix_millis() -> i64 {
     SystemTime::now()
@@ -46,10 +43,8 @@ fn now_unix_millis() -> i64 {
         .map_or(0, |d| d.as_millis() as i64)
 }
 
-/// Watermark generator with bounded out-of-orderness; the watermark is
-/// `max_timestamp_seen - max_out_of_orderness`. `on_event` ignores
-/// timestamps too far beyond wall clock so one bad producer clock can't
-/// poison it; `advance_watermark` is trusted. See ADR-002.
+/// Watermark = `max_timestamp_seen - max_out_of_orderness`. `on_event`
+/// ignores timestamps far beyond wall clock for advancement (ADR-002).
 pub struct BoundedOutOfOrdernessGenerator {
     max_out_of_orderness: i64,
     current_max_timestamp: i64,
@@ -74,9 +69,7 @@ impl BoundedOutOfOrdernessGenerator {
         }
     }
 
-    /// Overrides the future-skew ceiling. `<= 0` disables the guard
-    /// (unbounded — legacy behaviour). Wired from the `max.future.skew.ms`
-    /// source property.
+    /// Sets the future-skew ceiling; `<= 0` disables the guard.
     #[must_use]
     pub fn with_max_future_skew(mut self, skew_ms: i64) -> Self {
         self.max_future_skew_ms = skew_ms;
@@ -100,9 +93,7 @@ impl BoundedOutOfOrdernessGenerator {
 impl WatermarkGenerator for BoundedOutOfOrdernessGenerator {
     #[inline]
     fn on_event(&mut self, timestamp: i64) -> Option<Watermark> {
-        // Future-skew guard: a timestamp implausibly far ahead of wall
-        // clock is a corrupt producer clock, not time progress. Ignore it
-        // for watermark advancement (the row still flows downstream).
+        // Don't let a corrupt far-future producer clock advance the watermark.
         if self.max_future_skew_ms > 0 {
             let now = now_unix_millis();
             if now > 0 && timestamp > now.saturating_add(self.max_future_skew_ms) {
@@ -1079,14 +1070,5 @@ mod tests {
         assert_eq!(gen.current_watermark(), i64::MIN);
         // ...but a normal event still advances it.
         assert_eq!(gen.on_event(now), Some(Watermark::new(now)));
-    }
-
-    #[test]
-    fn advance_watermark_bypasses_the_future_guard() {
-        // External / source-provided watermarks are trusted; this is why
-        // the source-side late-drop tests still pass.
-        let mut gen = BoundedOutOfOrdernessGenerator::new(0);
-        let future = super::now_unix_millis() + 2 * 60 * 60 * 1000;
-        assert_eq!(gen.advance_watermark(future), Some(Watermark::new(future)));
     }
 }

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -639,7 +639,6 @@ impl ProcessingTimeGenerator {
             current_watermark: i64::MIN,
         }
     }
-
 }
 
 impl Default for ProcessingTimeGenerator {

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -32,12 +32,27 @@ pub trait WatermarkGenerator: Send {
     fn advance_watermark(&mut self, timestamp: i64) -> Option<Watermark>;
 }
 
+/// Default ceiling on how far a single event timestamp may exceed wall
+/// clock before it is treated as a corrupt clock rather than time
+/// progress (5 minutes). See [ADR-002].
+pub const DEFAULT_MAX_FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
+
 /// Watermark generator with bounded out-of-orderness. The watermark
 /// is always `max_timestamp_seen - max_out_of_orderness`.
+///
+/// `on_event` ignores — for watermark advancement only — timestamps more
+/// than `max_future_skew_ms` beyond wall clock, so a single future-dated
+/// event (e.g. a producer with a wrong clock) cannot drag the watermark
+/// arbitrarily far ahead and silently starve the stream (ADR-002). The
+/// row itself is not dropped here; only its ability to move the watermark
+/// is suppressed. `advance_watermark` (external / source-provided
+/// watermarks) is a trusted assertion and is never guarded.
 pub struct BoundedOutOfOrdernessGenerator {
     max_out_of_orderness: i64,
     current_max_timestamp: i64,
     current_watermark: i64,
+    /// `0` (or negative) disables the guard (unbounded — legacy behaviour).
+    max_future_skew_ms: i64,
 }
 
 impl BoundedOutOfOrdernessGenerator {
@@ -52,7 +67,27 @@ impl BoundedOutOfOrdernessGenerator {
             max_out_of_orderness,
             current_max_timestamp: i64::MIN,
             current_watermark: i64::MIN,
+            max_future_skew_ms: DEFAULT_MAX_FUTURE_SKEW_MS,
         }
+    }
+
+    /// Overrides the future-skew ceiling. `<= 0` disables the guard
+    /// (unbounded — legacy behaviour). Wired from the `max.future.skew.ms`
+    /// source property.
+    #[must_use]
+    pub fn with_max_future_skew(mut self, skew_ms: i64) -> Self {
+        self.max_future_skew_ms = skew_ms;
+        self
+    }
+
+    /// Wall clock in epoch millis, or `0` if the system clock is
+    /// unreadable — in which case the future-skew guard fails open
+    /// (preserving legacy behaviour rather than rejecting everything).
+    #[allow(clippy::cast_possible_truncation)]
+    fn now_ms() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_millis() as i64)
     }
 
     /// Creates a new generator from a `Duration`.
@@ -72,6 +107,15 @@ impl BoundedOutOfOrdernessGenerator {
 impl WatermarkGenerator for BoundedOutOfOrdernessGenerator {
     #[inline]
     fn on_event(&mut self, timestamp: i64) -> Option<Watermark> {
+        // Future-skew guard: a timestamp implausibly far ahead of wall
+        // clock is a corrupt producer clock, not time progress. Ignore it
+        // for watermark advancement (the row still flows downstream).
+        if self.max_future_skew_ms > 0 {
+            let now = Self::now_ms();
+            if now > 0 && timestamp > now.saturating_add(self.max_future_skew_ms) {
+                return None;
+            }
+        }
         if timestamp > self.current_max_timestamp {
             self.current_max_timestamp = timestamp;
             let new_watermark = timestamp.saturating_sub(self.max_out_of_orderness);
@@ -1038,5 +1082,41 @@ mod tests {
     fn test_processing_time_generator_default() {
         let gen = ProcessingTimeGenerator::default();
         assert_eq!(gen.current_watermark(), i64::MIN);
+    }
+
+    // --- ADR-002 future-skew guard ---
+
+    fn now_ms() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+
+    #[test]
+    fn future_skew_event_does_not_advance_watermark() {
+        let mut gen = BoundedOutOfOrdernessGenerator::new(0); // 5-min default skew
+        let now = now_ms();
+        // One event ~2h in the future must NOT poison the watermark.
+        assert_eq!(gen.on_event(now + 2 * 60 * 60 * 1000), None);
+        assert_eq!(gen.current_watermark(), i64::MIN);
+        // A normal event still advances it.
+        let wm = gen.on_event(now);
+        assert_eq!(wm, Some(Watermark::new(now)));
+    }
+
+    #[test]
+    fn future_skew_guard_disabled_restores_legacy() {
+        let mut gen = BoundedOutOfOrdernessGenerator::new(0).with_max_future_skew(0);
+        let future = now_ms() + 2 * 60 * 60 * 1000;
+        assert_eq!(gen.on_event(future), Some(Watermark::new(future)));
+    }
+
+    #[test]
+    fn advance_watermark_is_not_guarded() {
+        // External / source-provided watermarks are trusted assertions.
+        let mut gen = BoundedOutOfOrdernessGenerator::new(0);
+        let future = now_ms() + 2 * 60 * 60 * 1000;
+        assert_eq!(gen.advance_watermark(future), Some(Watermark::new(future)));
     }
 }

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -32,7 +32,7 @@ pub trait WatermarkGenerator: Send {
     fn advance_watermark(&mut self, timestamp: i64) -> Option<Watermark>;
 }
 
-/// Default `max_future_skew_ms` (5 min). See ADR-002.
+/// Default `max_future_skew_ms`: 5 min.
 pub const DEFAULT_MAX_FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
 
 /// Wall clock in epoch millis; `0` if unreadable (callers fail open).
@@ -44,7 +44,7 @@ fn now_unix_millis() -> i64 {
 }
 
 /// Watermark = `max_timestamp_seen - max_out_of_orderness`. `on_event`
-/// ignores timestamps far beyond wall clock for advancement (ADR-002).
+/// ignores timestamps far beyond wall clock for advancement.
 pub struct BoundedOutOfOrdernessGenerator {
     max_out_of_orderness: i64,
     current_max_timestamp: i64,
@@ -1059,7 +1059,7 @@ mod tests {
         assert_eq!(gen.current_watermark(), i64::MIN);
     }
 
-    // --- ADR-002 future-skew guard ---
+    // --- future-skew guard ---
 
     #[test]
     fn future_skew_event_does_not_advance_watermark() {

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -37,16 +37,19 @@ pub trait WatermarkGenerator: Send {
 /// progress (5 minutes). See [ADR-002].
 pub const DEFAULT_MAX_FUTURE_SKEW_MS: i64 = 5 * 60 * 1000;
 
-/// Watermark generator with bounded out-of-orderness. The watermark
-/// is always `max_timestamp_seen - max_out_of_orderness`.
-///
-/// `on_event` ignores — for watermark advancement only — timestamps more
-/// than `max_future_skew_ms` beyond wall clock, so a single future-dated
-/// event (e.g. a producer with a wrong clock) cannot drag the watermark
-/// arbitrarily far ahead and silently starve the stream (ADR-002). The
-/// row itself is not dropped here; only its ability to move the watermark
-/// is suppressed. `advance_watermark` (external / source-provided
-/// watermarks) is a trusted assertion and is never guarded.
+/// Wall clock in Unix epoch millis; `0` if the clock is unreadable
+/// (pre-1970 / failure), on which callers fail open.
+#[allow(clippy::cast_possible_truncation)]
+fn now_unix_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis() as i64)
+}
+
+/// Watermark generator with bounded out-of-orderness; the watermark is
+/// `max_timestamp_seen - max_out_of_orderness`. `on_event` ignores
+/// timestamps too far beyond wall clock so one bad producer clock can't
+/// poison it; `advance_watermark` is trusted. See ADR-002.
 pub struct BoundedOutOfOrdernessGenerator {
     max_out_of_orderness: i64,
     current_max_timestamp: i64,
@@ -80,16 +83,6 @@ impl BoundedOutOfOrdernessGenerator {
         self
     }
 
-    /// Wall clock in epoch millis, or `0` if the system clock is
-    /// unreadable — in which case the future-skew guard fails open
-    /// (preserving legacy behaviour rather than rejecting everything).
-    #[allow(clippy::cast_possible_truncation)]
-    fn now_ms() -> i64 {
-        std::time::SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_millis() as i64)
-    }
-
     /// Creates a new generator from a `Duration`.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)] // Duration.as_millis() fits i64 for practical values
@@ -111,7 +104,7 @@ impl WatermarkGenerator for BoundedOutOfOrdernessGenerator {
         // clock is a corrupt producer clock, not time progress. Ignore it
         // for watermark advancement (the row still flows downstream).
         if self.max_future_skew_ms > 0 {
-            let now = Self::now_ms();
+            let now = now_unix_millis();
             if now > 0 && timestamp > now.saturating_add(self.max_future_skew_ms) {
                 return None;
             }
@@ -647,14 +640,6 @@ impl ProcessingTimeGenerator {
         }
     }
 
-    /// Returns the current wall-clock time in milliseconds since Unix epoch.
-    #[allow(clippy::cast_possible_truncation)]
-    fn now_millis() -> i64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_millis() as i64
-    }
 }
 
 impl Default for ProcessingTimeGenerator {
@@ -672,7 +657,7 @@ impl WatermarkGenerator for ProcessingTimeGenerator {
 
     #[inline]
     fn on_periodic(&mut self) -> Option<Watermark> {
-        let now = Self::now_millis();
+        let now = now_unix_millis();
         if now > self.current_watermark {
             self.current_watermark = now;
             Some(Watermark::new(now))
@@ -1086,37 +1071,23 @@ mod tests {
 
     // --- ADR-002 future-skew guard ---
 
-    fn now_ms() -> i64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64
-    }
-
     #[test]
     fn future_skew_event_does_not_advance_watermark() {
-        let mut gen = BoundedOutOfOrdernessGenerator::new(0); // 5-min default skew
-        let now = now_ms();
-        // One event ~2h in the future must NOT poison the watermark.
+        let mut gen = BoundedOutOfOrdernessGenerator::new(0);
+        let now = super::now_unix_millis();
+        // A ~2h-future event must not poison the watermark...
         assert_eq!(gen.on_event(now + 2 * 60 * 60 * 1000), None);
         assert_eq!(gen.current_watermark(), i64::MIN);
-        // A normal event still advances it.
-        let wm = gen.on_event(now);
-        assert_eq!(wm, Some(Watermark::new(now)));
+        // ...but a normal event still advances it.
+        assert_eq!(gen.on_event(now), Some(Watermark::new(now)));
     }
 
     #[test]
-    fn future_skew_guard_disabled_restores_legacy() {
-        let mut gen = BoundedOutOfOrdernessGenerator::new(0).with_max_future_skew(0);
-        let future = now_ms() + 2 * 60 * 60 * 1000;
-        assert_eq!(gen.on_event(future), Some(Watermark::new(future)));
-    }
-
-    #[test]
-    fn advance_watermark_is_not_guarded() {
-        // External / source-provided watermarks are trusted assertions.
+    fn advance_watermark_bypasses_the_future_guard() {
+        // External / source-provided watermarks are trusted; this is why
+        // the source-side late-drop tests still pass.
         let mut gen = BoundedOutOfOrdernessGenerator::new(0);
-        let future = now_ms() + 2 * 60 * 60 * 1000;
+        let future = super::now_unix_millis() + 2 * 60 * 60 * 1000;
         assert_eq!(gen.advance_watermark(future), Some(Watermark::new(future)));
     }
 }

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -154,9 +154,8 @@ pub(crate) struct SourceWatermarkState {
     pub(crate) column: String,
 }
 
-/// Keep rows at/after the watermark; `Ok(None)` means every row was late.
-/// `Err` is schema drift (missing/!timestamp column) — distinct from
-/// all-late so the caller doesn't misreport it as a watermark drop.
+/// Keep rows at/after the watermark. `Ok(None)` = all rows late;
+/// `Err` = schema drift (missing/non-timestamp column).
 pub(crate) fn filter_late_rows(
     batch: &RecordBatch,
     column: &str,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -154,24 +154,20 @@ pub(crate) struct SourceWatermarkState {
     pub(crate) column: String,
 }
 
+/// Keep rows at/after the watermark; `Ok(None)` means every row was late.
+/// `Err` is schema drift (missing/!timestamp column) — distinct from
+/// all-late so the caller doesn't misreport it as a watermark drop.
 pub(crate) fn filter_late_rows(
     batch: &RecordBatch,
     column: &str,
     watermark: i64,
-) -> Option<RecordBatch> {
-    match laminar_core::time::filter_batch_by_timestamp(
+) -> Result<Option<RecordBatch>, laminar_core::time::FilterError> {
+    laminar_core::time::filter_batch_by_timestamp(
         batch,
         column,
         watermark,
         laminar_core::time::ThresholdOp::GreaterEq,
-    ) {
-        Ok(out) => out,
-        Err(e) => {
-            // Schema drift — drop the batch rather than silently admit late rows.
-            tracing::error!(%column, error = %e, "filter_late_rows: dropping batch");
-            None
-        }
-    }
+    )
 }
 
 pub(crate) use laminar_core::time::parse_duration_str;

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -2738,7 +2738,9 @@ fn test_filter_late_rows_filters_correctly() {
     .unwrap();
 
     // Watermark at 300: rows with ts >= 300 survive (ts=500, ts=800).
-    let filtered = filter_late_rows(&batch, "ts", 300).expect("should have some on-time rows");
+    let filtered = filter_late_rows(&batch, "ts", 300)
+        .expect("no schema drift")
+        .expect("some on-time rows");
     assert_eq!(filtered.num_rows(), 2);
 
     let ids = filtered
@@ -2772,7 +2774,10 @@ fn test_filter_late_rows_all_late() {
     .unwrap();
 
     let result = filter_late_rows(&batch, "ts", 1000);
-    assert!(result.is_none(), "all-late batch should return None");
+    assert!(
+        matches!(result, Ok(None)),
+        "all-late batch should be Ok(None), got {result:?}"
+    );
 }
 
 #[test]
@@ -2782,8 +2787,9 @@ fn test_filter_late_rows_no_column() {
     let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
     let batch = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2]))]).unwrap();
 
-    // Missing event-time column is schema drift — drop the batch.
-    assert!(filter_late_rows(&batch, "ts", 1000).is_none());
+    // Missing event-time column is schema drift — an error, distinct
+    // from an all-late batch so it isn't misreported as a watermark drop.
+    assert!(filter_late_rows(&batch, "ts", 1000).is_err());
 }
 
 /// Helper: creates a `RecordBatch` with (id: BIGINT, ts: BIGINT).

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -42,13 +42,12 @@ enum SinkFilterDispatch {
 /// 2. `spawn_blocking` on `current_thread` has no dedicated blocking pool
 /// 3. The compute thread is dedicated — blocking is acceptable
 // Throttled (~once/10s) WARN so silent watermark drops are diagnosable.
-#[allow(clippy::cast_possible_truncation)]
 fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize) {
     use std::sync::atomic::{AtomicI64, Ordering};
     static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_millis() as i64);
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
     if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
         return;
     }
@@ -668,9 +667,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         let after = out.as_ref().map_or(0, arrow_array::RecordBatch::num_rows);
                         let dropped = before.saturating_sub(after);
                         if dropped > 0 {
-                            #[allow(clippy::cast_possible_truncation)]
-                            let d = dropped as u64;
-                            self.prom.events_dropped.inc_by(d);
+                            self.prom
+                                .events_dropped
+                                .inc_by(u64::try_from(dropped).unwrap_or(u64::MAX));
                             warn_late_drops(source_name, &wm_state.column, current_wm, dropped);
                         }
                         return out;

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -41,6 +41,29 @@ enum SinkFilterDispatch {
 /// 1. `tokio::spawn` on `current_thread` has no parallelism benefit
 /// 2. `spawn_blocking` on `current_thread` has no dedicated blocking pool
 /// 3. The compute thread is dedicated — blocking is acceptable
+// Throttled (~once/10s) WARN so a watermark silently dropping rows is
+// diagnosable instead of looking like a hang.
+#[allow(clippy::cast_possible_truncation)]
+fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize) {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis() as i64);
+    if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
+        return;
+    }
+    LAST_WARN_MS.store(now_ms, Ordering::Relaxed);
+    tracing::warn!(
+        source,
+        time_column = column,
+        watermark_ms,
+        dropped,
+        "dropping rows older than the event-time watermark; a future-dated \
+         timestamp can advance the watermark and starve the stream"
+    );
+}
+
 pub(crate) struct ConnectorPipelineCallback {
     pub(crate) graph: crate::operator_graph::OperatorGraph,
     pub(crate) stream_sources: Vec<(String, streaming::Source<crate::catalog::ArrowRecord>)>,
@@ -640,7 +663,17 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if let Some(wm_state) = self.watermark_states.get(source_name) {
             let current_wm = wm_state.generator.current_watermark();
             if current_wm > i64::MIN {
-                return filter_late_rows(batch, &wm_state.column, current_wm);
+                let before = batch.num_rows();
+                let out = filter_late_rows(batch, &wm_state.column, current_wm);
+                let after = out.as_ref().map_or(0, arrow_array::RecordBatch::num_rows);
+                let dropped = before.saturating_sub(after);
+                if dropped > 0 {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let d = dropped as u64;
+                    self.prom.events_dropped.inc_by(d);
+                    warn_late_drops(source_name, &wm_state.column, current_wm, dropped);
+                }
+                return out;
             }
         }
         // No watermark configured → pass through all rows.

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -41,8 +41,7 @@ enum SinkFilterDispatch {
 /// 1. `tokio::spawn` on `current_thread` has no parallelism benefit
 /// 2. `spawn_blocking` on `current_thread` has no dedicated blocking pool
 /// 3. The compute thread is dedicated — blocking is acceptable
-// Throttled (~once/10s) WARN so a watermark silently dropping rows is
-// diagnosable instead of looking like a hang.
+// Throttled (~once/10s) WARN so silent watermark drops are diagnosable.
 #[allow(clippy::cast_possible_truncation)]
 fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize) {
     use std::sync::atomic::{AtomicI64, Ordering};
@@ -677,9 +676,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         return out;
                     }
                     Err(e) => {
-                        // Schema drift, not a late-data condition: drop the
-                        // batch (fail-safe) and log it as the error it is —
-                        // no misleading watermark warning.
+                        // Schema drift, not lateness: fail-safe drop + error.
                         tracing::error!(
                             source = source_name,
                             column = %wm_state.column,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -664,16 +664,31 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             let current_wm = wm_state.generator.current_watermark();
             if current_wm > i64::MIN {
                 let before = batch.num_rows();
-                let out = filter_late_rows(batch, &wm_state.column, current_wm);
-                let after = out.as_ref().map_or(0, arrow_array::RecordBatch::num_rows);
-                let dropped = before.saturating_sub(after);
-                if dropped > 0 {
-                    #[allow(clippy::cast_possible_truncation)]
-                    let d = dropped as u64;
-                    self.prom.events_dropped.inc_by(d);
-                    warn_late_drops(source_name, &wm_state.column, current_wm, dropped);
+                match filter_late_rows(batch, &wm_state.column, current_wm) {
+                    Ok(out) => {
+                        let after = out.as_ref().map_or(0, arrow_array::RecordBatch::num_rows);
+                        let dropped = before.saturating_sub(after);
+                        if dropped > 0 {
+                            #[allow(clippy::cast_possible_truncation)]
+                            let d = dropped as u64;
+                            self.prom.events_dropped.inc_by(d);
+                            warn_late_drops(source_name, &wm_state.column, current_wm, dropped);
+                        }
+                        return out;
+                    }
+                    Err(e) => {
+                        // Schema drift, not a late-data condition: drop the
+                        // batch (fail-safe) and log it as the error it is —
+                        // no misleading watermark warning.
+                        tracing::error!(
+                            source = source_name,
+                            column = %wm_state.column,
+                            error = %e,
+                            "filter_late_rows: dropping batch (schema drift)"
+                        );
+                        return None;
+                    }
                 }
-                return out;
             }
         }
         // No watermark configured → pass through all rows.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1123,10 +1123,17 @@ impl LaminarDB {
         // rather than time progress. `LAMINAR_MAX_FUTURE_SKEW_MS=0`
         // disables it (restores legacy unbounded behaviour) for the rare
         // legitimately-far-future pipeline.
-        let future_skew_ms = std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS")
-            .ok()
-            .and_then(|v| v.parse::<i64>().ok())
-            .unwrap_or(laminar_core::time::DEFAULT_MAX_FUTURE_SKEW_MS);
+        let future_skew_ms = match std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS") {
+            Ok(v) => v.parse::<i64>().unwrap_or_else(|_| {
+                tracing::warn!(
+                    value = %v,
+                    "invalid LAMINAR_MAX_FUTURE_SKEW_MS (expected an integer); \
+                     using the default"
+                );
+                laminar_core::time::DEFAULT_MAX_FUTURE_SKEW_MS
+            }),
+            Err(_) => laminar_core::time::DEFAULT_MAX_FUTURE_SKEW_MS,
+        };
         let source_names = self.catalog.list_sources();
         let mut watermark_states: FxHashMap<String, SourceWatermarkState> =
             FxHashMap::with_capacity_and_hasher(source_names.len(), rustc_hash::FxBuildHasher);

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1117,7 +1117,7 @@ impl LaminarDB {
             }
         }
 
-        // Per-source watermark state. ADR-002 future-skew ceiling;
+        // Per-source watermark state. Future-skew ceiling;
         // `LAMINAR_MAX_FUTURE_SKEW_MS=0` disables it (legacy unbounded).
         let future_skew_ms = match std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS") {
             Ok(v) => v.parse::<i64>().unwrap_or_else(|_| {

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1117,7 +1117,16 @@ impl LaminarDB {
             }
         }
 
-        // Build per-source watermark tracking state (connector pipeline)
+        // Build per-source watermark tracking state (connector pipeline).
+        // ADR-002: cap how far a single event timestamp may run ahead of
+        // wall clock before it's treated as a corrupt producer clock
+        // rather than time progress. `LAMINAR_MAX_FUTURE_SKEW_MS=0`
+        // disables it (restores legacy unbounded behaviour) for the rare
+        // legitimately-far-future pipeline.
+        let future_skew_ms = std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(laminar_core::time::DEFAULT_MAX_FUTURE_SKEW_MS);
         let source_names = self.catalog.list_sources();
         let mut watermark_states: FxHashMap<String, SourceWatermarkState> =
             FxHashMap::with_capacity_and_hasher(source_names.len(), rustc_hash::FxBuildHasher);
@@ -1139,7 +1148,8 @@ impl LaminarDB {
                         Box::new(laminar_core::time::ProcessingTimeGenerator::new())
                     } else {
                         Box::new(
-                            laminar_core::time::BoundedOutOfOrdernessGenerator::from_duration(dur),
+                            laminar_core::time::BoundedOutOfOrdernessGenerator::from_duration(dur)
+                                .with_max_future_skew(future_skew_ms),
                         )
                     };
                     let id = source_ids.len();
@@ -1185,7 +1195,8 @@ impl LaminarDB {
                         Box::new(
                             laminar_core::time::BoundedOutOfOrdernessGenerator::from_duration(
                                 ooo_bound,
-                            ),
+                            )
+                            .with_max_future_skew(future_skew_ms),
                         )
                     };
                     let id = source_ids.len();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1117,12 +1117,8 @@ impl LaminarDB {
             }
         }
 
-        // Build per-source watermark tracking state (connector pipeline).
-        // ADR-002: cap how far a single event timestamp may run ahead of
-        // wall clock before it's treated as a corrupt producer clock
-        // rather than time progress. `LAMINAR_MAX_FUTURE_SKEW_MS=0`
-        // disables it (restores legacy unbounded behaviour) for the rare
-        // legitimately-far-future pipeline.
+        // Per-source watermark state. ADR-002 future-skew ceiling;
+        // `LAMINAR_MAX_FUTURE_SKEW_MS=0` disables it (legacy unbounded).
         let future_skew_ms = match std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS") {
             Ok(v) => v.parse::<i64>().unwrap_or_else(|_| {
                 tracing::warn!(


### PR DESCRIPTION
## Problem

A source with a declared `WATERMARK FOR` silently discarded **all** data
after a single future-dated event. `BoundedOutOfOrdernessGenerator`
advanced from any larger timestamp with no ceiling, so one event with a
bad producer clock (observed live on the Bluesky firehose: a `+2h`
`createdAt`) pinned the watermark hours ahead permanently. Every
subsequent real-time row was then classified late and dropped at the
source. `events_ingested_total` climbed unbounded while
`events_emitted_total` froze and `events_dropped_total` stayed `0` —
operationally indistinguishable from a hang.

## Changes

- **`cf6394c6` — observability.** `filter_late_rows` now counts dropped
  rows into the existing `events_dropped` counter and emits a throttled
  (~once/10s) WARN naming source/column/watermark. No semantic change.
- **`2a658457` — future-skew guard (ADR-002).**
  `BoundedOutOfOrdernessGenerator::on_event` ignores, *for watermark
  advancement only*, timestamps more than `max_future_skew_ms` beyond
  wall clock. The row still flows downstream; only its ability to drag
  the watermark is suppressed. `advance_watermark` (external /
  source-provided watermarks) is a trusted assertion and stays
  unguarded. Secure by default (`DEFAULT_MAX_FUTURE_SKEW_MS` = 5 min),
  overridable via `LAMINAR_MAX_FUTURE_SKEW_MS` (`0` = legacy unbounded).
- **`e8ddb410` — review fixups.** Dedupe the two identical wall-clock
  readers into one `now_unix_millis()`; trim docs/tests.

## Deliberately *not* changed

Source-side late-filtering of **non-windowed** consumers is intended,
regression-tested behaviour (`db::tests` —
`test_late_data_dropped_after_external_watermark` asserts a pure
projection drops late rows; `WATERMARK FOR` means "drop late data
here"). Scoping the filter to time-sensitive consumers was prototyped
and **reverted** — it breaks 10 tests and changes a published contract.
The fix is making the watermark robust, not narrowing where it applies.

## Design

Full rationale, alternatives, and the as-built scope (reference clock =
wall clock at watermark generation; per-batch capture + checkpoint
persistence refined out as disproportionate for a sub-skew, crash-only
boundary residual) are in `ADR-002-event-time-watermark-future-skew.md`
(private docs submodule).

## Testing

- `laminar-core`: watermark unit tests (incl. gross-future ignored,
  `advance_watermark` unguarded) + doctests — green.
- `laminar-db`: full lib suite **657 passed, 0 failed**, including the
  10 watermark/late-drop tests that pin the preserved contract.
- `cargo clippy -D warnings`, `cargo fmt` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded event-time watermarks to ignore far-future timestamps and added clear observability for true late-row drops, not schema drift. Prevents a bad producer clock from pinning the watermark and starving real-time data.

- **Bug Fixes**
  - In `laminar-core`, `BoundedOutOfOrdernessGenerator::on_event` ignores timestamps >5 min ahead of wall clock for watermark advancement; rows still flow; `advance_watermark` stays trusted. Exported `DEFAULT_MAX_FUTURE_SKEW_MS` and re-exported `FilterError`. Configurable via `LAMINAR_MAX_FUTURE_SKEW_MS` (`0` disables); invalid values log a WARN and fall back to the default.
  - In `laminar-db`, `filter_late_rows` now returns `Result<Option<RecordBatch>, FilterError>` so all-late (`Ok(None)`) is distinct from schema drift (`Err`). Only genuine late drops increment `events_dropped_total` and trigger a throttled WARN; schema drift logs an error and is not counted.

- **Refactors**
  - Replaced cast allows with explicit, saturating conversions in core/db; no behavior change.
  - Trimmed dead ADR references in source comments.

<sup>Written for commit 5facd30ff454750cc2810c2745414f645b77e515. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/388?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable maximum future skew bound for event timestamps, preventing implausibly large timestamps from advancing the watermark and protecting data quality.
  * Enhanced observability with logging and metrics reporting when late rows are dropped due to watermark progression, including row counts and watermark details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->