### PR TITLE
fix(core,db,connectors): guard untrusted numeric casts; drop vestigial watermark message

### DIFF
--- a/crates/laminar-connectors/src/cdc/mysql/decoder.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/decoder.rs
@@ -248,7 +248,8 @@ impl ColumnValue {
                 // Floor-divide so the sub-second part is always non-negative,
                 // even for pre-epoch (negative) microsecond timestamps.
                 let secs = us.div_euclid(1_000_000);
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)] // rem_euclid yields [0, 999_999]
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+                // rem_euclid yields [0, 999_999]
                 let micros = us.rem_euclid(1_000_000) as u32;
                 format!("{secs}.{micros:06}")
             }

--- a/crates/laminar-connectors/src/cdc/mysql/decoder.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/decoder.rs
@@ -245,11 +245,11 @@ impl ColumnValue {
                 }
             }
             ColumnValue::Timestamp(us) => {
-                // Convert microseconds to ISO format
-                let secs = us / 1_000_000;
-                // us % 1_000_000 is always in [0, 999_999] so u32 cast is safe
-                #[allow(clippy::cast_sign_loss)]
-                let micros = (us % 1_000_000) as u32;
+                // Floor-divide so the sub-second part is always non-negative,
+                // even for pre-epoch (negative) microsecond timestamps.
+                let secs = us.div_euclid(1_000_000);
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)] // rem_euclid yields [0, 999_999]
+                let micros = us.rem_euclid(1_000_000) as u32;
                 format!("{secs}.{micros:06}")
             }
         }

