### PR TITLE
ci(docker): fix Trivy scan failing on stale pinned version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -252,10 +252,13 @@ jobs:
         run: echo "short=$(echo '${{ github.sha }}' | head -c 7)" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: "${{ env.GHCR_IMAGE }}:sha-${{ steps.sha.outputs.short }}"
-          version: "v0.69.2"
+          # Track the latest Trivy release. Pinning an old binary breaks the
+          # scan once the vulnerability-DB schema advances past it; the action
+          # itself stays pinned for supply-chain reproducibility.
+          version: "latest"
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL"


### PR DESCRIPTION
The container security scan was failing because the Trivy binary was pinned to an old release (`v0.69.2`). Once Trivy's vulnerability-DB schema advances past a pinned binary, the scan errors out ("database schema version doesn't match Trivy version") rather than reporting findings.

## Change
- Bump `aquasecurity/trivy-action` `0.35.0 → 0.36.0`.
- Track the latest Trivy release (`version: "latest"`) instead of re-pinning a fixed binary, so the scan can't go stale again. The **action** stays pinned for supply-chain reproducibility; only the scanner binary floats.

`severity: CRITICAL`, `ignore-unfixed: true`, and the existing `.trivyignore` are unchanged, so the scan still fails only on fixable CRITICAL vulnerabilities.

Scoped to `.github/workflows/docker.yml`; no application or image changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker CI Trivy scan failing due to a stale pinned binary. Updates `aquasecurity/trivy-action` to 0.36.0 and sets the Trivy binary to track the latest release in `.github/workflows/docker.yml` to keep the DB schema in sync.

<sup>Written for commit 5a0771398f7653bbae24ed84792852b4f9db5407. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/398?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

