### PR TITLE
fix(db): bound ASOF right-buffer memory with watermark-driven eviction

### DIFF
--- a/crates/laminar-db/src/asof_batch.rs
+++ b/crates/laminar-db/src/asof_batch.rs
@@ -416,6 +416,28 @@ impl AsofRightBuffer {
         Ok(())
     }
 
+    /// Keep, per key, the latest right row at or below `watermark` plus every
+    /// newer row; drop the rest. A future left (`ts >= watermark`) backward- or
+    /// nearest-matches the latest right `<= its ts`, which is never older than
+    /// the latest right `<= watermark`, so older rows are unreachable. Unlike
+    /// [`Self::evict_before`] this retains the boundary row, making it safe with
+    /// no tolerance.
+    pub fn evict_superseded(&mut self, watermark: i64) -> Result<(), DbError> {
+        for btree in self.index.values_mut() {
+            // Greatest ts <= watermark; keep it and everything newer, drop the
+            // rest. `split_off(&keep_ts)` returns the `>= keep_ts` tail.
+            if let Some((&keep_ts, _)) = btree.range(..=watermark).next_back() {
+                *btree = btree.split_off(&keep_ts);
+            }
+        }
+        self.index.retain(|_, btree| !btree.is_empty());
+
+        if self.ingest_count >= ASOF_COMPACTION_THRESHOLD {
+            self.compact()?;
+        }
+        Ok(())
+    }
+
     fn compact(&mut self) -> Result<(), DbError> {
         let Some(ref batch) = self.right_concat else {
             return Ok(());
@@ -1083,5 +1105,114 @@ mod tests {
         assert_eq!(symbols.value(0), "AAPL");
         assert!(result.column(0).is_null(1)); // null key row
         assert!(result.column(3).is_null(1)); // right-side quote_ts is null
+    }
+
+    /// Single-key quote row matching `quotes_batch`'s schema, at timestamp `ts`.
+    fn quote_at(symbol: &str, ts: i64) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("symbol", DataType::Utf8, false),
+            Field::new("quote_ts", DataType::Int64, false),
+            Field::new("bid", DataType::Float64, false),
+            Field::new("ask", DataType::Float64, false),
+        ]));
+        #[allow(clippy::cast_precision_loss)]
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![symbol])),
+                Arc::new(Int64Array::from(vec![ts])),
+                Arc::new(Float64Array::from(vec![ts as f64])),
+                Arc::new(Float64Array::from(vec![ts as f64 + 1.0])),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Single-key trade row matching `trades_batch`'s schema, at timestamp `ts`.
+    fn trade_at(symbol: &str, ts: i64) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("symbol", DataType::Utf8, false),
+            Field::new("trade_ts", DataType::Int64, false),
+            Field::new("price", DataType::Float64, false),
+        ]));
+        #[allow(clippy::cast_precision_loss)]
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![symbol])),
+                Arc::new(Int64Array::from(vec![ts])),
+                Arc::new(Float64Array::from(vec![ts as f64])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn asof_no_tolerance_evicts_superseded_right() {
+        // Backward, no tolerance. Three right rows for one key at t=1,2,3.
+        let config = backward_config();
+        let mut buf = AsofRightBuffer::default();
+        for ts in [1_i64, 2, 3] {
+            buf.ingest(&[quote_at("AAPL", ts)], "symbol", "quote_ts")
+                .unwrap();
+        }
+        assert_eq!(buf.index.values().next().unwrap().len(), 3);
+
+        // Advance the left watermark to 3: any future left L >= 3 backward-
+        // matches the latest right <= L, which is >= the latest right <= 3.
+        // So only t=3 is reachable; t=1 and t=2 are superseded.
+        buf.evict_superseded(3).unwrap();
+        let btree = buf.index.values().next().unwrap();
+        assert_eq!(btree.len(), 1, "only the latest <= watermark is kept");
+        assert!(btree.contains_key(&3));
+
+        // A future left at t=5 still backward-matches the retained right at t=3.
+        let out =
+            execute_asof_join_with_state(&[trade_at("AAPL", 5)], &buf, &config, None).unwrap();
+        let quote_ts = out
+            .column_by_name("quote_ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(quote_ts.value(0), 3);
+    }
+
+    #[test]
+    fn asof_evict_superseded_then_compact_remaps_offsets() {
+        // The riskiest path: sparse per-key eviction followed by compaction,
+        // which rebuilds `right_concat` and must remap the surviving index
+        // offsets. Ingest past ASOF_COMPACTION_THRESHOLD so eviction compacts.
+        let mut buf = AsofRightBuffer::default();
+        for ts in 1..=40_i64 {
+            buf.ingest(&[quote_at("AAPL", ts)], "symbol", "quote_ts")
+                .unwrap();
+        }
+
+        // Keep only t=39 (latest <= 39) and t=40 (newer than the watermark).
+        buf.evict_superseded(39).unwrap();
+        assert!(
+            buf.ingest_count < ASOF_COMPACTION_THRESHOLD,
+            "compact() should have run and reset ingest_count"
+        );
+        let btree = buf.index.values().next().unwrap();
+        assert_eq!(btree.len(), 2);
+        assert_eq!(
+            buf.right_concat.as_ref().unwrap().num_rows(),
+            2,
+            "data buffer shrinks with the index"
+        );
+
+        // After remapping, matches still resolve against the compacted buffer.
+        let config = backward_config();
+        let out =
+            execute_asof_join_with_state(&[trade_at("AAPL", 100)], &buf, &config, None).unwrap();
+        let quote_ts = out
+            .column_by_name("quote_ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(quote_ts.value(0), 40); // backward match = latest <= 100
     }
 }

--- a/crates/laminar-db/src/operator/asof_join.rs
+++ b/crates/laminar-db/src/operator/asof_join.rs
@@ -10,6 +10,7 @@ use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use datafusion::prelude::SessionContext;
 
+use laminar_sql::parser::join_parser::AsofSqlDirection;
 use laminar_sql::translator::AsofJoinTranslatorConfig;
 
 use crate::asof_batch::{execute_asof_join_with_state, AsofBufferCheckpoint, AsofRightBuffer};
@@ -67,24 +68,6 @@ impl GraphOperator for AsofJoinOperator {
             &self.config.right_time_column,
         )?;
 
-        // Right rows are needed until no future left event can match them.
-        // Future left events have ts >= left_wm, so right rows at
-        // ts < left_wm - tolerance are unreachable. Crossed logic:
-        // right eviction depends on LEFT watermark.
-        let max_lookback_ms = self.config.tolerance.map_or(i64::MAX, |d| {
-            i64::try_from(d.as_millis()).unwrap_or(i64::MAX)
-        });
-        let left_wm = watermarks.first().copied().unwrap_or(i64::MIN);
-        let cutoff = left_wm.saturating_sub(max_lookback_ms);
-        if cutoff > self.last_evicted_watermark {
-            self.right_buffer.evict_before(cutoff)?;
-            self.last_evicted_watermark = cutoff;
-        }
-
-        if left_batches.is_empty() {
-            return Ok(Vec::new());
-        }
-
         // Capture the right schema from the first batch we see, so a later
         // cycle with an empty right buffer can still emit left rows with null
         // right columns instead of dropping them.
@@ -94,18 +77,53 @@ impl GraphOperator for AsofJoinOperator {
             }
         }
 
-        let joined = execute_asof_join_with_state(
-            left_batches,
-            &self.right_buffer,
-            &self.config,
-            self.right_schema.as_ref(),
-        )?;
+        // Join before evicting: a batch can carry rows below its own watermark
+        // (they set it) whose backward/nearest match still needs older right
+        // rows. Eviction (below) only constrains future cycles.
+        let output = if left_batches.is_empty() {
+            Vec::new()
+        } else {
+            let joined = execute_asof_join_with_state(
+                left_batches,
+                &self.right_buffer,
+                &self.config,
+                self.right_schema.as_ref(),
+            )?;
+            if joined.num_rows() == 0 {
+                Vec::new()
+            } else {
+                self.projection.apply(vec![joined]).await?
+            }
+        };
 
-        if joined.num_rows() == 0 {
-            return Ok(Vec::new());
+        // Prune the right buffer to what a future left (ts >= left_wm) can still
+        // match. Backward/Nearest keep the latest right <= left_wm per key; a
+        // bounded tolerance also drops rows below left_wm - tolerance. Forward
+        // drops everything below left_wm. Driving this off the watermark (not a
+        // tolerance-derived cutoff) is what bounds memory with no tolerance,
+        // where the old `left_wm - i64::MAX` cutoff was always i64::MIN.
+        let left_wm = watermarks.first().copied().unwrap_or(i64::MIN);
+        if left_wm > self.last_evicted_watermark {
+            match self.config.direction {
+                AsofSqlDirection::Forward => {
+                    self.right_buffer.evict_before(left_wm)?;
+                }
+                AsofSqlDirection::Backward | AsofSqlDirection::Nearest => {
+                    self.right_buffer.evict_superseded(left_wm)?;
+                    if let Some(tol) = self
+                        .config
+                        .tolerance
+                        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+                    {
+                        self.right_buffer
+                            .evict_before(left_wm.saturating_sub(tol))?;
+                    }
+                }
+            }
+            self.last_evicted_watermark = left_wm;
         }
 
-        self.projection.apply(vec![joined]).await
+        Ok(output)
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {


### PR DESCRIPTION
## Problem

A no-tolerance `ASOF JOIN` derived its eviction cutoff as `left_wm - i64::MAX`, which saturates to `i64::MIN`. That never exceeds the initial `last_evicted_watermark`, so **eviction (and compaction) never ran** — the right buffer accumulated every right row for the lifetime of the query and grew without bound (multi-GB over hours on a long-running backward join).

The existing "uniform cutoff = `left_wm - max_lookback`" model is only correct for the bounded-tolerance backward case.

## Fix

Drive eviction off the **left watermark** instead of the tolerance-derived cutoff:

- **Backward / Nearest** — `AsofRightBuffer::evict_superseded(left_wm)` keeps, per key, the latest right row `<= left_wm` plus everything newer. A future left (`ts >= left_wm`) matches the latest right `<= its ts`, which is never older than the latest right `<= left_wm`, so older rows are unreachable. A uniform cutoff can't express this; `evict_before(left_wm)` would wrongly drop the boundary row a future left still needs.
- **Bounded tolerance** — additionally layers `evict_before(left_wm - tolerance)` to drop rows below the tolerance floor.
- **Forward** — keeps the tight `evict_before(left_wm)`.

### Eviction runs *after* the join, not before

A single left batch can carry rows below its own watermark — those rows are precisely what set `left_wm = max(batch ts)`. Evicting first would drop right rows that an earlier (lower-timestamped) row in the same batch still backward-matches. Joining against the full buffer first, then evicting, is sound because the watermark only constrains *future* cycles. (This was latent before the fix because the no-tolerance path never evicted at all.)

`last_evicted_watermark` now tracks `left_wm` rather than the cutoff; the checkpoint wire format is unchanged (still `i64`), so no version bump.

## Tests

- `asof_no_tolerance_evicts_superseded_right` — backward + no tolerance: superseded rows dropped, boundary row retained, a later left still matches it.
- `asof_evict_superseded_then_compact_remaps_offsets` — sparse per-key eviction past the compaction threshold; confirms `compact()` rebuilds `right_concat` offsets correctly.
- The after-join ordering is covered by the existing `asof_join_in_materialized_view_emits_backward_match` gate test.

All `laminar-db` lib tests pass; `clippy -D warnings` (lib + tests) and `fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds ASOF right-buffer memory by switching to left-watermark driven eviction and adding per-key `evict_superseded` for backward/nearest joins. Fixes no-tolerance ASOF never evicting, which caused unbounded growth.

- **Bug Fixes**
  - Evict from the left watermark. Backward/Nearest keep the latest right <= watermark per key plus newer via `AsofRightBuffer::evict_superseded`.
  - Bounded tolerance also applies `evict_before(left_wm - tol)`; Forward keeps `evict_before(left_wm)`.
  - Run eviction after the join so earlier rows in the same batch still match.
  - Track `last_evicted_watermark = left_wm`; removes the `i64::MIN` cutoff bug in no-tolerance mode.
  - Checkpoint wire format unchanged.
  - Tests added: `asof_no_tolerance_evicts_superseded_right`, `asof_evict_superseded_then_compact_remaps_offsets`.

<sup>Written for commit 771edc648779d86dd4210e88683b5be25878e9e4. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/394?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized memory management for ASOF JOIN operations through intelligent row eviction strategies.
  * Enhanced backward and nearest join handling with direction-aware buffer pruning.
  * Improved operator execution flow to compute outputs before cleanup cycles.

* **Tests**
  * Added test utilities and cases validating eviction correctness and compaction interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->