--- a/crates/laminar-connectors/src/cdc/mysql/mysql_io.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/mysql_io.rs
@@ -386,10 +386,11 @@ fn mysql_value_to_column_value(val: &mysql_async::Value) -> ColumnValue {
             }
         }
         mysql_async::Value::Time(is_negative, days, hours, minutes, seconds, micros) => {
-            // Convert days+hours to total hours.
-            // days is u32 and hours is u8, product fits in i32.
-            #[allow(clippy::cast_possible_wrap)]
-            let total_hours = (*days as i32) * 24 + i32::from(*hours);
+            // `days`/`hours` come off the wire; compute in i64 and clamp so a
+            // corrupt value can't overflow or sign-flip (a valid MySQL TIME is
+            // at most 838 hours).
+            let total_hours_wide = i64::from(*days) * 24 + i64::from(*hours);
+            let total_hours = i32::try_from(total_hours_wide).unwrap_or(i32::MAX);
             let h = if *is_negative {
                 -total_hours
             } else {

--- a/crates/laminar-connectors/src/cdc/mysql/mysql_io.rs
+++ b/crates/laminar-connectors/src/cdc/mysql/mysql_io.rs
@@ -386,11 +386,11 @@ fn mysql_value_to_column_value(val: &mysql_async::Value) -> ColumnValue {
             }
         }
         mysql_async::Value::Time(is_negative, days, hours, minutes, seconds, micros) => {
-            // `days`/`hours` come off the wire; compute in i64 and clamp so a
-            // corrupt value can't overflow or sign-flip (a valid MySQL TIME is
-            // at most 838 hours).
+            // MySQL TIME is bounded to ±838:59:59. Compute in i64 and clamp a
+            // corrupt/garbage wire value to that domain so it can't overflow,
+            // sign-flip, or masquerade as a fabricated multi-million-hour value.
             let total_hours_wide = i64::from(*days) * 24 + i64::from(*hours);
-            let total_hours = i32::try_from(total_hours_wide).unwrap_or(i32::MAX);
+            let total_hours = i32::try_from(total_hours_wide.min(838)).unwrap_or(838);
             let h = if *is_negative {
                 -total_hours
             } else {

--- a/crates/laminar-connectors/src/mongodb/source.rs
+++ b/crates/laminar-connectors/src/mongodb/source.rs
@@ -125,7 +125,7 @@ pub struct MongoDbCdcSource {
 }
 
 /// Payload from the background change stream reader task.
-#[allow(dead_code)]
+#[allow(dead_code)] // constructed + consumed only with feature = "mongodb-cdc"
 enum ChangeStreamPayload {
     /// A change event.
     Event(Box<MongoDbChangeEvent>),

--- a/crates/laminar-connectors/src/prom.rs
+++ b/crates/laminar-connectors/src/prom.rs
@@ -18,9 +18,12 @@ impl RegHandle<'_> {
         self.registry
     }
 
-    /// Register an `IntCounter`. Panics on a malformed name/help.
+    /// Register an `IntCounter`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name`/`help` is not a valid Prometheus identifier.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
     pub fn counter(&self, name: &str, help: &str) -> IntCounter {
         let c =
             IntCounter::new(name, help).unwrap_or_else(|e| panic!("invalid counter '{name}': {e}"));
@@ -28,18 +31,24 @@ impl RegHandle<'_> {
         c
     }
 
-    /// Register an `IntGauge`. Panics on a malformed name/help.
+    /// Register an `IntGauge`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name`/`help` is not a valid Prometheus identifier.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
     pub fn gauge(&self, name: &str, help: &str) -> IntGauge {
         let g = IntGauge::new(name, help).unwrap_or_else(|e| panic!("invalid gauge '{name}': {e}"));
         self.registry.register(Box::new(g.clone())).ok();
         g
     }
 
-    /// Register an `IntCounterVec`. Panics on malformed name/help/labels.
+    /// Register an `IntCounterVec`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name`/`help`/`labels` are not valid Prometheus identifiers.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
     pub fn counter_vec(&self, name: &str, help: &str, labels: &[&str]) -> IntCounterVec {
         let v = IntCounterVec::new(Opts::new(name, help), labels)
             .unwrap_or_else(|e| panic!("invalid counter_vec '{name}': {e}"));
@@ -47,9 +56,12 @@ impl RegHandle<'_> {
         v
     }
 
-    /// Register an `IntGaugeVec`. Panics on malformed name/help/labels.
+    /// Register an `IntGaugeVec`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name`/`help`/`labels` are not valid Prometheus identifiers.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
     pub fn gauge_vec(&self, name: &str, help: &str, labels: &[&str]) -> IntGaugeVec {
         let v = IntGaugeVec::new(Opts::new(name, help), labels)
             .unwrap_or_else(|e| panic!("invalid gauge_vec '{name}': {e}"));
@@ -62,7 +74,7 @@ impl RegHandle<'_> {
 /// in `local` (which must outlive construction). Pattern:
 /// `let mut local = None; let reg = reg_or_local(registry, &mut local);`
 #[must_use]
-#[allow(clippy::missing_panics_doc)]
+#[allow(clippy::missing_panics_doc)] // `expect` follows an unconditional `*local = Some(..)`
 pub fn reg_or_local<'a>(
     registry: Option<&'a Registry>,
     local: &'a mut Option<Registry>,

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -1071,7 +1071,14 @@ fn extract_timestamp(
         return Ok(millis_to_unit(n, unit));
     }
     if let Some(f) = value.as_f64() {
-        #[allow(clippy::cast_possible_truncation)]
+        // `f as i64` saturates (NaN -> 0, +-huge -> i64::MIN/MAX), which would
+        // silently turn a garbage timestamp into a valid-looking one and
+        // poison event-time/watermarks. Reject out-of-range values so the
+        // configured type-mismatch strategy applies, like any other bad value.
+        if !(-9_223_372_036_854_775_808.0..9_223_372_036_854_775_808.0).contains(&f) {
+            return Err(format!("timestamp {f} out of i64 millisecond range"));
+        }
+        #[allow(clippy::cast_possible_truncation)] // range-checked above; drops sub-ms fraction
         let ms = f as i64;
         return Ok(millis_to_unit(ms, unit));
     }
@@ -1438,6 +1445,27 @@ mod tests {
             .as_primitive::<arrow_array::types::TimestampNanosecondType>();
         // 1705312200000 ms * 1_000_000 = nanos
         assert_eq!(ts_col.value(0), 1_705_312_200_000_000_000);
+    }
+
+    #[test]
+    fn test_decode_out_of_range_float_timestamp_is_rejected() {
+        // A garbage float epoch-ms must not silently saturate to i64::MAX
+        // and poison event-time/watermarks — it routes through the
+        // configured type-mismatch path instead.
+        let schema = make_schema(vec![(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        )]);
+        let decoder = JsonDecoder::new(schema);
+        let records = vec![json_record(r#"{"ts": 1e30}"#)];
+        let result = decoder.decode_batch(&records);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("out of i64 millisecond range"));
     }
 
     // ── Nested objects as LargeBinary ─────────────────────────

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -1071,15 +1071,19 @@ fn extract_timestamp(
         return Ok(millis_to_unit(n, unit));
     }
     if let Some(f) = value.as_f64() {
-        // `f as i64` saturates (NaN -> 0, +-huge -> i64::MIN/MAX), which would
-        // silently turn a garbage timestamp into a valid-looking one and
-        // poison event-time/watermarks. Reject out-of-range values so the
-        // configured type-mismatch strategy applies, like any other bad value.
-        if !(-9_223_372_036_854_775_808.0..9_223_372_036_854_775_808.0).contains(&f) {
+        // 2^63 == i64::MAX + 1; exclusive upper bound for a lossless f64->i64.
+        const POW2_63: f64 = 9_223_372_036_854_775_808.0;
+        // `f as i64` saturates (NaN -> 0, +-huge -> i64::MIN/MAX), silently
+        // turning a garbage timestamp into a valid-looking one that poisons
+        // event-time/watermarks. Round to the nearest millisecond and reject
+        // out-of-range/non-finite so the configured type-mismatch strategy
+        // applies, like any other bad value.
+        let rounded = f.round();
+        if !(-POW2_63..POW2_63).contains(&rounded) {
             return Err(format!("timestamp {f} out of i64 millisecond range"));
         }
-        #[allow(clippy::cast_possible_truncation)] // range-checked above; drops sub-ms fraction
-        let ms = f as i64;
+        #[allow(clippy::cast_possible_truncation)] // range-checked; already integral
+        let ms = rounded as i64;
         return Ok(millis_to_unit(ms, unit));
     }
 

--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -1068,7 +1068,7 @@ fn extract_timestamp(
 ) -> Result<i64, String> {
     // Numeric values: treat as epoch milliseconds.
     if let Some(n) = value.as_i64() {
-        return Ok(millis_to_unit(n, unit));
+        return checked_millis_to_unit(n, unit);
     }
     if let Some(f) = value.as_f64() {
         // 2^63 == i64::MAX + 1; exclusive upper bound for a lossless f64->i64.
@@ -1084,7 +1084,7 @@ fn extract_timestamp(
         }
         #[allow(clippy::cast_possible_truncation)] // range-checked; already integral
         let ms = rounded as i64;
-        return Ok(millis_to_unit(ms, unit));
+        return checked_millis_to_unit(ms, unit);
     }
 
     // String values: try configured timestamp formats.
@@ -1107,13 +1107,18 @@ fn extract_timestamp(
     Err(format!("expected timestamp, got {}", json_type_name(value)))
 }
 
-/// Converts epoch milliseconds to the target time unit.
-fn millis_to_unit(ms: i64, unit: TimeUnit) -> i64 {
+/// Converts epoch milliseconds to the target `TimeUnit`, erroring rather
+/// than wrapping when scaling overflows i64 (Microsecond/Nanosecond).
+fn checked_millis_to_unit(ms: i64, unit: TimeUnit) -> Result<i64, String> {
     match unit {
-        TimeUnit::Second => ms / 1_000,
-        TimeUnit::Millisecond => ms,
-        TimeUnit::Microsecond => ms * 1_000,
-        TimeUnit::Nanosecond => ms * 1_000_000,
+        TimeUnit::Second => Ok(ms / 1_000),
+        TimeUnit::Millisecond => Ok(ms),
+        TimeUnit::Microsecond => ms
+            .checked_mul(1_000)
+            .ok_or_else(|| format!("timestamp {ms} out of i64 microsecond range")),
+        TimeUnit::Nanosecond => ms
+            .checked_mul(1_000_000)
+            .ok_or_else(|| format!("timestamp {ms} out of i64 nanosecond range")),
     }
 }
 
@@ -1470,6 +1475,26 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("out of i64 millisecond range"));
+    }
+
+    #[test]
+    fn test_decode_timestamp_overflow_on_nanosecond_scaling_is_rejected() {
+        // A ms value that fits i64 but overflows when scaled to nanoseconds
+        // must error, not wrap into a bogus (watermark-poisoning) timestamp.
+        let schema = make_schema(vec![(
+            "ts",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            false,
+        )]);
+        let decoder = JsonDecoder::new(schema);
+        let records = vec![json_record(r#"{"ts": 9999999999999999}"#)];
+        let result = decoder.decode_batch(&records);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("out of i64 nanosecond range"));
     }
 
     // ── Nested objects as LargeBinary ─────────────────────────

--- a/crates/laminar-connectors/src/websocket/parser.rs
+++ b/crates/laminar-connectors/src/websocket/parser.rs
@@ -48,6 +48,9 @@ impl MessageParser {
                 delimiter,
                 has_header,
             } => {
+                // `parse_format` hard-codes the CSV delimiter to ',', so this
+                // is ASCII by construction. If the delimiter ever becomes
+                // user-configurable, validate `is_ascii()` at config parse.
                 #[allow(clippy::cast_possible_truncation)]
                 let csv_config = CsvDecoderConfig {
                     delimiter: *delimiter as u8,

--- a/crates/laminar-core/src/cluster/discovery/static_discovery.rs
+++ b/crates/laminar-core/src/cluster/discovery/static_discovery.rs
@@ -80,7 +80,6 @@ struct PeerState {
 pub struct StaticDiscovery {
     config: StaticDiscoveryConfig,
     peers: Arc<RwLock<HashMap<u64, PeerState>>>,
-    #[allow(dead_code)]
     membership_tx: watch::Sender<Vec<NodeInfo>>,
     membership_rx: watch::Receiver<Vec<NodeInfo>>,
     cancel: CancellationToken,

--- a/crates/laminar-core/src/shuffle/transport.rs
+++ b/crates/laminar-core/src/shuffle/transport.rs
@@ -353,7 +353,7 @@ impl ShuffleReceiver {
     /// Single-owner; concurrent callers serialise via `rx_returned`.
     /// Cancellation-safe — a dropped `recv()` future returns the
     /// receiver to its slot via the internal RAII guard.
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc)] // `expect` upholds a local invariant set 3 lines above
     pub async fn recv(&self) -> Option<(ShufflePeerId, ShuffleMessage)> {
         loop {
             // Scope the guard so it is dropped before any `.await` —

--- a/crates/laminar-core/src/streaming/checkpoint.rs
+++ b/crates/laminar-core/src/streaming/checkpoint.rs
@@ -11,6 +11,9 @@ pub struct StreamCheckpointConfig {
     pub data_dir: Option<std::path::PathBuf>,
     /// Maximum number of retained checkpoints. `None` = default (3).
     pub max_retained: Option<usize>,
+    /// Barrier-alignment timeout in milliseconds at fan-in operators.
+    /// `None` = default (`30_000`).
+    pub alignment_timeout_ms: Option<u64>,
 }
 
 /// Errors from checkpoint operations.
@@ -55,5 +58,6 @@ mod tests {
         assert!(config.interval_ms.is_none());
         assert!(config.data_dir.is_none());
         assert!(config.max_retained.is_none());
+        assert!(config.alignment_timeout_ms.is_none());
     }
 }

--- a/crates/laminar-core/src/streaming/source.rs
+++ b/crates/laminar-core/src/streaming/source.rs
@@ -55,9 +55,6 @@ pub(crate) enum SourceMessage<T> {
 
     /// A batch of Arrow records.
     Batch(RecordBatch),
-
-    /// A watermark timestamp.
-    Watermark(#[allow(dead_code)] i64),
 }
 
 /// Shared state for watermark tracking.
@@ -197,7 +194,7 @@ impl<T: Record> Source<T> {
                     value: r,
                     error: StreamingError::ChannelFull,
                 },
-                _ => unreachable!(),
+                SourceMessage::Batch(_) => unreachable!("only Record is pushed here"),
             })?;
 
         self.inner.sequence.fetch_add(1, Ordering::Relaxed);
@@ -275,14 +272,11 @@ impl<T: Record> Source<T> {
     /// Watermarks are monotonically increasing - if a lower timestamp is
     /// passed, it will be ignored.
     pub fn watermark(&self, timestamp: i64) {
+        // The shared atomic is the authoritative watermark: the pipeline's
+        // watermark UDF, late-row filter, and checkpoint registration all
+        // read it via `watermark_atomic()`. Subscribers receive data only,
+        // so there is no in-band watermark message to emit.
         self.inner.watermark.update(timestamp);
-
-        // Best-effort send of watermark message
-        // It's okay if this fails - the atomic watermark state is updated
-        let _ = self
-            .inner
-            .producer
-            .try_push(SourceMessage::Watermark(timestamp));
     }
 
     /// Returns the current watermark value.

--- a/crates/laminar-core/src/streaming/subscription.rs
+++ b/crates/laminar-core/src/streaming/subscription.rs
@@ -27,17 +27,13 @@ impl<T: Record> Subscription<T> {
         }
     }
 
-    /// Non-blocking poll. Returns the next batch, skipping watermarks.
+    /// Non-blocking poll. Returns the next batch.
     /// Returns `None` on empty or closed channel. Check `is_disconnected()`
     /// to distinguish.
     pub fn poll(&mut self) -> Option<RecordBatch> {
         loop {
             match self.rx.try_recv() {
-                Ok(msg) => {
-                    if let Some(batch) = message_to_batch(msg) {
-                        return Some(batch);
-                    }
-                }
+                Ok(msg) => return Some(to_batch(msg)),
                 Err(broadcast::error::TryRecvError::Empty) => return None,
                 Err(broadcast::error::TryRecvError::Closed) => {
                     self.closed = true;
@@ -48,7 +44,7 @@ impl<T: Record> Subscription<T> {
         }
     }
 
-    /// Async receive. Awaits the next batch, skipping watermarks.
+    /// Async receive. Awaits the next batch.
     ///
     /// # Errors
     ///
@@ -56,11 +52,7 @@ impl<T: Record> Subscription<T> {
     pub async fn recv_async(&mut self) -> Result<RecordBatch, RecvError> {
         loop {
             match self.rx.recv().await {
-                Ok(msg) => {
-                    if let Some(batch) = message_to_batch(msg) {
-                        return Ok(batch);
-                    }
-                }
+                Ok(msg) => return Ok(to_batch(msg)),
                 Err(broadcast::error::RecvError::Closed) => {
                     self.closed = true;
                     return Err(RecvError::Disconnected);
@@ -78,11 +70,7 @@ impl<T: Record> Subscription<T> {
     pub fn recv(&mut self) -> Result<RecordBatch, RecvError> {
         loop {
             match self.rx.blocking_recv() {
-                Ok(msg) => {
-                    if let Some(batch) = message_to_batch(msg) {
-                        return Ok(batch);
-                    }
-                }
+                Ok(msg) => return Ok(to_batch(msg)),
                 Err(broadcast::error::RecvError::Closed) => {
                     self.closed = true;
                     return Err(RecvError::Disconnected);
@@ -120,11 +108,10 @@ impl<T: Record> Subscription<T> {
     }
 }
 
-fn message_to_batch<T: Record>(msg: SourceMessage<T>) -> Option<RecordBatch> {
+fn to_batch<T: Record>(msg: SourceMessage<T>) -> RecordBatch {
     match msg {
-        SourceMessage::Record(r) => Some(r.to_record_batch()),
-        SourceMessage::Batch(b) => Some(b),
-        SourceMessage::Watermark(_) => None,
+        SourceMessage::Record(r) => r.to_record_batch(),
+        SourceMessage::Batch(b) => b,
     }
 }
 

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1268,7 +1268,10 @@ impl LaminarDB {
                 .checkpoint
                 .as_ref()
                 .and_then(|c| c.alignment_timeout_ms)
-                .map_or(std::time::Duration::from_secs(30), std::time::Duration::from_millis),
+                .map_or(
+                    std::time::Duration::from_secs(30),
+                    std::time::Duration::from_millis,
+                ),
             delivery_guarantee: self.config.delivery_guarantee,
             // cycle_budget is a soft cap for logging; ensure it's at least
             // drain + query so sub-budgets can actually be used.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1263,10 +1263,12 @@ impl LaminarDB {
                 } else {
                     std::time::Duration::ZERO
                 }),
-            // Tracks CheckpointConfig::default().alignment_timeout.
-            // TODO: expose alignment_timeout_ms in LaminarDbConfig.checkpoint
-            // so users can configure this.
-            barrier_alignment_timeout: std::time::Duration::from_secs(30),
+            barrier_alignment_timeout: self
+                .config
+                .checkpoint
+                .as_ref()
+                .and_then(|c| c.alignment_timeout_ms)
+                .map_or(std::time::Duration::from_secs(30), std::time::Duration::from_millis),
             delivery_guarantee: self.config.delivery_guarantee,
             // cycle_budget is a soft cap for logging; ensure it's at least
             // drain + query so sub-budgets can actually be used.

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -308,11 +308,17 @@ impl<'a> RecoveryManager<'a> {
         let mut all_resolved = true;
         for (name, op) in &mut manifest.operator_states {
             if op.external {
-                #[allow(clippy::cast_possible_truncation)] // Sidecar files are always < 4 GB
-                let start = op.external_offset as usize;
-                #[allow(clippy::cast_possible_truncation)]
-                let end = start + op.external_length as usize;
-                if end <= state_data.len() {
+                // `external_offset`/`external_length` are u64 read from the
+                // on-disk manifest; compute bounds with checked arithmetic so a
+                // corrupt/tampered manifest can't overflow past the length
+                // check below.
+                let bounds = usize::try_from(op.external_offset).ok().and_then(|start| {
+                    usize::try_from(op.external_length)
+                        .ok()
+                        .and_then(|len| start.checked_add(len))
+                        .map(|end| (start, end))
+                });
+                if let Some((start, end)) = bounds.filter(|&(_, end)| end <= state_data.len()) {
                     let external_offset = op.external_offset;
                     let external_length = op.external_length;
                     let data = &state_data[start..end];
@@ -326,11 +332,12 @@ impl<'a> RecoveryManager<'a> {
                 } else {
                     error!(
                         operator = %name,
-                        offset = start,
+                        offset = op.external_offset,
                         length = op.external_length,
                         sidecar_len = state_data.len(),
-                        "[LDB-6010] sidecar too small for external operator state — \
-                         operator will start with empty state"
+                        "[LDB-6010] sidecar too small or offset/length out of \
+                         range for external operator state — operator will \
+                         start with empty state"
                     );
                     *op = laminar_storage::checkpoint_manifest::OperatorCheckpoint::inline(&[]);
                     all_resolved = false;

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -308,17 +308,18 @@ impl<'a> RecoveryManager<'a> {
         let mut all_resolved = true;
         for (name, op) in &mut manifest.operator_states {
             if op.external {
-                // `external_offset`/`external_length` are u64 read from the
-                // on-disk manifest; compute bounds with checked arithmetic so a
-                // corrupt/tampered manifest can't overflow past the length
-                // check below.
-                let bounds = usize::try_from(op.external_offset).ok().and_then(|start| {
-                    usize::try_from(op.external_length)
-                        .ok()
-                        .and_then(|len| start.checked_add(len))
-                        .map(|end| (start, end))
-                });
-                if let Some((start, end)) = bounds.filter(|&(_, end)| end <= state_data.len()) {
+                // `external_offset`/`external_length` are u64 from the on-disk
+                // manifest; use checked arithmetic so a corrupt/tampered
+                // manifest can't overflow past the length check.
+                let range = match (
+                    usize::try_from(op.external_offset),
+                    usize::try_from(op.external_length),
+                ) {
+                    (Ok(start), Ok(len)) => start.checked_add(len).map(|end| (start, end)),
+                    _ => None,
+                }
+                .filter(|&(_, end)| end <= state_data.len());
+                if let Some((start, end)) = range {
                     let external_offset = op.external_offset;
                     let external_length = op.external_length;
                     let data = &state_data[start..end];

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -380,8 +380,7 @@ pub(crate) fn extract_projection_exprs(
 pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperatorConfig) -> i64 {
     match config.window_type {
         WindowType::Tumbling => {
-            #[allow(clippy::cast_possible_truncation)]
-            let size = config.size.as_millis() as i64;
+            let size = i64::try_from(config.size.as_millis()).unwrap_or(i64::MAX);
             if size <= 0 {
                 tracing::warn!("tumbling window size is zero or negative, EOWC filtering disabled");
                 return watermark_ms;
@@ -394,15 +393,16 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
             floored.saturating_add(offset)
         }
         WindowType::Session => {
-            #[allow(clippy::cast_possible_truncation)]
-            let gap = config.gap.map_or(0, |g| g.as_millis() as i64);
+            let gap = config
+                .gap
+                .map_or(0, |g| i64::try_from(g.as_millis()).unwrap_or(i64::MAX));
             watermark_ms.saturating_sub(gap)
         }
         WindowType::Sliding => {
-            #[allow(clippy::cast_possible_truncation)]
-            let size = config.size.as_millis() as i64;
-            #[allow(clippy::cast_possible_truncation)]
-            let slide = config.slide.map_or(size, |s| s.as_millis() as i64);
+            let size = i64::try_from(config.size.as_millis()).unwrap_or(i64::MAX);
+            let slide = config
+                .slide
+                .map_or(size, |s| i64::try_from(s.as_millis()).unwrap_or(i64::MAX));
             if slide <= 0 || size <= 0 {
                 tracing::warn!(
                     slide_ms = slide,
@@ -426,8 +426,7 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
         WindowType::Cumulate => {
             // Cumulate windows share the same epoch alignment as tumbling.
             // A full epoch is closed when watermark >= epoch_end.
-            #[allow(clippy::cast_possible_truncation)]
-            let size = config.size.as_millis() as i64;
+            let size = i64::try_from(config.size.as_millis()).unwrap_or(i64::MAX);
             if size <= 0 {
                 tracing::warn!("cumulate window size is zero or negative, EOWC filtering disabled");
                 return watermark_ms;

--- a/crates/laminar-db/src/sql_utils.rs
+++ b/crates/laminar-db/src/sql_utils.rs
@@ -289,14 +289,14 @@ pub fn sql_values_to_record_batch(
                 )?)));
             }
             DataType::Int16 => {
-                columns.push(std::sync::Arc::new(Int16Array::from(narrow_i64_col::<i16>(
-                    values, col_idx, field, "INT16",
-                )?)));
+                columns.push(std::sync::Arc::new(Int16Array::from(
+                    narrow_i64_col::<i16>(values, col_idx, field, "INT16")?,
+                )));
             }
             DataType::Int32 => {
-                columns.push(std::sync::Arc::new(Int32Array::from(narrow_i64_col::<i32>(
-                    values, col_idx, field, "INT32",
-                )?)));
+                columns.push(std::sync::Arc::new(Int32Array::from(
+                    narrow_i64_col::<i32>(values, col_idx, field, "INT32")?,
+                )));
             }
             DataType::Int64 => {
                 let arr: Int64Array = values

--- a/crates/laminar-db/src/sql_utils.rs
+++ b/crates/laminar-db/src/sql_utils.rs
@@ -227,6 +227,31 @@ pub fn expr_to_bool(expr: Option<&sqlparser::ast::Expr>) -> Option<bool> {
     }
 }
 
+/// Narrow `i64` SQL literals to a smaller signed Arrow integer type,
+/// erroring on out-of-range values rather than silently wrapping.
+fn narrow_i64_col<N: TryFrom<i64>>(
+    values: &[Vec<sqlparser::ast::Expr>],
+    col_idx: usize,
+    field: &arrow::datatypes::Field,
+    sql_ty: &str,
+) -> Result<Vec<Option<N>>, DbError> {
+    values
+        .iter()
+        .map(|row| {
+            expr_to_i64(row.get(col_idx))
+                .map(|v| {
+                    N::try_from(v).map_err(|_| {
+                        DbError::InsertError(format!(
+                            "literal {v} out of range for {sql_ty} column '{}'",
+                            field.name()
+                        ))
+                    })
+                })
+                .transpose()
+        })
+        .collect()
+}
+
 /// Convert SQL `VALUES (...)` rows into an Arrow `RecordBatch`.
 ///
 /// Each inner `Vec<Expr>` is one row. Columns are matched positionally
@@ -236,7 +261,7 @@ pub fn expr_to_bool(expr: Option<&sqlparser::ast::Expr>) -> Option<bool> {
 ///
 /// Returns `DbError::InsertError` if the batch cannot be constructed
 /// (e.g. column count mismatch).
-#[allow(clippy::cast_possible_truncation)] // SQL literal values converted to Arrow numeric types
+#[allow(clippy::cast_possible_truncation)] // SQL float literals widened to Arrow f32
 pub fn sql_values_to_record_batch(
     schema: &arrow::datatypes::SchemaRef,
     values: &[Vec<sqlparser::ast::Expr>],
@@ -259,25 +284,19 @@ pub fn sql_values_to_record_batch(
                 columns.push(std::sync::Arc::new(arr));
             }
             DataType::Int8 => {
-                let arr: Int8Array = values
-                    .iter()
-                    .map(|row| expr_to_i64(row.get(col_idx)).map(|v| v as i8))
-                    .collect();
-                columns.push(std::sync::Arc::new(arr));
+                columns.push(std::sync::Arc::new(Int8Array::from(narrow_i64_col::<i8>(
+                    values, col_idx, field, "INT8",
+                )?)));
             }
             DataType::Int16 => {
-                let arr: Int16Array = values
-                    .iter()
-                    .map(|row| expr_to_i64(row.get(col_idx)).map(|v| v as i16))
-                    .collect();
-                columns.push(std::sync::Arc::new(arr));
+                columns.push(std::sync::Arc::new(Int16Array::from(narrow_i64_col::<i16>(
+                    values, col_idx, field, "INT16",
+                )?)));
             }
             DataType::Int32 => {
-                let arr: Int32Array = values
-                    .iter()
-                    .map(|row| expr_to_i64(row.get(col_idx)).map(|v| v as i32))
-                    .collect();
-                columns.push(std::sync::Arc::new(arr));
+                columns.push(std::sync::Arc::new(Int32Array::from(narrow_i64_col::<i32>(
+                    values, col_idx, field, "INT32",
+                )?)));
             }
             DataType::Int64 => {
                 let arr: Int64Array = values
@@ -391,6 +410,29 @@ mod tests {
     fn test_block_comment_only_segment() {
         let stmts = split_statements("/* just a block comment */");
         assert!(stmts.is_empty());
+    }
+
+    #[test]
+    fn int8_literal_out_of_range_is_an_error_not_a_silent_wrap() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        use sqlparser::dialect::GenericDialect;
+        use sqlparser::parser::Parser;
+
+        let lit = |s: &str| {
+            Parser::new(&GenericDialect {})
+                .try_with_sql(s)
+                .unwrap()
+                .parse_expr()
+                .unwrap()
+        };
+        let schema = std::sync::Arc::new(Schema::new(vec![Field::new("v", DataType::Int8, true)]));
+
+        // In range → Ok.
+        assert!(sql_values_to_record_batch(&schema, &[vec![lit("42")]]).is_ok());
+
+        // Out of i8 range → hard error (previously silently wrapped to 159i8).
+        let err = sql_values_to_record_batch(&schema, &[vec![lit("99999")]]).unwrap_err();
+        assert!(matches!(err, DbError::InsertError(_)));
     }
 
     #[test]

--- a/crates/laminar-db/src/table_backend.rs
+++ b/crates/laminar-db/src/table_backend.rs
@@ -129,7 +129,11 @@ mod tests {
         let schema = test_schema();
         backend.put("2", make_batch(2, "C", 3.0)).unwrap();
         assert_eq!(
-            backend.to_record_batch(&schema).unwrap().unwrap().num_rows(),
+            backend
+                .to_record_batch(&schema)
+                .unwrap()
+                .unwrap()
+                .num_rows(),
             2
         );
 

--- a/crates/laminar-db/src/table_backend.rs
+++ b/crates/laminar-db/src/table_backend.rs
@@ -11,10 +11,6 @@ use arrow::datatypes::SchemaRef;
 use crate::error::DbError;
 
 /// Backend storage for a single reference table.
-// Single-variant backend abstraction: `contains_key`/`len`/`drain`/`is_empty`
-// are exercised by unit tests / reserved for a future persistent backend;
-// the rest are used by `table_store.rs`.
-#[allow(dead_code)]
 pub(crate) enum TableBackend {
     /// In-memory storage (default behavior).
     InMemory {
@@ -23,7 +19,9 @@ pub(crate) enum TableBackend {
     },
 }
 
-#[allow(dead_code, clippy::unnecessary_wraps)] // see TableBackend: not all methods are wired into prod yet
+// `get`/`remove` are used by `table_store` reference-table read paths that
+// aren't reachable in the minimal (no-default-features) lib build.
+#[allow(dead_code, clippy::unnecessary_wraps)]
 impl TableBackend {
     /// Create a new in-memory backend.
     pub fn in_memory() -> Self {
@@ -58,31 +56,10 @@ impl TableBackend {
         }
     }
 
-    /// Check if a key exists.
-    pub fn contains_key(&self, key: &str) -> Result<bool, DbError> {
-        match self {
-            Self::InMemory { rows } => Ok(rows.contains_key(key)),
-        }
-    }
-
     /// Collect all keys.
     pub fn keys(&self) -> Result<Vec<String>, DbError> {
         match self {
             Self::InMemory { rows } => Ok(rows.keys().cloned().collect()),
-        }
-    }
-
-    /// Row count.
-    pub fn len(&self) -> Result<usize, DbError> {
-        match self {
-            Self::InMemory { rows } => Ok(rows.len()),
-        }
-    }
-
-    /// Drain all rows from the backend and return them.
-    pub fn drain(&mut self) -> Result<Vec<(String, RecordBatch)>, DbError> {
-        match self {
-            Self::InMemory { rows } => Ok(rows.drain().collect()),
         }
     }
 
@@ -105,11 +82,6 @@ impl TableBackend {
     #[allow(clippy::unused_self)]
     pub fn is_persistent(&self) -> bool {
         false
-    }
-
-    /// Whether this backend is empty.
-    pub fn is_empty(&self) -> Result<bool, DbError> {
-        self.len().map(|n| n == 0)
     }
 }
 
@@ -142,67 +114,26 @@ mod tests {
     }
 
     #[test]
-    fn test_in_memory_crud() {
+    fn in_memory_backend_round_trips_the_used_api() {
         let mut backend = TableBackend::in_memory();
         assert!(!backend.is_persistent());
-        assert!(backend.is_empty().unwrap());
 
-        // Put
-        let existed = backend.put("1", make_batch(1, "A", 1.0)).unwrap();
-        assert!(!existed);
-        assert_eq!(backend.len().unwrap(), 1);
+        // Insert (new) then update (existing) report the right prior state.
+        assert!(!backend.put("1", make_batch(1, "A", 1.0)).unwrap());
+        assert!(backend.put("1", make_batch(1, "B", 2.0)).unwrap());
 
-        // Get
-        let row = backend.get("1").unwrap().unwrap();
-        assert_eq!(row.num_rows(), 1);
+        assert_eq!(backend.get("1").unwrap().unwrap().num_rows(), 1);
+        assert_eq!(backend.keys().unwrap(), vec!["1".to_string()]);
 
-        // Contains
-        assert!(backend.contains_key("1").unwrap());
-        assert!(!backend.contains_key("2").unwrap());
-
-        // Update
-        let existed = backend.put("1", make_batch(1, "B", 2.0)).unwrap();
-        assert!(existed);
-        assert_eq!(backend.len().unwrap(), 1);
-
-        // Remove
-        let existed = backend.remove("1").unwrap();
-        assert!(existed);
-        assert!(backend.is_empty().unwrap());
-
-        // Remove missing
-        let existed = backend.remove("1").unwrap();
-        assert!(!existed);
-    }
-
-    #[test]
-    fn test_in_memory_keys_and_drain() {
-        let mut backend = TableBackend::in_memory();
-        backend.put("a", make_batch(1, "A", 1.0)).unwrap();
-        backend.put("b", make_batch(2, "B", 2.0)).unwrap();
-
-        let mut keys = backend.keys().unwrap();
-        keys.sort();
-        assert_eq!(keys, vec!["a", "b"]);
-
-        let items = backend.drain().unwrap();
-        assert_eq!(items.len(), 2);
-        assert!(backend.is_empty().unwrap());
-    }
-
-    #[test]
-    fn test_in_memory_to_record_batch() {
-        let mut backend = TableBackend::in_memory();
+        // Empty schema-only batch when present; row when populated.
         let schema = test_schema();
+        backend.put("2", make_batch(2, "C", 3.0)).unwrap();
+        assert_eq!(
+            backend.to_record_batch(&schema).unwrap().unwrap().num_rows(),
+            2
+        );
 
-        // Empty
-        let batch = backend.to_record_batch(&schema).unwrap().unwrap();
-        assert_eq!(batch.num_rows(), 0);
-
-        // With data
-        backend.put("1", make_batch(1, "A", 1.0)).unwrap();
-        backend.put("2", make_batch(2, "B", 2.0)).unwrap();
-        let batch = backend.to_record_batch(&schema).unwrap().unwrap();
-        assert_eq!(batch.num_rows(), 2);
+        assert!(backend.remove("1").unwrap());
+        assert!(!backend.remove("1").unwrap());
     }
 }

--- a/crates/laminar-db/src/table_backend.rs
+++ b/crates/laminar-db/src/table_backend.rs
@@ -11,6 +11,9 @@ use arrow::datatypes::SchemaRef;
 use crate::error::DbError;
 
 /// Backend storage for a single reference table.
+// Single-variant backend abstraction: `contains_key`/`len`/`drain`/`is_empty`
+// are exercised by unit tests / reserved for a future persistent backend;
+// the rest are used by `table_store.rs`.
 #[allow(dead_code)]
 pub(crate) enum TableBackend {
     /// In-memory storage (default behavior).
@@ -20,7 +23,7 @@ pub(crate) enum TableBackend {
     },
 }
 
-#[allow(dead_code, clippy::unnecessary_wraps)]
+#[allow(dead_code, clippy::unnecessary_wraps)] // see TableBackend: not all methods are wired into prod yet
 impl TableBackend {
     /// Create a new in-memory backend.
     pub fn in_memory() -> Self {

--- a/crates/laminar-db/tests/common/cluster_harness.rs
+++ b/crates/laminar-db/tests/common/cluster_harness.rs
@@ -161,6 +161,7 @@ impl ClusterEngineHarness {
                 interval_ms: None, // manual only — tests drive checkpoint() explicitly
                 data_dir: Some(checkpoint_dirs[idx].path().to_path_buf()),
                 max_retained: Some(3),
+                ..StreamCheckpointConfig::default()
             };
 
             // Skip `.profile(Cluster)` — `ObjectStoreCheckpointStore`

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -254,6 +254,8 @@ pub(crate) fn apply_checkpoint_config(
         interval_ms: Some(checkpoint.interval.as_millis() as u64),
         data_dir: file_url_to_path(checkpoint_url),
         max_retained: Some(checkpoint.max_retained),
+        // Not yet exposed in the server TOML; keeps the 30s default.
+        alignment_timeout_ms: None,
     };
     builder = builder.checkpoint(cfg);
 

--- a/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
+++ b/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
@@ -344,8 +344,19 @@ fn extract_i64_timestamps(col: &dyn arrow_array::Array) -> Result<Int64Array> {
                 .as_any()
                 .downcast_ref::<Float64Array>()
                 .ok_or_else(|| DataFusionError::Internal("expected Float64Array".into()))?;
-            #[allow(clippy::cast_possible_truncation)]
-            return Ok(arr.unary::<_, Int64Type>(|v| v as i64));
+            // A non-finite/out-of-range float join key would saturate
+            // (NaN -> 0, huge -> i64::MIN/MAX) and silently mis-join.
+            return arr.try_unary::<_, Int64Type, DataFusionError>(|v| {
+                let r = v.round();
+                if !(-9_223_372_036_854_775_808.0..9_223_372_036_854_775_808.0).contains(&r) {
+                    return Err(DataFusionError::Plan(format!(
+                        "Float64 temporal-join key {v} out of i64 range"
+                    )));
+                }
+                #[allow(clippy::cast_possible_truncation)] // range-checked; integral
+                let ms = r as i64;
+                Ok(ms)
+            });
         }
         other => {
             return Err(DataFusionError::Plan(format!(


### PR DESCRIPTION
## Summary

Follow-up from a codebase-wide `#[allow(...)]` / `.unwrap()` / `missing_panics_doc` / TODO audit. Fixes four real correctness issues in untrusted-input numeric handling, removes a vestigial broadcast message that could lose subscriber data, and tightens lint hygiene — net-negative LOC.

## Correctness fixes

- **Checkpoint recovery overflow** (`recovery_manager.rs`): `external_offset`/`external_length` (u64 from the on-disk manifest) were cast `as usize` and added before the bounds check, so a corrupt/tampered manifest could overflow past it. Now uses checked `try_from` + `checked_add` via a flat `match`; out-of-range routes to the existing "empty state" path.
- **MySQL TIME overflow** (`cdc/mysql/mysql_io.rs`): `(*days as i32) * 24` could overflow/sign-flip on garbage binlog data. Computed in `i64` and clamped to MySQL's documented `±838h` domain (deliberately not saturated to `i32::MAX` — a corrupt value must not masquerade as a fabricated multi-million-hour duration).
- **INSERT literal silent wrap** (`sql_utils.rs`): `INSERT ... VALUES` integer literals were narrowed `i64 as i8/i16/i32`, silently wrapping out-of-range values into stored data. Now range-checked via one generic `narrow_i64_col::<N>` helper returning `DbError::InsertError`.
- **JSON timestamp poisoning** (`schema/json/decoder.rs`): a float epoch-ms `f as i64` saturates (NaN→0, ±huge→`i64::MIN/MAX`), silently turning a garbage timestamp into a valid-looking one that poisons event-time/watermarks. Now rounds to nearest ms, range-checks, and returns `Err` so the configured type-mismatch strategy (Null/Coerce/Reject) applies like any other bad value.

## Streaming cleanup

- Removed `SourceMessage::Watermark`: the pipeline watermark flows via the shared `AtomicI64`; the in-band message was discarded by its only consumer and flooded the bounded `tokio::broadcast` ring, evicting real `Record`/`Batch` data for slow subscribers. Consolidated to a single `to_batch()` helper.

## Hygiene

- Centralized the `# Panics` docs on the 4 `prom.rs` registry helpers (the real panic site); reverted the scattered metrics-ctor allows to the original pattern.
- Removed a stale `#[allow(dead_code)]` (`static_discovery.membership_tx` is used); documented the feature-gated `table_backend` / `mongodb::ChangeStreamPayload` allows.

## Tests

Two focused tests (one per behavioral change): out-of-range INSERT literal → error; out-of-range JSON float timestamp → rejected.

## Verification

- `cargo clippy --workspace --no-default-features -- -D warnings` — clean
- `cargo test --workspace --lib --no-default-features` — 2,383 pass / 0 fail
- Feature-gated connectors clippy + lib tests (`mysql-cdc,mongodb-cdc,postgres-cdc,postgres-sink,nats,kafka`) — clean, 1,185 pass / 0 fail

## Out of scope (noted, not addressed)

`resolve_external_states` in non-strict mode resumes an operator with **empty state** on a corrupt checkpoint (silent exactly-once degradation; strict mode already gates it). Pre-existing; warrants a separate ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow and silent-cast bugs in untrusted inputs and removes the unused in‑band watermark message that could evict real data. Adds a checkpoint alignment-timeout knob (default 30s) to improve recovery/ingest and reduce `tokio::broadcast` pressure.

- **Bug Fixes**
  - Checkpoint recovery: guard `u64 -> usize` conversions and addition with `try_from` + `checked_add`; invalid ranges start with empty state.
  - Time-related inputs: clamp MySQL TIME to ±838h and format pre-epoch microsecond timestamps correctly; round JSON float epoch-ms to nearest ms and reject non-finite/out-of-range values; check ms→µs/ns scaling so overflow errors instead of wrapping; for temporal joins, round and range-check `Float64` keys to `i64` to prevent silent mis-joins.
  - INSERT literals: range-check `i64` to `i8/i16/i32`; return `DbError::InsertError` instead of wrapping.
  - Windowing: use checked `i64` conversions for size/slide/gap to avoid truncation/overflow in boundary math.
  - Tests: update cluster harness to use `..StreamCheckpointConfig::default()` to include the new `alignment_timeout_ms` field.

- **Refactors**
  - Removed `SourceMessage::Watermark`; watermark now flows only via shared `AtomicI64`. Consolidated to a single `to_batch()` helper and avoided `tokio::broadcast` ring eviction.
  - Exposed `alignment_timeout_ms` in checkpoint config and plumbed through pipeline (defaults to 30s).
  - Hygiene: centralized Prometheus `# Panics` docs; documented feature-gated `#[allow(dead_code)]`; trimmed unused/test-only `TableBackend` methods and tests.

<sup>Written for commit b29da2ea5249ef58ca8fc6599822723c2131f209. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/390?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MySQL TIME value overflow handling to prevent incorrect results with extreme values
  * Fixed JSON timestamp validation to properly reject out-of-range float values
  * Fixed integer literal handling to catch overflow instead of silent wrapping
  * Improved external operator state recovery with safer arithmetic validation

* **Documentation**
  * Enhanced API documentation with explicit panic specifications

* **Refactor**
  * Streamlined watermark message handling in the streaming layer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->