### PR TITLE
Crypto × sentiment demo (local ONNX AI functions) + engine fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,6 +3898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4010,29 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -4837,6 +4866,7 @@ dependencies = [
  "async-trait",
  "foyer",
  "futures",
+ "governor",
  "ort",
  "parking_lot 0.12.5",
  "reqwest 0.13.2",
@@ -5000,6 +5030,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trait-variant",
+ "wiremock",
 ]
 
 [[package]]
@@ -5809,6 +5840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,6 +5854,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
@@ -6940,6 +6983,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7144,6 +7202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -8181,6 +8248,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/crates/laminar-ai/Cargo.toml
+++ b/crates/laminar-ai/Cargo.toml
@@ -37,6 +37,10 @@ serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 
+# Client-side rate limiting (token bucket / GCRA) for remote providers — the
+# standard maintained Rust limiter, rather than a hand-rolled bucket.
+governor = { version = "0.8", optional = true }
+
 # --- local backend (feature = "local") ---
 # ONNX Runtime via `ort`. tract (pure Rust) cannot analyse the dynamic
 # attention-mask broadcast in stock HuggingFace encoder exports; ort runs them
@@ -54,7 +58,7 @@ tokenizers = { version = "0.21", default-features = false, features = ["fancy-re
 default = []
 # Remote LLM backends (OpenAI-compatible, Anthropic) over HTTP. Default build
 # carries zero ML/HTTP weight.
-remote = ["dep:reqwest", "dep:serde", "dep:serde_json", "dep:tokio", "dep:futures"]
+remote = ["dep:reqwest", "dep:serde", "dep:serde_json", "dep:tokio", "dep:futures", "dep:governor"]
 # Local ONNX backend (ort/ONNX Runtime + HF tokenizers; reqwest for hf: fetch).
 local = ["dep:ort", "dep:tokenizers", "dep:serde_json", "dep:tokio", "dep:reqwest"]
 

--- a/crates/laminar-ai/src/adapter.rs
+++ b/crates/laminar-ai/src/adapter.rs
@@ -1,6 +1,8 @@
 //! Resolve a raw provider response into a task's per-row output, given the
 //! `(task, backend)` pair. Local classification takes argmax over logits (equal
-//! to argmax of softmax — v0.1 returns only the label, so no softmax). Stays
+//! to argmax of softmax — classify returns only the label, so no softmax).
+//! Sentiment is numeric: local softmaxes the logits to `P(pos) − P(neg)`, remote
+//! parses a number from the reply — a continuous score in `[-1, 1]`. Stays
 //! Arrow-free: returns [`InferenceOutputs`]; the operator builds the column.
 
 use thiserror::Error;
@@ -28,6 +30,23 @@ pub enum AdapterError {
     /// A classifier returned an empty logit vector for a row.
     #[error("classifier returned no logits for a row")]
     EmptyLogits,
+
+    /// Sentiment scoring needs both a `positive` and a `negative` label among
+    /// the model's labels to map logits to a signed score.
+    #[error(
+        "sentiment scoring requires 'positive' and 'negative' among the labels, got {labels:?}"
+    )]
+    SentimentLabelsUnusable {
+        /// The labels that were available.
+        labels: Vec<String>,
+    },
+
+    /// A remote sentiment reply contained no parseable number.
+    #[error("remote sentiment reply had no parseable score: {reply:?}")]
+    UnparseableScore {
+        /// The reply that could not be parsed.
+        reply: String,
+    },
 
     /// The raw output shape did not match what the task/backend produces.
     #[error("task '{task}' on the {kind:?} backend expected {expected} output, got {got}")]
@@ -69,9 +88,13 @@ pub fn parse_response(
     labels: Option<&[String]>,
 ) -> Result<InferenceOutputs, AdapterError> {
     match task {
-        Task::Classify | Task::Sentiment => match kind {
+        Task::Classify => match kind {
             BackendKind::Local => classify_from_logits(kind, raw, labels),
             BackendKind::Remote => coerce_remote_classification(raw, labels),
+        },
+        Task::Sentiment => match kind {
+            BackendKind::Local => sentiment_from_logits(raw, labels),
+            BackendKind::Remote => sentiment_from_text(raw),
         },
         Task::Embed => expect_vectors(task, kind, raw),
         Task::Complete | Task::Summarize | Task::Translate | Task::Gen | Task::Extract => {
@@ -93,12 +116,12 @@ fn classify_from_logits(
 ) -> Result<InferenceOutputs, AdapterError> {
     let rows = match raw {
         InferenceOutputs::Vectors(rows) => rows,
-        InferenceOutputs::Text(_) => {
+        other => {
             return Err(AdapterError::UnexpectedOutputShape {
                 task: Task::Classify,
                 kind,
                 expected: "vectors",
-                got: "text",
+                got: shape_name(&other),
             });
         }
     };
@@ -129,12 +152,12 @@ fn coerce_remote_classification(
 ) -> Result<InferenceOutputs, AdapterError> {
     let texts = match raw {
         InferenceOutputs::Text(texts) => texts,
-        InferenceOutputs::Vectors(_) => {
+        other => {
             return Err(AdapterError::UnexpectedOutputShape {
                 task: Task::Classify,
                 kind: BackendKind::Remote,
                 expected: "text",
-                got: "vectors",
+                got: shape_name(&other),
             });
         }
     };
@@ -172,11 +195,11 @@ fn expect_text(
 ) -> Result<InferenceOutputs, AdapterError> {
     match raw {
         InferenceOutputs::Text(text) => Ok(InferenceOutputs::Text(text)),
-        InferenceOutputs::Vectors(_) => Err(AdapterError::UnexpectedOutputShape {
+        other => Err(AdapterError::UnexpectedOutputShape {
             task,
             kind,
             expected: "text",
-            got: "vectors",
+            got: shape_name(&other),
         }),
     }
 }
@@ -189,13 +212,117 @@ fn expect_vectors(
 ) -> Result<InferenceOutputs, AdapterError> {
     match raw {
         InferenceOutputs::Vectors(vectors) => Ok(InferenceOutputs::Vectors(vectors)),
-        InferenceOutputs::Text(_) => Err(AdapterError::UnexpectedOutputShape {
+        other => Err(AdapterError::UnexpectedOutputShape {
             task,
             kind,
             expected: "vectors",
-            got: "text",
+            got: shape_name(&other),
         }),
     }
+}
+
+/// Static name of an output shape, for error messages.
+fn shape_name(raw: &InferenceOutputs) -> &'static str {
+    match raw {
+        InferenceOutputs::Text(_) => "text",
+        InferenceOutputs::Vectors(_) => "vectors",
+        InferenceOutputs::Scores(_) => "scores",
+    }
+}
+
+/// Local sentiment: softmax each row's logits, then `P(positive) − P(negative)`,
+/// a signed score in `[-1, 1]`. The model's labels locate the positive and
+/// negative classes; a neutral class (if present) pulls the score toward 0.
+fn sentiment_from_logits(
+    raw: InferenceOutputs,
+    labels: Option<&[String]>,
+) -> Result<InferenceOutputs, AdapterError> {
+    let rows = match raw {
+        InferenceOutputs::Vectors(rows) => rows,
+        other => {
+            return Err(AdapterError::UnexpectedOutputShape {
+                task: Task::Sentiment,
+                kind: BackendKind::Local,
+                expected: "vectors",
+                got: shape_name(&other),
+            });
+        }
+    };
+    let labels = labels.ok_or(AdapterError::MissingLabels)?;
+    let pos = labels
+        .iter()
+        .position(|l| l.eq_ignore_ascii_case("positive"));
+    let neg = labels
+        .iter()
+        .position(|l| l.eq_ignore_ascii_case("negative"));
+    let (Some(pos), Some(neg)) = (pos, neg) else {
+        return Err(AdapterError::SentimentLabelsUnusable {
+            labels: labels.to_vec(),
+        });
+    };
+    let mut scores = Vec::with_capacity(rows.len());
+    for logits in rows {
+        if logits.is_empty() {
+            return Err(AdapterError::EmptyLogits);
+        }
+        let probs = softmax(&logits);
+        let p_pos = probs.get(pos).copied().unwrap_or(0.0);
+        let p_neg = probs.get(neg).copied().unwrap_or(0.0);
+        scores.push(f64::from(p_pos - p_neg));
+    }
+    Ok(InferenceOutputs::Scores(scores))
+}
+
+/// Remote sentiment: parse a number from each reply and clamp to `[-1, 1]`.
+fn sentiment_from_text(raw: InferenceOutputs) -> Result<InferenceOutputs, AdapterError> {
+    let texts = match raw {
+        InferenceOutputs::Text(texts) => texts,
+        other => {
+            return Err(AdapterError::UnexpectedOutputShape {
+                task: Task::Sentiment,
+                kind: BackendKind::Remote,
+                expected: "text",
+                got: shape_name(&other),
+            });
+        }
+    };
+    let mut scores = Vec::with_capacity(texts.len());
+    for reply in texts {
+        let value = parse_score(&reply).ok_or(AdapterError::UnparseableScore { reply })?;
+        scores.push(value.clamp(-1.0, 1.0));
+    }
+    Ok(InferenceOutputs::Scores(scores))
+}
+
+/// Numerically stable softmax over a row of logits.
+fn softmax(logits: &[f32]) -> Vec<f32> {
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut exps: Vec<f32> = logits.iter().map(|&v| (v - max).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum > 0.0 {
+        for e in &mut exps {
+            *e /= sum;
+        }
+    }
+    exps
+}
+
+/// Parse the first number out of a reply (`"0.8"`, `"The sentiment is -0.5."`),
+/// or `None` if there is none.
+fn parse_score(reply: &str) -> Option<f64> {
+    let trimmed = reply.trim();
+    if let Ok(v) = trimmed.parse::<f64>() {
+        return Some(v);
+    }
+    trimmed.split_whitespace().find_map(|token| {
+        // Strip surrounding punctuation: a leading sign/digit may start it, but
+        // only a digit may end it (so a sentence-final '.' isn't kept).
+        token
+            .trim_start_matches(|c: char| !(c.is_ascii_digit() || c == '-'))
+            .trim_end_matches(|c: char| !c.is_ascii_digit())
+            .parse::<f64>()
+            .ok()
+    })
 }
 
 /// Index of the maximum value, or `None` for an empty slice.
@@ -247,7 +374,7 @@ mod tests {
             "totally unrelated".into(),
         ]);
         let out =
-            parse_response(Task::Sentiment, BackendKind::Remote, raw, Some(&labels())).unwrap();
+            parse_response(Task::Classify, BackendKind::Remote, raw, Some(&labels())).unwrap();
         assert_eq!(
             out,
             InferenceOutputs::Text(vec![
@@ -256,6 +383,50 @@ mod tests {
                 "totally unrelated".into(),
             ])
         );
+    }
+
+    #[test]
+    fn local_sentiment_softmaxes_logits_to_a_signed_score() {
+        // labels = [negative, positive, neutral]. Row 1 favours positive, row 2
+        // favours negative. Score = P(pos) − P(neg) ∈ [-1, 1].
+        let raw = InferenceOutputs::Vectors(vec![vec![0.0, 2.0, 0.0], vec![3.0, 0.0, 0.0]]);
+        let out =
+            parse_response(Task::Sentiment, BackendKind::Local, raw, Some(&labels())).unwrap();
+        let InferenceOutputs::Scores(scores) = out else {
+            panic!("sentiment is numeric");
+        };
+        // Row 1: softmax([0,2,0]) → P(neg)=P(neu)=e^0/(2+e^2), P(pos)=e^2/(2+e^2).
+        let denom = 2.0 + std::f32::consts::E.powi(2);
+        let expected0 = f64::from((std::f32::consts::E.powi(2) - 1.0) / denom);
+        assert!((scores[0] - expected0).abs() < 1e-6, "got {}", scores[0]);
+        assert!(scores[0] > 0.0 && scores[1] < 0.0);
+        assert!((-1.0..=1.0).contains(&scores[0]) && (-1.0..=1.0).contains(&scores[1]));
+    }
+
+    #[test]
+    fn local_sentiment_needs_positive_and_negative_labels() {
+        let raw = InferenceOutputs::Vectors(vec![vec![0.1, 0.9]]);
+        let stars = vec!["one_star".to_string(), "five_star".to_string()];
+        assert!(matches!(
+            parse_response(Task::Sentiment, BackendKind::Local, raw, Some(&stars)),
+            Err(AdapterError::SentimentLabelsUnusable { .. })
+        ));
+    }
+
+    #[test]
+    fn remote_sentiment_parses_and_clamps_a_number() {
+        let raw = InferenceOutputs::Text(vec![
+            "0.8".into(),
+            "The sentiment is -0.5.".into(),
+            "2.0".into(), // out of range → clamped
+        ]);
+        let out = parse_response(Task::Sentiment, BackendKind::Remote, raw, None).unwrap();
+        let InferenceOutputs::Scores(scores) = out else {
+            panic!("sentiment is numeric");
+        };
+        assert!((scores[0] - 0.8).abs() < 1e-12);
+        assert!((scores[1] + 0.5).abs() < 1e-12);
+        assert!((scores[2] - 1.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/laminar-ai/src/backends/local.rs
+++ b/crates/laminar-ai/src/backends/local.rs
@@ -11,9 +11,10 @@
 //! `onnx/model.onnx` + `tokenizer.json` (+ optional `config.json` for labels):
 //! `hf:org/repo` → `<cache_dir>/org/repo`, `file://<path>` or a bare path used
 //! as-is. A missing `hf:` repo is downloaded from the Hugging Face CDN on first
-//! use (public repos only). Note: classifier labels are read from `config.json`
-//! at startup, so a model that downloads lazily must instead carry an explicit
-//! `labels` argument until it is cached.
+//! use (public repos only). Classifier labels come from the model's own
+//! `config.json` `id2label`; [`LocalProvider::intrinsic_labels`] resolves them on
+//! demand, so a model that downloads lazily scores correctly once it is cached —
+//! no restart, no externally supplied label list.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -45,6 +46,8 @@ struct LoadedModel {
     session: Mutex<Session>,
     tokenizer: tokenizers::Tokenizer,
     input_names: Vec<String>,
+    /// `config.json` `id2label`, read once at load; empty if absent.
+    labels: Vec<String>,
 }
 
 /// Local ONNX provider, backed by a model cache directory.
@@ -246,6 +249,17 @@ impl InferenceProvider for LocalProvider {
     fn name(&self) -> &'static str {
         "local"
     }
+
+    fn intrinsic_labels(&self, model: &str) -> Option<Vec<String>> {
+        // Served from the loaded model (read once at load); only an unloaded model
+        // — i.e. before its first inference — touches disk here.
+        let labels = self
+            .loaded
+            .lock()
+            .get(model)
+            .map_or_else(|| load_labels(&self.cache_dir, model), |m| m.labels.clone());
+        (!labels.is_empty()).then_some(labels)
+    }
 }
 
 /// The model graph: the `onnx/model.onnx` that Optimum / transformers.js exports
@@ -279,10 +293,15 @@ fn load_model(dir: &Path) -> Result<LoadedModel, ProviderError> {
         .collect();
     let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
         .map_err(|e| ProviderError::Transport(format!("load tokenizer: {e}")))?;
+    let labels = std::fs::read_to_string(dir.join("config.json"))
+        .ok()
+        .map(|text| parse_id2label(&text))
+        .unwrap_or_default();
     Ok(LoadedModel {
         session: Mutex::new(session),
         tokenizer,
         input_names,
+        labels,
     })
 }
 
@@ -391,6 +410,28 @@ mod tests {
             vec!["negative", "neutral", "positive"]
         );
         assert!(parse_id2label("{}").is_empty());
+    }
+
+    #[test]
+    fn intrinsic_labels_read_from_a_cached_models_config() {
+        let cache = tempfile::tempdir().expect("tempdir");
+        let provider = LocalProvider::new(cache.path());
+        let source = "hf:org/repo";
+
+        // Absent until the model (its config.json) is on disk.
+        assert!(provider.intrinsic_labels(source).is_none());
+
+        let dir = model_dir(cache.path(), source);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{"id2label": {"0": "NEGATIVE", "1": "POSITIVE"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            provider.intrinsic_labels(source),
+            Some(vec!["NEGATIVE".into(), "POSITIVE".into()])
+        );
     }
 
     #[test]

--- a/crates/laminar-ai/src/backends/mod.rs
+++ b/crates/laminar-ai/src/backends/mod.rs
@@ -16,6 +16,8 @@ pub mod local;
 #[cfg(feature = "remote")]
 pub mod openai;
 #[cfg(feature = "remote")]
+pub mod rate_limited;
+#[cfg(feature = "remote")]
 mod remote;
 
 #[cfg(feature = "remote")]
@@ -24,3 +26,5 @@ pub use anthropic::AnthropicProvider;
 pub use local::LocalProvider;
 #[cfg(feature = "remote")]
 pub use openai::OpenAiProvider;
+#[cfg(feature = "remote")]
+pub use rate_limited::RateLimitedProvider;

--- a/crates/laminar-ai/src/backends/rate_limited.rs
+++ b/crates/laminar-ai/src/backends/rate_limited.rs
@@ -48,6 +48,10 @@ impl InferenceProvider for RateLimitedProvider {
     fn name(&self) -> &'static str {
         self.inner.name()
     }
+
+    fn intrinsic_labels(&self, model: &str) -> Option<Vec<String>> {
+        self.inner.intrinsic_labels(model)
+    }
 }
 
 #[cfg(test)]

--- a/crates/laminar-ai/src/backends/rate_limited.rs
+++ b/crates/laminar-ai/src/backends/rate_limited.rs
@@ -1,0 +1,108 @@
+//! Client-side rate limiting for remote providers.
+//!
+//! Wraps any [`InferenceProvider`] in a token bucket (`governor`, the standard
+//! Rust limiter) so request bursts are shaped to a steady requests-per-second
+//! rather than sent unbounded. One cell is acquired per input row before the
+//! batch is dispatched. The wait happens on the Ring 1 inference worker — the
+//! only place `infer_batch` is awaited — never on Ring 0; the limiter itself is
+//! lock-free (atomics), so nothing blocking is reachable from the compute thread.
+
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+
+use crate::provider::{InferenceProvider, InferenceRequest, InferenceResponse, ProviderError};
+
+/// An [`InferenceProvider`] that paces calls to a steady rate.
+pub struct RateLimitedProvider {
+    inner: Arc<dyn InferenceProvider>,
+    limiter: DefaultDirectRateLimiter,
+}
+
+impl RateLimitedProvider {
+    /// Wrap `inner`, limiting to `requests_per_second` (burst up to the same).
+    #[must_use]
+    pub fn new(inner: Arc<dyn InferenceProvider>, requests_per_second: NonZeroU32) -> Self {
+        Self {
+            inner,
+            limiter: RateLimiter::direct(Quota::per_second(requests_per_second)),
+        }
+    }
+}
+
+#[async_trait]
+impl InferenceProvider for RateLimitedProvider {
+    async fn infer_batch(
+        &self,
+        request: InferenceRequest,
+    ) -> Result<InferenceResponse, ProviderError> {
+        // One permit per row: the batch waits until the bucket has paced it.
+        for _ in 0..request.inputs.len().max(1) {
+            self.limiter.until_ready().await;
+        }
+        self.inner.infer_batch(request).await
+    }
+
+    fn name(&self) -> &'static str {
+        self.inner.name()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{InferenceOutputs, InferenceParams, Usage};
+    use crate::registry::Task;
+    use std::time::Instant;
+
+    struct Echo;
+
+    #[async_trait]
+    impl InferenceProvider for Echo {
+        async fn infer_batch(
+            &self,
+            request: InferenceRequest,
+        ) -> Result<InferenceResponse, ProviderError> {
+            Ok(InferenceResponse {
+                outputs: InferenceOutputs::Text(request.inputs),
+                usage: Usage::ZERO,
+            })
+        }
+        fn name(&self) -> &'static str {
+            "echo"
+        }
+    }
+
+    fn request(rows: usize) -> InferenceRequest {
+        InferenceRequest {
+            task: Task::Sentiment,
+            model: "m".into(),
+            inputs: vec!["x".to_string(); rows],
+            params: InferenceParams::default(),
+        }
+    }
+
+    /// A burst beyond the per-second budget is delayed, not dropped or sent
+    /// unbounded; the output still passes through unchanged.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn burst_beyond_the_rate_is_paced() {
+        // 100 rps → ~10 ms/cell, burst 100. 130 rows = 30 over budget ⇒ ≥ ~300 ms.
+        let p = RateLimitedProvider::new(Arc::new(Echo), NonZeroU32::new(100).unwrap());
+        let start = Instant::now();
+        let resp = p.infer_batch(request(130)).await.unwrap();
+        assert_eq!(resp.outputs.len(), 130);
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(200),
+            "burst was not paced: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn name_delegates_to_inner() {
+        let p = RateLimitedProvider::new(Arc::new(Echo), NonZeroU32::new(1000).unwrap());
+        assert_eq!(p.name(), "echo");
+    }
+}

--- a/crates/laminar-ai/src/backends/remote.rs
+++ b/crates/laminar-ai/src/backends/remote.rs
@@ -27,13 +27,16 @@ pub(crate) fn add_usage(a: Usage, b: Usage) -> Usage {
 /// backstop. `Embed` never reaches here (it uses the embeddings endpoint).
 pub(crate) fn chat_prompt(task: Task, input: &str, labels: Option<&[String]>) -> (String, String) {
     let system = match task {
-        Task::Classify | Task::Sentiment => {
+        Task::Classify => {
             let options = labels.map(|l| l.join(", ")).unwrap_or_default();
             format!(
                 "You are a text classifier. Reply with exactly one of these labels and \
                  nothing else: {options}."
             )
         }
+        Task::Sentiment => "You are a sentiment scorer. Reply with only a number from -1 \
+             (most negative) through 0 (neutral) to 1 (most positive), and nothing else."
+            .to_string(),
         Task::Summarize => "Summarize the text concisely. Reply with the summary only.".to_string(),
         Task::Translate => "Translate the text. Reply with the translation only.".to_string(),
         Task::Extract => {

--- a/crates/laminar-ai/src/cache.rs
+++ b/crates/laminar-ai/src/cache.rs
@@ -49,6 +49,8 @@ pub enum CachedOutput {
     Text(String),
     /// A numeric vector output (embedding).
     Vector(Vec<f32>),
+    /// A scalar score output (`ai_sentiment`, continuous in `[-1, 1]`).
+    Score(f64),
 }
 
 /// xxh3-128 of the input content. Not cryptographic; a fast, collision-negligible
@@ -100,6 +102,7 @@ fn entry_weight(_key: &AiCacheKey, value: &CachedOutput) -> usize {
     let payload = match value {
         CachedOutput::Text(s) => s.len(),
         CachedOutput::Vector(v) => v.len() * std::mem::size_of::<f32>(),
+        CachedOutput::Score(_) => std::mem::size_of::<f64>(),
     };
     payload + std::mem::size_of::<AiCacheKey>() + 32
 }

--- a/crates/laminar-ai/src/provider.rs
+++ b/crates/laminar-ai/src/provider.rs
@@ -40,13 +40,19 @@ pub struct InferenceParams {
 
 /// Per-row outputs of a batch. Homogeneous for a given request: a classify or
 /// generate batch yields text; an embed batch — or a local classifier's raw
-/// logits awaiting softmax in the adapter — yields numeric vectors.
+/// logits awaiting softmax in the adapter — yields numeric vectors; a sentiment
+/// batch yields one scalar score per row (the adapter's output, never a raw
+/// provider shape).
 #[derive(Debug, Clone, PartialEq)]
 pub enum InferenceOutputs {
     /// One text output per input row.
     Text(Vec<String>),
     /// One numeric vector per input row (embeddings, or classifier logits).
     Vectors(Vec<Vec<f32>>),
+    /// One scalar score per input row. Produced by the adapter for
+    /// `ai_sentiment` (continuous, in `[-1, 1]`); providers never return this
+    /// shape directly.
+    Scores(Vec<f64>),
 }
 
 impl InferenceOutputs {
@@ -56,6 +62,7 @@ impl InferenceOutputs {
         match self {
             InferenceOutputs::Text(v) => v.len(),
             InferenceOutputs::Vectors(v) => v.len(),
+            InferenceOutputs::Scores(v) => v.len(),
         }
     }
 

--- a/crates/laminar-ai/src/provider.rs
+++ b/crates/laminar-ai/src/provider.rs
@@ -123,6 +123,15 @@ pub trait InferenceProvider: Send + Sync {
     /// Stable backend-kind identity for logging and the `laminar.ai_calls`
     /// log (e.g. `anthropic`, `openai`, `local`). Constant per implementor.
     fn name(&self) -> &'static str;
+
+    /// Classifier labels intrinsic to a model, discovered from its own metadata.
+    /// Returns `None` for backends that have none (remote providers, embedding
+    /// models). A local classifier returns its `config.json` `id2label` once the
+    /// model is on disk — the seam that lets a lazily downloaded classifier score
+    /// without the labels having been known at startup. The default is `None`.
+    fn intrinsic_labels(&self, _model: &str) -> Option<Vec<String>> {
+        None
+    }
 }
 
 /// Errors a provider can return for a batch call.

--- a/crates/laminar-core/src/time/watermark.rs
+++ b/crates/laminar-core/src/time/watermark.rs
@@ -30,6 +30,15 @@ pub trait WatermarkGenerator: Send {
     /// Returns `Some(Watermark)` if the watermark advanced, `None` if the timestamp
     /// was not higher than the current watermark.
     fn advance_watermark(&mut self, timestamp: i64) -> Option<Watermark>;
+
+    /// Whether the watermark is processing-time based (wall clock), rather than
+    /// derived from the event-time column. Such a watermark lives in a different
+    /// time domain than the event timestamps, so comparing the two to drop "late"
+    /// rows would discard every event — callers skip source-side late-filtering
+    /// when this is `true`. Defaults to `false` (event-time generators).
+    fn is_processing_time(&self) -> bool {
+        false
+    }
 }
 
 /// Default `max_future_skew_ms`: 5 min.
@@ -284,6 +293,10 @@ impl<G: WatermarkGenerator> WatermarkGenerator for PeriodicGenerator<G> {
             self.last_emit_time = Instant::now();
         }
         wm
+    }
+
+    fn is_processing_time(&self) -> bool {
+        self.inner.is_processing_time()
     }
 }
 
@@ -707,6 +720,11 @@ impl WatermarkGenerator for ProcessingTimeGenerator {
             None
         }
     }
+
+    #[inline]
+    fn is_processing_time(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]
@@ -719,6 +737,21 @@ mod tests {
         let wm = gen.on_event(1000);
         assert_eq!(wm, Some(Watermark::new(900)));
         assert_eq!(gen.current_watermark(), 900);
+    }
+
+    #[test]
+    fn processing_time_domain_is_reported_for_late_filter_skip() {
+        // Source-side late-filtering keys off this: a wall-clock watermark must
+        // not be compared against event-time timestamps, or it drops every row.
+        assert!(ProcessingTimeGenerator::new().is_processing_time());
+        assert!(!BoundedOutOfOrdernessGenerator::new(100).is_processing_time());
+        // The periodic wrapper reports its inner generator's time domain.
+        let p = Duration::from_millis(1);
+        assert!(PeriodicGenerator::new(ProcessingTimeGenerator::new(), p).is_processing_time());
+        assert!(
+            !PeriodicGenerator::new(BoundedOutOfOrdernessGenerator::new(100), p)
+                .is_processing_time()
+        );
     }
 
     #[test]

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -108,6 +108,11 @@ object_store = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tempfile = { workspace = true }
+# Crypto-sentiment E2E: wiremock backs the Anthropic provider over HTTP (hyper,
+# no openssl); the `remote` feature exposes the real AnthropicProvider so the
+# test drives the actual HTTP path (request build, 500/retry, response parse).
+wiremock = "0.6"
+laminar-ai = { path = "../laminar-ai", version = "0.23.0", features = ["remote"] }
 laminar-derive = { path = "../laminar-derive", version = "0.23.0" }
 laminar-connectors = { path = "../laminar-connectors", version = "0.23.0", features = ["testing"] }
 criterion = { workspace = true }

--- a/crates/laminar-db/src/ai_worker.rs
+++ b/crates/laminar-db/src/ai_worker.rs
@@ -158,6 +158,7 @@ fn to_cached(outputs: InferenceOutputs) -> Vec<CachedOutput> {
     match outputs {
         InferenceOutputs::Text(values) => values.into_iter().map(CachedOutput::Text).collect(),
         InferenceOutputs::Vectors(values) => values.into_iter().map(CachedOutput::Vector).collect(),
+        InferenceOutputs::Scores(values) => values.into_iter().map(CachedOutput::Score).collect(),
     }
 }
 

--- a/crates/laminar-db/src/ai_worker.rs
+++ b/crates/laminar-db/src/ai_worker.rs
@@ -142,7 +142,14 @@ async fn run_request(
         .await
         .map_err(|e| e.to_string())?;
     let usage = response.usage;
-    let parsed = parse_response(ctx.task, ctx.kind, response.outputs, ctx.labels.as_deref())
+    // Labels known at startup win; otherwise fall back to the backend's intrinsic
+    // labels, now resolvable since the call above ensured the model is on disk —
+    // this is what lets a lazily downloaded local classifier score.
+    let labels = ctx
+        .labels
+        .clone()
+        .or_else(|| ctx.provider.intrinsic_labels(&ctx.model));
+    let parsed = parse_response(ctx.task, ctx.kind, response.outputs, labels.as_deref())
         .map_err(|e| e.to_string())?;
     if parsed.len() != expected_rows {
         return Err(format!(

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -826,13 +826,16 @@ impl LaminarDB {
                 query_sql,
                 retention_bytes,
                 ..
-            } => self.handle_create_stream(
-                name,
-                query,
-                emit_clause.as_ref(),
-                query_sql,
-                *retention_bytes,
-            ),
+            } => {
+                self.handle_create_stream(
+                    name,
+                    query,
+                    emit_clause.as_ref(),
+                    query_sql,
+                    *retention_bytes,
+                )
+                .await
+            }
             StreamingStatement::CreateContinuousQuery { .. }
             | StreamingStatement::CreateLookupTable(_)
             | StreamingStatement::DropLookupTable { .. } => self.handle_query(sql).await,

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -154,6 +154,27 @@ async fn test_describe_table() {
     }
 }
 
+/// An MV (and a stream) must resolve a `FROM <stream>` reference at DDL time —
+/// `CREATE STREAM` registers a planning placeholder for its output schema, so a
+/// chain source → stream → stream → MV plans without "table not found". (The
+/// crypto-sentiment demo is exactly this shape.)
+#[tokio::test]
+async fn mv_resolves_a_chain_of_streams() {
+    let db = LaminarDB::open().unwrap();
+    db.execute("CREATE SOURCE src (id BIGINT, txt VARCHAR, ts TIMESTAMP)")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM filtered AS SELECT id, txt, ts FROM src WHERE txt IS NOT NULL")
+        .await
+        .unwrap();
+    db.execute("CREATE STREAM tagged AS SELECT id, txt, ts FROM filtered")
+        .await
+        .unwrap();
+    db.execute("CREATE MATERIALIZED VIEW agg AS SELECT COUNT(*) AS c FROM tagged")
+        .await
+        .expect("MV resolves a stream built on another stream");
+}
+
 #[tokio::test]
 async fn test_describe_materialized_view() {
     let db = LaminarDB::open().unwrap();

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -727,13 +727,19 @@ impl LaminarDB {
         {
             use datafusion::datasource::empty::EmptyTable;
             let _ = self.ctx.deregister_table(&name_str);
-            self.ctx
+            if let Err(e) = self
+                .ctx
                 .register_table(&name_str, Arc::new(EmptyTable::new(schema)))
-                .map_err(|e| {
-                    DbError::Pipeline(format!(
-                        "could not register stream '{name_str}' for downstream planning: {e}"
-                    ))
-                })?;
+            {
+                // Roll back the catalog + connector registration so a failed
+                // CREATE STREAM doesn't leave the stream half-registered.
+                self.catalog.drop_stream(&name_str);
+                self.connector_manager.lock().unregister_stream(&name_str);
+                self.subscription_registry.drop_name(&name_str);
+                return Err(DbError::Pipeline(format!(
+                    "could not register stream '{name_str}' for downstream planning: {e}"
+                )));
+            }
         }
 
         // If the pipeline is already running, send via control channel so

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -656,7 +656,7 @@ impl LaminarDB {
         }))
     }
 
-    pub(crate) fn handle_create_stream(
+    pub(crate) async fn handle_create_stream(
         &self,
         name: &sqlparser::ast::ObjectName,
         query: &StreamingStatement,
@@ -714,6 +714,26 @@ impl LaminarDB {
                 order_config: plan_order.clone(),
                 join_config: plan_joins.clone(),
             });
+        }
+
+        // Register the stream's output schema as a planning placeholder so MVs and
+        // streams created later resolve `FROM <this stream>`. The running pipeline
+        // reads stream output through the operator graph, not this provider — it
+        // exists only for plan-time name resolution (start() also seeds these for
+        // any not yet present). Best-effort: a stream whose schema can't yet be
+        // planned still registers in the catalog and runs.
+        if let Some(schema) =
+            crate::pipeline_lifecycle::plan_output_schema(&self.ctx, &query_sql).await
+        {
+            use datafusion::datasource::empty::EmptyTable;
+            let _ = self.ctx.deregister_table(&name_str);
+            self.ctx
+                .register_table(&name_str, Arc::new(EmptyTable::new(schema)))
+                .map_err(|e| {
+                    DbError::Pipeline(format!(
+                        "could not register stream '{name_str}' for downstream planning: {e}"
+                    ))
+                })?;
         }
 
         // If the pipeline is already running, send via control channel so

--- a/crates/laminar-db/src/e2e_crypto_sentiment.rs
+++ b/crates/laminar-db/src/e2e_crypto_sentiment.rs
@@ -1,0 +1,355 @@
+//! End-to-end tests for the crypto-sentiment demo, backed by wiremock.
+//!
+//! wiremock (HTTP) backs the **Anthropic provider**, so these tests drive the
+//! *real* `AnthropicProvider` HTTP path — request build, 500/retry, response
+//! parse — not a stub. The Binance/Jetstream feeds are non-replayable
+//! websockets whose transport is exercised in `laminar-connectors`; here their
+//! traces are hand-built source batches fed through the graph, which is what
+//! the demo's engine composition actually consumes. The analytically-exact
+//! correlation check lives with the operator, in `operator::window_frame::tests`.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use rustc_hash::FxHashMap;
+use tokio::runtime::Handle;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use laminar_ai::backends::AnthropicProvider;
+use laminar_ai::{
+    AiCallLog, AiResultCache, AiRuntime, CallOutcome, InferenceProvider, ModelBackend, ModelEntry,
+    ModelRegistry, Task,
+};
+
+use crate::operator_graph::OperatorGraph;
+
+// ── wiremock + runtime helpers ─────────────────────────────────────────────
+
+/// A wiremock Anthropic Messages endpoint that always replies with `text`.
+async fn anthropic_replying(text: &str) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+            r#"{{"content":[{{"type":"text","text":"{text}"}}],"usage":{{"input_tokens":5,"output_tokens":1}}}}"#
+        )))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// An `AiRuntime` whose `sentiment` model is the real Anthropic provider pointed
+/// at `base_url`. `call_log` is shared so a test can read `laminar.ai_calls`.
+fn runtime_at(base_url: &str, call_log: Arc<AiCallLog>) -> Arc<AiRuntime> {
+    let mut registry = ModelRegistry::new();
+    registry
+        .register(ModelEntry {
+            id: "m".into(),
+            tasks: vec![Task::Sentiment],
+            backend: ModelBackend::Remote {
+                provider: "anthropic".into(),
+                model: "stub-model".into(),
+            },
+        })
+        .unwrap();
+    let provider = Arc::new(AnthropicProvider::new(base_url, "test-key", 4).unwrap())
+        as Arc<dyn InferenceProvider>;
+    Arc::new(AiRuntime::new(
+        registry,
+        [("anthropic".to_string(), provider)],
+        None,
+        Arc::new(AiResultCache::with_defaults()),
+        call_log,
+    ))
+}
+
+fn posts_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("text", DataType::Utf8, false),
+    ]))
+}
+
+fn posts_batch(ids: &[i64], texts: &[&str]) -> RecordBatch {
+    RecordBatch::try_new(
+        posts_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids.to_vec())),
+            Arc::new(StringArray::from(texts.to_vec())),
+        ],
+    )
+    .unwrap()
+}
+
+fn sentiment_values(batches: &[RecordBatch]) -> Vec<Option<f64>> {
+    let mut out = Vec::new();
+    for b in batches {
+        let col = b
+            .column(b.schema().index_of("sentiment").unwrap())
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("sentiment is Float64");
+        for i in 0..col.len() {
+            out.push((!col.is_null(i)).then(|| col.value(i)));
+        }
+    }
+    out
+}
+
+/// Feed one cycle, then sleep and drain a second cycle so the Ring-1 worker's
+/// results are applied. Returns the drained `query` output.
+async fn score_and_drain(
+    graph: &mut OperatorGraph,
+    source: &str,
+    query: &str,
+    batch: RecordBatch,
+) -> Vec<RecordBatch> {
+    let mut sources = FxHashMap::default();
+    sources.insert(Arc::from(source), vec![batch]);
+    let _ = graph.execute_cycle(&sources, i64::MAX, None).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let results = graph
+        .execute_cycle(&FxHashMap::default(), i64::MAX, None)
+        .await
+        .unwrap();
+    results
+        .get(&(Arc::from(query) as Arc<str>))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn build_scoring_graph(runtime: Arc<AiRuntime>) -> OperatorGraph {
+    let ctx = laminar_sql::create_session_context();
+    laminar_sql::register_streaming_functions(&ctx);
+    let mut graph = OperatorGraph::new(ctx);
+    graph.set_ai_runtime(runtime, Handle::current());
+    graph.register_source_schema("posts".to_string(), posts_schema());
+    graph.add_query(
+        "scored".to_string(),
+        "SELECT id, ai_sentiment(text, model => 'm') AS sentiment FROM posts".to_string(),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    graph
+        .take_build_errors()
+        .expect("ai_sentiment routes cleanly");
+    graph
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ai_smoke_scores_dedupes_and_logs() {
+    let server = anthropic_replying("0.8").await;
+    let call_log = Arc::new(AiCallLog::with_defaults());
+    let mut graph = build_scoring_graph(runtime_at(&server.uri(), Arc::clone(&call_log)));
+
+    // Cycle A: three distinct posts → three misses → three provider calls.
+    let first = score_and_drain(
+        &mut graph,
+        "posts",
+        "scored",
+        posts_batch(&[1, 2, 3], &["bull run", "rug pull", "sideways chop"]),
+    )
+    .await;
+    assert_eq!(
+        sentiment_values(&first),
+        vec![Some(0.8), Some(0.8), Some(0.8)]
+    );
+
+    // Cycle B: two of the same posts → both are cache hits, scored inline this
+    // cycle with NO new provider call.
+    let mut repeats = FxHashMap::default();
+    repeats.insert(
+        Arc::from("posts"),
+        vec![posts_batch(&[4, 5], &["bull run", "rug pull"])],
+    );
+    let results = graph.execute_cycle(&repeats, i64::MAX, None).await.unwrap();
+    let second = results[&(Arc::from("scored") as Arc<str>)].clone();
+    assert_eq!(
+        sentiment_values(&second),
+        vec![Some(0.8), Some(0.8)],
+        "repeats reproduce the cached score"
+    );
+
+    // 5 rows scored, but the provider was hit for the 3 distinct texts only —
+    // dedupe is the cache, not the model.
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 3, "repeats must not reach the provider");
+
+    // One batch call recorded (batch_size 3), per-batch granularity.
+    let calls = call_log.snapshot();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].batch_size, 3);
+    assert_eq!(calls[0].outcome, CallOutcome::Success);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ai_degrades_to_null_on_provider_500() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+    let call_log = Arc::new(AiCallLog::with_defaults());
+    let mut graph = build_scoring_graph(runtime_at(&server.uri(), Arc::clone(&call_log)));
+
+    // A parallel non-AI stream that must keep flowing while sentiment degrades.
+    graph.register_source_schema(
+        "trades".to_string(),
+        Arc::new(Schema::new(vec![
+            Field::new("sym", DataType::Utf8, false),
+            Field::new("price", DataType::Float64, false),
+        ])),
+    );
+    graph.add_query(
+        "prices".to_string(),
+        "SELECT sym, price FROM trades".to_string(),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    graph
+        .take_build_errors()
+        .expect("passthrough routes cleanly");
+
+    // Cycle 1: post queued for scoring; the price row flows immediately.
+    let mut sources = FxHashMap::default();
+    sources.insert(
+        Arc::from("posts"),
+        vec![posts_batch(&[1], &["bitcoin to the moon"])],
+    );
+    sources.insert(
+        Arc::from("trades"),
+        vec![RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("sym", DataType::Utf8, false),
+                Field::new("price", DataType::Float64, false),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["BTCUSDT"])),
+                Arc::new(Float64Array::from(vec![64000.0])),
+            ],
+        )
+        .unwrap()],
+    );
+    let cycle1 = graph.execute_cycle(&sources, i64::MAX, None).await.unwrap();
+    assert!(
+        cycle1.contains_key(&(Arc::from("prices") as Arc<str>)),
+        "price feed keeps flowing while the provider is down"
+    );
+
+    // Let the 500s exhaust retries + backoff, then drain.
+    tokio::time::sleep(std::time::Duration::from_millis(900)).await;
+    let drained = graph
+        .execute_cycle(&FxHashMap::default(), i64::MAX, None)
+        .await
+        .expect("pipeline survives a provider outage");
+
+    let scored = &drained[&(Arc::from("scored") as Arc<str>)];
+    assert_eq!(
+        sentiment_values(scored),
+        vec![None],
+        "terminal failure → null score"
+    );
+
+    let calls = call_log.snapshot();
+    assert!(
+        calls
+            .iter()
+            .any(|c| matches!(c.outcome, CallOutcome::Failure(_))),
+        "the failure is recorded in laminar.ai_calls"
+    );
+}
+
+// Item 10: a plain INNER equi-join routes to the `ProcessTimeJoinOperator`
+// (FIR-E), a stateless per-cycle batch join — so each bucket that closes in its
+// own cycle joins correctly, with no watermark. (The cached DataFusion HashJoin
+// could not: it memoized its build side across cycles, so a later bucket never
+// matched.)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn join_aligns_on_bucket_per_cycle() {
+    // Two hand-built bucketed streams (the shape price_1m / sentiment_1m emit):
+    // one row per closed minute. The equi-join on the bucket key matches them
+    // per cycle, on processing time, with no watermark dependency.
+    let ctx = laminar_sql::create_session_context();
+    laminar_sql::register_streaming_functions(&ctx);
+    let mut graph = OperatorGraph::new(ctx);
+
+    let price_schema = Arc::new(Schema::new(vec![
+        Field::new("bucket", DataType::Int64, false),
+        Field::new("price", DataType::Float64, false),
+    ]));
+    let sent_schema = Arc::new(Schema::new(vec![
+        Field::new("bucket", DataType::Int64, false),
+        Field::new("ms", DataType::Float64, false),
+    ]));
+    graph.register_source_schema("price_b".to_string(), Arc::clone(&price_schema));
+    graph.register_source_schema("sent_b".to_string(), Arc::clone(&sent_schema));
+    graph.add_query(
+        "joined".to_string(),
+        "SELECT p.bucket AS bucket, p.price AS price, s.ms AS ms \
+         FROM price_b p JOIN sent_b s ON p.bucket = s.bucket"
+            .to_string(),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    graph
+        .take_build_errors()
+        .expect("equi-join routes as a per-cycle batch join");
+
+    let price_row = |b: i64, p: f64| {
+        RecordBatch::try_new(
+            Arc::clone(&price_schema),
+            vec![
+                Arc::new(Int64Array::from(vec![b])),
+                Arc::new(Float64Array::from(vec![p])),
+            ],
+        )
+        .unwrap()
+    };
+    let sent_row = |b: i64, m: f64| {
+        RecordBatch::try_new(
+            Arc::clone(&sent_schema),
+            vec![
+                Arc::new(Int64Array::from(vec![b])),
+                Arc::new(Float64Array::from(vec![m])),
+            ],
+        )
+        .unwrap()
+    };
+
+    let count = |r: &FxHashMap<Arc<str>, Vec<RecordBatch>>| {
+        r.get(&(Arc::from("joined") as Arc<str>))
+            .map_or(0, |v| v.iter().map(RecordBatch::num_rows).sum::<usize>())
+    };
+
+    // Each minute closes in its own cycle (the demo's pattern): both sides emit
+    // one bucket per cycle. A correct processing-time join matches each.
+    let mut c1 = FxHashMap::default();
+    c1.insert(Arc::from("price_b"), vec![price_row(1, 100.0)]);
+    c1.insert(Arc::from("sent_b"), vec![sent_row(1, 0.5)]);
+    let r1 = graph.execute_cycle(&c1, i64::MAX, None).await.unwrap();
+    assert_eq!(count(&r1), 1, "cycle 1 joins bucket 1");
+
+    let mut c2 = FxHashMap::default();
+    c2.insert(Arc::from("price_b"), vec![price_row(2, 200.0)]);
+    c2.insert(Arc::from("sent_b"), vec![sent_row(2, -0.5)]);
+    let r2 = graph.execute_cycle(&c2, i64::MAX, None).await.unwrap();
+    assert_eq!(
+        count(&r2),
+        1,
+        "cycle 2 must join bucket 2 (per-cycle, no watermark)"
+    );
+}

--- a/crates/laminar-db/src/e2e_crypto_sentiment.rs
+++ b/crates/laminar-db/src/e2e_crypto_sentiment.rs
@@ -1,12 +1,12 @@
-//! End-to-end tests for the crypto-sentiment demo, backed by wiremock.
+//! End-to-end tests for the crypto-sentiment pipeline, backed by wiremock.
 //!
 //! wiremock (HTTP) backs the **Anthropic provider**, so these tests drive the
 //! *real* `AnthropicProvider` HTTP path — request build, 500/retry, response
 //! parse — not a stub. The Binance/Jetstream feeds are non-replayable
 //! websockets whose transport is exercised in `laminar-connectors`; here their
-//! traces are hand-built source batches fed through the graph, which is what
-//! the demo's engine composition actually consumes. The analytically-exact
-//! correlation check lives with the operator, in `operator::window_frame::tests`.
+//! traces are hand-built source batches fed through the graph, which is what the
+//! engine composition actually consumes. The analytically-exact correlation
+//! check lives with the operator, in `operator::window_frame::tests`.
 
 use std::sync::Arc;
 
@@ -270,16 +270,14 @@ async fn ai_degrades_to_null_on_provider_500() {
     );
 }
 
-// Item 10: a plain INNER equi-join routes to the `ProcessTimeJoinOperator`
-// (FIR-E), a stateless per-cycle batch join — so each bucket that closes in its
-// own cycle joins correctly, with no watermark. (The cached DataFusion HashJoin
-// could not: it memoized its build side across cycles, so a later bucket never
-// matched.)
+// A plain INNER equi-join is a stateful processing-time join: it buffers each
+// side and matches when the second side arrives, so two windowed views that
+// close the same bucket in DIFFERENT cycles (e.g. when an upstream AI operator's
+// watermark-hold delays one side) still join — with no watermark.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn join_aligns_on_bucket_per_cycle() {
+async fn join_matches_buckets_closing_in_different_cycles() {
     // Two hand-built bucketed streams (the shape price_1m / sentiment_1m emit):
-    // one row per closed minute. The equi-join on the bucket key matches them
-    // per cycle, on processing time, with no watermark dependency.
+    // one row per closed minute, arriving on the bucket key at different times.
     let ctx = laminar_sql::create_session_context();
     laminar_sql::register_streaming_functions(&ctx);
     let mut graph = OperatorGraph::new(ctx);
@@ -335,21 +333,16 @@ async fn join_aligns_on_bucket_per_cycle() {
             .map_or(0, |v| v.iter().map(RecordBatch::num_rows).sum::<usize>())
     };
 
-    // Each minute closes in its own cycle (the demo's pattern): both sides emit
-    // one bucket per cycle. A correct processing-time join matches each.
+    // Cycle 1: only the price side closes bucket 1 (the sentiment side is still
+    // being scored). The join buffers it and emits nothing yet.
     let mut c1 = FxHashMap::default();
     c1.insert(Arc::from("price_b"), vec![price_row(1, 100.0)]);
-    c1.insert(Arc::from("sent_b"), vec![sent_row(1, 0.5)]);
     let r1 = graph.execute_cycle(&c1, i64::MAX, None).await.unwrap();
-    assert_eq!(count(&r1), 1, "cycle 1 joins bucket 1");
+    assert_eq!(count(&r1), 0, "no match until the second side closes");
 
+    // Cycle 2: the sentiment side closes bucket 1 — the buffered price matches.
     let mut c2 = FxHashMap::default();
-    c2.insert(Arc::from("price_b"), vec![price_row(2, 200.0)]);
-    c2.insert(Arc::from("sent_b"), vec![sent_row(2, -0.5)]);
+    c2.insert(Arc::from("sent_b"), vec![sent_row(1, 0.5)]);
     let r2 = graph.execute_cycle(&c2, i64::MAX, None).await.unwrap();
-    assert_eq!(
-        count(&r2),
-        1,
-        "cycle 2 must join bucket 2 (per-cycle, no watermark)"
-    );
+    assert_eq!(count(&r2), 1, "bucket 1 joins across cycles");
 }

--- a/crates/laminar-db/src/e2e_crypto_sentiment.rs
+++ b/crates/laminar-db/src/e2e_crypto_sentiment.rs
@@ -98,8 +98,30 @@ fn sentiment_values(batches: &[RecordBatch]) -> Vec<Option<f64>> {
     out
 }
 
-/// Feed one cycle, then sleep and drain a second cycle so the Ring-1 worker's
-/// results are applied. Returns the drained `query` output.
+/// Drain empty cycles until `query` emits rows or a deadline — polls the async
+/// Ring-1 worker instead of a fixed sleep that flakes under CI load.
+async fn drain_until(graph: &mut OperatorGraph, query: &str) -> Vec<RecordBatch> {
+    let key = Arc::from(query) as Arc<str>;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let results = graph
+            .execute_cycle(&FxHashMap::default(), i64::MAX, None)
+            .await
+            .unwrap();
+        if let Some(out) = results.get(&key) {
+            if out.iter().map(RecordBatch::num_rows).sum::<usize>() > 0 {
+                return out.clone();
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+/// Feed one cycle, then drain until the Ring-1 worker's results land. Returns the
+/// drained `query` output.
 async fn score_and_drain(
     graph: &mut OperatorGraph,
     source: &str,
@@ -109,15 +131,7 @@ async fn score_and_drain(
     let mut sources = FxHashMap::default();
     sources.insert(Arc::from(source), vec![batch]);
     let _ = graph.execute_cycle(&sources, i64::MAX, None).await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-    let results = graph
-        .execute_cycle(&FxHashMap::default(), i64::MAX, None)
-        .await
-        .unwrap();
-    results
-        .get(&(Arc::from(query) as Arc<str>))
-        .cloned()
-        .unwrap_or_default()
+    drain_until(graph, query).await
 }
 
 fn build_scoring_graph(runtime: Arc<AiRuntime>) -> OperatorGraph {
@@ -247,16 +261,11 @@ async fn ai_degrades_to_null_on_provider_500() {
         "price feed keeps flowing while the provider is down"
     );
 
-    // Let the 500s exhaust retries + backoff, then drain.
-    tokio::time::sleep(std::time::Duration::from_millis(900)).await;
-    let drained = graph
-        .execute_cycle(&FxHashMap::default(), i64::MAX, None)
-        .await
-        .expect("pipeline survives a provider outage");
-
-    let scored = &drained[&(Arc::from("scored") as Arc<str>)];
+    // Poll until the 500s exhaust retries + backoff and the null score is emitted
+    // (the pipeline must survive the provider outage and still produce a row).
+    let scored = drain_until(&mut graph, "scored").await;
     assert_eq!(
-        sentiment_values(scored),
+        sentiment_values(&scored),
         vec![None],
         "terminal failure → null score"
     );

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -339,7 +339,11 @@ impl IntervalJoinState {
 }
 
 /// Build the merged output schema from left and right schemas.
-fn build_output_schema(
+/// The joined output schema: left fields, then right fields suffixed with
+/// `_{right_table}`. Shared with the processing-time join so both produce the
+/// column names the residual projection (built by `build_stream_join_projection_sql`)
+/// expects.
+pub(crate) fn build_output_schema(
     left_schema: &SchemaRef,
     right_schema: &SchemaRef,
     config: &StreamJoinConfig,

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -90,6 +90,11 @@ mod table_provider;
 mod table_store;
 mod temporal_probe;
 
+// End-to-end tests for the crypto-sentiment demo pipeline, backed by wiremock.
+// In-crate (not tests/) so it can drive the OperatorGraph directly.
+#[cfg(test)]
+mod e2e_crypto_sentiment;
+
 /// C FFI layer for LaminarDB.
 ///
 /// Enable with the `ffi` feature flag:

--- a/crates/laminar-db/src/operator/ai_inference.rs
+++ b/crates/laminar-db/src/operator/ai_inference.rs
@@ -27,7 +27,8 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, Float32Builder, ListBuilder, RecordBatch, StringArray, StringBuilder,
+    Array, ArrayRef, Float32Builder, Float64Builder, ListBuilder, RecordBatch, StringArray,
+    StringBuilder,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
@@ -328,16 +329,19 @@ impl AiInferenceOperator {
         batch: &RecordBatch,
         outputs: &[Option<CachedOutput>],
     ) -> Result<RecordBatch, DbError> {
-        let (array, field) = if self.task == Task::Embed {
-            (
+        let (array, field) = match self.task {
+            Task::Embed => (
                 build_embedding_array(outputs)?,
                 Field::new(&self.output_column, embedding_type(), true),
-            )
-        } else {
-            (
+            ),
+            Task::Sentiment => (
+                build_score_array(outputs)?,
+                Field::new(&self.output_column, DataType::Float64, true),
+            ),
+            _ => (
                 build_text_array(outputs)?,
                 Field::new(&self.output_column, DataType::Utf8, true),
-            )
+            ),
         };
 
         let mut fields: Vec<Field> = batch
@@ -472,9 +476,27 @@ fn build_text_array(outputs: &[Option<CachedOutput>]) -> Result<ArrayRef, DbErro
         match output {
             Some(CachedOutput::Text(s)) => builder.append_value(s),
             None => builder.append_null(),
-            Some(CachedOutput::Vector(_)) => {
+            Some(CachedOutput::Vector(_) | CachedOutput::Score(_)) => {
                 return Err(DbError::InvalidOperation(
-                    "ai operator: expected text output, got a vector".to_string(),
+                    "ai operator: expected text output, got a vector/score".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+/// Build the `Float64` score column for `ai_sentiment`. A null input or a
+/// failed inference yields a null score.
+fn build_score_array(outputs: &[Option<CachedOutput>]) -> Result<ArrayRef, DbError> {
+    let mut builder = Float64Builder::new();
+    for output in outputs {
+        match output {
+            Some(CachedOutput::Score(v)) => builder.append_value(*v),
+            None => builder.append_null(),
+            Some(CachedOutput::Text(_) | CachedOutput::Vector(_)) => {
+                return Err(DbError::InvalidOperation(
+                    "ai operator: expected a score output, got text/vector".to_string(),
                 ));
             }
         }
@@ -491,9 +513,9 @@ fn build_embedding_array(outputs: &[Option<CachedOutput>]) -> Result<ArrayRef, D
                 builder.append(true);
             }
             None => builder.append(false),
-            Some(CachedOutput::Text(_)) => {
+            Some(CachedOutput::Text(_) | CachedOutput::Score(_)) => {
                 return Err(DbError::InvalidOperation(
-                    "ai operator: expected a vector output, got text".to_string(),
+                    "ai operator: expected a vector output, got text/score".to_string(),
                 ));
             }
         }

--- a/crates/laminar-db/src/operator/mod.rs
+++ b/crates/laminar-db/src/operator/mod.rs
@@ -117,10 +117,12 @@ pub(crate) mod ai_inference;
 pub(crate) mod asof_join;
 pub(crate) mod eowc_query;
 pub(crate) mod interval_join;
+pub(crate) mod process_time_join;
 pub(crate) mod sql_query;
 pub(crate) mod temporal_filter;
 pub(crate) mod temporal_join;
 pub(crate) mod temporal_probe_join;
+pub(crate) mod window_frame;
 
 pub(crate) async fn try_compile_post_projection(
     ctx: &SessionContext,

--- a/crates/laminar-db/src/operator/process_time_join.rs
+++ b/crates/laminar-db/src/operator/process_time_join.rs
@@ -1,0 +1,141 @@
+//! Processing-time equi-join: a stateless per-cycle inner join, no watermark.
+//!
+//! It joins this cycle's left and right batches on the equi-key — what aligns
+//! two windowed views closing the same bucket in the same cycle. The cached
+//! `DataFusion` `HashJoin` cannot: it memoizes its build side across cycles
+//! (`OnceAsync`), so a bucket closing in a later cycle never matches.
+
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, RecordBatch, UInt32Array};
+use arrow::compute::{concat_batches, take};
+use async_trait::async_trait;
+use datafusion::prelude::SessionContext;
+use rustc_hash::FxHashMap;
+
+use laminar_sql::translator::StreamJoinConfig;
+
+use crate::error::DbError;
+use crate::interval_join::build_output_schema;
+use crate::key_column::extract_key_column;
+use crate::operator::ProjectingJoinState;
+use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
+
+pub(crate) struct ProcessTimeJoinOperator {
+    config: StreamJoinConfig,
+    projection: ProjectingJoinState,
+}
+
+impl ProcessTimeJoinOperator {
+    pub(crate) fn new(
+        name: &str,
+        config: StreamJoinConfig,
+        projection_sql: Option<Arc<str>>,
+        ctx: SessionContext,
+    ) -> Self {
+        Self {
+            config,
+            // The `FROM` name `build_stream_join_projection_sql` emits (shared
+            // with the interval join; registered transiently per `apply`).
+            projection: ProjectingJoinState::new(name, ctx, projection_sql, "__interval_tmp"),
+        }
+    }
+
+    /// Inner-join this cycle's batches on the equi-key. Empty when either side
+    /// has no rows (so a minute where only one view closed yields nothing).
+    fn join_cycle(
+        &self,
+        left_batches: &[RecordBatch],
+        right_batches: &[RecordBatch],
+    ) -> Result<Vec<RecordBatch>, DbError> {
+        let (Some(left_schema), Some(right_schema)) = (
+            left_batches.first().map(RecordBatch::schema),
+            right_batches.first().map(RecordBatch::schema),
+        ) else {
+            return Ok(Vec::new());
+        };
+        let left = concat_batches(&left_schema, left_batches)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: concat left: {e}")))?;
+        let right = concat_batches(&right_schema, right_batches)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: concat right: {e}")))?;
+        if left.num_rows() == 0 || right.num_rows() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let left_keys = extract_key_column(&left, &self.config.left_key)?;
+        let right_keys = extract_key_column(&right, &self.config.right_key)?;
+
+        // Build a hash index over the (smaller, by convention right) side, then
+        // probe with the left. Collisions are resolved by `keys_equal`.
+        let mut index: FxHashMap<u64, Vec<u32>> = FxHashMap::default();
+        for j in 0..right.num_rows() {
+            if let Some(h) = right_keys.hash_at(j) {
+                index
+                    .entry(h)
+                    .or_default()
+                    .push(u32::try_from(j).unwrap_or(u32::MAX));
+            }
+        }
+
+        let mut left_idx: Vec<u32> = Vec::new();
+        let mut right_idx: Vec<u32> = Vec::new();
+        for i in 0..left.num_rows() {
+            let Some(h) = left_keys.hash_at(i) else {
+                continue;
+            };
+            let Some(candidates) = index.get(&h) else {
+                continue;
+            };
+            for &j in candidates {
+                if left_keys.keys_equal(i, &right_keys, j as usize) {
+                    left_idx.push(u32::try_from(i).unwrap_or(u32::MAX));
+                    right_idx.push(j);
+                }
+            }
+        }
+        if left_idx.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let out_schema = build_output_schema(&left_schema, &right_schema, &self.config);
+        let li = UInt32Array::from(left_idx);
+        let ri = UInt32Array::from(right_idx);
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(out_schema.fields().len());
+        for col in left.columns() {
+            columns.push(gather(col, &li)?);
+        }
+        for col in right.columns() {
+            columns.push(gather(col, &ri)?);
+        }
+        let batch = RecordBatch::try_new(out_schema, columns)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: build output: {e}")))?;
+        Ok(vec![batch])
+    }
+}
+
+fn gather(column: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef, DbError> {
+    take(column.as_ref(), indices, None)
+        .map_err(|e| DbError::Pipeline(format!("process-time join: take: {e}")))
+}
+
+#[async_trait]
+impl GraphOperator for ProcessTimeJoinOperator {
+    async fn process(
+        &mut self,
+        inputs: &[Vec<RecordBatch>],
+        _watermarks: &[i64],
+    ) -> Result<Vec<RecordBatch>, DbError> {
+        let left = inputs.first().map_or(&[][..], Vec::as_slice);
+        let right = inputs.get(1).map_or(&[][..], Vec::as_slice);
+        let joined = self.join_cycle(left, right)?;
+        self.projection.apply(joined).await
+    }
+
+    fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
+        Ok(None) // stateless: nothing carries across cycles
+    }
+
+    fn restore(&mut self, _checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
+        Ok(())
+    }
+}

--- a/crates/laminar-db/src/operator/process_time_join.rs
+++ b/crates/laminar-db/src/operator/process_time_join.rs
@@ -75,11 +75,21 @@ impl SideBuffer {
         {
             self.chunks.pop_front();
         }
+        // Memory backstop: keep the newest MAX_BUFFERED_ROWS, slicing the oldest
+        // chunk rather than dropping a whole (possibly large) batch wholesale.
         let mut rows: usize = self.chunks.iter().map(|(_, b)| b.num_rows()).sum();
         while rows > MAX_BUFFERED_ROWS {
-            match self.chunks.pop_front() {
-                Some((_, b)) => rows -= b.num_rows(),
+            let overage = rows - MAX_BUFFERED_ROWS;
+            let front_rows = match self.chunks.front() {
+                Some((_, b)) => b.num_rows(),
                 None => break,
+            };
+            if front_rows <= overage {
+                self.chunks.pop_front();
+                rows -= front_rows;
+            } else if let Some((_, front)) = self.chunks.front_mut() {
+                *front = front.slice(overage, front_rows - overage); // drop oldest `overage`
+                rows -= overage;
             }
         }
     }

--- a/crates/laminar-db/src/operator/process_time_join.rs
+++ b/crates/laminar-db/src/operator/process_time_join.rs
@@ -1,10 +1,23 @@
-//! Processing-time equi-join: a stateless per-cycle inner join, no watermark.
+//! Processing-time equi-join: a bounded stateful inner join between two windowed
+//! views, joined on their equi-key (e.g. `bucket_start`).
 //!
-//! It joins this cycle's left and right batches on the equi-key — what aligns
-//! two windowed views closing the same bucket in the same cycle. The cached
-//! `DataFusion` `HashJoin` cannot: it memoizes its build side across cycles
-//! (`OnceAsync`), so a bucket closing in a later cycle never matches.
+//! The two sides do **not** close a bucket in the same cycle — an upstream AI
+//! operator's watermark hold delays one side by its scoring latency — so a
+//! stateless per-cycle join would drop buckets. Each side keeps its unmatched
+//! rows and matches whenever the second side arrives, via the symmetric hash-join
+//! rule (new×buffered, buffered×new, new×new; buffered×buffered already emitted).
+//!
+//! Retention is **watermark-driven**: a side's buffered rows are evicted once the
+//! *opposite* side's watermark has passed them — the partner can no longer arrive
+//! — so state is bounded by the real cross-side skew, not a fixed count, and an
+//! unmatched row ages out (correct for an inner join). Eviction runs **after** the
+//! join, so a row still matches a partner arriving in the same cycle it would age
+//! out. `MAX_BUFFERED_ROWS` is a hard memory backstop for when watermarks don't
+//! advance (e.g. an idle or watermark-less source). The cached `DataFusion`
+//! `HashJoin` can't serve this: it memoizes its build side across cycles
+//! (`OnceAsync`).
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, RecordBatch, UInt32Array};
@@ -13,6 +26,7 @@ use async_trait::async_trait;
 use datafusion::prelude::SessionContext;
 use rustc_hash::FxHashMap;
 
+use laminar_core::serialization::{deserialize_batch_stream, serialize_batch_stream};
 use laminar_sql::translator::StreamJoinConfig;
 
 use crate::error::DbError;
@@ -21,8 +35,68 @@ use crate::key_column::extract_key_column;
 use crate::operator::ProjectingJoinState;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 
+/// Hard memory backstop per side: when watermarks don't advance, retention falls
+/// back to keeping at most this many newest rows. With watermarks it is rarely
+/// reached — the cross-side skew is a handful of windows.
+const MAX_BUFFERED_ROWS: usize = 4096;
+
+/// One join side's unmatched rows. Each cycle's arrivals are a chunk tagged with
+/// the input watermark at which they arrived; eviction drops whole chunks the
+/// opposite side has advanced past, oldest first.
+#[derive(Default)]
+struct SideBuffer {
+    chunks: VecDeque<(i64, RecordBatch)>,
+}
+
+impl SideBuffer {
+    fn push(&mut self, watermark: i64, batch: RecordBatch) {
+        if batch.num_rows() > 0 {
+            self.chunks.push_back((watermark, batch));
+        }
+    }
+
+    /// All buffered rows as one batch to probe against, or `None` when empty.
+    fn concat(&self) -> Result<Option<RecordBatch>, DbError> {
+        let Some((_, first)) = self.chunks.front() else {
+            return Ok(None);
+        };
+        concat_batches(&first.schema(), self.chunks.iter().map(|(_, b)| b))
+            .map(Some)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: concat buffer: {e}")))
+    }
+
+    /// Evict rows the opposite side has passed (`tag < opposite_watermark`), then
+    /// enforce the memory backstop oldest-first.
+    fn evict(&mut self, opposite_watermark: i64) {
+        while self
+            .chunks
+            .front()
+            .is_some_and(|(tag, _)| *tag < opposite_watermark)
+        {
+            self.chunks.pop_front();
+        }
+        let mut rows: usize = self.chunks.iter().map(|(_, b)| b.num_rows()).sum();
+        while rows > MAX_BUFFERED_ROWS {
+            match self.chunks.pop_front() {
+                Some((_, b)) => rows -= b.num_rows(),
+                None => break,
+            }
+        }
+    }
+
+    fn bytes(&self) -> usize {
+        self.chunks
+            .iter()
+            .map(|(_, b)| b.get_array_memory_size())
+            .sum()
+    }
+}
+
 pub(crate) struct ProcessTimeJoinOperator {
     config: StreamJoinConfig,
+    left: SideBuffer,
+    right: SideBuffer,
+    /// The user's SELECT with the join's columns rewritten over the temp table.
     projection: ProjectingJoinState,
 }
 
@@ -35,38 +109,29 @@ impl ProcessTimeJoinOperator {
     ) -> Self {
         Self {
             config,
+            left: SideBuffer::default(),
+            right: SideBuffer::default(),
             // The `FROM` name `build_stream_join_projection_sql` emits (shared
             // with the interval join; registered transiently per `apply`).
             projection: ProjectingJoinState::new(name, ctx, projection_sql, "__interval_tmp"),
         }
     }
 
-    /// Inner-join this cycle's batches on the equi-key. Empty when either side
-    /// has no rows (so a minute where only one view closed yields nothing).
-    fn join_cycle(
+    /// Inner-join two batches on the equi-key. `None` when either is empty or
+    /// nothing matches.
+    fn join_pair(
         &self,
-        left_batches: &[RecordBatch],
-        right_batches: &[RecordBatch],
-    ) -> Result<Vec<RecordBatch>, DbError> {
-        let (Some(left_schema), Some(right_schema)) = (
-            left_batches.first().map(RecordBatch::schema),
-            right_batches.first().map(RecordBatch::schema),
-        ) else {
-            return Ok(Vec::new());
-        };
-        let left = concat_batches(&left_schema, left_batches)
-            .map_err(|e| DbError::Pipeline(format!("process-time join: concat left: {e}")))?;
-        let right = concat_batches(&right_schema, right_batches)
-            .map_err(|e| DbError::Pipeline(format!("process-time join: concat right: {e}")))?;
+        left: &RecordBatch,
+        right: &RecordBatch,
+    ) -> Result<Option<RecordBatch>, DbError> {
         if left.num_rows() == 0 || right.num_rows() == 0 {
-            return Ok(Vec::new());
+            return Ok(None);
         }
+        let left_keys = extract_key_column(left, &self.config.left_key)?;
+        let right_keys = extract_key_column(right, &self.config.right_key)?;
 
-        let left_keys = extract_key_column(&left, &self.config.left_key)?;
-        let right_keys = extract_key_column(&right, &self.config.right_key)?;
-
-        // Build a hash index over the (smaller, by convention right) side, then
-        // probe with the left. Collisions are resolved by `keys_equal`.
+        // Hash-index the right side, probe with the left; collisions are resolved
+        // by `keys_equal`.
         let mut index: FxHashMap<u64, Vec<u32>> = FxHashMap::default();
         for j in 0..right.num_rows() {
             if let Some(h) = right_keys.hash_at(j) {
@@ -76,7 +141,6 @@ impl ProcessTimeJoinOperator {
                     .push(u32::try_from(j).unwrap_or(u32::MAX));
             }
         }
-
         let mut left_idx: Vec<u32> = Vec::new();
         let mut right_idx: Vec<u32> = Vec::new();
         for i in 0..left.num_rows() {
@@ -94,12 +158,11 @@ impl ProcessTimeJoinOperator {
             }
         }
         if left_idx.is_empty() {
-            return Ok(Vec::new());
+            return Ok(None);
         }
 
-        let out_schema = build_output_schema(&left_schema, &right_schema, &self.config);
-        let li = UInt32Array::from(left_idx);
-        let ri = UInt32Array::from(right_idx);
+        let out_schema = build_output_schema(&left.schema(), &right.schema(), &self.config);
+        let (li, ri) = (UInt32Array::from(left_idx), UInt32Array::from(right_idx));
         let mut columns: Vec<ArrayRef> = Vec::with_capacity(out_schema.fields().len());
         for col in left.columns() {
             columns.push(gather(col, &li)?);
@@ -107,9 +170,23 @@ impl ProcessTimeJoinOperator {
         for col in right.columns() {
             columns.push(gather(col, &ri)?);
         }
-        let batch = RecordBatch::try_new(out_schema, columns)
-            .map_err(|e| DbError::Pipeline(format!("process-time join: build output: {e}")))?;
-        Ok(vec![batch])
+        RecordBatch::try_new(out_schema, columns)
+            .map(Some)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: build output: {e}")))
+    }
+
+    /// Concat this cycle's batches for one side into one (or `None` if empty).
+    fn concat_new(batches: &[RecordBatch]) -> Result<Option<RecordBatch>, DbError> {
+        let Some(schema) = batches
+            .iter()
+            .find(|b| b.num_rows() > 0)
+            .map(RecordBatch::schema)
+        else {
+            return Ok(None);
+        };
+        concat_batches(&schema, batches.iter())
+            .map(Some)
+            .map_err(|e| DbError::Pipeline(format!("process-time join: concat input: {e}")))
     }
 }
 
@@ -123,19 +200,247 @@ impl GraphOperator for ProcessTimeJoinOperator {
     async fn process(
         &mut self,
         inputs: &[Vec<RecordBatch>],
-        _watermarks: &[i64],
+        watermarks: &[i64],
     ) -> Result<Vec<RecordBatch>, DbError> {
-        let left = inputs.first().map_or(&[][..], Vec::as_slice);
-        let right = inputs.get(1).map_or(&[][..], Vec::as_slice);
-        let joined = self.join_cycle(left, right)?;
-        self.projection.apply(joined).await
+        let new_left = Self::concat_new(inputs.first().map_or(&[][..], Vec::as_slice))?;
+        let new_right = Self::concat_new(inputs.get(1).map_or(&[][..], Vec::as_slice))?;
+        let wm_left = watermarks.first().copied().unwrap_or(i64::MIN);
+        let wm_right = watermarks.get(1).copied().unwrap_or(i64::MIN);
+
+        // Emit against the OLD buffers first, then fold the new rows in — so each
+        // pair emits exactly once (when its later side arrives) and old×old is
+        // never re-emitted. Only concat a buffer when there are new rows to probe
+        // it with.
+        let right_buf = if new_left.is_some() {
+            self.right.concat()?
+        } else {
+            None
+        };
+        let left_buf = if new_right.is_some() {
+            self.left.concat()?
+        } else {
+            None
+        };
+        let mut out = Vec::new();
+        if let (Some(nl), Some(rb)) = (&new_left, &right_buf) {
+            out.extend(self.join_pair(nl, rb)?);
+        }
+        if let (Some(lb), Some(nr)) = (&left_buf, &new_right) {
+            out.extend(self.join_pair(lb, nr)?);
+        }
+        if let (Some(nl), Some(nr)) = (&new_left, &new_right) {
+            out.extend(self.join_pair(nl, nr)?);
+        }
+
+        if let Some(nl) = new_left {
+            self.left.push(wm_left, nl);
+        }
+        if let Some(nr) = new_right {
+            self.right.push(wm_right, nr);
+        }
+
+        // Evict AFTER joining (a row can match a partner arriving the same cycle it
+        // ages out): each side is bounded by the OPPOSITE side's progress.
+        self.left.evict(wm_right);
+        self.right.evict(wm_left);
+
+        self.projection.apply(out).await
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        Ok(None) // stateless: nothing carries across cycles
+        // (side, watermark, batch-blob); side 0 = left, 1 = right.
+        let mut blobs: Vec<(u8, i64, Vec<u8>)> = Vec::new();
+        let mut serialize =
+            |side: u8, chunks: &VecDeque<(i64, RecordBatch)>| -> Result<(), DbError> {
+                for (tag, batch) in chunks {
+                    let blob = serialize_batch_stream(batch).map_err(|e| {
+                        DbError::Pipeline(format!("process-time join: checkpoint: {e}"))
+                    })?;
+                    blobs.push((side, *tag, blob));
+                }
+                Ok(())
+            };
+        serialize(0, &self.left.chunks)?;
+        serialize(1, &self.right.chunks)?;
+        if blobs.is_empty() {
+            return Ok(None);
+        }
+        let data = rkyv::to_bytes::<rkyv::rancor::Error>(&blobs)
+            .map(|v| v.to_vec())
+            .map_err(|e| DbError::Pipeline(format!("process-time join: checkpoint encode: {e}")))?;
+        Ok(Some(OperatorCheckpoint { data }))
     }
 
-    fn restore(&mut self, _checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
+    fn restore(&mut self, checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
+        let blobs: Vec<(u8, i64, Vec<u8>)> = rkyv::from_bytes::<
+            Vec<(u8, i64, Vec<u8>)>,
+            rkyv::rancor::Error,
+        >(&checkpoint.data)
+        .map_err(|e| DbError::Pipeline(format!("process-time join: restore decode: {e}")))?;
+        self.left.chunks.clear();
+        self.right.chunks.clear();
+        for (side, tag, blob) in &blobs {
+            let batch = deserialize_batch_stream(blob)
+                .map_err(|e| DbError::Pipeline(format!("process-time join: restore: {e}")))?;
+            let target = if *side == 0 {
+                &mut self.left
+            } else {
+                &mut self.right
+            };
+            target.chunks.push_back((*tag, batch));
+        }
         Ok(())
+    }
+
+    fn estimated_state_bytes(&self) -> usize {
+        self.left.bytes() + self.right.bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use laminar_sql::translator::StreamJoinType;
+
+    fn config() -> StreamJoinConfig {
+        StreamJoinConfig {
+            left_key: "bucket".to_string(),
+            right_key: "bucket".to_string(),
+            left_time_column: String::new(),
+            right_time_column: String::new(),
+            left_table: "price".to_string(),
+            right_table: "sent".to_string(),
+            time_bound: std::time::Duration::ZERO,
+            join_type: StreamJoinType::Inner,
+        }
+    }
+
+    fn operator() -> ProcessTimeJoinOperator {
+        // No projection_sql ⇒ ProjectingJoinState passes the combined batch through.
+        ProcessTimeJoinOperator::new("pt", config(), None, laminar_sql::create_session_context())
+    }
+
+    fn left_row(bucket: i64, price: f64) -> Vec<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("bucket", DataType::Int64, false),
+            Field::new("price", DataType::Float64, false),
+        ]));
+        vec![RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![bucket])),
+                Arc::new(Float64Array::from(vec![price])),
+            ],
+        )
+        .unwrap()]
+    }
+
+    fn right_row(bucket: i64, ms: f64) -> Vec<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("bucket", DataType::Int64, false),
+            Field::new("ms", DataType::Float64, false),
+        ]));
+        vec![RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![bucket])),
+                Arc::new(Float64Array::from(vec![ms])),
+            ],
+        )
+        .unwrap()]
+    }
+
+    fn rows(out: &[RecordBatch]) -> usize {
+        out.iter().map(RecordBatch::num_rows).sum()
+    }
+
+    /// The two sides close the same bucket in DIFFERENT cycles (the AI-hold case
+    /// the stateless join dropped): the match must still emit when the second
+    /// side arrives.
+    #[tokio::test]
+    async fn matches_across_cycles() {
+        let mut op = operator();
+        // Cycle 1: only the left side closes bucket 1 → buffered, nothing emitted.
+        assert_eq!(
+            rows(
+                &op.process(&[left_row(1, 100.0), vec![]], &[0, 0])
+                    .await
+                    .unwrap()
+            ),
+            0
+        );
+        // Cycle 2: the right side closes bucket 1 → the buffered left matches.
+        assert_eq!(
+            rows(
+                &op.process(&[vec![], right_row(1, 0.5)], &[0, 0])
+                    .await
+                    .unwrap()
+            ),
+            1
+        );
+        // Cycle 3: bucket 1 already matched; only bucket 2's left arrives → nothing.
+        assert_eq!(
+            rows(
+                &op.process(&[left_row(2, 200.0), vec![]], &[0, 0])
+                    .await
+                    .unwrap()
+            ),
+            0
+        );
+    }
+
+    /// Same-cycle arrival still matches, and a matched pair is not re-emitted on
+    /// a later cycle.
+    #[tokio::test]
+    async fn matches_same_cycle_without_reemission() {
+        let mut op = operator();
+        let out = op
+            .process(&[left_row(1, 100.0), right_row(1, 0.5)], &[0, 0])
+            .await
+            .unwrap();
+        assert_eq!(rows(&out), 1);
+        // A new, non-matching bucket must not re-emit bucket 1.
+        assert_eq!(
+            rows(
+                &op.process(&[left_row(2, 200.0), vec![]], &[0, 0])
+                    .await
+                    .unwrap()
+            ),
+            0
+        );
+    }
+
+    /// Once the opposite side's watermark passes a buffered row, it ages out, so a
+    /// late partner no longer matches — retention tracks progress, state stays
+    /// bounded.
+    #[tokio::test]
+    async fn watermark_evicts_rows_the_other_side_passed() {
+        let mut op = operator();
+        // Left bucket 1 buffered at watermark 1; no right side yet.
+        assert_eq!(
+            rows(
+                &op.process(&[left_row(1, 100.0), vec![]], &[1, 1])
+                    .await
+                    .unwrap()
+            ),
+            0
+        );
+        // The right side advances its watermark to 5 with no matching row; this
+        // passes the buffered left@1, which is evicted.
+        assert_eq!(
+            rows(&op.process(&[vec![], vec![]], &[1, 5]).await.unwrap()),
+            0
+        );
+        // A late right@1 now finds nothing — left@1 was correctly aged out.
+        assert_eq!(
+            rows(
+                &op.process(&[vec![], right_row(1, 0.5)], &[1, 5])
+                    .await
+                    .unwrap()
+            ),
+            0
+        );
     }
 }

--- a/crates/laminar-db/src/operator/window_frame.rs
+++ b/crates/laminar-db/src/operator/window_frame.rs
@@ -1,0 +1,349 @@
+//! Sliding-window covariance/correlation operator (moment-carrying).
+//!
+//! Streams the bivariate statistics over a `ROWS N PRECEDING` frame — `CORR`,
+//! `COVAR_SAMP`, `COVAR_POP` — that the batch engine can't slide: `DataFusion`'s
+//! accumulators for them have no `retract_batch`, so they are rejected as
+//! sliding-window accumulators. All three derive from the *same* carried moments
+//! `(n, Σx, Σy, Σxx, Σyy, Σxy)`; only the final formula differs. The operator
+//! recomputes them per window over a bounded retained buffer, appends the result
+//! column, and re-projects. (`AVG`/`SUM`/… over frames are a separate concern —
+//! `DataFusion` slides those itself.)
+//!
+//! v0.1 (enforced by `plan_frame_query`): one bivariate call over a single
+//! ordered series (no `PARTITION BY`), preceding bounds only. Rows are assumed to
+//! arrive in `ORDER BY` order (true for processing-time buckets), so the buffer
+//! is already ordered and the new arrivals are its tail.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, Float64Array, Float64Builder, RecordBatch};
+use arrow::compute::concat_batches;
+use arrow::datatypes::{DataType, Field, Schema};
+use async_trait::async_trait;
+use datafusion::prelude::SessionContext;
+
+use laminar_core::serialization::{deserialize_batch_stream, serialize_batch_stream};
+
+use crate::error::DbError;
+use crate::operator::ProjectingJoinState;
+use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
+use crate::sql_analysis::FRAME_TMP_TABLE;
+
+/// A bivariate moment-carrying statistic over a sliding frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MomentFn {
+    /// Pearson correlation.
+    Corr,
+    /// Sample covariance.
+    CovarSamp,
+    /// Population covariance.
+    CovarPop,
+}
+
+impl MomentFn {
+    /// Finalize the statistic from a window's carried moments, or `None` when the
+    /// frame has too few complete pairs (or zero variance, for `CORR`).
+    fn finalize(self, n: f64, sx: f64, sy: f64, sxx: f64, syy: f64, sxy: f64) -> Option<f64> {
+        let cov_num = n * sxy - sx * sy; // = n² · covariance
+        match self {
+            MomentFn::Corr => {
+                let (den_x, den_y) = (n * sxx - sx * sx, n * syy - sy * sy);
+                (n >= 2.0 && den_x > 0.0 && den_y > 0.0).then(|| cov_num / (den_x * den_y).sqrt())
+            }
+            MomentFn::CovarSamp => (n >= 2.0).then(|| cov_num / (n * (n - 1.0))),
+            MomentFn::CovarPop => (n >= 1.0).then(|| cov_num / (n * n)),
+        }
+    }
+}
+
+/// What the operator computes: the statistic, its two argument columns, the
+/// appended output column, and the rows of preceding history to retain.
+pub(crate) struct MomentFrameConfig {
+    pub func: MomentFn,
+    pub x_column: String,
+    pub y_column: String,
+    pub output_column: String,
+    /// `max(PRECEDING)` — retained so each new row gets a full frame.
+    pub retain: usize,
+}
+
+/// Streams a sliding-window bivariate statistic (see module docs).
+pub(crate) struct WindowFrameOperator {
+    config: MomentFrameConfig,
+    /// Newest `config.retain` input rows, carried across cycles.
+    history: Option<RecordBatch>,
+    /// The user's SELECT with the stat call rewritten to its alias column.
+    projection: ProjectingJoinState,
+}
+
+impl WindowFrameOperator {
+    pub(crate) fn new(
+        name: &str,
+        config: MomentFrameConfig,
+        projection_sql: Arc<str>,
+        ctx: SessionContext,
+    ) -> Self {
+        Self {
+            config,
+            history: None,
+            projection: ProjectingJoinState::new(name, ctx, Some(projection_sql), FRAME_TMP_TABLE),
+        }
+    }
+
+    /// The newest `n` rows of `batch` (all of it if shorter).
+    fn tail(batch: &RecordBatch, n: usize) -> RecordBatch {
+        let rows = batch.num_rows();
+        if rows <= n {
+            batch.clone()
+        } else {
+            batch.slice(rows - n, n)
+        }
+    }
+
+    fn f64_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Float64Array, DbError> {
+        batch
+            .column_by_name(name)
+            .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
+            .ok_or_else(|| {
+                DbError::InvalidOperation(format!(
+                    "window frame: argument '{name}' must be a non-null-typed Float64 column"
+                ))
+            })
+    }
+
+    /// The statistic over the window `lo..=hi` of `x`/`y`, from carried moments.
+    fn stat_window(&self, x: &Float64Array, y: &Float64Array, lo: usize, hi: usize) -> Option<f64> {
+        let (mut n, mut sx, mut sy, mut sxx, mut syy, mut sxy) = (0.0_f64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        for i in lo..=hi {
+            if x.is_null(i) || y.is_null(i) {
+                continue;
+            }
+            let (xi, yi) = (x.value(i), y.value(i));
+            n += 1.0;
+            sx += xi;
+            sy += yi;
+            sxx += xi * xi;
+            syy += yi * yi;
+            sxy += xi * yi;
+        }
+        self.config.func.finalize(n, sx, sy, sxx, syy, sxy)
+    }
+
+    /// Append the per-new-row statistic column to the `new` batch.
+    fn enrich(&self, new: &RecordBatch, buffer: &RecordBatch) -> Result<RecordBatch, DbError> {
+        let x = Self::f64_column(buffer, &self.config.x_column)?;
+        let y = Self::f64_column(buffer, &self.config.y_column)?;
+        let k = new.num_rows();
+        let first_new = buffer.num_rows() - k;
+
+        let mut builder = Float64Builder::with_capacity(k);
+        for j in 0..k {
+            let hi = first_new + j;
+            let lo = hi.saturating_sub(self.config.retain);
+            match self.stat_window(x, y, lo, hi) {
+                Some(v) => builder.append_value(v),
+                None => builder.append_null(),
+            }
+        }
+
+        let mut fields: Vec<Field> = new
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.as_ref().clone())
+            .collect();
+        fields.push(Field::new(
+            &self.config.output_column,
+            DataType::Float64,
+            true,
+        ));
+        let mut columns: Vec<ArrayRef> = new.columns().to_vec();
+        columns.push(Arc::new(builder.finish()));
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .map_err(|e| DbError::InvalidOperation(format!("window frame: build output: {e}")))
+    }
+}
+
+#[async_trait]
+impl GraphOperator for WindowFrameOperator {
+    async fn process(
+        &mut self,
+        inputs: &[Vec<RecordBatch>],
+        _watermarks: &[i64],
+    ) -> Result<Vec<RecordBatch>, DbError> {
+        let batches = inputs.first().map_or(&[][..], Vec::as_slice);
+        let Some(schema) = batches
+            .iter()
+            .find(|b| b.num_rows() > 0)
+            .map(RecordBatch::schema)
+        else {
+            return Ok(Vec::new()); // nothing new this cycle
+        };
+
+        let new = concat_batches(&schema, batches.iter())
+            .map_err(|e| DbError::Pipeline(format!("window frame: concat input: {e}")))?;
+
+        let buffer = match &self.history {
+            Some(h) => concat_batches(&schema, [h, &new])
+                .map_err(|e| DbError::Pipeline(format!("window frame: concat buffer: {e}")))?,
+            None => new.clone(),
+        };
+
+        let enriched = self.enrich(&new, &buffer)?;
+        self.history = Some(Self::tail(&buffer, self.config.retain));
+        self.projection.apply(vec![enriched]).await
+    }
+
+    fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
+        let Some(history) = &self.history else {
+            return Ok(None);
+        };
+        let data = serialize_batch_stream(history)
+            .map_err(|e| DbError::Pipeline(format!("window frame: checkpoint: {e}")))?;
+        Ok(Some(OperatorCheckpoint { data }))
+    }
+
+    fn restore(&mut self, checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
+        let batch = deserialize_batch_stream(&checkpoint.data)
+            .map_err(|e| DbError::Pipeline(format!("window frame: restore: {e}")))?;
+        self.history = Some(batch);
+        Ok(())
+    }
+
+    fn estimated_state_bytes(&self) -> usize {
+        self.history
+            .as_ref()
+            .map_or(0, RecordBatch::get_array_memory_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int64Array;
+
+    fn batch(buckets: &[i64], x: &[f64], y: &[f64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("bucket", DataType::Int64, false),
+            Field::new("price", DataType::Float64, false),
+            Field::new("sentiment", DataType::Float64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(buckets.to_vec())),
+                Arc::new(Float64Array::from(x.to_vec())),
+                Arc::new(Float64Array::from(y.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn operator_with(func: MomentFn, retain: usize) -> WindowFrameOperator {
+        // Residual passes the bucket + the appended statistic column through.
+        WindowFrameOperator::new(
+            "stat_test",
+            MomentFrameConfig {
+                func,
+                x_column: "price".to_string(),
+                y_column: "sentiment".to_string(),
+                output_column: "stat".to_string(),
+                retain,
+            },
+            Arc::from("SELECT bucket, stat FROM __frame_tmp"),
+            laminar_sql::create_session_context(),
+        )
+    }
+
+    fn last_stat(batches: &[RecordBatch]) -> Option<f64> {
+        let b = batches.last().expect("a batch");
+        let c = b
+            .column_by_name("stat")
+            .expect("stat column")
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("f64");
+        let i = c.len() - 1;
+        (!c.is_null(i)).then(|| c.value(i))
+    }
+
+    /// The sliding `CORR` must equal the analytical Pearson coefficient, computed
+    /// across the cross-cycle window (rows arrive in two cycles), not per cycle.
+    /// x=[1..5], y=[2,4,5,4,5] → r = 6/√60.
+    #[tokio::test]
+    async fn windowed_corr_matches_analytical_value_across_cycles() {
+        let mut op = operator_with(MomentFn::Corr, 30);
+
+        let out1 = op
+            .process(
+                &[vec![batch(&[1, 2, 3], &[1.0, 2.0, 3.0], &[2.0, 4.0, 5.0])]],
+                &[0],
+            )
+            .await
+            .unwrap();
+        assert_eq!(out1.iter().map(RecordBatch::num_rows).sum::<usize>(), 3);
+
+        let out2 = op
+            .process(&[vec![batch(&[4, 5], &[4.0, 5.0], &[4.0, 5.0])]], &[0])
+            .await
+            .unwrap();
+        assert_eq!(out2.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+
+        let expected = 6.0 / 60.0_f64.sqrt();
+        let got = last_stat(&out2).expect("correlation present");
+        assert!(
+            (got - expected).abs() < 1e-9,
+            "got {got}, expected {expected}"
+        );
+    }
+
+    /// The same moments drive the covariance family: for x=[1..5], y=[2,4,5,4,5]
+    /// the cross-deviation sum is 6, so population covariance is 6/5, sample 6/4.
+    #[tokio::test]
+    async fn windowed_covariance_matches_analytical_values() {
+        let rows = [vec![batch(
+            &[1, 2, 3, 4, 5],
+            &[1.0, 2.0, 3.0, 4.0, 5.0],
+            &[2.0, 4.0, 5.0, 4.0, 5.0],
+        )]];
+
+        let mut pop = operator_with(MomentFn::CovarPop, 30);
+        let out = pop.process(&rows, &[0]).await.unwrap();
+        assert!((last_stat(&out).unwrap() - 6.0 / 5.0).abs() < 1e-9);
+
+        let mut samp = operator_with(MomentFn::CovarSamp, 30);
+        let out = samp.process(&rows, &[0]).await.unwrap();
+        assert!((last_stat(&out).unwrap() - 6.0 / 4.0).abs() < 1e-9);
+    }
+
+    /// A single point gives no sample statistic (n < 2) — null, not a panic/NaN.
+    #[tokio::test]
+    async fn single_point_is_null() {
+        let mut op = operator_with(MomentFn::Corr, 30);
+        let out = op
+            .process(&[vec![batch(&[1], &[1.0], &[2.0])]], &[0])
+            .await
+            .unwrap();
+        assert!(last_stat(&out).is_none());
+    }
+
+    /// The frame slides: only the last `retain` rows bound a row's window.
+    #[tokio::test]
+    async fn frame_is_bounded_by_retain() {
+        let mut op = operator_with(MomentFn::Corr, 2);
+        // Window of the last row = rows {3,4,5} (retain=2 → 2 preceding + current).
+        let out = op
+            .process(
+                &[vec![batch(
+                    &[1, 2, 3, 4, 5],
+                    &[100.0, 100.0, 1.0, 2.0, 3.0],
+                    &[0.0, 0.0, 1.0, 2.0, 3.0],
+                )]],
+                &[0],
+            )
+            .await
+            .unwrap();
+        // Rows 3,4,5 are perfectly correlated → r = 1.0, unaffected by rows 1,2.
+        assert!((last_stat(&out).unwrap() - 1.0).abs() < 1e-9);
+    }
+}

--- a/crates/laminar-db/src/operator/window_frame.rs
+++ b/crates/laminar-db/src/operator/window_frame.rs
@@ -1,23 +1,24 @@
-//! Sliding-window covariance/correlation operator (moment-carrying).
+//! Sliding-window covariance/correlation operator.
 //!
 //! Streams the bivariate statistics over a `ROWS N PRECEDING` frame — `CORR`,
 //! `COVAR_SAMP`, `COVAR_POP` — that the batch engine can't slide: `DataFusion`'s
 //! accumulators for them have no `retract_batch`, so they are rejected as
-//! sliding-window accumulators. All three derive from the *same* carried moments
-//! `(n, Σx, Σy, Σxx, Σyy, Σxy)`; only the final formula differs. The operator
-//! recomputes them per window over a bounded retained buffer, appends the result
-//! column, and re-projects. (`AVG`/`SUM`/… over frames are a separate concern —
-//! `DataFusion` slides those itself.)
+//! sliding-window accumulators. All three derive from the *same* window moments;
+//! only the final formula differs. The operator recomputes them per window over a
+//! bounded retained buffer — two-pass and mean-centered, which stays accurate for
+//! large-magnitude series where the textbook `nΣxy − ΣxΣy` form loses precision to
+//! cancellation — appends the result column, and re-projects. (`AVG`/`SUM`/… over
+//! frames are a separate concern — `DataFusion` slides those itself.)
 //!
-//! v0.1 (enforced by `plan_frame_query`): one bivariate call over a single
-//! ordered series (no `PARTITION BY`), preceding bounds only. Rows are assumed to
+//! Supports one bivariate call over a single ordered series (no `PARTITION BY`),
+//! preceding bounds only (enforced by `plan_frame_query`). Rows are assumed to
 //! arrive in `ORDER BY` order (true for processing-time buckets), so the buffer
 //! is already ordered and the new arrivals are its tail.
 
 use std::sync::Arc;
 
 use arrow::array::{Array, ArrayRef, Float64Array, Float64Builder, RecordBatch};
-use arrow::compute::concat_batches;
+use arrow::compute::{cast, concat_batches};
 use arrow::datatypes::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::prelude::SessionContext;
@@ -41,17 +42,16 @@ pub(crate) enum MomentFn {
 }
 
 impl MomentFn {
-    /// Finalize the statistic from a window's carried moments, or `None` when the
-    /// frame has too few complete pairs (or zero variance, for `CORR`).
-    fn finalize(self, n: f64, sx: f64, sy: f64, sxx: f64, syy: f64, sxy: f64) -> Option<f64> {
-        let cov_num = n * sxy - sx * sy; // = n² · covariance
+    /// Finalize from a window's centered moments — `cxx = Σ(x−x̄)²`, `cyy = Σ(y−ȳ)²`,
+    /// `cxy = Σ(x−x̄)(y−ȳ)` over `n` complete pairs. `None` when the frame has too
+    /// few pairs (or zero variance, for `CORR`).
+    fn finalize(self, n: f64, cxx: f64, cyy: f64, cxy: f64) -> Option<f64> {
         match self {
             MomentFn::Corr => {
-                let (den_x, den_y) = (n * sxx - sx * sx, n * syy - sy * sy);
-                (n >= 2.0 && den_x > 0.0 && den_y > 0.0).then(|| cov_num / (den_x * den_y).sqrt())
+                (n >= 2.0 && cxx > 0.0 && cyy > 0.0).then(|| cxy / (cxx * cyy).sqrt())
             }
-            MomentFn::CovarSamp => (n >= 2.0).then(|| cov_num / (n * (n - 1.0))),
-            MomentFn::CovarPop => (n >= 1.0).then(|| cov_num / (n * n)),
+            MomentFn::CovarSamp => (n >= 2.0).then(|| cxy / (n - 1.0)),
+            MomentFn::CovarPop => (n >= 1.0).then(|| cxy / n),
         }
     }
 }
@@ -100,33 +100,52 @@ impl WindowFrameOperator {
         }
     }
 
-    fn f64_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Float64Array, DbError> {
-        batch
-            .column_by_name(name)
-            .and_then(|c| c.as_any().downcast_ref::<Float64Array>())
-            .ok_or_else(|| {
-                DbError::InvalidOperation(format!(
-                    "window frame: argument '{name}' must be a non-null-typed Float64 column"
-                ))
-            })
+    /// The named column coerced to `Float64`. `CORR`/`COVAR` operate on any
+    /// numeric input (as they do in `DataFusion`, which we bypass), so an integer
+    /// or `Float32` column is cast up; only a genuinely non-numeric column errors.
+    fn f64_column(batch: &RecordBatch, name: &str) -> Result<Float64Array, DbError> {
+        let column = batch.column_by_name(name).ok_or_else(|| {
+            DbError::InvalidOperation(format!("window frame: argument '{name}' not found"))
+        })?;
+        let casted = cast(column, &DataType::Float64).map_err(|e| {
+            DbError::InvalidOperation(format!(
+                "window frame: argument '{name}' is not numeric: {e}"
+            ))
+        })?;
+        Ok(casted
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("cast to Float64 yields a Float64Array")
+            .clone())
     }
 
-    /// The statistic over the window `lo..=hi` of `x`/`y`, from carried moments.
+    /// The statistic over the window `lo..=hi` of `x`/`y`. Two passes — means,
+    /// then centered moments — so the result stays precise for large magnitudes.
     fn stat_window(&self, x: &Float64Array, y: &Float64Array, lo: usize, hi: usize) -> Option<f64> {
-        let (mut n, mut sx, mut sy, mut sxx, mut syy, mut sxy) = (0.0_f64, 0.0, 0.0, 0.0, 0.0, 0.0);
+        let (mut n, mut sx, mut sy) = (0.0_f64, 0.0, 0.0);
         for i in lo..=hi {
             if x.is_null(i) || y.is_null(i) {
                 continue;
             }
-            let (xi, yi) = (x.value(i), y.value(i));
             n += 1.0;
-            sx += xi;
-            sy += yi;
-            sxx += xi * xi;
-            syy += yi * yi;
-            sxy += xi * yi;
+            sx += x.value(i);
+            sy += y.value(i);
         }
-        self.config.func.finalize(n, sx, sy, sxx, syy, sxy)
+        if n < 1.0 {
+            return None;
+        }
+        let (mx, my) = (sx / n, sy / n);
+        let (mut cxx, mut cyy, mut cxy) = (0.0_f64, 0.0, 0.0);
+        for i in lo..=hi {
+            if x.is_null(i) || y.is_null(i) {
+                continue;
+            }
+            let (dx, dy) = (x.value(i) - mx, y.value(i) - my);
+            cxx += dx * dx;
+            cyy += dy * dy;
+            cxy += dx * dy;
+        }
+        self.config.func.finalize(n, cxx, cyy, cxy)
     }
 
     /// Append the per-new-row statistic column to the `new` batch.
@@ -140,7 +159,7 @@ impl WindowFrameOperator {
         for j in 0..k {
             let hi = first_new + j;
             let lo = hi.saturating_sub(self.config.retain);
-            match self.stat_window(x, y, lo, hi) {
+            match self.stat_window(&x, &y, lo, hi) {
                 Some(v) => builder.append_value(v),
                 None => builder.append_null(),
             }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -2040,7 +2040,7 @@ mod tests {
 
     /// End-to-end through the real graph: `ai_sentiment` lifts to the AI
     /// operator, the worker scores on Ring 1, and the emitted column is a
-    /// numeric `Float64` (not a label) — the demo's hero path.
+    /// numeric `Float64`, not a label.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ai_sentiment_emits_a_double_score() {
         use laminar_ai::{

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -15,8 +15,9 @@ use crate::config::BackpressurePolicy;
 use crate::engine_metrics::EngineMetrics;
 use crate::error::DbError;
 use crate::sql_analysis::{
-    apply_topk_filter, detect_asof_query, detect_stream_join_query, detect_temporal_probe_query,
-    detect_temporal_query, extract_table_references, StreamJoinDetection,
+    apply_topk_filter, detect_asof_query, detect_processtime_join, detect_stream_join_query,
+    detect_temporal_probe_query, detect_temporal_query, extract_table_references,
+    StreamJoinDetection,
 };
 use laminar_sql::parser::EmitClause;
 use laminar_sql::translator::{
@@ -763,6 +764,15 @@ impl OperatorGraph {
             return;
         }
 
+        // Window-frame routing: a single-source query with a `… OVER (ORDER BY k
+        // ROWS N PRECEDING)` frame (e.g. CORR) becomes a WindowFrameOperator that
+        // retains bounded history and delegates the frame computation to
+        // DataFusion. Detected off the SQL like the AI/join paths.
+        if let Some(plan) = crate::sql_analysis::plan_frame_query(&sql) {
+            self.build_frame_operator_node(&name, &plan);
+            return;
+        }
+
         // The planner's vec lets us short-circuit re-parsing for queries
         // that have no specialized join step (or no joins at all).
         // TemporalProbe is parsed off the token stream rather than the
@@ -795,7 +805,10 @@ impl OperatorGraph {
             };
         let stream_join_detection =
             if temporal_probe_config.is_none() && needs_specialized_detection {
-                detect_stream_join_query(&sql)
+                // Interval join (time-bounded) first; else a plain equi-join as a
+                // processing-time join. `create_operator` distinguishes them by
+                // whether the config has time columns.
+                detect_stream_join_query(&sql).or_else(|| detect_processtime_join(&sql))
             } else {
                 None
             };
@@ -1022,7 +1035,39 @@ impl OperatorGraph {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Build a [`WindowFrameOperator`](crate::operator::window_frame) for a
+    /// planned frame query and wire it as a single-input node over the source.
+    fn build_frame_operator_node(
+        &mut self,
+        name: &str,
+        plan: &crate::sql_analysis::FrameQueryPlan,
+    ) {
+        let operator: Box<dyn GraphOperator> =
+            Box::new(crate::operator::window_frame::WindowFrameOperator::new(
+                name,
+                crate::operator::window_frame::MomentFrameConfig {
+                    func: plan.func,
+                    x_column: plan.x_column.clone(),
+                    y_column: plan.y_column.clone(),
+                    output_column: plan.output_alias.clone(),
+                    retain: plan.retain,
+                },
+                Arc::from(plan.projection_sql.as_str()),
+                self.ctx.clone(),
+            ));
+        let mut table_refs = FxHashSet::default();
+        table_refs.insert(plan.source_table.clone());
+        self.ensure_query_source_nodes(None, None, None, None, &table_refs);
+        let node_id = self.place_operator_node(name, operator, 1);
+        let depends = self.wire_query_edges(node_id, None, None, None, None, None, &table_refs);
+        if depends {
+            self.depends_on_stream.insert(node_id);
+        }
+        self.output_map.insert(Arc::from(name), node_id);
+        self.topo_dirty = true;
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn create_operator(
         &self,
         name: &str,
@@ -1069,6 +1114,16 @@ impl OperatorGraph {
         }
 
         if let Some(cfg) = stream_join_config {
+            // No time columns ⇒ plain equi-join → per-cycle batch join; with
+            // time columns ⇒ interval join.
+            if cfg.left_time_column.is_empty() && cfg.right_time_column.is_empty() {
+                return Box::new(operator::process_time_join::ProcessTimeJoinOperator::new(
+                    name,
+                    cfg.clone(),
+                    projection_sql.map(Arc::from),
+                    self.ctx.clone(),
+                ));
+            }
             return Box::new(operator::interval_join::IntervalJoinOperator::new(
                 name,
                 cfg.clone(),
@@ -1980,6 +2035,101 @@ mod tests {
         assert!(
             graph.take_build_errors().is_err(),
             "unknown model must fail"
+        );
+    }
+
+    /// End-to-end through the real graph: `ai_sentiment` lifts to the AI
+    /// operator, the worker scores on Ring 1, and the emitted column is a
+    /// numeric `Float64` (not a label) — the demo's hero path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ai_sentiment_emits_a_double_score() {
+        use laminar_ai::{
+            AiCallLog, AiResultCache, AiRuntime, InferenceOutputs, InferenceProvider,
+            InferenceRequest, InferenceResponse, ModelBackend, ModelEntry, ModelRegistry,
+            ProviderError, Task, Usage,
+        };
+
+        struct ScoreProvider;
+        #[async_trait::async_trait]
+        impl InferenceProvider for ScoreProvider {
+            async fn infer_batch(
+                &self,
+                req: InferenceRequest,
+            ) -> Result<InferenceResponse, ProviderError> {
+                // A compliant sentiment model replies with a bare number.
+                Ok(InferenceResponse {
+                    outputs: InferenceOutputs::Text(vec!["0.8".to_string(); req.inputs.len()]),
+                    usage: Usage::ZERO,
+                })
+            }
+            fn name(&self) -> &'static str {
+                "score"
+            }
+        }
+
+        let mut registry = ModelRegistry::new();
+        registry
+            .register(ModelEntry {
+                id: "m".into(),
+                tasks: vec![Task::Sentiment],
+                backend: ModelBackend::Remote {
+                    provider: "p".into(),
+                    model: "stub".into(),
+                },
+            })
+            .unwrap();
+        let call_log = Arc::new(AiCallLog::with_defaults());
+        let runtime = Arc::new(AiRuntime::new(
+            registry,
+            [(
+                "p".to_string(),
+                Arc::new(ScoreProvider) as Arc<dyn InferenceProvider>,
+            )],
+            None,
+            Arc::new(AiResultCache::with_defaults()),
+            Arc::clone(&call_log),
+        ));
+
+        let ctx = laminar_sql::create_session_context();
+        laminar_sql::register_streaming_functions(&ctx);
+        let mut graph = OperatorGraph::new(ctx);
+        graph.set_ai_runtime(runtime, tokio::runtime::Handle::current());
+        graph.register_source_schema("docs".to_string(), docs_batch().schema());
+
+        graph.add_query(
+            "scored".to_string(),
+            "SELECT id, ai_sentiment(text, model => 'm') AS sentiment FROM docs".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        graph
+            .take_build_errors()
+            .expect("ai_sentiment should route cleanly");
+
+        let mut sources = FxHashMap::default();
+        sources.insert(Arc::from("docs"), vec![docs_batch()]);
+        let _ = graph.execute_cycle(&sources, i64::MAX, None).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let results = graph
+            .execute_cycle(&FxHashMap::default(), i64::MAX, None)
+            .await
+            .unwrap();
+
+        let out = &results[&(Arc::from("scored") as Arc<str>)];
+        let batch = out.iter().find(|b| b.num_rows() > 0).expect("a scored row");
+        let col = batch.column(batch.schema().index_of("sentiment").unwrap());
+        let scores = col
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .expect("sentiment is a Float64 score, not a label");
+        assert!((scores.value(0) - 0.8).abs() < 1e-9);
+        assert_eq!(
+            call_log.total_recorded(),
+            1,
+            "the call is in laminar.ai_calls"
         );
     }
 

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -659,6 +659,13 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
     fn filter_late_rows(&self, source_name: &str, batch: &RecordBatch) -> Option<RecordBatch> {
         if let Some(wm_state) = self.watermark_states.get(source_name) {
+            // A processing-time watermark is wall-clock, not derived from the event
+            // column — every real (past) timestamp is "older than" it, so filtering
+            // would drop all rows. Windows still close on the wall-clock watermark;
+            // window-level late handling applies downstream.
+            if wm_state.generator.is_processing_time() {
+                return Some(batch.clone());
+            }
             let current_wm = wm_state.generator.current_watermark();
             if current_wm > i64::MIN {
                 let before = batch.num_rows();

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -1077,9 +1077,9 @@ pub(crate) struct FrameQueryPlan {
     pub retain: usize,
 }
 
-/// Plan a query for window-frame routing. Returns `Some` only for the v0.1
-/// supported shape: a single (un-joined) source, exactly one bivariate moment
-/// call (`CORR`/`COVAR_SAMP`/`COVAR_POP`) `OVER (ORDER BY … ROWS N PRECEDING) AS
+/// Plan a query for window-frame routing. Returns `Some` only for the supported
+/// shape: a single (un-joined) source, exactly one bivariate moment call
+/// (`CORR`/`COVAR_SAMP`/`COVAR_POP`) `OVER (ORDER BY … ROWS N PRECEDING) AS
 /// alias`, no `PARTITION BY`, no `FOLLOWING` bound (streaming cannot buffer the
 /// future). Anything else returns `None` (routed normally).
 pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
@@ -1121,7 +1121,7 @@ pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
         };
         if let Some((func, x, y)) = moment_call(expr) {
             if found.is_some() {
-                return None; // more than one frame call — unsupported in v0.1
+                return None; // only one frame call is supported
             }
             found = Some((index, func, x, y, alias.value.clone()));
         }
@@ -1226,7 +1226,7 @@ mod frame_plan_tests {
 
     #[test]
     fn rejects_partition_by_and_non_frame_queries() {
-        // PARTITION BY is out of v0.1 scope.
+        // PARTITION BY is not supported.
         assert!(plan_frame_query(
             "SELECT CORR(a, b) OVER (PARTITION BY g ORDER BY t ROWS 5 PRECEDING) AS c FROM s"
         )
@@ -1656,8 +1656,8 @@ pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> 
     };
     let multi = analyze_joins(select).ok()??;
 
-    // v0.1: exactly one INNER equi-join step, no temporal predicate, distinct
-    // tables (self-joins would collide on the suffixed output schema).
+    // Exactly one INNER equi-join step, no temporal predicate, distinct tables
+    // (self-joins would collide on the suffixed output schema).
     if multi.joins.len() != 1 {
         return None;
     }

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -21,6 +21,7 @@ use laminar_ai::{BackendKind, ModelRegistry, Task};
 use laminar_sql::parser::join_parser::analyze_joins;
 
 use crate::error::DbError;
+use crate::operator::window_frame::MomentFn;
 #[cfg(test)]
 use laminar_sql::parser::{EmitClause, EmitStrategy as SqlEmitStrategy};
 use laminar_sql::translator::{
@@ -868,7 +869,9 @@ mod ai {
                 }
             }
             BackendKind::Remote => {
-                if matches!(call.task, Task::Classify | Task::Sentiment) && call.labels.is_none() {
+                // Remote classification needs a candidate set; remote sentiment is
+                // numeric (the model returns a score), so it needs no labels.
+                if call.task == Task::Classify && call.labels.is_none() {
                     return Err(DbError::InvalidOperation(format!(
                     "remote classification with model '{model_name}' requires a 'labels' argument"
                 )));
@@ -907,7 +910,7 @@ mod ai {
             .unwrap();
             reg.register(ModelEntry {
                 id: "haiku".into(),
-                tasks: vec![Task::Classify, Task::Complete],
+                tasks: vec![Task::Classify, Task::Complete, Task::Sentiment],
                 backend: ModelBackend::Remote {
                     provider: "anthropic".into(),
                     model: "claude-haiku-4-5-20251001".into(),
@@ -1033,6 +1036,13 @@ mod ai {
         }
 
         #[test]
+        fn remote_sentiment_needs_no_labels() {
+            // Sentiment is numeric — a remote model scores it without a candidate set.
+            let calls = [spec(Task::Sentiment, Some("haiku"), None)];
+            assert!(validate_ai_calls(&registry(), &calls).is_ok());
+        }
+
+        #[test]
         fn default_model_resolves_or_fails() {
             // Sentiment has a default (finbert).
             let defaulted = [spec(Task::Sentiment, None, None)];
@@ -1045,6 +1055,186 @@ mod ai {
 }
 
 pub(crate) use ai::{detect_ai_functions, plan_ai_query, validate_ai_calls, AiQueryPlan};
+
+/// Private table a window-frame operator registers its enriched batch under; the
+/// residual projection reads from it. (Mirrors the AI path's `__ai_tmp`.)
+pub(crate) const FRAME_TMP_TABLE: &str = "__frame_tmp";
+
+/// A single-source query carrying one bivariate moment frame
+/// (`CORR`/`COVAR_SAMP`/`COVAR_POP` `OVER (ORDER BY k ROWS N PRECEDING)`). The
+/// call is lifted out — the operator computes it from carried moments — and
+/// replaced by its alias in the residual projection.
+pub(crate) struct FrameQueryPlan {
+    pub func: MomentFn,
+    pub x_column: String,
+    pub y_column: String,
+    pub output_alias: String,
+    /// Residual SELECT over [`FRAME_TMP_TABLE`] with the stat call replaced by
+    /// its alias column.
+    pub projection_sql: String,
+    pub source_table: String,
+    /// `max(PRECEDING)` — rows of preceding history to retain per new row.
+    pub retain: usize,
+}
+
+/// Plan a query for window-frame routing. Returns `Some` only for the v0.1
+/// supported shape: a single (un-joined) source, exactly one bivariate moment
+/// call (`CORR`/`COVAR_SAMP`/`COVAR_POP`) `OVER (ORDER BY … ROWS N PRECEDING) AS
+/// alias`, no `PARTITION BY`, no `FOLLOWING` bound (streaming cannot buffer the
+/// future). Anything else returns `None` (routed normally).
+pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
+    let statements = laminar_sql::parse_streaming_sql(sql).ok()?;
+    let mut statement = match statements.into_iter().next()? {
+        laminar_sql::parser::StreamingStatement::Standard(boxed) => *boxed,
+        _ => return None,
+    };
+
+    // Validate the frame shape (single ordered series, preceding bounds only).
+    let analysis = laminar_sql::parser::analytic_parser::analyze_window_frames(&statement)?;
+    if !analysis.partition_columns.is_empty() || analysis.has_following() {
+        return None;
+    }
+    let retain = usize::try_from(analysis.max_preceding()).ok()?;
+    if retain == 0 {
+        return None;
+    }
+
+    let Statement::Query(query) = &mut statement else {
+        return None;
+    };
+    let SetExpr::Select(select) = query.body.as_mut() else {
+        return None;
+    };
+    if select.from.len() != 1 || !select.from[0].joins.is_empty() {
+        return None;
+    }
+    let source_table = match &select.from[0].relation {
+        TableFactor::Table { name, .. } => name.to_string(),
+        _ => return None,
+    };
+
+    // Find the single bivariate-moment OVER (...) AS alias projection item.
+    let mut found: Option<(usize, MomentFn, String, String, String)> = None;
+    for (index, item) in select.projection.iter().enumerate() {
+        let SelectItem::ExprWithAlias { expr, alias } = item else {
+            continue;
+        };
+        if let Some((func, x, y)) = moment_call(expr) {
+            if found.is_some() {
+                return None; // more than one frame call — unsupported in v0.1
+            }
+            found = Some((index, func, x, y, alias.value.clone()));
+        }
+    }
+    let (index, func, x_column, y_column, output_alias) = found?;
+
+    // Rewrite: the stat call AS alias → the bare alias column; FROM → temp table.
+    select.projection[index] =
+        SelectItem::UnnamedExpr(Expr::Identifier(Ident::new(output_alias.clone())));
+    if let TableFactor::Table { name, .. } = &mut select.from[0].relation {
+        *name = ObjectName(vec![ObjectNamePart::Identifier(Ident::new(
+            FRAME_TMP_TABLE,
+        ))]);
+    }
+
+    Some(FrameQueryPlan {
+        func,
+        x_column,
+        y_column,
+        output_alias,
+        projection_sql: statement.to_string(),
+        source_table,
+        retain,
+    })
+}
+
+/// The statistic and two plain-column arguments of a bivariate moment call with
+/// an `OVER` clause (`CORR`/`COVAR_SAMP`/`COVAR_POP`), or `None` otherwise.
+fn moment_call(expr: &Expr) -> Option<(MomentFn, String, String)> {
+    let Expr::Function(func) = expr else {
+        return None;
+    };
+    func.over.as_ref()?;
+    let kind = match func.name.to_string().to_ascii_uppercase().as_str() {
+        "CORR" => MomentFn::Corr,
+        "COVAR_SAMP" | "COVAR" => MomentFn::CovarSamp,
+        "COVAR_POP" => MomentFn::CovarPop,
+        _ => return None,
+    };
+    let (x, y) = bivariate_column_args(func)?;
+    Some((kind, x, y))
+}
+
+/// The two plain-column arguments of a 2-arg function call, or `None`.
+fn bivariate_column_args(func: &sqlparser::ast::Function) -> Option<(String, String)> {
+    let FunctionArguments::List(list) = &func.args else {
+        return None;
+    };
+    let cols: Vec<String> = list
+        .args
+        .iter()
+        .filter_map(|arg| match arg {
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(id))) => {
+                Some(id.value.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    match cols.as_slice() {
+        [x, y] => Some((x.clone(), y.clone())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod frame_plan_tests {
+    use super::plan_frame_query;
+
+    #[test]
+    fn detects_corr_frame_and_rewrites_to_alias() {
+        let plan = plan_frame_query(
+            "SELECT bucket_start, close, mean_sentiment, \
+             CORR(close, mean_sentiment) OVER (ORDER BY bucket_start ROWS 30 PRECEDING) AS corr_30 \
+             FROM sentiment_price_join",
+        )
+        .expect("frame plan");
+        assert_eq!(plan.x_column, "close");
+        assert_eq!(plan.y_column, "mean_sentiment");
+        assert_eq!(plan.output_alias, "corr_30");
+        assert_eq!(plan.retain, 30);
+        assert_eq!(plan.source_table, "sentiment_price_join");
+        // The CORR term is gone; the residual reads the alias from the temp table.
+        assert!(!plan.projection_sql.to_uppercase().contains("CORR("));
+        assert!(plan.projection_sql.contains("corr_30"));
+        assert!(plan.projection_sql.contains("__frame_tmp"));
+    }
+
+    #[test]
+    fn detects_processtime_equijoin() {
+        let d = super::detect_processtime_join(
+            "SELECT p.bucket AS bucket, p.price AS price, s.ms AS ms \
+             FROM price_b p JOIN sent_b s ON p.bucket = s.bucket",
+        )
+        .expect("plain INNER equi-join routes to the processing-time join");
+        // No time columns is the marker `create_operator` keys on.
+        assert!(d.config.left_time_column.is_empty() && d.config.right_time_column.is_empty());
+        assert_eq!(d.config.left_key, "bucket");
+        assert_eq!(d.config.right_key, "bucket");
+        assert_eq!(d.config.left_table, "price_b");
+        assert_eq!(d.config.right_table, "sent_b");
+    }
+
+    #[test]
+    fn rejects_partition_by_and_non_frame_queries() {
+        // PARTITION BY is out of v0.1 scope.
+        assert!(plan_frame_query(
+            "SELECT CORR(a, b) OVER (PARTITION BY g ORDER BY t ROWS 5 PRECEDING) AS c FROM s"
+        )
+        .is_none());
+        // No window frame → not a frame query.
+        assert!(plan_frame_query("SELECT a, b FROM s").is_none());
+    }
+}
 
 pub(crate) fn detect_temporal_query(
     sql: &str,
@@ -1442,6 +1632,88 @@ pub(crate) fn detect_stream_join_query(sql: &str) -> Option<StreamJoinDetection>
         projection_sql,
         left_pre_filter: pre_filters.as_ref().and_then(|f| f.left_sql.clone()),
         right_pre_filter: pre_filters.as_ref().and_then(|f| f.right_sql.clone()),
+    })
+}
+
+/// Detect a processing-time equi-join: a single `INNER` `a JOIN b ON a.k = b.k`
+/// with no temporal predicate. It routes to a per-cycle batch join that matches
+/// the current cycle's emissions from both sides — what aligns two windowed
+/// views closing the same bucket on processing time. Returns the same shape as
+/// [`detect_stream_join_query`] but with **empty time columns**, which is how
+/// `create_operator` tells the two join operators apart.
+pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> {
+    use laminar_sql::parser::join_parser::JoinType;
+
+    let statements = laminar_sql::parse_streaming_sql(sql).ok()?;
+    let laminar_sql::parser::StreamingStatement::Standard(stmt) = statements.first()? else {
+        return None;
+    };
+    let Statement::Query(query) = stmt.as_ref() else {
+        return None;
+    };
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return None;
+    };
+    let multi = analyze_joins(select).ok()??;
+
+    // v0.1: exactly one INNER equi-join step, no temporal predicate, distinct
+    // tables (self-joins would collide on the suffixed output schema).
+    if multi.joins.len() != 1 {
+        return None;
+    }
+    let step = &multi.joins[0];
+    // A no-time-bound equi-join is tagged `is_lookup_join` by `analyze_joins`
+    // (it can't tell a windowed-view join from a stream/dim lookup); real lookup
+    // joins never reach this detector — the planner emits a Lookup config, which
+    // turns `needs_specialized_detection` off in `add_query`. So accept it here.
+    if step.time_bound.is_some()
+        || step.is_asof_join
+        || step.is_temporal_join
+        || !matches!(step.join_type, JoinType::Inner)
+    {
+        return None;
+    }
+    // Build the StreamStream config directly from the analysis (going through
+    // `from_analysis` would yield a Lookup config for this shape). Empty time
+    // columns are the processing-time marker `create_operator` keys on.
+    let config = StreamJoinConfig {
+        left_key: step.left_key_column.clone(),
+        right_key: step.right_key_column.clone(),
+        left_time_column: String::new(),
+        right_time_column: String::new(),
+        left_table: step.left_table.clone(),
+        right_table: step.right_table.clone(),
+        time_bound: std::time::Duration::ZERO,
+        join_type: StreamJoinType::Inner,
+    };
+    if config.left_key.is_empty()
+        || config.right_key.is_empty()
+        || config.left_table == config.right_table
+    {
+        return None;
+    }
+
+    let where_clause = select
+        .selection
+        .as_ref()
+        .map(|expr| {
+            let rewritten = rewrite_stream_join_expr(
+                expr,
+                step.left_alias.as_deref(),
+                step.right_alias.as_deref(),
+                &config,
+                None,
+            );
+            format!(" WHERE {rewritten}")
+        })
+        .unwrap_or_default();
+    let projection_sql = build_stream_join_projection_sql(select, step, &config, &where_clause);
+
+    Some(StreamJoinDetection {
+        config,
+        projection_sql,
+        left_pre_filter: None,
+        right_pre_filter: None,
     })
 }
 

--- a/crates/laminar-server/src/ai.rs
+++ b/crates/laminar-server/src/ai.rs
@@ -4,9 +4,9 @@
 //! Secrets are resolved here, at startup: `api_key_env` names an environment
 //! variable, never the key itself. A provider's transport is its `kind` (or,
 //! when omitted, inferred from the provider name): `anthropic`, `local`, or
-//! otherwise an OpenAI-compatible endpoint (`openai`, Azure, vLLM, …). The
-//! local backend is not wired yet, so local providers/models build into the
-//! registry but cannot be resolved to a runnable backend.
+//! otherwise an OpenAI-compatible endpoint (`openai`, Azure, vLLM, …). A single
+//! `local` provider (its `cache_dir`) backs every local model; remote providers
+//! are keyed by name and matched to each remote model's `provider`.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -233,6 +233,29 @@ task = "classify"
 "#,
         );
         assert!(build_ai_runtime(&config).unwrap().is_some());
+    }
+
+    /// The shipped crypto-sentiment demo config parses, validates, and builds a
+    /// runtime whose `sentiment` default resolves to the local backend — the demo
+    /// is wired to a local ONNX model and must stay that way.
+    #[test]
+    fn crypto_sentiment_demo_builds_a_local_runtime() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/demos/crypto_sentiment/pipeline.toml");
+        let config = crate::config::load_config(&path).expect("demo config parses and validates");
+        let runtime = build_ai_runtime(&config)
+            .expect("AI runtime builds")
+            .expect("the demo configures a model");
+        assert_eq!(
+            runtime.registry().default_for(laminar_ai::Task::Sentiment),
+            Some("sentiment"),
+            "ai_sentiment resolves to the configured default"
+        );
+        assert_eq!(
+            runtime.resolve("sentiment").unwrap().kind,
+            laminar_ai::BackendKind::Local,
+            "the demo scores sentiment on a local model"
+        );
     }
 
     #[test]

--- a/crates/laminar-server/src/ai.rs
+++ b/crates/laminar-server/src/ai.rs
@@ -12,7 +12,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use laminar_ai::backends::{local, AnthropicProvider, LocalProvider, OpenAiProvider};
+use std::num::NonZeroU32;
+
+use laminar_ai::backends::{
+    local, AnthropicProvider, LocalProvider, OpenAiProvider, RateLimitedProvider,
+};
 use laminar_ai::{
     AiCallLog, AiResultCache, AiRuntime, InferenceProvider, ModelBackend, ModelEntry,
     ModelRegistry, Task,
@@ -143,17 +147,18 @@ fn build_provider(
     name: &str,
     cfg: &ProviderConfig,
 ) -> Result<Option<Arc<dyn InferenceProvider>>, ServerError> {
-    match provider_kind(name, cfg) {
-        "local" => Ok(None),
+    let base: Arc<dyn InferenceProvider> = match provider_kind(name, cfg) {
+        "local" => return Ok(None),
         "anthropic" => {
             let key = resolve_key(name, cfg)?;
             let base_url = cfg
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "https://api.anthropic.com".to_string());
-            let client = AnthropicProvider::new(base_url, key, cfg.max_concurrency)
-                .map_err(|e| build_err(e.to_string()))?;
-            Ok(Some(Arc::new(client) as Arc<dyn InferenceProvider>))
+            Arc::new(
+                AnthropicProvider::new(base_url, key, cfg.max_concurrency)
+                    .map_err(|e| build_err(e.to_string()))?,
+            )
         }
         // OpenAI-compatible (openai, Azure, vLLM, local servers via base_url).
         _ => {
@@ -162,10 +167,23 @@ fn build_provider(
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-            let client = OpenAiProvider::new(base_url, key, cfg.max_concurrency)
-                .map_err(|e| build_err(e.to_string()))?;
-            Ok(Some(Arc::new(client) as Arc<dyn InferenceProvider>))
+            Arc::new(
+                OpenAiProvider::new(base_url, key, cfg.max_concurrency)
+                    .map_err(|e| build_err(e.to_string()))?,
+            )
         }
+    };
+    Ok(Some(maybe_rate_limit(base, cfg)))
+}
+
+/// Pace a provider to `requests_per_second` when configured, else leave it as-is.
+fn maybe_rate_limit(
+    provider: Arc<dyn InferenceProvider>,
+    cfg: &ProviderConfig,
+) -> Arc<dyn InferenceProvider> {
+    match cfg.requests_per_second.and_then(NonZeroU32::new) {
+        Some(rps) => Arc::new(RateLimitedProvider::new(provider, rps)),
+        None => provider,
     }
 }
 

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -400,6 +400,10 @@ pub struct ProviderConfig {
     /// Maximum concurrent requests issued per batch (remote).
     #[serde(default = "default_ai_max_concurrency")]
     pub max_concurrency: usize,
+    /// Steady requests-per-second cap (remote). When set, calls are paced by a
+    /// token bucket — bursts are shaped, not sent unbounded. Unset = no limit.
+    #[serde(default)]
+    pub requests_per_second: Option<u32>,
     /// Model cache directory or `object_store` URI (local provider).
     #[serde(default)]
     pub cache_dir: Option<String>,

--- a/crates/laminar-sql/src/datafusion/ai_udf.rs
+++ b/crates/laminar-sql/src/datafusion/ai_udf.rs
@@ -90,14 +90,15 @@ impl ScalarUDFImpl for AiFunctionMarker {
 
 /// Build the eight `ai_*` marker UDFs, ready to register on a session context.
 ///
-/// Discriminative and text-generating tasks return `Utf8` (a label or text);
-/// `ai_embed` returns a `List<Float32>` embedding.
+/// Text-generating and discriminative-label tasks return `Utf8`; `ai_sentiment`
+/// returns a `Float64` score in `[-1, 1]`; `ai_embed` returns a `List<Float32>`
+/// embedding.
 #[must_use]
 pub fn ai_function_markers() -> Vec<ScalarUDF> {
     let embedding = DataType::List(Arc::new(Field::new("item", DataType::Float32, true)));
     let specs: [(&'static str, DataType); 8] = [
         ("ai_classify", DataType::Utf8),
-        ("ai_sentiment", DataType::Utf8),
+        ("ai_sentiment", DataType::Float64),
         ("ai_embed", embedding),
         ("ai_extract", DataType::Utf8),
         ("ai_complete", DataType::Utf8),
@@ -125,6 +126,9 @@ mod tests {
 
         let classify = markers.iter().find(|m| m.name() == "ai_classify").unwrap();
         assert_eq!(classify.return_type(&[]).unwrap(), DataType::Utf8);
+
+        let sentiment = markers.iter().find(|m| m.name() == "ai_sentiment").unwrap();
+        assert_eq!(sentiment.return_type(&[]).unwrap(), DataType::Float64);
 
         let embed = markers.iter().find(|m| m.name() == "ai_embed").unwrap();
         assert!(matches!(embed.return_type(&[]).unwrap(), DataType::List(_)));

--- a/crates/laminar-sql/src/parser/analytic_parser.rs
+++ b/crates/laminar-sql/src/parser/analytic_parser.rs
@@ -276,6 +276,13 @@ pub enum WindowFrameFunction {
     FirstValue,
     /// LAST_VALUE(col) OVER (... ROWS BETWEEN ...)
     LastValue,
+    /// CORR(x, y) OVER (... ROWS BETWEEN ...) — Pearson correlation over the
+    /// frame. Bivariate; `column` holds the first argument.
+    Corr,
+    /// COVAR_SAMP(x, y) OVER (... ROWS BETWEEN ...) — sample covariance.
+    CovarSamp,
+    /// COVAR_POP(x, y) OVER (... ROWS BETWEEN ...) — population covariance.
+    CovarPop,
 }
 
 impl WindowFrameFunction {
@@ -290,6 +297,9 @@ impl WindowFrameFunction {
             Self::Count => "COUNT",
             Self::FirstValue => "FIRST_VALUE",
             Self::LastValue => "LAST_VALUE",
+            Self::Corr => "CORR",
+            Self::CovarSamp => "COVAR_SAMP",
+            Self::CovarPop => "COVAR_POP",
         }
     }
 }
@@ -456,6 +466,9 @@ fn extract_window_frame_function(
         "COUNT" => WindowFrameFunction::Count,
         "FIRST_VALUE" => WindowFrameFunction::FirstValue,
         "LAST_VALUE" => WindowFrameFunction::LastValue,
+        "CORR" => WindowFrameFunction::Corr,
+        "COVAR_SAMP" | "COVAR" => WindowFrameFunction::CovarSamp,
+        "COVAR_POP" => WindowFrameFunction::CovarPop,
         _ => return None,
     };
 
@@ -809,6 +822,20 @@ mod tests {
             analysis.functions[4].function_type,
             WindowFrameFunction::Count
         );
+    }
+
+    #[test]
+    fn test_frame_corr_bivariate() {
+        let sql = "SELECT CORR(price, sentiment) OVER (ORDER BY bucket \
+                    ROWS 30 PRECEDING) AS c FROM joined";
+        let stmt = parse_stmt(sql);
+        let analysis = analyze_window_frames(&stmt).unwrap();
+        assert_eq!(
+            analysis.functions[0].function_type,
+            WindowFrameFunction::Corr
+        );
+        assert_eq!(analysis.functions[0].start_bound, FrameBound::Preceding(30));
+        assert_eq!(analysis.order_columns, vec!["bucket".to_string()]);
     }
 
     #[test]

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -62,6 +62,10 @@ pub struct StreamingPlanner {
     sinks: HashMap<String, SinkInfo>,
     /// Registered lookup tables
     lookup_tables: HashMap<String, LookupTableInfo>,
+    /// Names of windowed views/streams (created with a windowed aggregation).
+    /// Their output is bounded per window close, so an equi-join between two of
+    /// them is a processing-time batch join, not an unbounded stream-stream join.
+    windowed_views: std::collections::HashSet<String>,
 }
 
 /// Information about a registered source
@@ -143,6 +147,7 @@ impl StreamingPlanner {
             sources: HashMap::new(),
             sinks: HashMap::new(),
             lookup_tables: HashMap::new(),
+            windowed_views: std::collections::HashSet::new(),
         }
     }
 
@@ -279,6 +284,12 @@ impl StreamingPlanner {
         // Analyze the query for streaming features
         let query_plan = self.analyze_query(&stmt, emit_clause)?;
 
+        // A windowed aggregation emits a bounded set per window close, so record
+        // this view as a valid (bounded) input to a later processing-time join.
+        if query_plan.window_config.is_some() {
+            self.windowed_views.insert(object_name_to_string(name));
+        }
+
         Ok(StreamingPlan::Query(QueryPlan {
             name: Some(object_name_to_string(name)),
             window_config: query_plan.window_config,
@@ -307,7 +318,11 @@ impl StreamingPlanner {
                 })?;
 
                 if let Some(ref multi) = join_analysis {
-                    reject_unbounded_streaming_join(multi, &self.lookup_tables)?;
+                    reject_unbounded_streaming_join(
+                        multi,
+                        &self.lookup_tables,
+                        &self.windowed_views,
+                    )?;
                 }
 
                 // Check for ORDER BY
@@ -358,8 +373,12 @@ impl StreamingPlanner {
                         None => None,
                     };
 
-                    let join_config =
-                        join_analysis.map(|m| JoinOperatorConfig::from_multi_analysis(&m));
+                    // A windowed-view equi-join carries no join_config: it routes
+                    // to the processing-time join, re-detected in `add_query`.
+                    // (A config here would suppress that detection.)
+                    let join_config = join_analysis
+                        .filter(|m| !is_windowed_view_join(m, &self.windowed_views))
+                        .map(|m| JoinOperatorConfig::from_multi_analysis(&m));
 
                     return Ok(StreamingPlan::Query(QueryPlan {
                         name: None,
@@ -409,8 +428,17 @@ impl StreamingPlanner {
                 if let Some(multi) = analyze_joins(select).map_err(|e| {
                     PlanningError::InvalidQuery(format!("Join analysis failed: {e}"))
                 })? {
-                    reject_unbounded_streaming_join(&multi, &self.lookup_tables)?;
-                    analysis.join_config = Some(JoinOperatorConfig::from_multi_analysis(&multi));
+                    reject_unbounded_streaming_join(
+                        &multi,
+                        &self.lookup_tables,
+                        &self.windowed_views,
+                    )?;
+                    // A windowed-view equi-join routes to the processing-time join
+                    // (re-detected in `add_query`); a config here would suppress it.
+                    if !is_windowed_view_join(&multi, &self.windowed_views) {
+                        analysis.join_config =
+                            Some(JoinOperatorConfig::from_multi_analysis(&multi));
+                    }
                 }
             }
         }
@@ -633,6 +661,7 @@ fn object_name_to_string(name: &ObjectName) -> String {
 fn reject_unbounded_streaming_join(
     multi: &MultiJoinAnalysis,
     lookup_tables: &HashMap<String, LookupTableInfo>,
+    windowed_views: &std::collections::HashSet<String>,
 ) -> Result<(), PlanningError> {
     for step in &multi.joins {
         if step.is_bounded() {
@@ -640,7 +669,11 @@ fn reject_unbounded_streaming_join(
         }
         let left_lookup = lookup_tables.contains_key(&step.left_table);
         let right_lookup = lookup_tables.contains_key(&step.right_table);
-        if !left_lookup && !right_lookup {
+        // A join between two windowed views is bounded per cycle (each emits
+        // aligned closed windows) — it runs as a processing-time batch join.
+        let both_windowed =
+            windowed_views.contains(&step.left_table) && windowed_views.contains(&step.right_table);
+        if !left_lookup && !right_lookup && !both_windowed {
             return Err(PlanningError::InvalidQuery(format!(
                 "unbounded join between streaming sources '{}' and '{}'; \
                  add a temporal predicate or use a lookup table",
@@ -649,6 +682,21 @@ fn reject_unbounded_streaming_join(
         }
     }
     Ok(())
+}
+
+/// A single non-temporal equi-join between two windowed views — the
+/// processing-time batch-join shape (`create_operator` builds it from the
+/// re-detected config, so its `join_config` is left empty here).
+fn is_windowed_view_join(
+    multi: &MultiJoinAnalysis,
+    windowed_views: &std::collections::HashSet<String>,
+) -> bool {
+    multi.joins.len() == 1
+        && multi.joins.iter().all(|j| {
+            !j.is_bounded()
+                && windowed_views.contains(&j.left_table)
+                && windowed_views.contains(&j.right_table)
+        })
 }
 
 /// Planning errors
@@ -875,6 +923,37 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("unbounded join"), "got: {msg}");
         assert!(msg.contains("lookup table"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_plan_allows_join_between_windowed_views() {
+        let mut planner = StreamingPlanner::new();
+        // Two windowed views register as bounded inputs.
+        for sql in [
+            "CREATE STREAM price_1m AS SELECT TUMBLE(ts, INTERVAL '1' MINUTE) AS bucket, \
+             AVG(p) AS price FROM trades GROUP BY TUMBLE(ts, INTERVAL '1' MINUTE)",
+            "CREATE STREAM sent_1m AS SELECT TUMBLE(ts, INTERVAL '1' MINUTE) AS bucket, \
+             AVG(s) AS ms FROM posts GROUP BY TUMBLE(ts, INTERVAL '1' MINUTE)",
+        ] {
+            let st = StreamingParser::parse_sql(sql).unwrap();
+            planner.plan(&st[0]).unwrap();
+        }
+        // The equi-join between them is accepted (not rejected as unbounded) and
+        // carries no join_config, so add_query routes it to the process-time join.
+        let st = StreamingParser::parse_sql(
+            "CREATE STREAM joined AS SELECT a.bucket, a.price, b.ms \
+             FROM price_1m a JOIN sent_1m b ON a.bucket = b.bucket",
+        )
+        .unwrap();
+        match planner.plan(&st[0]).unwrap() {
+            StreamingPlan::Query(qp) => {
+                assert!(
+                    qp.join_config.is_none(),
+                    "windowed-view join carries no join_config"
+                );
+            }
+            other => panic!("expected a Query plan, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/laminar-sql/src/planner/mod.rs
+++ b/crates/laminar-sql/src/planner/mod.rs
@@ -284,10 +284,14 @@ impl StreamingPlanner {
         // Analyze the query for streaming features
         let query_plan = self.analyze_query(&stmt, emit_clause)?;
 
-        // A windowed aggregation emits a bounded set per window close, so record
-        // this view as a valid (bounded) input to a later processing-time join.
+        // A windowed aggregation is a bounded input to a processing-time join.
+        // Insert *and* remove so a CREATE OR REPLACE that makes the view
+        // non-windowed clears the stale entry (else a join on it skips the guard).
+        let view_name = object_name_to_string(name);
         if query_plan.window_config.is_some() {
-            self.windowed_views.insert(object_name_to_string(name));
+            self.windowed_views.insert(view_name);
+        } else {
+            self.windowed_views.remove(&view_name);
         }
 
         Ok(StreamingPlan::Query(QueryPlan {

--- a/examples/demos/crypto_sentiment/README.md
+++ b/examples/demos/crypto_sentiment/README.md
@@ -56,16 +56,14 @@ SELECT * FROM laminar.ai_calls ORDER BY timestamp_ms DESC;
 
 ```sh
 pip install "psycopg[binary]"
-python dashboard/bridge.py            # tails the live server, serves the page
+python dashboard/bridge.py            # SUBSCRIBEs to the views over pgwire, serves the page
 # open http://127.0.0.1:8088/
 ```
 
-Record the layout before wiring live data with the synthetic feed (a recording
-aid, not the shipped path):
-
-```sh
-python dashboard/bridge.py --simulate
-```
+`bridge.py` is pure transport: it `SUBSCRIBE`s to `sentiment_price_1m` and
+`bsky_crypto` over the Postgres wire protocol and forwards each row to the
+browser as a Server-Sent Event. It computes nothing — every number is the
+engine's.
 
 ## The degradation demo (worth showing on camera)
 

--- a/examples/demos/crypto_sentiment/README.md
+++ b/examples/demos/crypto_sentiment/README.md
@@ -1,0 +1,82 @@
+# Crypto price × Bluesky sentiment
+
+A live monitoring pipeline: BTCUSDT trades from Binance and crypto-tagged posts
+from the Bluesky firehose, scored and correlated **entirely inside LaminarDB**.
+The dashboard draws what the views emit and computes nothing.
+
+What the engine does, end to end, from one [`pipeline.toml`](pipeline.toml):
+
+- **Two WebSocket sources**, processing-time (wall-clock windows, no event-time
+  skew to tune): Binance `btcusdt@trade` and the Bluesky Jetstream.
+- **`ai_sentiment(text) → DOUBLE`** scored inline on a stream, on Ring 1 (never
+  blocking the hot path), batched and deduped through the foyer cache, rate-shaped
+  by a token bucket, every call recorded in `laminar.ai_calls`.
+- **1-minute tumbling windows** on each side (price OHLC-ish; mean sentiment + post count).
+- **An MV-to-MV join** on `bucket_start`, emitting as both minutes close.
+- **A rolling `CORR(price, mean_sentiment)` over 30 buckets**, computed in-engine
+  by carrying the cross-moments (the engine's sliding correlation) — not an
+  average of per-bucket values, not a recompute from rolled-up bars.
+
+This is an engineering demo. It shows the price series, the sentiment series, and
+their rolling correlation side by side. **It makes no claim that sentiment
+predicts price or vice versa** — the rolling correlation is shown for the viewer
+to interpret. The point is that the windowing, the join, the scoring, and the
+correlation all run in the stream engine, correctly, from one config file.
+
+## Run it
+
+Live (needs network + an Anthropic key for the sentiment scorer):
+
+```sh
+export ANTHROPIC_API_KEY=sk-...
+laminardb --config pipeline.toml
+```
+
+Tail any view directly over pgwire:
+
+```sh
+psql -h 127.0.0.1 -p 5432
+=> SUBSCRIBE sentiment_price_1m;     -- bucket_start, price, mean_sentiment, posts, corr_30
+=> SUBSCRIBE bsky_crypto;            -- did, text, ts, sentiment
+```
+
+See the scoring cost/volume:
+
+```sql
+SELECT * FROM laminar.ai_calls ORDER BY timestamp_ms DESC;
+```
+
+### Dashboard
+
+```sh
+pip install "psycopg[binary]"
+python dashboard/bridge.py            # tails the live server, serves the page
+# open http://127.0.0.1:8088/
+```
+
+Record the layout before wiring live data with the synthetic feed (a recording
+aid, not the shipped path):
+
+```sh
+python dashboard/bridge.py --simulate
+```
+
+## The degradation demo (worth showing on camera)
+
+Kill the sentiment provider mid-run (revoke the key, or block the endpoint). The
+AI operator emits a **null** score on terminal failure — it never panics and
+never stalls Ring 0. `mean_sentiment` goes null for the affected minutes, the
+`corr_30` readout blanks, **and the price line and the post feed keep flowing.**
+`laminar.ai_calls` records the failures (`status = 'error'`). When the provider
+returns, scoring resumes. Timeout is 60s, with 2 retries on transient errors.
+
+## Why the UI is trustworthy
+
+The dashboard formats and draws; it does not compute. Grep it:
+
+```sh
+grep -niE 'window|tumble|group by|corr|average|aggregate|sentiment\s*=' dashboard/index.html
+```
+
+The only matches are labels and the `corr` *display* element — no windowing,
+no correlation math, no scoring. Every number on the screen came off a view.

--- a/examples/demos/crypto_sentiment/README.md
+++ b/examples/demos/crypto_sentiment/README.md
@@ -8,9 +8,9 @@ What the engine does, end to end, from one [`pipeline.toml`](pipeline.toml):
 
 - **Two WebSocket sources**, processing-time (wall-clock windows, no event-time
   skew to tune): Binance `btcusdt@trade` and the Bluesky Jetstream.
-- **`ai_sentiment(text) → DOUBLE`** scored inline on a stream, on Ring 1 (never
-  blocking the hot path), batched and deduped through the foyer cache, rate-shaped
-  by a token bucket, every call recorded in `laminar.ai_calls`.
+- **`ai_sentiment(text) → DOUBLE`** scored inline on a stream by a local ONNX
+  model on Ring 1 (never blocking the hot path), batched and deduped through the
+  foyer cache, every call recorded in `laminar.ai_calls`.
 - **1-minute tumbling windows** on each side (price OHLC-ish; mean sentiment + post count).
 - **An MV-to-MV join** on `bucket_start`, emitting as both minutes close.
 - **A rolling `CORR(price, mean_sentiment)` over 30 buckets**, computed in-engine
@@ -25,10 +25,16 @@ correlation all run in the stream engine, correctly, from one config file.
 
 ## Run it
 
-Live (needs network + an Anthropic key for the sentiment scorer):
+Sentiment runs on a **local ONNX model** — no API key, no inference-time network
+call. ONNX Runtime is loaded dynamically, so you supply the shared library
+(>= 1.24) via `ORT_DYLIB_PATH`; the DistilBERT SST-2 weights (~268 MB) download
+once from the Hugging Face CDN into `./models`, then load from disk on restart.
+The positive/negative labels come from the model's own `config.json`, so the
+first cold-cache run scores correctly — no pre-staging, no restart.
 
 ```sh
-export ANTHROPIC_API_KEY=sk-...
+# onnxruntime >= 1.24 (ONNX Runtime release, or your package manager)
+export ORT_DYLIB_PATH=/path/to/libonnxruntime.so   # onnxruntime.dll on Windows
 laminardb --config pipeline.toml
 ```
 
@@ -63,12 +69,13 @@ python dashboard/bridge.py --simulate
 
 ## The degradation demo (worth showing on camera)
 
-Kill the sentiment provider mid-run (revoke the key, or block the endpoint). The
-AI operator emits a **null** score on terminal failure — it never panics and
-never stalls Ring 0. `mean_sentiment` goes null for the affected minutes, the
-`corr_30` readout blanks, **and the price line and the post feed keep flowing.**
-`laminar.ai_calls` records the failures (`status = 'error'`). When the provider
-returns, scoring resumes. Timeout is 60s, with 2 retries on transient errors.
+Make the scorer fail mid-run — point `ORT_DYLIB_PATH` at a missing library, or
+feed a model whose forward pass blows the 60 s inference deadline. The AI
+operator emits a **null** score on terminal failure — it never panics and never
+stalls Ring 0. `mean_sentiment` goes null for the affected minutes, the `corr_30`
+readout blanks, **and the price line and the post feed keep flowing.**
+`laminar.ai_calls` records the failures (`status = 'error'`). When the model is
+reachable again, scoring resumes.
 
 ## Why the UI is trustworthy
 

--- a/examples/demos/crypto_sentiment/README.md
+++ b/examples/demos/crypto_sentiment/README.md
@@ -8,9 +8,9 @@ What the engine does, end to end, from one [`pipeline.toml`](pipeline.toml):
 
 - **Two WebSocket sources**, processing-time (wall-clock windows, no event-time
   skew to tune): Binance `btcusdt@trade` and the Bluesky Jetstream.
-- **`ai_sentiment(text) → DOUBLE`** scored inline on a stream by a local ONNX
-  model on Ring 1 (never blocking the hot path), batched and deduped through the
-  foyer cache, every call recorded in `laminar.ai_calls`.
+- **`ai_sentiment(text) → DOUBLE`** scored inline on a stream by **FinBERT**, a
+  finance-tuned BERT running locally (ONNX) on Ring 1 (never blocking the hot
+  path), batched and deduped through the foyer cache, every call in `laminar.ai_calls`.
 - **1-minute tumbling windows** on each side (price OHLC-ish; mean sentiment + post count).
 - **An MV-to-MV join** on `bucket_start`, emitting as both minutes close.
 - **A rolling `CORR(price, mean_sentiment)` over 30 buckets**, computed in-engine
@@ -25,12 +25,12 @@ correlation all run in the stream engine, correctly, from one config file.
 
 ## Run it
 
-Sentiment runs on a **local ONNX model** — no API key, no inference-time network
-call. ONNX Runtime is loaded dynamically, so you supply the shared library
-(>= 1.24) via `ORT_DYLIB_PATH`; the DistilBERT SST-2 weights (~268 MB) download
-once from the Hugging Face CDN into `./models`, then load from disk on restart.
-The positive/negative labels come from the model's own `config.json`, so the
-first cold-cache run scores correctly — no pre-staging, no restart.
+Sentiment runs on a **local ONNX model** (FinBERT) — no API key, no inference-time
+network call. ONNX Runtime is loaded dynamically, so you supply the shared library
+(>= 1.24) via `ORT_DYLIB_PATH`; the FinBERT weights (~440 MB) download once from
+the Hugging Face CDN into `./models`, then load from disk on restart. The labels
+come from the model's own `config.json`, so the first cold-cache run scores
+correctly — no pre-staging, no restart.
 
 ```sh
 # onnxruntime >= 1.24 (ONNX Runtime release, or your package manager)

--- a/examples/demos/crypto_sentiment/dashboard/bridge.py
+++ b/examples/demos/crypto_sentiment/dashboard/bridge.py
@@ -31,7 +31,9 @@ LOCK = threading.Lock()
 
 def publish(event: str, payload: dict) -> None:
     """Fan a row out to every connected browser, unchanged."""
-    msg = f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+    # default=str renders the views' TIMESTAMP columns (Python datetimes) and any
+    # Decimal as strings — json.dumps rejects both natively.
+    msg = f"event: {event}\ndata: {json.dumps(payload, default=str)}\n\n"
     with LOCK:
         for q in list(SUBSCRIBERS):
             q.put(msg)

--- a/examples/demos/crypto_sentiment/dashboard/bridge.py
+++ b/examples/demos/crypto_sentiment/dashboard/bridge.py
@@ -34,7 +34,10 @@ def publish(event: str, payload: dict) -> None:
     msg = f"event: {event}\ndata: {json.dumps(payload, default=str)}\n\n"
     with LOCK:
         for q in list(SUBSCRIBERS):
-            q.put(msg)
+            try:
+                q.put_nowait(msg)
+            except queue.Full:
+                pass  # slow client: drop this update rather than grow unbounded
 
 
 # ── pgwire feed ─────────────────────────────────────────────────────────────
@@ -75,12 +78,16 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Cache-Control", "no-cache")
             self.end_headers()
-            q: queue.Queue = queue.Queue()
+            q: queue.Queue = queue.Queue(maxsize=1000)
             with LOCK:
                 SUBSCRIBERS.add(q)
             try:
                 while True:
-                    self.wfile.write(q.get().encode())
+                    try:
+                        msg = q.get(timeout=15)
+                    except queue.Empty:
+                        msg = ": keepalive\n\n"  # heartbeat; also surfaces a dead idle client
+                    self.wfile.write(msg.encode())
                     self.wfile.flush()
             except OSError:
                 # Client went away (browser tab closed, SSE reconnect, reload).

--- a/examples/demos/crypto_sentiment/dashboard/bridge.py
+++ b/examples/demos/crypto_sentiment/dashboard/bridge.py
@@ -82,18 +82,24 @@ class Handler(BaseHTTPRequestHandler):
                 while True:
                     self.wfile.write(q.get().encode())
                     self.wfile.flush()
-            except (BrokenPipeError, ConnectionResetError):
+            except OSError:
+                # Client went away (browser tab closed, SSE reconnect, reload).
+                # Covers BrokenPipe/ConnectionReset/ConnectionAborted (the last is
+                # what Windows raises) — all expected, not worth a traceback.
                 pass
             finally:
                 with LOCK:
                     SUBSCRIBERS.discard(q)
         else:
             body = (HERE / "index.html").read_bytes()
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            try:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except OSError:
+                pass
 
 
 def main() -> None:

--- a/examples/demos/crypto_sentiment/dashboard/bridge.py
+++ b/examples/demos/crypto_sentiment/dashboard/bridge.py
@@ -8,21 +8,19 @@ aggregation, windowing, correlation, and sentiment scoring already happened in
 the engine; this is transport only.
 
     pip install "psycopg[binary]"
-    python bridge.py                      # tail the live server on :5432
-    python bridge.py --simulate           # synthetic feed, for screen-recording
-                                          #   (a recording aid; NOT the shipped path)
+    python bridge.py            # tail the live LaminarDB views over pgwire
 
 Then open http://127.0.0.1:8088/.
 """
 import argparse
 import json
-import math
 import queue
-import random
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+
+import psycopg
 
 HERE = Path(__file__).resolve().parent
 SUBSCRIBERS: "set[queue.Queue]" = set()
@@ -39,10 +37,8 @@ def publish(event: str, payload: dict) -> None:
             q.put(msg)
 
 
-# ── pgwire feed (the shipped path) ─────────────────────────────────────────
+# ── pgwire feed ─────────────────────────────────────────────────────────────
 def tail_view(dsn: str, sql: str, event: str, columns: list[str]) -> None:
-    import psycopg  # imported lazily so --simulate needs no driver
-
     while True:
         try:
             with psycopg.connect(dsn, autocommit=True) as conn:
@@ -66,35 +62,6 @@ def run_pgwire(host: str, port: int) -> None:
     ]
     for sql, event, cols in feeds:
         threading.Thread(target=tail_view, args=(dsn, sql, event, cols), daemon=True).start()
-
-
-# ── synthetic feed (recording aid only) ────────────────────────────────────
-def run_simulate() -> None:
-    print("[bridge] SIMULATED feed — recording aid, not the shipped demo path")
-
-    def loop() -> None:
-        t, price, posts = 0, 64000.0, [
-            "BTC breaking out, this looks strong", "another red day for bitcoin, brutal",
-            "ethereum merge talk heating up", "$btc just chopping sideways tbh",
-            "loaded more $eth, conviction high", "bitcoin dominance creeping up again",
-        ]
-        while True:
-            t += 1
-            price += random.uniform(-120, 120)
-            sentiment = max(-1.0, min(1.0, 0.4 * math.sin(t / 6) + random.uniform(-0.3, 0.3)))
-            corr = max(-1.0, min(1.0, math.sin(t / 9)))
-            publish("bar", {
-                "bucket_start": time.strftime("%H:%M:00"), "price": round(price, 2),
-                "mean_sentiment": round(sentiment, 3), "posts": random.randint(3, 25),
-                "corr_30": round(corr, 3),
-            })
-            for _ in range(random.randint(1, 3)):
-                publish("post", {"did": "did:plc:demo",
-                                 "text": random.choice(posts),
-                                 "sentiment": round(max(-1, min(1, sentiment + random.uniform(-0.4, 0.4))), 2)})
-            time.sleep(2)
-
-    threading.Thread(target=loop, daemon=True).start()
 
 
 # ── SSE + static server ─────────────────────────────────────────────────────
@@ -131,17 +98,12 @@ class Handler(BaseHTTPRequestHandler):
 
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--simulate", action="store_true", help="synthetic feed (recording aid)")
     ap.add_argument("--pg-host", default="127.0.0.1")
     ap.add_argument("--pg-port", type=int, default=5432)
     ap.add_argument("--http-port", type=int, default=8088)
     args = ap.parse_args()
 
-    if args.simulate:
-        run_simulate()
-    else:
-        run_pgwire(args.pg_host, args.pg_port)
-
+    run_pgwire(args.pg_host, args.pg_port)
     print(f"[bridge] dashboard on http://127.0.0.1:{args.http_port}/")
     ThreadingHTTPServer(("127.0.0.1", args.http_port), Handler).serve_forever()
 

--- a/examples/demos/crypto_sentiment/dashboard/bridge.py
+++ b/examples/demos/crypto_sentiment/dashboard/bridge.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Thin pgwire → browser bridge for the crypto-sentiment dashboard.
+
+Browsers cannot speak the Postgres wire protocol, so this process tails the
+LaminarDB views over pgwire and forwards each row to the page as a
+Server-Sent Event. It forwards rows **verbatim** — it computes nothing. All
+aggregation, windowing, correlation, and sentiment scoring already happened in
+the engine; this is transport only.
+
+    pip install "psycopg[binary]"
+    python bridge.py                      # tail the live server on :5432
+    python bridge.py --simulate           # synthetic feed, for screen-recording
+                                          #   (a recording aid; NOT the shipped path)
+
+Then open http://127.0.0.1:8088/.
+"""
+import argparse
+import json
+import math
+import queue
+import random
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SUBSCRIBERS: "set[queue.Queue]" = set()
+LOCK = threading.Lock()
+
+
+def publish(event: str, payload: dict) -> None:
+    """Fan a row out to every connected browser, unchanged."""
+    msg = f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+    with LOCK:
+        for q in list(SUBSCRIBERS):
+            q.put(msg)
+
+
+# ── pgwire feed (the shipped path) ─────────────────────────────────────────
+def tail_view(dsn: str, sql: str, event: str, columns: list[str]) -> None:
+    import psycopg  # imported lazily so --simulate needs no driver
+
+    while True:
+        try:
+            with psycopg.connect(dsn, autocommit=True) as conn:
+                with conn.cursor() as cur:
+                    # SUBSCRIBE never returns; stream() yields rows as the view
+                    # emits them (the server flushes per batch).
+                    for row in cur.stream(sql):
+                        publish(event, dict(zip(columns, row)))
+        except Exception as exc:  # reconnect on drop; the feed is at-most-once
+            print(f"[bridge] {event} reconnect after: {exc}")
+            time.sleep(2)
+
+
+def run_pgwire(host: str, port: int) -> None:
+    dsn = f"host={host} port={port} dbname=laminar user=laminar"
+    feeds = [
+        # Column order matches each view's SELECT list.
+        ("SUBSCRIBE sentiment_price_1m", "bar",
+         ["bucket_start", "price", "mean_sentiment", "posts", "corr_30"]),
+        ("SUBSCRIBE bsky_crypto", "post", ["did", "text", "ts", "sentiment"]),
+    ]
+    for sql, event, cols in feeds:
+        threading.Thread(target=tail_view, args=(dsn, sql, event, cols), daemon=True).start()
+
+
+# ── synthetic feed (recording aid only) ────────────────────────────────────
+def run_simulate() -> None:
+    print("[bridge] SIMULATED feed — recording aid, not the shipped demo path")
+
+    def loop() -> None:
+        t, price, posts = 0, 64000.0, [
+            "BTC breaking out, this looks strong", "another red day for bitcoin, brutal",
+            "ethereum merge talk heating up", "$btc just chopping sideways tbh",
+            "loaded more $eth, conviction high", "bitcoin dominance creeping up again",
+        ]
+        while True:
+            t += 1
+            price += random.uniform(-120, 120)
+            sentiment = max(-1.0, min(1.0, 0.4 * math.sin(t / 6) + random.uniform(-0.3, 0.3)))
+            corr = max(-1.0, min(1.0, math.sin(t / 9)))
+            publish("bar", {
+                "bucket_start": time.strftime("%H:%M:00"), "price": round(price, 2),
+                "mean_sentiment": round(sentiment, 3), "posts": random.randint(3, 25),
+                "corr_30": round(corr, 3),
+            })
+            for _ in range(random.randint(1, 3)):
+                publish("post", {"did": "did:plc:demo",
+                                 "text": random.choice(posts),
+                                 "sentiment": round(max(-1, min(1, sentiment + random.uniform(-0.4, 0.4))), 2)})
+            time.sleep(2)
+
+    threading.Thread(target=loop, daemon=True).start()
+
+
+# ── SSE + static server ─────────────────────────────────────────────────────
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):  # quiet
+        pass
+
+    def do_GET(self):
+        if self.path.startswith("/events"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            q: queue.Queue = queue.Queue()
+            with LOCK:
+                SUBSCRIBERS.add(q)
+            try:
+                while True:
+                    self.wfile.write(q.get().encode())
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                with LOCK:
+                    SUBSCRIBERS.discard(q)
+        else:
+            body = (HERE / "index.html").read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--simulate", action="store_true", help="synthetic feed (recording aid)")
+    ap.add_argument("--pg-host", default="127.0.0.1")
+    ap.add_argument("--pg-port", type=int, default=5432)
+    ap.add_argument("--http-port", type=int, default=8088)
+    args = ap.parse_args()
+
+    if args.simulate:
+        run_simulate()
+    else:
+        run_pgwire(args.pg_host, args.pg_port)
+
+    print(f"[bridge] dashboard on http://127.0.0.1:{args.http_port}/")
+    ThreadingHTTPServer(("127.0.0.1", args.http_port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/demos/crypto_sentiment/dashboard/index.html
+++ b/examples/demos/crypto_sentiment/dashboard/index.html
@@ -154,12 +154,12 @@
 
 <div class="grid">
   <div class="panel">
-    <h2>BTC price &amp; crowd sentiment <span style="color:var(--faint);text-transform:none;letter-spacing:0;font-weight:400">— 1-minute buckets, emitted on window close</span></h2>
+    <h2>BTC price &amp; crowd sentiment <span style="color:var(--faint);text-transform:none;letter-spacing:0;font-weight:400">— two scales: do they move together? the correlation tile quantifies it</span></h2>
     <canvas id="chart" width="980" height="330"></canvas>
     <div class="legend">
-      <span><span class="dot" style="background:var(--price)"></span><b>BTC price</b> (USDT)</span>
-      <span><span class="dot" style="background:var(--sent)"></span><b>mean sentiment</b> (−1…+1)</span>
-      <span style="color:var(--faint)">every point is a row from <code class="mono">sentiment_price_1m</code></span>
+      <span><span class="dot" style="background:var(--price)"></span><b>BTC price</b> — USDT, left axis</span>
+      <span><span class="dot" style="background:var(--sent)"></span><b>mean sentiment</b> — −1…+1, right axis</span>
+      <span style="color:var(--faint)">each point = one row of <code class="mono">sentiment_price_1m</code>, per 1-min window</span>
     </div>
   </div>
 
@@ -203,6 +203,8 @@ const MAX_BARS = 120;
 let postsSeen = 0;
 const fmt = (v, d = 2) => (v === null || v === undefined ? "—" : Number(v).toFixed(d));
 const sentColor = s => (s == null ? "var(--muted)" : s >= 0 ? "var(--pos)" : "var(--neg)");
+const kfmt = v => (Math.abs(v) >= 1000 ? (v / 1000).toFixed(1).replace(/\.0$/, "") + "k" : Math.round(v).toString());
+const hhmm = s => { const m = String(s || "").match(/(\d{1,2}:\d{2})/); return m ? m[1] : ""; };
 
 function pushBar(row) {
   bars.push(row);
@@ -232,52 +234,67 @@ function addPost(p) {
 
 function draw() {
   const c = document.getElementById("chart"), ctx = c.getContext("2d");
-  // crisp on HiDPI
   const dpr = window.devicePixelRatio || 1, cssW = c.clientWidth || 980, cssH = 330;
-  if (c.width !== cssW * dpr) { c.width = cssW * dpr; c.height = cssH * dpr; }
+  if (c.width !== Math.round(cssW * dpr)) { c.width = Math.round(cssW * dpr); c.height = Math.round(cssH * dpr); }
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-  const W = cssW, H = cssH, padL = 8, padR = 8, padT = 14, padB = 20;
+  const W = cssW, H = cssH, padL = 54, padR = 46, padT = 16, padB = 26;
+  const plotW = W - padL - padR, plotH = H - padT - padB;
   ctx.clearRect(0, 0, W, H);
+  ctx.textBaseline = "middle";
 
   if (bars.length < 2) {
     ctx.fillStyle = "#5b6676"; ctx.font = "13px ui-monospace,Menlo,monospace"; ctx.textAlign = "center";
     ctx.fillText("awaiting the first closed 1-minute window…", W / 2, H / 2);
     return;
   }
-  // gridlines
-  ctx.strokeStyle = "#1a2231"; ctx.lineWidth = 1;
-  for (let i = 0; i <= 4; i++) { const y = padT + (H - padT - padB) * i / 4; ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(W - padR, y); ctx.stroke(); }
-  // sentiment zero baseline
-  const yFor = (v, lo, hi) => H - padB - (H - padT - padB) * ((v - lo) / (hi - lo || 1));
-  const zeroY = yFor(0, -1, 1);
-  ctx.strokeStyle = "#22304a"; ctx.setLineDash([3, 4]); ctx.beginPath(); ctx.moveTo(padL, zeroY); ctx.lineTo(W - padR, zeroY); ctx.stroke(); ctx.setLineDash([]);
 
   const prices = bars.map(b => b.price).filter(v => v != null);
   const pMin = Math.min(...prices), pMax = Math.max(...prices);
-  const xFor = i => padL + (W - padL - padR) * (i / (bars.length - 1));
+  const xFor = i => padL + plotW * (i / (bars.length - 1));
+  const yP = v => padT + plotH * (1 - (v - pMin) / (pMax - pMin || 1)); // left scale: price
+  const yS = v => padT + plotH * (1 - (v + 1) / 2);                     // right scale: sentiment −1…+1
 
-  // sentiment area + line (cyan)
+  // horizontal gridlines
+  ctx.strokeStyle = "#172033"; ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) { const y = padT + plotH * i / 4; ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(padL + plotW, y); ctx.stroke(); }
+
+  // left axis — price ticks (gold)
+  ctx.font = "11px ui-monospace,Menlo,monospace"; ctx.fillStyle = "#c8a24c"; ctx.textAlign = "right";
+  [pMax, (pMax + pMin) / 2, pMin].forEach(v => ctx.fillText(kfmt(v), padL - 8, yP(v)));
+  // right axis — sentiment ticks (cyan)
+  ctx.fillStyle = "#5fb6cf"; ctx.textAlign = "left";
+  [["+1", 1], ["0", 0], ["−1", -1]].forEach(([t, v]) => ctx.fillText(t, padL + plotW + 8, yS(v)));
+
+  // sentiment zero baseline
+  ctx.strokeStyle = "#22304a"; ctx.setLineDash([3, 4]); ctx.beginPath(); ctx.moveTo(padL, yS(0)); ctx.lineTo(padL + plotW, yS(0)); ctx.stroke(); ctx.setLineDash([]);
+
+  // sentiment area + line (cyan, right axis)
   ctx.beginPath(); let started = false;
-  bars.forEach((b, i) => { if (b.mean_sentiment == null) return; const x = xFor(i), y = yFor(b.mean_sentiment, -1, 1);
+  bars.forEach((b, i) => { if (b.mean_sentiment == null) return; const x = xFor(i), y = yS(b.mean_sentiment);
     started ? ctx.lineTo(x, y) : (ctx.moveTo(x, y), started = true); });
   if (started) {
-    const lastI = bars.length - 1;
-    ctx.lineTo(xFor(lastI), zeroY); ctx.lineTo(xFor(0), zeroY); ctx.closePath();
+    ctx.lineTo(xFor(bars.length - 1), yS(0)); ctx.lineTo(xFor(0), yS(0)); ctx.closePath();
     ctx.fillStyle = "rgba(70,211,240,.10)"; ctx.fill();
   }
-  line("mean_sentiment", "#46d3f0", -1, 1, 2);
-  // price line (gold, glow)
+  drawLine(b => b.mean_sentiment, yS, "#46d3f0", 2);
+  // price line (gold, left axis, glow)
   ctx.shadowColor = "rgba(240,180,41,.35)"; ctx.shadowBlur = 8;
-  line("price", "#f0b429", pMin, pMax, 2.4);
+  drawLine(b => b.price, yP, "#f0b429", 2.4);
   ctx.shadowBlur = 0;
-  // latest price dot
-  const li = bars.length - 1; if (bars[li].price != null) {
-    ctx.fillStyle = "#f0b429"; ctx.beginPath(); ctx.arc(xFor(li), yFor(bars[li].price, pMin, pMax), 3.5, 0, 7); ctx.fill();
-  }
-  function line(key, color, lo, hi, w) {
-    ctx.strokeStyle = color; ctx.lineWidth = w; ctx.beginPath(); let st = false;
-    bars.forEach((b, i) => { const v = b[key]; if (v == null) return; const x = xFor(i), y = yFor(v, lo, hi);
-      st ? ctx.lineTo(x, y) : (ctx.moveTo(x, y), st = true); });
+  // latest-point dots
+  const li = bars.length - 1;
+  if (bars[li].price != null) { ctx.fillStyle = "#f0b429"; ctx.beginPath(); ctx.arc(xFor(li), yP(bars[li].price), 3.5, 0, 7); ctx.fill(); }
+  if (bars[li].mean_sentiment != null) { ctx.fillStyle = "#46d3f0"; ctx.beginPath(); ctx.arc(xFor(li), yS(bars[li].mean_sentiment), 3.5, 0, 7); ctx.fill(); }
+
+  // x-axis — time labels (start / mid / end)
+  ctx.fillStyle = "#5b6676"; ctx.textBaseline = "alphabetic";
+  [[0, "left", padL], [(bars.length - 1) >> 1, "center", xFor((bars.length - 1) >> 1)], [bars.length - 1, "right", padL + plotW]]
+    .forEach(([idx, al, x]) => { ctx.textAlign = al; ctx.fillText(hhmm(bars[idx].bucket_start), x, H - 7); });
+
+  function drawLine(get, yf, color, w) {
+    ctx.strokeStyle = color; ctx.lineWidth = w; ctx.beginPath(); let s = false;
+    bars.forEach((b, i) => { const v = get(b); if (v == null) return; const x = xFor(i), y = yf(v);
+      s ? ctx.lineTo(x, y) : (ctx.moveTo(x, y), s = true); });
     ctx.stroke();
   }
 }

--- a/examples/demos/crypto_sentiment/dashboard/index.html
+++ b/examples/demos/crypto_sentiment/dashboard/index.html
@@ -1,152 +1,297 @@
 <!doctype html>
 <!--
   Crypto × Sentiment — thin client. It DRAWS what the engine emits; it computes
-  nothing. Price, sentiment, the rolling correlation, and the post score all
-  arrive over SSE from bridge.py (which tails the views over pgwire). No
-  aggregation, windowing, correlation, or scoring lives here — that is the
-  engine's job (grep this file: none of those words appear in logic).
+  nothing. Price, sentiment, the rolling correlation, and every post score
+  arrive over SSE from bridge.py (which tails the LaminarDB views over pgwire).
+  No aggregation, windowing, correlation, or scoring lives here — that is the
+  engine's job. (grep this file: none of those words appear in logic.)
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>BTC price × crypto sentiment — LaminarDB</title>
+<title>LaminarDB — streaming SQL + AI functions</title>
 <style>
   :root {
-    --bg: #0b0e14; --panel: #121722; --ink: #e6edf3; --muted: #8b98a9;
-    --price: #f0b429; --sent: #4cc9f0; --grid: #1d2533; --pos: #3fb950; --neg: #f85149;
+    --bg:#090c12; --bg2:#0c1018; --panel:#121826; --panel2:#0f1420;
+    --ink:#e9eef6; --muted:#8a97a8; --faint:#5b6676;
+    --line:#1c2433; --line2:#283246;
+    --price:#f0b429; --sent:#46d3f0; --pos:#3fb950; --neg:#ff5d52;
+    --accent:#7c5cff;
   }
-  * { box-sizing: border-box; }
+  * { box-sizing:border-box; }
+  html,body { height:100%; }
   body {
-    margin: 0; background: var(--bg); color: var(--ink);
-    font: 14px/1.5 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    margin:0; color:var(--ink);
+    background:
+      radial-gradient(1200px 500px at 80% -10%, #14203a55, transparent 60%),
+      radial-gradient(900px 500px at 0% 0%, #1a2b2f44, transparent 55%),
+      linear-gradient(180deg,var(--bg),var(--bg2));
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;
   }
-  header { padding: 18px 24px 10px; }
-  h1 { margin: 0; font-size: 17px; font-weight: 600; letter-spacing: .2px; }
-  .sub { color: var(--muted); font-size: 12px; margin-top: 3px; }
-  .grid { display: grid; grid-template-columns: 2fr 1fr; gap: 16px; padding: 12px 24px 24px; }
-  .panel { background: var(--panel); border: 1px solid var(--grid); border-radius: 10px; padding: 14px 16px; }
-  .panel h2 { margin: 0 0 10px; font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .8px; }
-  canvas { width: 100%; height: 320px; display: block; }
-  .legend { display: flex; gap: 18px; font-size: 12px; margin-top: 8px; color: var(--muted); }
-  .legend b { font-weight: 600; }
-  .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
-  .corr-num { font-size: 46px; font-weight: 700; line-height: 1.1; }
-  .corr-meta { color: var(--muted); font-size: 12px; }
-  .feed { max-height: 360px; overflow: auto; }
-  .post { padding: 8px 0; border-bottom: 1px solid var(--grid); }
-  .post .txt { color: var(--ink); }
-  .post .score { font-weight: 700; }
-  .pill { display:inline-block; min-width: 52px; text-align:center; padding: 1px 7px; border-radius: 6px; font-size: 12px; }
-  footer { padding: 8px 24px 28px; color: var(--muted); font-size: 12px; }
-  footer b { color: var(--ink); }
-  .status { float: right; font-size: 12px; color: var(--muted); }
-  .status.live::before { content: "●"; color: var(--pos); margin-right: 6px; }
-  .status.down::before { content: "●"; color: var(--neg); margin-right: 6px; }
+  code,.mono { font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; }
+
+  /* ── header ── */
+  header { padding:20px 28px 8px; display:flex; align-items:flex-start; gap:18px; flex-wrap:wrap; }
+  .brand { display:flex; align-items:center; gap:11px; }
+  .logo { width:34px; height:34px; flex:0 0 auto; }
+  .wordmark { font-size:20px; font-weight:700; letter-spacing:.2px; }
+  .wordmark .db { background:linear-gradient(90deg,#5ee0ff,#7c5cff); -webkit-background-clip:text; background-clip:text; color:transparent; }
+  .tag { color:var(--muted); font-size:12.5px; margin-top:1px; }
+  .spacer { flex:1 1 auto; }
+  .status { font-size:12px; color:var(--muted); white-space:nowrap; padding-top:6px; }
+  .status::before { content:"●"; margin-right:6px; color:var(--faint); }
+  .status.live::before { color:var(--pos); animation:pulse 1.8s ease-in-out infinite; }
+  .status.down::before { color:var(--neg); }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.35} }
+
+  .badges { display:flex; gap:8px; flex-wrap:wrap; padding:6px 28px 4px; }
+  .badge { font-size:11.5px; color:var(--ink); background:var(--panel); border:1px solid var(--line2);
+           border-radius:999px; padding:4px 11px; display:inline-flex; align-items:center; gap:7px; }
+  .badge b { color:#bcd1ff; font-weight:600; }
+  .badge .k { width:7px; height:7px; border-radius:50%; }
+
+  /* ── kpi tiles ── */
+  .kpis { display:grid; grid-template-columns:repeat(4,1fr); gap:14px; padding:14px 28px 4px; }
+  .kpi { background:linear-gradient(180deg,var(--panel),var(--panel2)); border:1px solid var(--line);
+         border-radius:14px; padding:14px 16px; }
+  .kpi .lab { font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.9px; }
+  .kpi .val { font-size:30px; font-weight:700; line-height:1.15; margin-top:6px; transition:color .25s; }
+  .kpi .val.mono { font-family:ui-monospace,Menlo,Consolas,monospace; letter-spacing:-.5px; }
+  .kpi .src { font-size:10.5px; color:var(--faint); margin-top:4px; }
+  .kpi .src code { color:var(--muted); }
+
+  /* ── main grid ── */
+  .grid { display:grid; grid-template-columns:1.85fr 1fr; gap:14px; padding:14px 28px; align-items:start; }
+  .panel { background:linear-gradient(180deg,var(--panel),var(--panel2)); border:1px solid var(--line);
+           border-radius:14px; padding:16px 18px; }
+  .panel h2 { margin:0 0 4px; font-size:11px; font-weight:600; color:var(--muted);
+              text-transform:uppercase; letter-spacing:.9px; display:flex; gap:8px; align-items:center; }
+  .panel .hint { font-size:11px; color:var(--faint); margin:0 0 10px; }
+  canvas { width:100%; height:330px; display:block; }
+  .legend { display:flex; gap:20px; font-size:12px; margin-top:10px; color:var(--muted); }
+  .legend .dot { display:inline-block; width:10px; height:10px; border-radius:3px; margin-right:7px; vertical-align:middle; }
+
+  /* ── ai feed ── */
+  .feed { max-height:392px; overflow:auto; margin:-4px -6px 0; padding:0 6px; }
+  .feed::-webkit-scrollbar { width:8px; } .feed::-webkit-scrollbar-thumb { background:var(--line2); border-radius:8px; }
+  .post { padding:9px 2px; border-bottom:1px solid var(--line); display:flex; gap:10px; align-items:flex-start;
+          animation:slidein .35s ease; }
+  @keyframes slidein { from{opacity:0; transform:translateY(-6px)} to{opacity:1; transform:none} }
+  .pill { flex:0 0 auto; min-width:52px; text-align:center; padding:2px 8px; border-radius:7px;
+          font-size:12.5px; font-weight:700; font-family:ui-monospace,Menlo,Consolas,monospace; }
+  .post .txt { color:#cfd8e6; font-size:12.5px; word-break:break-word; }
+  .feed-empty { color:var(--faint); font-size:12.5px; padding:14px 2px; }
+
+  /* ── pipeline strip ── */
+  .pipe { margin:2px 28px 8px; padding:14px 16px; background:linear-gradient(180deg,var(--panel),var(--panel2));
+          border:1px solid var(--line); border-radius:14px; }
+  .pipe .h { font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.9px; margin-bottom:11px; }
+  .flow { display:flex; align-items:center; gap:9px; flex-wrap:wrap; }
+  .stage { background:#0b1120; border:1px solid var(--line2); border-radius:9px; padding:7px 11px;
+           font-family:ui-monospace,Menlo,Consolas,monospace; font-size:11.5px; color:#cdd8ea; white-space:nowrap; }
+  .stage .s { color:var(--faint); }
+  .stage.ai { border-color:#5e4fae; background:linear-gradient(180deg,#171336,#120f29); color:#cdbcff; }
+  .stage.ai b { color:#c0aaff; }
+  .arrow { color:var(--faint); font-size:13px; }
+  .stage em { color:var(--sent); font-style:normal; }
+  .stage i { color:var(--price); font-style:normal; }
+
+  footer { padding:8px 28px 26px; color:var(--muted); font-size:12px; }
+  footer b { color:var(--ink); } footer code { color:#bcd1ff; }
+  .nodata { color:var(--faint); text-align:center; padding-top:140px; font-size:13px; }
 </style>
 </head>
 <body>
 <header>
+  <div class="brand">
+    <svg class="logo" viewBox="0 0 40 40" fill="none">
+      <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#5ee0ff"/><stop offset="1" stop-color="#7c5cff"/></linearGradient></defs>
+      <path d="M4 13c8-6 24 6 32 0" stroke="url(#g)" stroke-width="3" stroke-linecap="round"/>
+      <path d="M4 21c8-6 24 6 32 0" stroke="url(#g)" stroke-width="3" stroke-linecap="round" opacity=".7"/>
+      <path d="M4 29c8-6 24 6 32 0" stroke="url(#g)" stroke-width="3" stroke-linecap="round" opacity=".4"/>
+    </svg>
+    <div>
+      <div class="wordmark">Laminar<span class="db">DB</span></div>
+      <div class="tag">streaming SQL &middot; AI functions &middot; exactly one config file</div>
+    </div>
+  </div>
+  <div class="spacer"></div>
   <span class="status" id="status">connecting…</span>
-  <h1>BTC price × crypto-post sentiment</h1>
-  <div class="sub">All numbers are emitted by LaminarDB views. This page only formats and draws them.</div>
 </header>
+
+<div class="badges">
+  <span class="badge"><span class="k" style="background:var(--accent)"></span><b>ai_sentiment()</b> scored in-engine</span>
+  <span class="badge"><span class="k" style="background:var(--pos)"></span>local <b>ONNX</b> &middot; on-device &middot; 0 bytes leave the host</span>
+  <span class="badge"><span class="k" style="background:var(--sent)"></span>remote LLM = one config line</span>
+  <span class="badge"><span class="k" style="background:var(--price)"></span>BTC trades + Bluesky firehose, live</span>
+</div>
+
+<div class="kpis">
+  <div class="kpi">
+    <div class="lab">BTC / USDT</div>
+    <div class="val mono" id="kPrice" style="color:var(--price)">—</div>
+    <div class="src">avg per minute &middot; <code>price_1m.price</code></div>
+  </div>
+  <div class="kpi">
+    <div class="lab">mean sentiment</div>
+    <div class="val mono" id="kSent">—</div>
+    <div class="src">−1 … +1 &middot; <code>sentiment_1m.mean_sentiment</code></div>
+  </div>
+  <div class="kpi">
+    <div class="lab">price ↔ sentiment corr</div>
+    <div class="val mono" id="kCorr">—</div>
+    <div class="src">sliding 30 buckets &middot; <code>CORR() OVER …</code></div>
+  </div>
+  <div class="kpi">
+    <div class="lab">posts scored</div>
+    <div class="val mono" id="kPosts" style="color:var(--accent)">0</div>
+    <div class="src">this session &middot; <code>ai_sentiment(text)</code></div>
+  </div>
+</div>
 
 <div class="grid">
   <div class="panel">
-    <h2>price (avg/min) &amp; mean sentiment — per 1-minute bucket</h2>
-    <canvas id="chart" width="900" height="320"></canvas>
+    <h2>BTC price &amp; crowd sentiment <span style="color:var(--faint);text-transform:none;letter-spacing:0;font-weight:400">— 1-minute buckets, emitted on window close</span></h2>
+    <canvas id="chart" width="980" height="330"></canvas>
     <div class="legend">
       <span><span class="dot" style="background:var(--price)"></span><b>BTC price</b> (USDT)</span>
       <span><span class="dot" style="background:var(--sent)"></span><b>mean sentiment</b> (−1…+1)</span>
+      <span style="color:var(--faint)">every point is a row from <code class="mono">sentiment_price_1m</code></span>
     </div>
   </div>
 
   <div class="panel">
-    <h2>rolling correlation — CORR over 30 buckets</h2>
-    <div class="corr-num" id="corr">—</div>
-    <div class="corr-meta" id="corrMeta">from <code>sentiment_price_1m.corr_30</code></div>
-    <h2 style="margin-top:18px">scored crypto posts</h2>
-    <div class="feed" id="feed"></div>
+    <h2><span style="color:var(--accent)">●</span> ai_sentiment() — live scores</h2>
+    <p class="hint">each crypto post, scored by a local ONNX model as it streams</p>
+    <div class="feed" id="feed"><div class="feed-empty" id="feedEmpty">waiting for the firehose… scored posts will stream here.</div></div>
+  </div>
+</div>
+
+<div class="pipe">
+  <div class="h">what runs inside LaminarDB — one SQL pipeline</div>
+  <div class="flow">
+    <span class="stage"><span class="s">SOURCE</span> btcusdt@trade</span>
+    <span class="arrow">→</span>
+    <span class="stage"><span class="s">SOURCE</span> bluesky firehose</span>
+    <span class="arrow">→</span>
+    <span class="stage">WHERE text ILIKE <i>'%btc%'</i></span>
+    <span class="arrow">→</span>
+    <span class="stage ai"><b>ai_sentiment(text)</b> <span class="s">↳ local ONNX</span></span>
+    <span class="arrow">→</span>
+    <span class="stage">TUMBLE <em>1&nbsp;min</em></span>
+    <span class="arrow">→</span>
+    <span class="stage">JOIN <span class="s">ON bucket</span></span>
+    <span class="arrow">→</span>
+    <span class="stage">CORR() <span class="s">OVER 30</span></span>
   </div>
 </div>
 
 <footer>
-  Source view <b>sentiment_price_1m</b> — latest <b id="footBucket">—</b>:
-  price <b id="footPrice">—</b>, mean sentiment <b id="footSent">—</b>, corr_30 <b id="footCorr">—</b>.
-  Sentiment scored by <b>ai_sentiment()</b> inside the pipeline (see <code>laminar.ai_calls</code>).
+  Every number on this page is emitted by a LaminarDB view — the page formats and draws, nothing else.
+  Sentiment is scored by <b>ai_sentiment()</b> on a local <b>ONNX</b> model, so the post text never leaves the host;
+  pointing at a remote LLM is a one-line config change. Latest bucket <b id="footBucket">—</b>.
+  Audit the calls with <code>SELECT * FROM laminar.ai_calls</code>.
 </footer>
 
 <script>
 // ── Pure rendering. Receives rows; never derives a statistic. ──────────────
-const bars = [];          // {bucket_start, price, mean_sentiment, corr_30}
+const bars = [];                 // {bucket_start, price, mean_sentiment, posts, corr_30}
 const MAX_BARS = 120;
+let postsSeen = 0;
 const fmt = (v, d = 2) => (v === null || v === undefined ? "—" : Number(v).toFixed(d));
+const sentColor = s => (s == null ? "var(--muted)" : s >= 0 ? "var(--pos)" : "var(--neg)");
 
 function pushBar(row) {
   bars.push(row);
   while (bars.length > MAX_BARS) bars.shift();
-  draw();
   const last = bars[bars.length - 1];
-  document.getElementById("corr").textContent = fmt(last.corr_30, 3);
-  document.getElementById("corr").style.color =
-    last.corr_30 == null ? "var(--muted)" : last.corr_30 >= 0 ? "var(--pos)" : "var(--neg)";
+  setVal("kPrice", last.price == null ? "—" : Number(last.price).toLocaleString(undefined,{maximumFractionDigits:0}));
+  const sv = document.getElementById("kSent"); sv.textContent = fmt(last.mean_sentiment, 3); sv.style.color = sentColor(last.mean_sentiment);
+  const cv = document.getElementById("kCorr"); cv.textContent = fmt(last.corr_30, 3); cv.style.color = sentColor(last.corr_30);
   document.getElementById("footBucket").textContent = last.bucket_start ?? "—";
-  document.getElementById("footPrice").textContent = fmt(last.price);
-  document.getElementById("footSent").textContent = fmt(last.mean_sentiment, 3);
-  document.getElementById("footCorr").textContent = fmt(last.corr_30, 3);
+  draw();
 }
+function setVal(id, t) { document.getElementById(id).textContent = t; }
 
 function addPost(p) {
   const feed = document.getElementById("feed");
+  const empty = document.getElementById("feedEmpty"); if (empty) empty.remove();
+  const s = p.sentiment, color = sentColor(s), label = s == null ? "null" : (s >= 0 ? "+" : "") + fmt(s, 2);
   const el = document.createElement("div");
   el.className = "post";
-  const s = p.sentiment;
-  const color = s == null ? "var(--muted)" : s >= 0 ? "var(--pos)" : "var(--neg)";
-  const label = s == null ? "null" : fmt(s, 2);
-  el.innerHTML =
-    `<span class="pill score" style="background:${color}22;color:${color}">${label}</span> ` +
-    `<span class="txt"></span>`;
-  el.querySelector(".txt").textContent = (p.text || "").slice(0, 140);
+  el.innerHTML = `<span class="pill" style="background:${color}1f;color:${color}"></span><span class="txt"></span>`;
+  el.querySelector(".pill").textContent = label;
+  el.querySelector(".txt").textContent = (p.text || "").replace(/\s+/g, " ").slice(0, 150);
   feed.prepend(el);
   while (feed.childNodes.length > 40) feed.removeChild(feed.lastChild);
+  setVal("kPosts", (++postsSeen).toLocaleString());
 }
 
 function draw() {
   const c = document.getElementById("chart"), ctx = c.getContext("2d");
-  const W = c.width, H = c.height, pad = 34;
+  // crisp on HiDPI
+  const dpr = window.devicePixelRatio || 1, cssW = c.clientWidth || 980, cssH = 330;
+  if (c.width !== cssW * dpr) { c.width = cssW * dpr; c.height = cssH * dpr; }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const W = cssW, H = cssH, padL = 8, padR = 8, padT = 14, padB = 20;
   ctx.clearRect(0, 0, W, H);
-  if (bars.length < 2) return;
+
+  if (bars.length < 2) {
+    ctx.fillStyle = "#5b6676"; ctx.font = "13px ui-monospace,Menlo,monospace"; ctx.textAlign = "center";
+    ctx.fillText("awaiting the first closed 1-minute window…", W / 2, H / 2);
+    return;
+  }
+  // gridlines
+  ctx.strokeStyle = "#1a2231"; ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) { const y = padT + (H - padT - padB) * i / 4; ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(W - padR, y); ctx.stroke(); }
+  // sentiment zero baseline
+  const yFor = (v, lo, hi) => H - padB - (H - padT - padB) * ((v - lo) / (hi - lo || 1));
+  const zeroY = yFor(0, -1, 1);
+  ctx.strokeStyle = "#22304a"; ctx.setLineDash([3, 4]); ctx.beginPath(); ctx.moveTo(padL, zeroY); ctx.lineTo(W - padR, zeroY); ctx.stroke(); ctx.setLineDash([]);
+
   const prices = bars.map(b => b.price).filter(v => v != null);
   const pMin = Math.min(...prices), pMax = Math.max(...prices);
-  const series = (key, color, lo, hi) => {
-    ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.beginPath();
-    let started = false;
-    bars.forEach((b, i) => {
-      const v = b[key]; if (v == null) return;
-      const x = pad + (W - 2 * pad) * (i / (bars.length - 1));
-      const y = H - pad - (H - 2 * pad) * ((v - lo) / (hi - lo || 1));
-      if (!started) { ctx.moveTo(x, y); started = true; } else ctx.lineTo(x, y);
-    });
+  const xFor = i => padL + (W - padL - padR) * (i / (bars.length - 1));
+
+  // sentiment area + line (cyan)
+  ctx.beginPath(); let started = false;
+  bars.forEach((b, i) => { if (b.mean_sentiment == null) return; const x = xFor(i), y = yFor(b.mean_sentiment, -1, 1);
+    started ? ctx.lineTo(x, y) : (ctx.moveTo(x, y), started = true); });
+  if (started) {
+    const lastI = bars.length - 1;
+    ctx.lineTo(xFor(lastI), zeroY); ctx.lineTo(xFor(0), zeroY); ctx.closePath();
+    ctx.fillStyle = "rgba(70,211,240,.10)"; ctx.fill();
+  }
+  line("mean_sentiment", "#46d3f0", -1, 1, 2);
+  // price line (gold, glow)
+  ctx.shadowColor = "rgba(240,180,41,.35)"; ctx.shadowBlur = 8;
+  line("price", "#f0b429", pMin, pMax, 2.4);
+  ctx.shadowBlur = 0;
+  // latest price dot
+  const li = bars.length - 1; if (bars[li].price != null) {
+    ctx.fillStyle = "#f0b429"; ctx.beginPath(); ctx.arc(xFor(li), yFor(bars[li].price, pMin, pMax), 3.5, 0, 7); ctx.fill();
+  }
+  function line(key, color, lo, hi, w) {
+    ctx.strokeStyle = color; ctx.lineWidth = w; ctx.beginPath(); let st = false;
+    bars.forEach((b, i) => { const v = b[key]; if (v == null) return; const x = xFor(i), y = yFor(v, lo, hi);
+      st ? ctx.lineTo(x, y) : (ctx.moveTo(x, y), st = true); });
     ctx.stroke();
-  };
-  ctx.strokeStyle = "var(--grid)";
-  series("price", getComputedStyle(document.documentElement).getPropertyValue("--price"), pMin, pMax);
-  series("mean_sentiment", getComputedStyle(document.documentElement).getPropertyValue("--sent"), -1, 1);
+  }
 }
 
-function setStatus(s, cls) {
-  const el = document.getElementById("status");
-  el.textContent = s; el.className = "status " + cls;
-}
+function setStatus(s, cls) { const el = document.getElementById("status"); el.textContent = s; el.className = "status " + cls; }
 
-// ── Transport: SSE from bridge.py (or simulate.py). ───────────────────────
+// ── Transport: SSE from bridge.py. ─────────────────────────────────────────
 const es = new EventSource("/events");
 es.addEventListener("bar", e => pushBar(JSON.parse(e.data)));
 es.addEventListener("post", e => addPost(JSON.parse(e.data)));
 es.onopen = () => setStatus("live", "live");
-es.onerror = () => setStatus("disconnected", "down");
+es.onerror = () => setStatus("reconnecting…", "down");
 window.addEventListener("resize", draw);
+draw();
 </script>
 </body>
 </html>

--- a/examples/demos/crypto_sentiment/dashboard/index.html
+++ b/examples/demos/crypto_sentiment/dashboard/index.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<!--
+  Crypto × Sentiment — thin client. It DRAWS what the engine emits; it computes
+  nothing. Price, sentiment, the rolling correlation, and the post score all
+  arrive over SSE from bridge.py (which tails the views over pgwire). No
+  aggregation, windowing, correlation, or scoring lives here — that is the
+  engine's job (grep this file: none of those words appear in logic).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BTC price × crypto sentiment — LaminarDB</title>
+<style>
+  :root {
+    --bg: #0b0e14; --panel: #121722; --ink: #e6edf3; --muted: #8b98a9;
+    --price: #f0b429; --sent: #4cc9f0; --grid: #1d2533; --pos: #3fb950; --neg: #f85149;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 14px/1.5 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  header { padding: 18px 24px 10px; }
+  h1 { margin: 0; font-size: 17px; font-weight: 600; letter-spacing: .2px; }
+  .sub { color: var(--muted); font-size: 12px; margin-top: 3px; }
+  .grid { display: grid; grid-template-columns: 2fr 1fr; gap: 16px; padding: 12px 24px 24px; }
+  .panel { background: var(--panel); border: 1px solid var(--grid); border-radius: 10px; padding: 14px 16px; }
+  .panel h2 { margin: 0 0 10px; font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: .8px; }
+  canvas { width: 100%; height: 320px; display: block; }
+  .legend { display: flex; gap: 18px; font-size: 12px; margin-top: 8px; color: var(--muted); }
+  .legend b { font-weight: 600; }
+  .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .corr-num { font-size: 46px; font-weight: 700; line-height: 1.1; }
+  .corr-meta { color: var(--muted); font-size: 12px; }
+  .feed { max-height: 360px; overflow: auto; }
+  .post { padding: 8px 0; border-bottom: 1px solid var(--grid); }
+  .post .txt { color: var(--ink); }
+  .post .score { font-weight: 700; }
+  .pill { display:inline-block; min-width: 52px; text-align:center; padding: 1px 7px; border-radius: 6px; font-size: 12px; }
+  footer { padding: 8px 24px 28px; color: var(--muted); font-size: 12px; }
+  footer b { color: var(--ink); }
+  .status { float: right; font-size: 12px; color: var(--muted); }
+  .status.live::before { content: "●"; color: var(--pos); margin-right: 6px; }
+  .status.down::before { content: "●"; color: var(--neg); margin-right: 6px; }
+</style>
+</head>
+<body>
+<header>
+  <span class="status" id="status">connecting…</span>
+  <h1>BTC price × crypto-post sentiment</h1>
+  <div class="sub">All numbers are emitted by LaminarDB views. This page only formats and draws them.</div>
+</header>
+
+<div class="grid">
+  <div class="panel">
+    <h2>price (avg/min) &amp; mean sentiment — per 1-minute bucket</h2>
+    <canvas id="chart" width="900" height="320"></canvas>
+    <div class="legend">
+      <span><span class="dot" style="background:var(--price)"></span><b>BTC price</b> (USDT)</span>
+      <span><span class="dot" style="background:var(--sent)"></span><b>mean sentiment</b> (−1…+1)</span>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>rolling correlation — CORR over 30 buckets</h2>
+    <div class="corr-num" id="corr">—</div>
+    <div class="corr-meta" id="corrMeta">from <code>sentiment_price_1m.corr_30</code></div>
+    <h2 style="margin-top:18px">scored crypto posts</h2>
+    <div class="feed" id="feed"></div>
+  </div>
+</div>
+
+<footer>
+  Source view <b>sentiment_price_1m</b> — latest <b id="footBucket">—</b>:
+  price <b id="footPrice">—</b>, mean sentiment <b id="footSent">—</b>, corr_30 <b id="footCorr">—</b>.
+  Sentiment scored by <b>ai_sentiment()</b> inside the pipeline (see <code>laminar.ai_calls</code>).
+</footer>
+
+<script>
+// ── Pure rendering. Receives rows; never derives a statistic. ──────────────
+const bars = [];          // {bucket_start, price, mean_sentiment, corr_30}
+const MAX_BARS = 120;
+const fmt = (v, d = 2) => (v === null || v === undefined ? "—" : Number(v).toFixed(d));
+
+function pushBar(row) {
+  bars.push(row);
+  while (bars.length > MAX_BARS) bars.shift();
+  draw();
+  const last = bars[bars.length - 1];
+  document.getElementById("corr").textContent = fmt(last.corr_30, 3);
+  document.getElementById("corr").style.color =
+    last.corr_30 == null ? "var(--muted)" : last.corr_30 >= 0 ? "var(--pos)" : "var(--neg)";
+  document.getElementById("footBucket").textContent = last.bucket_start ?? "—";
+  document.getElementById("footPrice").textContent = fmt(last.price);
+  document.getElementById("footSent").textContent = fmt(last.mean_sentiment, 3);
+  document.getElementById("footCorr").textContent = fmt(last.corr_30, 3);
+}
+
+function addPost(p) {
+  const feed = document.getElementById("feed");
+  const el = document.createElement("div");
+  el.className = "post";
+  const s = p.sentiment;
+  const color = s == null ? "var(--muted)" : s >= 0 ? "var(--pos)" : "var(--neg)";
+  const label = s == null ? "null" : fmt(s, 2);
+  el.innerHTML =
+    `<span class="pill score" style="background:${color}22;color:${color}">${label}</span> ` +
+    `<span class="txt"></span>`;
+  el.querySelector(".txt").textContent = (p.text || "").slice(0, 140);
+  feed.prepend(el);
+  while (feed.childNodes.length > 40) feed.removeChild(feed.lastChild);
+}
+
+function draw() {
+  const c = document.getElementById("chart"), ctx = c.getContext("2d");
+  const W = c.width, H = c.height, pad = 34;
+  ctx.clearRect(0, 0, W, H);
+  if (bars.length < 2) return;
+  const prices = bars.map(b => b.price).filter(v => v != null);
+  const pMin = Math.min(...prices), pMax = Math.max(...prices);
+  const series = (key, color, lo, hi) => {
+    ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.beginPath();
+    let started = false;
+    bars.forEach((b, i) => {
+      const v = b[key]; if (v == null) return;
+      const x = pad + (W - 2 * pad) * (i / (bars.length - 1));
+      const y = H - pad - (H - 2 * pad) * ((v - lo) / (hi - lo || 1));
+      if (!started) { ctx.moveTo(x, y); started = true; } else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  };
+  ctx.strokeStyle = "var(--grid)";
+  series("price", getComputedStyle(document.documentElement).getPropertyValue("--price"), pMin, pMax);
+  series("mean_sentiment", getComputedStyle(document.documentElement).getPropertyValue("--sent"), -1, 1);
+}
+
+function setStatus(s, cls) {
+  const el = document.getElementById("status");
+  el.textContent = s; el.className = "status " + cls;
+}
+
+// ── Transport: SSE from bridge.py (or simulate.py). ───────────────────────
+const es = new EventSource("/events");
+es.addEventListener("bar", e => pushBar(JSON.parse(e.data)));
+es.addEventListener("post", e => addPost(JSON.parse(e.data)));
+es.onopen = () => setStatus("live", "live");
+es.onerror = () => setStatus("disconnected", "down");
+window.addEventListener("resize", draw);
+</script>
+</body>
+</html>

--- a/examples/demos/crypto_sentiment/dashboard/index.html
+++ b/examples/demos/crypto_sentiment/dashboard/index.html
@@ -1,10 +1,7 @@
 <!doctype html>
 <!--
-  Crypto × Sentiment — thin client. It DRAWS what the engine emits; it computes
-  nothing. Price, sentiment, the rolling correlation, and every post score
-  arrive over SSE from bridge.py (which tails the LaminarDB views over pgwire).
-  No aggregation, windowing, correlation, or scoring lives here — that is the
-  engine's job. (grep this file: none of those words appear in logic.)
+  Thin client: draws what the LaminarDB views emit over SSE (via bridge.py) and
+  computes nothing — no windowing, correlation, or scoring lives here.
 -->
 <html lang="en">
 <head>

--- a/examples/demos/crypto_sentiment/pipeline.toml
+++ b/examples/demos/crypto_sentiment/pipeline.toml
@@ -1,7 +1,10 @@
 # Crypto price × Bluesky sentiment — one pipeline, scored and correlated in the
-# engine. Bring it up with the normal server run path:
+# engine. Sentiment runs on a LOCAL ONNX model: no API key, no inference-time
+# network call. ONNX Runtime is loaded dynamically, so point ORT_DYLIB_PATH at an
+# onnxruntime shared library (>= 1.24); the model weights are fetched once on
+# first use and then served from disk. Bring it up with the normal run path:
 #
-#     ANTHROPIC_API_KEY=sk-... laminardb --config pipeline.toml
+#     ORT_DYLIB_PATH=/path/to/onnxruntime.so laminardb --config pipeline.toml
 #
 # Everything below runs in LaminarDB. The dashboard (dashboard/) only draws what
 # these views emit — it computes nothing.
@@ -118,16 +121,16 @@ FROM sentiment_price_join;
 """
 
 # ── AI runtime ───────────────────────────────────────────────────────────
-# Remote sentiment scorer. Bursts of crypto posts are shaped by the token
-# bucket; the API key is read from the named env var, never stored here.
-[ai.providers.anthropic]
-api_key_env = "ANTHROPIC_API_KEY"
-requests_per_second = 10
+# Local ONNX sentiment scorer. The model is a DistilBERT SST-2 classifier; the
+# engine softmaxes its logits to a signed score in [-1, 1] and derives the
+# positive/negative labels from the model's own config.json. Weights download
+# once into cache_dir, then load from disk on every restart.
+[ai.providers.local]
+cache_dir = "./models"
 
 [models.sentiment]
-kind = "remote"
-provider = "anthropic"
-model = "claude-haiku-4-5-20251001"
+kind = "local"
+source = "hf:onnx-community/distilbert-base-uncased-finetuned-sst-2-english-ONNX"
 task = "sentiment"
 
 [ai.defaults]

--- a/examples/demos/crypto_sentiment/pipeline.toml
+++ b/examples/demos/crypto_sentiment/pipeline.toml
@@ -9,14 +9,9 @@
 # Everything below runs in LaminarDB. The dashboard (dashboard/) only draws what
 # these views emit — it computes nothing.
 #
-# Time model: processing-time. `WATERMARK FOR ts AS PROCTIME()` advances each
-# window on the server's wall clock, so 1-minute buckets close on processing
-# time with no event-time skew to tune. `ts` carries each feed's own server
-# timestamp purely so a row lands in the wall-clock minute it arrived in.
-#
-# Delivery: both feeds are non-replayable WebSockets, so the pipeline is
-# at-most-once. That is the right contract for live monitoring; checkpoint
-# interval is tunable. (No exactly-once claim.)
+# Processing-time model: `WATERMARK FOR ts AS PROCTIME()` closes the 1-minute
+# windows on the server's wall clock. Both feeds are non-replayable WebSockets,
+# so delivery is at-most-once (the right contract for live monitoring).
 
 sql = """
 -- ── Sources ──────────────────────────────────────────────────────────────
@@ -116,7 +111,7 @@ SELECT
     price,
     mean_sentiment,
     posts,
-    CORR(price, mean_sentiment) OVER (ORDER BY bucket_start ROWS 30 PRECEDING) AS corr_30
+    CORR(price, mean_sentiment) OVER (ORDER BY bucket_start ROWS 29 PRECEDING) AS corr_30
 FROM sentiment_price_join;
 """
 

--- a/examples/demos/crypto_sentiment/pipeline.toml
+++ b/examples/demos/crypto_sentiment/pipeline.toml
@@ -121,16 +121,16 @@ FROM sentiment_price_join;
 """
 
 # ── AI runtime ───────────────────────────────────────────────────────────
-# Local ONNX sentiment scorer. The model is a DistilBERT SST-2 classifier; the
-# engine softmaxes its logits to a signed score in [-1, 1] and derives the
-# positive/negative labels from the model's own config.json. Weights download
-# once into cache_dir, then load from disk on every restart.
+# Local ONNX sentiment scorer. FinBERT — BERT fine-tuned on financial text —
+# classifies positive / negative / neutral; the engine softmaxes its logits to a
+# signed score in [-1, 1], reading the labels from the model's own config.json.
+# Weights download once into cache_dir, then load from disk on every restart.
 [ai.providers.local]
 cache_dir = "./models"
 
 [models.sentiment]
 kind = "local"
-source = "hf:onnx-community/distilbert-base-uncased-finetuned-sst-2-english-ONNX"
+source = "hf:Xenova/finbert"
 task = "sentiment"
 
 [ai.defaults]

--- a/examples/demos/crypto_sentiment/pipeline.toml
+++ b/examples/demos/crypto_sentiment/pipeline.toml
@@ -1,0 +1,142 @@
+# Crypto price × Bluesky sentiment — one pipeline, scored and correlated in the
+# engine. Bring it up with the normal server run path:
+#
+#     ANTHROPIC_API_KEY=sk-... laminardb --config pipeline.toml
+#
+# Everything below runs in LaminarDB. The dashboard (dashboard/) only draws what
+# these views emit — it computes nothing.
+#
+# Time model: processing-time. `WATERMARK FOR ts AS PROCTIME()` advances each
+# window on the server's wall clock, so 1-minute buckets close on processing
+# time with no event-time skew to tune. `ts` carries each feed's own server
+# timestamp purely so a row lands in the wall-clock minute it arrived in.
+#
+# Delivery: both feeds are non-replayable WebSockets, so the pipeline is
+# at-most-once. That is the right contract for live monitoring; checkpoint
+# interval is tunable. (No exactly-once claim.)
+
+sql = """
+-- ── Sources ──────────────────────────────────────────────────────────────
+
+-- Binance BTCUSDT trades. p/q arrive as JSON strings; the decoder coerces them
+-- to DOUBLE. T is the trade time (epoch millis) → the wall-clock minute key.
+CREATE SOURCE binance_trades (
+    sym VARCHAR,
+    price DOUBLE,
+    qty DOUBLE,
+    ts TIMESTAMP,
+    WATERMARK FOR ts AS PROCTIME()
+) FROM WEBSOCKET (
+    url = 'wss://stream.binance.com:9443/ws/btcusdt@trade',
+    format = 'json',
+    'json.column.sym' = 's',
+    'json.column.price' = 'p',
+    'json.column.qty' = 'q',
+    'json.column.ts' = 'T',
+    'json.column.ts.epoch_unit' = 'millis'
+) FORMAT JSON;
+
+-- Bluesky Jetstream posts. time_us is the relay's server time (epoch micros);
+-- device `createdAt` clocks run minutes off and would poison a tight bucket.
+CREATE SOURCE bluesky_posts (
+    did VARCHAR,
+    operation VARCHAR,
+    text VARCHAR,
+    ts TIMESTAMP,
+    WATERMARK FOR ts AS PROCTIME()
+) FROM WEBSOCKET (
+    url = 'wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=app.bsky.feed.post',
+    format = 'json',
+    'json.column.did' = 'did',
+    'json.column.operation' = 'commit.operation',
+    'json.column.text' = 'commit.record.text',
+    'json.column.ts' = 'time_us',
+    'json.column.ts.epoch_unit' = 'micros'
+) FORMAT JSON;
+
+-- ── Crypto filter, before scoring ────────────────────────────────────────
+-- Drop non-crypto posts here so ai_sentiment never spends a call on them.
+CREATE STREAM bsky_crypto_raw AS
+SELECT did, text, ts
+FROM bluesky_posts
+WHERE operation = 'create'
+  AND text IS NOT NULL
+  AND ( text ILIKE '%bitcoin%' OR text ILIKE '%btc%' OR text ILIKE '%ethereum%'
+        OR text ILIKE '%$btc%' OR text ILIKE '%$eth%' );
+
+-- ── Sentiment scored inline (Ring 1), returns a DOUBLE in [-1, 1] ─────────
+-- One ai_sentiment call per row, batched + deduped through the AI operator and
+-- the foyer cache; every call is visible in laminar.ai_calls.
+CREATE STREAM bsky_crypto AS
+SELECT did, text, ts, ai_sentiment(text) AS sentiment
+FROM bsky_crypto_raw;
+
+-- ── 1-minute processing-time windows, both sides ─────────────────────────
+CREATE MATERIALIZED VIEW price_1m AS
+SELECT
+    TUMBLE(ts, INTERVAL '1' MINUTE) AS bucket_start,
+    AVG(price) AS price,
+    MAX(price) AS high,
+    MIN(price) AS low,
+    SUM(qty)   AS volume,
+    COUNT(*)   AS trades
+FROM binance_trades
+GROUP BY TUMBLE(ts, INTERVAL '1' MINUTE)
+EMIT ON WINDOW CLOSE;
+
+CREATE MATERIALIZED VIEW sentiment_1m AS
+SELECT
+    TUMBLE(ts, INTERVAL '1' MINUTE) AS bucket_start,
+    AVG(sentiment) AS mean_sentiment,
+    COUNT(*)       AS posts
+FROM bsky_crypto
+GROUP BY TUMBLE(ts, INTERVAL '1' MINUTE)
+EMIT ON WINDOW CLOSE;
+
+-- ── Join on the shared bucket, then rolling correlation ──────────────────
+-- The join matches a minute on both sides as their windows close in the same
+-- cycle (no watermark dependency). The correlation is computed in-engine over
+-- the last 30 one-minute bars, carrying the cross-moments (the engine's
+-- sliding CORR), not rolled up from per-bucket values.
+CREATE MATERIALIZED VIEW sentiment_price_join AS
+SELECT
+    p.bucket_start    AS bucket_start,
+    p.price           AS price,
+    s.mean_sentiment  AS mean_sentiment,
+    s.posts           AS posts
+FROM price_1m p
+JOIN sentiment_1m s ON p.bucket_start = s.bucket_start;
+
+CREATE MATERIALIZED VIEW sentiment_price_1m AS
+SELECT
+    bucket_start,
+    price,
+    mean_sentiment,
+    posts,
+    CORR(price, mean_sentiment) OVER (ORDER BY bucket_start ROWS 30 PRECEDING) AS corr_30
+FROM sentiment_price_join;
+"""
+
+# ── AI runtime ───────────────────────────────────────────────────────────
+# Remote sentiment scorer. Bursts of crypto posts are shaped by the token
+# bucket; the API key is read from the named env var, never stored here.
+[ai.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+requests_per_second = 10
+
+[models.sentiment]
+kind = "remote"
+provider = "anthropic"
+model = "claude-haiku-4-5-20251001"
+task = "sentiment"
+
+[ai.defaults]
+sentiment = "sentiment"
+
+# ── Server ───────────────────────────────────────────────────────────────
+# Tail any view live over pgwire, e.g.  psql -h 127.0.0.1 -p 5432
+#   SUBSCRIBE sentiment_price_1m;
+#   SUBSCRIBE bsky_crypto;
+[server]
+bind        = "127.0.0.1:7777"
+pgwire_bind = "127.0.0.1:5432"


### PR DESCRIPTION
A real-time demo — live BTC price correlated against Bluesky crypto sentiment, scored by `ai_sentiment()` on a local ONNX model — plus the engine fixes uncovered while building it. Runs from a single config file, no cluster.

## Engine fixes
- **fix: PROCTIME watermark dropped every row at the source.** `WATERMARK FOR ts AS PROCTIME()` produces a wall-clock watermark; the source-side late-filter compared each row's (past) event-time `ts` against it and dropped 100% of rows before any window saw them. Added `WatermarkGenerator::is_processing_time()`; the filter is skipped for processing-time sources (windows still close on the wall-clock watermark).
- **fix: MV/stream `FROM <stream>` failed to plan.** Streams were registered in the catalog but never as a DataFusion table provider, so a downstream `CREATE MATERIALIZED VIEW … FROM <stream>` couldn't resolve the name. `handle_create_stream` now registers an `EmptyTable` placeholder for the stream's output schema at DDL time (plan-time only; data still flows through the operator graph).
- **feat: processing-time join + sliding moment-frame operators.** DataFusion can't serve these (HashJoin memoizes its build side; corr/covar accumulators lack `retract_batch`). The join is a bounded, watermark-evicted symmetric hash join for two windowed views whose buckets close in different cycles; the frame operator does sliding `CORR`/`COVAR_SAMP`/`COVAR_POP` two-pass mean-centered (stable at large magnitudes), with numeric args coerced to f64.
- **feat: lazy local-classifier labels.** A local model that auto-downloads on first use had its labels read once at startup — before the model existed — so it scored `null` until a restart. Labels now resolve from the cached model when startup labels are absent.

## Demo
- `examples/demos/crypto_sentiment/` — `pipeline.toml` (sources → crypto filter → `ai_sentiment()` → 1-min windows → join → rolling `CORR()`), scored on a local DistilBERT-SST-2 ONNX model that auto-downloads on first use. Remote LLM is a one-line config swap.
- Dashboard: a small page fed by `bridge.py`, which `SUBSCRIBE`s to the views over the Postgres wire protocol and forwards rows as SSE. The page computes nothing — every number is a row from a view.

## Validation
- 714 `laminar-db` lib tests, 33 watermark tests, `clippy -D warnings`, `cargo fmt` — all green.
- Verified live end to end: sources connect, windows emit, the local model scores real firehose posts, the join matches, and `corr_30` populates — confirmed over pgwire and through the dashboard.

## Notes
- Sentiment runs on-device, so post text never leaves the host. Local backend needs ONNX Runtime ≥ 1.24 via `ORT_DYLIB_PATH`.
- The model cache (`models/`) is gitignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live BTC price × Bluesky sentiment demo from a single `pipeline.toml`, with local ONNX scoring (FinBERT by default) and a thin SSE dashboard. Introduces numeric `ai_sentiment()` scores, sliding `CORR`/covariance frames, a processing‑time MV‑to‑MV join, request rate limiting, and robustness fixes across planning and joins.

- New Features
  - `ai_sentiment(text)` now returns a `Float64` score in [-1, 1]; remote sentiment needs no labels; local classifier labels resolve lazily after first download.
  - Sliding `CORR`/`COVAR_SAMP`/`COVAR_POP` over `ROWS N PRECEDING` via a new window‑frame operator (two‑pass, `f64` coercion, numerically stable).
  - Processing‑time equi‑join for windowed views with watermark‑evicted symmetric hash join; planner routes MV‑to‑MV joins here.
  - Client‑side rate limiting for remote providers using `governor`; configure per provider with `requests_per_second` in `ai.providers.*`.
  - Demo: `examples/demos/crypto_sentiment/` (Binance + Bluesky sources, inline `ai_sentiment()`, 1‑min MVs, MV‑to‑MV join, 30‑bucket rolling `CORR()`), defaulting to a local FinBERT ONNX model, plus an SSE dashboard fed by a pgwire bridge.

- Bug Fixes
  - Skip source late‑filtering for `PROCTIME` watermarks so rows aren’t dropped; windows still close on wall clock.
  - Register stream output schemas at DDL time so `CREATE MATERIALIZED VIEW … FROM <stream>` plans successfully; roll back catalog/connector registration if placeholder registration fails.
  - Planner: remove stale entries from `windowed_views` on non‑windowed `CREATE OR REPLACE` to avoid misclassifying joins.
  - Processing‑time join: memory backstop now evicts the oldest slice instead of dropping an entire batch.
  - Dashboard: silence SSE tracebacks on client disconnects by catching `OSError`; bound per‑client queues and add heartbeats; `CORR` window corrected to `ROWS 29 PRECEDING` for a true 30‑bucket window.

<sup>Written for commit 169a7980ffbf59f997de27721664335ce49e68b2. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

