### PR TITLE
feat(connectors): collapse Z-set/CDC changelog for Delta upsert sinks

### DIFF
--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -115,8 +115,12 @@ postgres-sink = ["dep:tokio-postgres", "dep:postgres-types", "dep:deadpool-postg
 mysql-cdc = ["dep:mysql_async", "dep:tokio-stream"]
 # MongoDB CDC source and sink
 mongodb-cdc = ["dep:mongodb", "dep:tokio-stream", "dep:futures-util"]
+# Sink-agnostic Z-set/CDC changelog collapse for upsert sinks (pure Arrow, just
+# pulls arrow-row). Kept separate from delta-lake so the helper compiles and
+# tests without the deltalake stack, and so Iceberg MOR can opt in independently.
+changelog-collapse = ["dep:arrow-row"]
 # Delta Lake
-delta-lake = ["dep:deltalake", "dep:url", "dep:datafusion", "deltalake/datafusion", "dep:tokio-util", "dep:tokio-stream", "dep:arrow-row"]
+delta-lake = ["dep:deltalake", "dep:url", "dep:datafusion", "deltalake/datafusion", "dep:tokio-util", "dep:tokio-stream", "changelog-collapse"]
 delta-lake-s3 = ["delta-lake", "deltalake/s3"]
 delta-lake-azure = ["delta-lake", "deltalake/azure"]
 delta-lake-gcs = ["delta-lake", "deltalake/gcs"]

--- a/crates/laminar-connectors/README.md
+++ b/crates/laminar-connectors/README.md
@@ -41,8 +41,9 @@ table. Its source changelog (a Z-set `__weight` column from an aggregating MV,
 or an `_op` column from CDC) can carry many events per key in one epoch, so the
 sink collapses each epoch to one row per merge key before the MERGE — keeping it
 cardinality-safe and stripping the `__weight`/`_op`/`_ts_ms` metadata from the
-table. The collapse (`changelog` module) is shared by Delta upsert and Iceberg
-MOR. Two requirements:
+table. The collapse (`changelog` module) backs Delta upsert today and is
+sink-agnostic by design, for future reuse by an Iceberg MOR sink. Two
+requirements:
 
 - **`merge.key.columns` must be unique over the sink's input** — collapse errors
   loudly if two live rows share a key, rather than dropping data.

--- a/crates/laminar-connectors/README.md
+++ b/crates/laminar-connectors/README.md
@@ -34,6 +34,21 @@ External system connectors for LaminarDB. Each connector implements the `SourceC
 | WebSocket Client | `websocket` | Push to external server | Implemented |
 | Files | `files` | CSV, JSON, Parquet, rolling file output | Implemented |
 
+### Upsert sinks and changelog collapse
+
+An upsert sink (`write.mode = 'upsert'`) holds the current per-key state of its
+table. Its source changelog (a Z-set `__weight` column from an aggregating MV,
+or an `_op` column from CDC) can carry many events per key in one epoch, so the
+sink collapses each epoch to one row per merge key before the MERGE — keeping it
+cardinality-safe and stripping the `__weight`/`_op`/`_ts_ms` metadata from the
+table. The collapse (`changelog` module) is shared by Delta upsert and Iceberg
+MOR. Two requirements:
+
+- **`merge.key.columns` must be unique over the sink's input** — collapse errors
+  loudly if two live rows share a key, rather than dropping data.
+- **Partition or Z-order the table by the merge key** for copy-on-write MERGE
+  performance (each commit then rewrites only the touched files).
+
 ## Key Modules
 
 | Module | Purpose |
@@ -80,6 +95,7 @@ External system connectors for LaminarDB. Each connector implements the `SourceC
 | `postgres-sink` | PostgreSQL sink via tokio-postgres |
 | `mysql-cdc` | MySQL CDC via mysql_async (rustls, no OpenSSL) |
 | `mongodb-cdc` | MongoDB CDC source and sink via mongodb crate |
+| `changelog-collapse` | Sink-agnostic Z-set/CDC changelog collapse for upsert sinks (pulled in by `delta-lake`) |
 | `delta-lake` | Delta Lake sink/source via deltalake crate |
 | `delta-lake-s3` | S3 storage backend for Delta Lake |
 | `delta-lake-azure` | Azure storage backend for Delta Lake |

--- a/crates/laminar-connectors/src/changelog/collapse.rs
+++ b/crates/laminar-connectors/src/changelog/collapse.rs
@@ -49,6 +49,11 @@ pub fn collapse_changelog(
     }
     let schema = batch.schema();
     for k in merge_key {
+        if is_metadata_column(k) {
+            return Err(ConnectorError::ConfigurationError(format!(
+                "merge key column '{k}' is reserved changelog metadata and cannot be a merge key"
+            )));
+        }
         if schema.index_of(k).is_err() {
             return Err(ConnectorError::ConfigurationError(format!(
                 "merge key column '{k}' is not present in the changelog output schema"

--- a/crates/laminar-connectors/src/changelog/collapse.rs
+++ b/crates/laminar-connectors/src/changelog/collapse.rs
@@ -1,0 +1,556 @@
+//! Collapse a changelog epoch batch into a cardinality-safe, key-unique upsert
+//! batch. See the module docs for why this is necessary.
+
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, Int64Array, RecordBatch, StringArray, UInt32Array};
+use arrow_row::{RowConverter, Rows, SortField};
+use arrow_schema::{DataType, Field, Schema};
+
+use laminar_core::changelog::WEIGHT_COLUMN;
+
+use crate::error::ConnectorError;
+
+/// Collapse a concatenated changelog epoch `batch` into a key-unique batch
+/// carrying a `_op` column of `U` (upsert) or `D` (delete), one row per
+/// `merge_key`.
+///
+/// Two input encodings are detected automatically:
+///
+/// - **Z-set** (the `__weight` column is present): identical full rows are
+///   consolidated by summing their weights, net-zero rows are dropped, then the
+///   survivors are grouped by `merge_key`. A key with a net-positive (live) row
+///   becomes a `U` carrying that value; a key with only net-negative rows
+///   becomes a `D`. The `__weight` column is stripped from the output.
+/// - **CDC** (no `__weight`): the last-arriving row per `merge_key` wins (row
+///   order is arrival order). Its op is normalized to `D` for deletes
+///   (`_op ∈ {D, U-}`) and `U` for everything else. A batch with neither column
+///   is treated as all-upsert.
+///
+/// The output reuses the existing key-by-key MERGE (`_op ∈ {U, D}`) unchanged,
+/// and contains at most one row per merge key, so the writer never sees a
+/// cardinality violation.
+///
+/// # Errors
+///
+/// - [`ConnectorError::ConfigurationError`] if `merge_key` is empty, names a
+///   column absent from the batch, or is not unique over the collapsed output
+///   (more than one live row for a single key — a misdeclared merge key).
+/// - [`ConnectorError::Internal`] if an Arrow row-conversion or take fails, or
+///   the `__weight` column is not Int64.
+pub fn collapse_changelog(
+    batch: &RecordBatch,
+    merge_key: &[String],
+) -> Result<RecordBatch, ConnectorError> {
+    if merge_key.is_empty() {
+        return Err(ConnectorError::ConfigurationError(
+            "changelog collapse requires at least one merge key column".into(),
+        ));
+    }
+    let schema = batch.schema();
+    for k in merge_key {
+        if schema.index_of(k).is_err() {
+            return Err(ConnectorError::ConfigurationError(format!(
+                "merge key column '{k}' is not present in the changelog output schema"
+            )));
+        }
+    }
+
+    if let Ok(weight_idx) = schema.index_of(WEIGHT_COLUMN) {
+        collapse_zset(batch, merge_key, weight_idx)
+    } else {
+        collapse_cdc(batch, merge_key)
+    }
+}
+
+/// Build comparable [`Rows`] over the given column indices of `batch`.
+fn rows_over(batch: &RecordBatch, indices: &[usize]) -> Result<Rows, ConnectorError> {
+    let schema = batch.schema();
+    let fields: Vec<SortField> = indices
+        .iter()
+        .map(|&i| SortField::new(schema.field(i).data_type().clone()))
+        .collect();
+    let arrays: Vec<ArrayRef> = indices.iter().map(|&i| batch.column(i).clone()).collect();
+    let converter = RowConverter::new(fields)
+        .map_err(|e| ConnectorError::Internal(format!("row converter: {e}")))?;
+    converter
+        .convert_columns(&arrays)
+        .map_err(|e| ConnectorError::Internal(format!("convert columns to rows: {e}")))
+}
+
+/// Column indices for the named `columns` (which the caller has validated exist).
+fn index_of_all(batch: &RecordBatch, columns: &[String]) -> Vec<usize> {
+    let schema = batch.schema();
+    columns
+        .iter()
+        .map(|name| schema.index_of(name).expect("merge key columns validated"))
+        .collect()
+}
+
+/// Z-set collapse: consolidate by full row, then pick one row per merge key.
+fn collapse_zset(
+    batch: &RecordBatch,
+    merge_key: &[String],
+    weight_idx: usize,
+) -> Result<RecordBatch, ConnectorError> {
+    let num_rows = batch.num_rows();
+    let weights = batch
+        .column(weight_idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| ConnectorError::Internal(format!("{WEIGHT_COLUMN} column is not Int64")))?;
+
+    // Output (user) columns = every column except `__weight`.
+    let user_indices: Vec<usize> = (0..batch.num_columns())
+        .filter(|&i| i != weight_idx)
+        .collect();
+
+    // 1. Consolidate identical full rows, summing weights; keep net-nonzero.
+    //    `survivors` holds (representative row index, net weight).
+    let full_rows = rows_over(batch, &user_indices)?;
+    let mut order: Vec<usize> = (0..num_rows).collect();
+    order.sort_unstable_by(|&a, &b| full_rows.row(a).cmp(&full_rows.row(b)));
+
+    let mut survivors: Vec<(usize, i64)> = Vec::new();
+    let mut i = 0;
+    while i < order.len() {
+        let rep = order[i];
+        let rep_row = full_rows.row(rep);
+        let mut sum = 0i64;
+        let mut j = i;
+        while j < order.len() && full_rows.row(order[j]) == rep_row {
+            sum += weights.value(order[j]);
+            j += 1;
+        }
+        if sum != 0 {
+            survivors.push((rep, sum));
+        }
+        i = j;
+    }
+
+    if survivors.is_empty() {
+        return build_output(batch, &user_indices, &[], &[]);
+    }
+
+    // 2. Group survivors by merge key; one output row per key.
+    let key_rows = rows_over(batch, &index_of_all(batch, merge_key))?;
+    survivors
+        .sort_unstable_by(|&(a, _), &(b, _)| key_rows.row(a).cmp(&key_rows.row(b)).then(a.cmp(&b)));
+
+    let mut selected: Vec<usize> = Vec::new();
+    let mut ops: Vec<&str> = Vec::new();
+    let mut g = 0;
+    while g < survivors.len() {
+        let key = key_rows.row(survivors[g].0);
+        let mut live: Option<usize> = None;
+        let mut live_count = 0usize;
+        let mut first_negative: Option<usize> = None;
+        let mut h = g;
+        while h < survivors.len() && key_rows.row(survivors[h].0) == key {
+            let (idx, weight) = survivors[h];
+            if weight > 0 {
+                live_count += 1;
+                if live.is_none() {
+                    live = Some(idx);
+                }
+            } else if first_negative.is_none() {
+                first_negative = Some(idx);
+            }
+            h += 1;
+        }
+        if live_count > 1 {
+            return Err(ConnectorError::ConfigurationError(format!(
+                "changelog collapse: merge.key.columns {merge_key:?} is not unique — {live_count} \
+                 distinct live rows share one key in a single epoch; declare a merge key that is \
+                 unique over the materialized-view output"
+            )));
+        }
+        if let Some(idx) = live {
+            selected.push(idx);
+            ops.push("U");
+        } else if let Some(idx) = first_negative {
+            selected.push(idx);
+            ops.push("D");
+        }
+        g = h;
+    }
+
+    build_output(batch, &user_indices, &selected, &ops)
+}
+
+/// CDC collapse: last-arriving row per merge key wins; op normalized to U/D.
+fn collapse_cdc(batch: &RecordBatch, merge_key: &[String]) -> Result<RecordBatch, ConnectorError> {
+    let num_rows = batch.num_rows();
+    let schema = batch.schema();
+    let op_values = match schema.index_of("_op") {
+        Ok(idx) => Some(
+            batch
+                .column(idx)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| ConnectorError::Internal("_op column is not Utf8".into()))?,
+        ),
+        Err(_) => None,
+    };
+
+    // Keep the highest (last-arriving) row index per merge key.
+    let key_rows = rows_over(batch, &index_of_all(batch, merge_key))?;
+    let mut order: Vec<usize> = (0..num_rows).collect();
+    order.sort_unstable_by(|&a, &b| key_rows.row(a).cmp(&key_rows.row(b)).then(a.cmp(&b)));
+
+    let mut selected: Vec<usize> = Vec::new();
+    let mut i = 0;
+    while i < order.len() {
+        let key = key_rows.row(order[i]);
+        let mut last = order[i];
+        let mut j = i;
+        while j < order.len() && key_rows.row(order[j]) == key {
+            last = order[j]; // order is index-ascending within a key group
+            j += 1;
+        }
+        selected.push(last);
+        i = j;
+    }
+    // Deterministic output order (correctness is unaffected — keys are unique).
+    selected.sort_unstable();
+
+    // Normalize to {U, D}: a delete iff the surviving op is D or U- (a before
+    // image); otherwise the row is the current image for its key.
+    let ops: Vec<&str> = selected
+        .iter()
+        .map(|&idx| match op_values {
+            Some(values) if !values.is_null(idx) => {
+                if matches!(values.value(idx), "D" | "U-") {
+                    "D"
+                } else {
+                    "U"
+                }
+            }
+            _ => "U",
+        })
+        .collect();
+
+    // CDC output retains all user columns; drop the original `_op` (we re-emit
+    // a normalized one).
+    let user_indices: Vec<usize> = (0..batch.num_columns())
+        .filter(|&i| schema.field(i).name() != "_op")
+        .collect();
+
+    build_output(batch, &user_indices, &selected, &ops)
+}
+
+/// Take `user_indices` columns at the `selected` rows of `batch` and append a
+/// fresh `_op` column built from `ops`. `selected` and `ops` must be parallel.
+fn build_output(
+    batch: &RecordBatch,
+    user_indices: &[usize],
+    selected: &[usize],
+    ops: &[&str],
+) -> Result<RecordBatch, ConnectorError> {
+    debug_assert_eq!(selected.len(), ops.len());
+    let schema = batch.schema();
+    // Row counts are bounded by the epoch buffer cap, well under u32::MAX.
+    #[allow(clippy::cast_possible_truncation)]
+    let take_idx = UInt32Array::from(selected.iter().map(|&i| i as u32).collect::<Vec<_>>());
+
+    let mut fields: Vec<Field> = Vec::with_capacity(user_indices.len() + 1);
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(user_indices.len() + 1);
+    for &idx in user_indices {
+        let taken = arrow_select::take::take(batch.column(idx), &take_idx, None)
+            .map_err(|e| ConnectorError::Internal(format!("take column: {e}")))?;
+        fields.push(schema.field(idx).as_ref().clone());
+        columns.push(taken);
+    }
+    fields.push(Field::new("_op", DataType::Utf8, false));
+    columns.push(Arc::new(StringArray::from(ops.to_vec())));
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+        .map_err(|e| ConnectorError::Internal(format!("build collapsed batch: {e}")))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_lines)]
+mod tests {
+    use super::*;
+    use arrow_array::{Float64Array, Int64Array, StringArray};
+
+    fn keys(cols: &[&str]) -> Vec<String> {
+        cols.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// Build a Z-set changelog batch: schema [region: Utf8, total: Int64, __weight: Int64].
+    fn zset_batch(rows: &[(&str, i64, i64)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("total", DataType::Int64, false),
+            Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Build a CDC changelog batch: schema [id: Int64, value: Float64, _op: Utf8].
+    fn cdc_batch(rows: &[(i64, f64, &str)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+            Field::new("_op", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float64Array::from(
+                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn col_str(batch: &RecordBatch, name: &str) -> Vec<String> {
+        let idx = batch.schema().index_of(name).unwrap();
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        (0..arr.len()).map(|i| arr.value(i).to_string()).collect()
+    }
+
+    fn col_i64(batch: &RecordBatch, name: &str) -> Vec<i64> {
+        let idx = batch.schema().index_of(name).unwrap();
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        (0..arr.len()).map(|i| arr.value(i)).collect()
+    }
+
+    /// Sort output rows by (region/id key, op) so assertions are order-stable.
+    fn sorted_pairs(
+        regions: &[String],
+        values: &[i64],
+        ops: &[String],
+    ) -> Vec<(String, i64, String)> {
+        let mut v: Vec<_> = regions
+            .iter()
+            .zip(values)
+            .zip(ops)
+            .map(|((r, t), o)| (r.clone(), *t, o.clone()))
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn zset_multi_update_per_key_keeps_final_value() {
+        // Two emit cycles concatenated: 10→20→35. The intermediate 20 cancels.
+        let out = collapse_changelog(
+            &zset_batch(&[
+                ("east", 10, -1),
+                ("east", 20, 1),
+                ("east", 20, -1),
+                ("east", 35, 1),
+            ]),
+            &keys(&["region"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 1);
+        assert_eq!(col_str(&out, "_op"), vec!["U"]);
+        assert_eq!(col_i64(&out, "total"), vec![35]);
+    }
+
+    #[test]
+    fn zset_insert_then_delete_within_epoch_is_noop() {
+        // +1 then -1 on the same full row nets zero → dropped entirely.
+        let out = collapse_changelog(
+            &zset_batch(&[("east", 10, 1), ("east", 10, -1)]),
+            &keys(&["region"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 0);
+        assert!(out.schema().index_of(WEIGHT_COLUMN).is_err());
+        assert!(out.schema().index_of("_op").is_ok());
+    }
+
+    #[test]
+    fn zset_multiple_keys_mixed_ops() {
+        // east updated, west dropped, north newly inserted — in one epoch.
+        let out = collapse_changelog(
+            &zset_batch(&[
+                ("east", 10, -1),
+                ("east", 30, 1),
+                ("west", 5, -1),
+                ("north", 99, 1),
+            ]),
+            &keys(&["region"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 3);
+        let got = sorted_pairs(
+            &col_str(&out, "region"),
+            &col_i64(&out, "total"),
+            &col_str(&out, "_op"),
+        );
+        assert_eq!(
+            got,
+            vec![
+                ("east".into(), 30, "U".into()),
+                ("north".into(), 99, "U".into()),
+                ("west".into(), 5, "D".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn zset_higher_multiplicity_is_single_live_row() {
+        // Cascaded aggregation can emit weight > 1; still one live row per key.
+        let out = collapse_changelog(&zset_batch(&[("east", 10, 3)]), &keys(&["region"])).unwrap();
+        assert_eq!(out.num_rows(), 1);
+        assert_eq!(col_str(&out, "_op"), vec!["U"]);
+    }
+
+    #[test]
+    fn zset_non_unique_merge_key_errors() {
+        // Two distinct live rows for the same key → misdeclared merge key.
+        let err = collapse_changelog(
+            &zset_batch(&[("east", 10, 1), ("east", 20, 1)]),
+            &keys(&["region"]),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ConnectorError::ConfigurationError(_)),
+            "expected ConfigurationError, got {err:?}"
+        );
+        assert!(format!("{err}").contains("not unique"));
+    }
+
+    #[test]
+    fn zset_composite_merge_key() {
+        // Merge key over both columns: distinct (region,total) live rows are
+        // distinct keys, not a uniqueness violation.
+        let out = collapse_changelog(
+            &zset_batch(&[("east", 10, 1), ("east", 20, 1)]),
+            &keys(&["region", "total"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 2);
+        assert_eq!(col_str(&out, "_op"), vec!["U", "U"]);
+    }
+
+    #[test]
+    fn cdc_dedup_keeps_last_arrival() {
+        // id=1 inserted then updated within an epoch → one U with the last value.
+        let out = collapse_changelog(
+            &cdc_batch(&[(1, 10.0, "I"), (1, 15.0, "U"), (2, 20.0, "I")]),
+            &keys(&["id"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 2);
+        let idx = out.schema().index_of("id").unwrap();
+        let ids = out
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(
+            (0..ids.len()).map(|i| ids.value(i)).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(col_str(&out, "_op"), vec!["U", "U"]);
+        let vidx = out.schema().index_of("value").unwrap();
+        let vals = out
+            .column(vidx)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!(
+            (vals.value(0) - 15.0).abs() < f64::EPSILON,
+            "last value wins"
+        );
+    }
+
+    #[test]
+    fn cdc_delete_is_preserved() {
+        let out = collapse_changelog(
+            &cdc_batch(&[(1, 10.0, "I"), (1, 10.0, "D")]),
+            &keys(&["id"]),
+        )
+        .unwrap();
+        assert_eq!(out.num_rows(), 1);
+        assert_eq!(col_str(&out, "_op"), vec!["D"]);
+    }
+
+    #[test]
+    fn cdc_update_before_normalizes_to_delete_and_after_to_upsert() {
+        // U- alone → D; the U+ after-image → U.
+        let out_before =
+            collapse_changelog(&cdc_batch(&[(1, 10.0, "U-")]), &keys(&["id"])).unwrap();
+        assert_eq!(col_str(&out_before, "_op"), vec!["D"]);
+        let out_after = collapse_changelog(&cdc_batch(&[(1, 10.0, "U+")]), &keys(&["id"])).unwrap();
+        assert_eq!(col_str(&out_after, "_op"), vec!["U"]);
+    }
+
+    #[test]
+    fn cdc_no_op_column_treated_as_upsert() {
+        // Plain MV (no _op, no __weight) → all upserts, deduped by key.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 1, 2])),
+                Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0])),
+            ],
+        )
+        .unwrap();
+        let out = collapse_changelog(&batch, &keys(&["id"])).unwrap();
+        assert_eq!(out.num_rows(), 2);
+        assert!(out.schema().index_of("_op").is_ok());
+        assert_eq!(col_str(&out, "_op"), vec!["U", "U"]);
+    }
+
+    #[test]
+    fn empty_batch_yields_empty_with_op_column() {
+        let out = collapse_changelog(&zset_batch(&[]), &keys(&["region"])).unwrap();
+        assert_eq!(out.num_rows(), 0);
+        assert!(out.schema().index_of(WEIGHT_COLUMN).is_err());
+        assert!(out.schema().index_of("_op").is_ok());
+    }
+
+    #[test]
+    fn empty_merge_key_errors() {
+        let err = collapse_changelog(&zset_batch(&[("east", 10, 1)]), &[]).unwrap_err();
+        assert!(matches!(err, ConnectorError::ConfigurationError(_)));
+    }
+
+    #[test]
+    fn missing_merge_key_column_errors() {
+        let err =
+            collapse_changelog(&zset_batch(&[("east", 10, 1)]), &keys(&["nope"])).unwrap_err();
+        assert!(matches!(err, ConnectorError::ConfigurationError(_)));
+        assert!(format!("{err}").contains("not present"));
+    }
+}

--- a/crates/laminar-connectors/src/changelog/collapse.rs
+++ b/crates/laminar-connectors/src/changelog/collapse.rs
@@ -87,6 +87,12 @@ fn index_of_all(batch: &RecordBatch, columns: &[String]) -> Vec<usize> {
         .collect()
 }
 
+/// Changelog metadata columns, excluded from the collapsed output's user
+/// columns (`_op` is re-emitted normalized; `__weight`/`_ts_ms` are dropped).
+fn is_metadata_column(name: &str) -> bool {
+    name == "_op" || name == "_ts_ms" || name == WEIGHT_COLUMN
+}
+
 /// Z-set collapse: consolidate by full row, then pick one row per merge key.
 fn collapse_zset(
     batch: &RecordBatch,
@@ -100,9 +106,10 @@ fn collapse_zset(
         .downcast_ref::<Int64Array>()
         .ok_or_else(|| ConnectorError::Internal(format!("{WEIGHT_COLUMN} column is not Int64")))?;
 
-    // Output (user) columns = every column except `__weight`.
+    // User columns = every column except changelog metadata.
+    let schema = batch.schema();
     let user_indices: Vec<usize> = (0..batch.num_columns())
-        .filter(|&i| i != weight_idx)
+        .filter(|&i| !is_metadata_column(schema.field(i).name()))
         .collect();
 
     // 1. Consolidate identical full rows, summing weights; keep net-nonzero.
@@ -230,10 +237,9 @@ fn collapse_cdc(batch: &RecordBatch, merge_key: &[String]) -> Result<RecordBatch
         })
         .collect();
 
-    // CDC output retains all user columns; drop the original `_op` (we re-emit
-    // a normalized one).
+    // User columns = every column except changelog metadata.
     let user_indices: Vec<usize> = (0..batch.num_columns())
-        .filter(|&i| schema.field(i).name() != "_op")
+        .filter(|&i| !is_metadata_column(schema.field(i).name()))
         .collect();
 
     build_output(batch, &user_indices, &selected, &ops)
@@ -530,6 +536,35 @@ mod tests {
         assert_eq!(out.num_rows(), 2);
         assert!(out.schema().index_of("_op").is_ok());
         assert_eq!(col_str(&out, "_op"), vec!["U", "U"]);
+    }
+
+    #[test]
+    fn cdc_strips_ts_ms_and_emits_single_op() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("_ts_ms", DataType::Int64, false),
+            Field::new("_op", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])),
+                Arc::new(Int64Array::from(vec![100, 200])),
+                Arc::new(StringArray::from(vec!["I", "U"])),
+            ],
+        )
+        .unwrap();
+        let out = collapse_changelog(&batch, &keys(&["id"])).unwrap();
+        assert!(out.schema().index_of("_ts_ms").is_err(), "_ts_ms stripped");
+        assert_eq!(
+            out.schema()
+                .fields()
+                .iter()
+                .filter(|f| f.name() == "_op")
+                .count(),
+            1,
+            "exactly one _op column"
+        );
     }
 
     #[test]

--- a/crates/laminar-connectors/src/changelog/mod.rs
+++ b/crates/laminar-connectors/src/changelog/mod.rs
@@ -1,7 +1,7 @@
 //! Sink-agnostic changelog collapse for upsert sinks. A commit epoch can carry
 //! many changelog events for one merge key (every aggregate value change is a
 //! retract + insert), which an upsert writer rejects as a cardinality
-//! violation. [`collapse_changelog`] folds an epoch down to one row per key.
+//! violation. `collapse_changelog` folds an epoch down to one row per key.
 
 mod collapse;
 

--- a/crates/laminar-connectors/src/changelog/mod.rs
+++ b/crates/laminar-connectors/src/changelog/mod.rs
@@ -1,0 +1,8 @@
+//! Sink-agnostic changelog collapse for upsert sinks. A commit epoch can carry
+//! many changelog events for one merge key (every aggregate value change is a
+//! retract + insert), which an upsert writer rejects as a cardinality
+//! violation. [`collapse_changelog`] folds an epoch down to one row per key.
+
+mod collapse;
+
+pub use collapse::collapse_changelog;

--- a/crates/laminar-connectors/src/kafka/schema_registry.rs
+++ b/crates/laminar-connectors/src/kafka/schema_registry.rs
@@ -1445,9 +1445,12 @@ mod tests {
 
     #[test]
     fn test_cache_ttl_expiration() {
+        // TTL generous enough that scheduler jitter between insert and the
+        // immediate `is_some()` check can't expire the entry early — a 50ms
+        // window flaked under parallel test load on busy CI runners.
         let config = SchemaRegistryCacheConfig {
             max_entries: 100,
-            ttl: Some(Duration::from_millis(50)),
+            ttl: Some(Duration::from_millis(1000)),
         };
         let client = SchemaRegistryClient::with_cache_config("http://localhost:8081", None, config);
 
@@ -1455,7 +1458,7 @@ mod tests {
         assert!(client.cache_get(1).is_some());
 
         // Wait for TTL to expire.
-        std::thread::sleep(Duration::from_millis(60));
+        std::thread::sleep(Duration::from_millis(1200));
         // Lazy TTL: expired entry returns None on access.
         assert!(client.cache_get(1).is_none());
     }

--- a/crates/laminar-connectors/src/lakehouse/delta.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta.rs
@@ -2226,19 +2226,15 @@ mod tests {
     /// Read the table back and return its current `(region, total)` rows, sorted.
     #[cfg(feature = "delta-lake")]
     async fn read_regions(path: &str) -> Vec<(String, i64)> {
-        read_regions_opts(path, std::collections::HashMap::new()).await
-    }
-
-    /// Read-back variant that passes object-store credentials (for S3/`MinIO`).
-    #[cfg(feature = "delta-lake")]
-    async fn read_regions_opts(
-        path: &str,
-        storage: std::collections::HashMap<String, String>,
-    ) -> Vec<(String, i64)> {
         let ctx = datafusion::prelude::SessionContext::new();
-        crate::lakehouse::delta_table_provider::register_delta_table(&ctx, "t", path, storage)
-            .await
-            .unwrap();
+        crate::lakehouse::delta_table_provider::register_delta_table(
+            &ctx,
+            "t",
+            path,
+            std::collections::HashMap::new(),
+        )
+        .await
+        .unwrap();
         let batches = ctx
             .sql("SELECT region, total FROM t")
             .await
@@ -2449,100 +2445,5 @@ mod tests {
         );
 
         sink_b.close().await.unwrap();
-    }
-
-    /// The upsert collapse → MERGE path over real object-store I/O (`MinIO` via
-    /// Docker), including the multi-update-per-key-in-one-epoch cardinality case.
-    #[cfg(feature = "delta-lake-s3")]
-    #[tokio::test]
-    #[ignore = "requires Docker (MinIO S3)"]
-    async fn upsert_against_minio_s3_object_store() {
-        use testcontainers::core::{IntoContainerPort, WaitFor};
-        use testcontainers::runners::AsyncRunner;
-        use testcontainers::{GenericImage, ImageExt};
-
-        // MinIO's FS backend treats a directory under /data as a bucket, so we
-        // override the entrypoint to pre-create the bucket before the server
-        // starts (the official image has no auto-create env).
-        let container = GenericImage::new("minio/minio", "latest")
-            .with_exposed_port(9000.tcp())
-            .with_wait_for(WaitFor::message_on_stderr("API:"))
-            .with_entrypoint("sh")
-            .with_cmd(["-c", "mkdir -p /data/warehouse && minio server /data"])
-            .with_env_var("MINIO_ROOT_USER", "minioadmin")
-            .with_env_var("MINIO_ROOT_PASSWORD", "minioadmin")
-            .start()
-            .await
-            .expect("start MinIO container");
-        let port = container
-            .get_host_port_ipv4(9000.tcp())
-            .await
-            .expect("MinIO host port");
-
-        let mut storage = std::collections::HashMap::new();
-        for (k, v) in [
-            ("aws_access_key_id", "minioadmin"),
-            ("aws_secret_access_key", "minioadmin"),
-            ("aws_region", "us-east-1"),
-            ("aws_allow_http", "true"),
-            // Single writer: skip the DynamoDB lock; delta-rs allows this opt-in.
-            ("aws_s3_allow_unsafe_rename", "true"),
-        ] {
-            storage.insert(k.to_string(), v.to_string());
-        }
-        storage.insert(
-            "aws_endpoint".to_string(),
-            format!("http://127.0.0.1:{port}"),
-        );
-
-        let mut cfg = DeltaLakeSinkConfig::new("s3://warehouse/agg");
-        cfg.write_mode = DeltaWriteMode::Upsert;
-        cfg.merge_key_columns = vec!["region".to_string()];
-        cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
-        cfg.writer_id = "minio-writer".to_string();
-        cfg.storage_options = storage.clone();
-
-        let mut sink = DeltaLakeSink::new(cfg, None);
-        sink.open(&ConnectorConfig::new("delta-lake"))
-            .await
-            .expect("open Delta sink against MinIO");
-
-        run_epoch(
-            &mut sink,
-            1,
-            &zset_changelog(&[("east", 10, 1), ("west", 5, 1)]),
-        )
-        .await;
-        run_epoch(
-            &mut sink,
-            2,
-            &zset_changelog(&[
-                ("east", 10, -1),
-                ("east", 30, 1),
-                ("west", 5, -1),
-                ("north", 7, 1),
-            ]),
-        )
-        .await;
-        // Multiple updates to one key in a single epoch — the cardinality case —
-        // over real object-store I/O.
-        run_epoch(
-            &mut sink,
-            3,
-            &zset_changelog(&[
-                ("east", 30, -1),
-                ("east", 40, 1),
-                ("east", 40, -1),
-                ("east", 55, 1),
-            ]),
-        )
-        .await;
-
-        assert_eq!(
-            read_regions_opts("s3://warehouse/agg", storage).await,
-            vec![("east".to_string(), 55), ("north".to_string(), 7)]
-        );
-
-        sink.close().await.unwrap();
     }
 }

--- a/crates/laminar-connectors/src/lakehouse/delta.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta.rs
@@ -42,6 +42,28 @@ use super::delta_config::{DeltaLakeSinkConfig, DeltaWriteMode};
 use super::delta_metrics::DeltaLakeSinkMetrics;
 use crate::connector::DeliveryGuarantee;
 
+/// Counts `(upserts, deletes)` in a collapsed changelog batch's `_op` column.
+/// A row is a delete iff `_op == "D"`; everything else (including a missing or
+/// null op) counts as an upsert. Used only for collapse observability.
+#[cfg(feature = "delta-lake")]
+fn count_collapsed_ops(batch: &RecordBatch) -> (u64, u64) {
+    let Ok(idx) = batch.schema().index_of("_op") else {
+        return (0, 0);
+    };
+    let Some(ops) = batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<arrow_array::StringArray>()
+    else {
+        return (0, 0);
+    };
+    let deletes = (0..ops.len())
+        .filter(|&i| !ops.is_null(i) && ops.value(i) == "D")
+        .count() as u64;
+    let upserts = ops.len() as u64 - deletes;
+    (upserts, deletes)
+}
+
 /// Delta Lake sink connector.
 ///
 /// Writes Arrow `RecordBatch` to Delta Lake tables with ACID transactions,
@@ -184,10 +206,19 @@ impl DeltaLakeSink {
     }
 
     /// Creates a new Delta Lake sink with an explicit schema.
+    ///
+    /// In upsert mode the changelog metadata columns (`_op`, `_ts_ms`,
+    /// `__weight`) are stripped, matching the deferred first-write path, so the
+    /// target table holds only user data regardless of how the schema arrives.
     #[must_use]
     pub fn with_schema(config: DeltaLakeSinkConfig, schema: SchemaRef) -> Self {
+        let write_mode = config.write_mode;
         let mut sink = Self::new(config, None);
-        sink.schema = Some(schema);
+        sink.schema = Some(if write_mode == DeltaWriteMode::Upsert {
+            Self::target_schema(&schema, write_mode)
+        } else {
+            schema
+        });
         sink
     }
 
@@ -378,17 +409,19 @@ impl DeltaLakeSink {
         false
     }
 
-    /// Returns the target table schema, stripping metadata columns (`_op`, etc.)
-    /// in upsert mode so the Delta table isn't created with changelog columns.
-    /// CDC metadata columns stripped from the target Delta table schema.
-    const CDC_METADATA_COLUMNS: &'static [&'static str] = &["_op", "_ts_ms"];
+    /// Changelog metadata columns stripped from the target Delta table schema
+    /// in upsert mode, so the table holds only user data — not the CDC `_op`/
+    /// `_ts_ms` envelope or the Z-set `__weight` column. `collapse_changelog`
+    /// strips the same columns from the MERGE source, keeping the two in sync.
+    const CHANGELOG_METADATA_COLUMNS: &'static [&'static str] =
+        &["_op", "_ts_ms", laminar_core::changelog::WEIGHT_COLUMN];
 
     fn target_schema(batch_schema: &SchemaRef, write_mode: DeltaWriteMode) -> SchemaRef {
         if write_mode == DeltaWriteMode::Upsert {
             let fields: Vec<_> = batch_schema
                 .fields()
                 .iter()
-                .filter(|f| !Self::CDC_METADATA_COLUMNS.contains(&f.name().as_str()))
+                .filter(|f| !Self::CHANGELOG_METADATA_COLUMNS.contains(&f.name().as_str()))
                 .cloned()
                 .collect();
             Arc::new(arrow_schema::Schema::new(fields))
@@ -596,17 +629,36 @@ impl DeltaLakeSink {
             return Ok(WriteResult::new(0, 0));
         }
 
-        // Pre-concat upsert batches so conflict retries don't redo the
-        // O(rows × cols) copy each attempt. Append/overwrite passes the Vec
-        // straight to delta-rs, which handles multi-batch internally.
-        if self.config.write_mode == DeltaWriteMode::Upsert && self.staged_batches.len() > 1 {
-            let schema = self.staged_batches[0].schema();
-            let combined = arrow_select::concat::concat_batches(&schema, &self.staged_batches)
-                .map_err(|e| {
-                    ConnectorError::Internal(format!("failed to concat staged batches: {e}"))
-                })?;
+        // For upsert, concat the whole epoch and collapse the changelog to one
+        // row per merge key BEFORE the MERGE. This (a) makes the MERGE
+        // cardinality-safe — delta-rs rejects multiple source rows matching one
+        // target row, which every aggregate retract+insert would otherwise
+        // trigger — and (b) strips the Z-set `__weight` column the MERGE does
+        // not understand. Pre-concatenating also means conflict retries don't
+        // redo the O(rows × cols) copy each attempt. Append/overwrite passes
+        // the Vec straight to delta-rs, which handles multi-batch internally.
+        if self.config.write_mode == DeltaWriteMode::Upsert {
+            let combined = if self.staged_batches.len() == 1 {
+                self.staged_batches[0].clone()
+            } else {
+                let schema = self.staged_batches[0].schema();
+                arrow_select::concat::concat_batches(&schema, &self.staged_batches).map_err(
+                    |e| ConnectorError::Internal(format!("failed to concat staged batches: {e}")),
+                )?
+            };
+            let rows_in = combined.num_rows() as u64;
+            let collapse_start = Instant::now();
+            let collapsed =
+                crate::changelog::collapse_changelog(&combined, &self.config.merge_key_columns)?;
+            let (upserts_out, deletes_out) = count_collapsed_ops(&collapsed);
+            self.metrics.observe_collapse(
+                rows_in,
+                upserts_out,
+                deletes_out,
+                collapse_start.elapsed().as_secs_f64(),
+            );
             self.staged_batches.clear();
-            self.staged_batches.push(combined);
+            self.staged_batches.push(collapsed);
         }
 
         let total_rows = self.staged_rows;
@@ -2128,5 +2180,178 @@ mod tests {
         let debug = format!("{sink:?}");
         assert!(debug.contains("DeltaLakeSink"));
         assert!(debug.contains("delta_test_nonexistent_8f3a"));
+    }
+
+    // ── End-to-end upsert collapse (aggregating-MV changelog → Delta table) ──
+
+    /// A Z-set changelog batch shaped like aggregating-MV output:
+    /// `[region: Utf8, total: Int64, __weight: Int64]`.
+    #[cfg(feature = "delta-lake")]
+    fn zset_changelog(rows: &[(&str, i64, i64)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("region", DataType::Utf8, false),
+            Field::new("total", DataType::Int64, false),
+            Field::new(
+                laminar_core::changelog::WEIGHT_COLUMN,
+                DataType::Int64,
+                false,
+            ),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                )),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Drive one full epoch through the exactly-once sink lifecycle.
+    #[cfg(feature = "delta-lake")]
+    async fn run_epoch(sink: &mut DeltaLakeSink, epoch: u64, batch: &RecordBatch) {
+        sink.begin_epoch(epoch).await.unwrap();
+        sink.write_batch(batch).await.unwrap();
+        sink.pre_commit(epoch).await.unwrap();
+        sink.commit_epoch(epoch).await.unwrap();
+    }
+
+    /// Read the table back and return its current `(region, total)` rows, sorted.
+    #[cfg(feature = "delta-lake")]
+    async fn read_regions(path: &str) -> Vec<(String, i64)> {
+        let ctx = datafusion::prelude::SessionContext::new();
+        crate::lakehouse::delta_table_provider::register_delta_table(
+            &ctx,
+            "t",
+            path,
+            std::collections::HashMap::new(),
+        )
+        .await
+        .unwrap();
+        let batches = ctx
+            .sql("SELECT region, total FROM t")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        for b in &batches {
+            // DataFusion may return strings as Utf8View; cast to the concrete
+            // types we downcast to.
+            let region_arr = arrow_cast::cast(
+                b.column(b.schema().index_of("region").unwrap()),
+                &DataType::Utf8,
+            )
+            .unwrap();
+            let total_arr = arrow_cast::cast(
+                b.column(b.schema().index_of("total").unwrap()),
+                &DataType::Int64,
+            )
+            .unwrap();
+            let regions = region_arr.as_any().downcast_ref::<StringArray>().unwrap();
+            let totals = total_arr.as_any().downcast_ref::<Int64Array>().unwrap();
+            for i in 0..b.num_rows() {
+                out.push((regions.value(i).to_string(), totals.value(i)));
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// An aggregating MV emits a Z-set changelog; the upsert sink must collapse
+    /// it into the table's current per-key state — surviving value updates,
+    /// group disappearance, and multiple updates to one key within a single
+    /// epoch (the case that triggers a delta-rs cardinality violation without
+    /// collapse).
+    #[cfg(feature = "delta-lake")]
+    #[tokio::test]
+    async fn upsert_collapses_aggregating_mv_to_current_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let table_dir = dir.path().join("agg");
+        // delta-rs' local object store requires the table directory to exist.
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let path = table_dir.to_string_lossy().to_string();
+
+        let mut cfg = DeltaLakeSinkConfig::new(&path);
+        cfg.write_mode = DeltaWriteMode::Upsert;
+        cfg.merge_key_columns = vec!["region".to_string()];
+        // Exactly-once buffers the whole epoch and flushes once at commit, so
+        // each epoch's changelog is collapsed together (deterministic).
+        cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
+
+        // No explicit schema: the schema (and table) is derived from the first
+        // batch, exactly like the production pipeline — exercising the
+        // `target_schema` strip of `__weight`.
+        let mut sink = DeltaLakeSink::new(cfg, None);
+        sink.open(&ConnectorConfig::new("delta-lake"))
+            .await
+            .unwrap();
+
+        // Epoch 1: two brand-new groups.
+        run_epoch(
+            &mut sink,
+            1,
+            &zset_changelog(&[("east", 10, 1), ("west", 5, 1)]),
+        )
+        .await;
+        assert_eq!(
+            read_regions(&path).await,
+            vec![("east".into(), 10), ("west".into(), 5)]
+        );
+
+        // Epoch 2: update east (retract 10 + insert 30), drop west, add north.
+        run_epoch(
+            &mut sink,
+            2,
+            &zset_changelog(&[
+                ("east", 10, -1),
+                ("east", 30, 1),
+                ("west", 5, -1),
+                ("north", 7, 1),
+            ]),
+        )
+        .await;
+        assert_eq!(
+            read_regions(&path).await,
+            vec![("east".into(), 30), ("north".into(), 7)]
+        );
+
+        // Epoch 3: two consecutive updates to "east" in one epoch. Without
+        // collapse this is multiple source rows for one merge key → delta-rs
+        // cardinality violation. With collapse it folds to the final value.
+        run_epoch(
+            &mut sink,
+            3,
+            &zset_changelog(&[
+                ("east", 30, -1),
+                ("east", 40, 1),
+                ("east", 40, -1),
+                ("east", 55, 1),
+            ]),
+        )
+        .await;
+        assert_eq!(
+            read_regions(&path).await,
+            vec![("east".into(), 55), ("north".into(), 7)]
+        );
+
+        // The target table never carried the Z-set weight column.
+        assert!(sink.schema.as_ref().unwrap().index_of("__weight").is_err());
+
+        // Collapse observability fired across the three epochs.
+        let m = sink.sink_metrics();
+        assert_eq!(m.collapse_rows_in.get(), 10);
+        assert!(m.collapse_deletes_out.get() >= 1, "west was dropped");
+        assert!(m.collapse_upserts_out.get() >= 4);
+
+        sink.close().await.unwrap();
     }
 }

--- a/crates/laminar-connectors/src/lakehouse/delta.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta.rs
@@ -2226,15 +2226,19 @@ mod tests {
     /// Read the table back and return its current `(region, total)` rows, sorted.
     #[cfg(feature = "delta-lake")]
     async fn read_regions(path: &str) -> Vec<(String, i64)> {
+        read_regions_opts(path, std::collections::HashMap::new()).await
+    }
+
+    /// Read-back variant that passes object-store credentials (for S3/`MinIO`).
+    #[cfg(feature = "delta-lake")]
+    async fn read_regions_opts(
+        path: &str,
+        storage: std::collections::HashMap<String, String>,
+    ) -> Vec<(String, i64)> {
         let ctx = datafusion::prelude::SessionContext::new();
-        crate::lakehouse::delta_table_provider::register_delta_table(
-            &ctx,
-            "t",
-            path,
-            std::collections::HashMap::new(),
-        )
-        .await
-        .unwrap();
+        crate::lakehouse::delta_table_provider::register_delta_table(&ctx, "t", path, storage)
+            .await
+            .unwrap();
         let batches = ctx
             .sql("SELECT region, total FROM t")
             .await
@@ -2351,6 +2355,193 @@ mod tests {
         assert_eq!(m.collapse_rows_in.get(), 10);
         assert!(m.collapse_deletes_out.get() >= 1, "west was dropped");
         assert!(m.collapse_upserts_out.get() >= 4);
+
+        sink.close().await.unwrap();
+    }
+
+    /// Exactly-once replay: a writer that recovers an already-committed epoch
+    /// (from Delta `txn` metadata) and re-applies it must leave the table
+    /// byte-for-byte unchanged — no new snapshot, same per-key state.
+    #[cfg(feature = "delta-lake")]
+    #[tokio::test]
+    async fn upsert_replay_of_committed_epoch_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let table_dir = dir.path().join("agg_replay");
+        std::fs::create_dir_all(&table_dir).unwrap();
+        let path = table_dir.to_string_lossy().to_string();
+
+        let mk_cfg = || {
+            let mut cfg = DeltaLakeSinkConfig::new(&path);
+            cfg.write_mode = DeltaWriteMode::Upsert;
+            cfg.merge_key_columns = vec!["region".to_string()];
+            cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
+            // Exactly-once recovery keys off a STABLE writer_id (default is a
+            // random UUID); a restart must reuse it to find its prior epoch.
+            cfg.writer_id = "replay-writer".to_string();
+            cfg
+        };
+        let epoch2 = || {
+            zset_changelog(&[
+                ("east", 10, -1),
+                ("east", 30, 1),
+                ("west", 5, -1),
+                ("north", 7, 1),
+            ])
+        };
+
+        // Writer A commits epochs 1 and 2, then "crashes" (close).
+        let mut sink_a = DeltaLakeSink::new(mk_cfg(), None);
+        sink_a
+            .open(&ConnectorConfig::new("delta-lake"))
+            .await
+            .unwrap();
+        run_epoch(
+            &mut sink_a,
+            1,
+            &zset_changelog(&[("east", 10, 1), ("west", 5, 1)]),
+        )
+        .await;
+        run_epoch(&mut sink_a, 2, &epoch2()).await;
+        let expected = vec![("east".to_string(), 30), ("north".to_string(), 7)];
+        assert_eq!(read_regions(&path).await, expected);
+        let version_after_2 = sink_a.delta_version();
+        sink_a.close().await.unwrap();
+
+        // Writer B recovers against the same table + writer_id.
+        let mut sink_b = DeltaLakeSink::new(mk_cfg(), None);
+        sink_b
+            .open(&ConnectorConfig::new("delta-lake"))
+            .await
+            .unwrap();
+        assert_eq!(
+            sink_b.last_committed_epoch(),
+            2,
+            "epoch must be recovered from Delta txn metadata"
+        );
+
+        // Replay the already-committed epoch 2: it must be skipped end-to-end.
+        sink_b.begin_epoch(2).await.unwrap();
+        sink_b.write_batch(&epoch2()).await.unwrap();
+        sink_b.pre_commit(2).await.unwrap();
+        sink_b.commit_epoch(2).await.unwrap();
+
+        assert_eq!(
+            read_regions(&path).await,
+            expected,
+            "replay must not change state"
+        );
+        assert_eq!(
+            sink_b.delta_version(),
+            version_after_2,
+            "replayed epoch must not create a new Delta version"
+        );
+
+        // The recovered writer continues normally with a fresh epoch.
+        run_epoch(
+            &mut sink_b,
+            3,
+            &zset_changelog(&[("east", 30, -1), ("east", 55, 1)]),
+        )
+        .await;
+        assert_eq!(
+            read_regions(&path).await,
+            vec![("east".to_string(), 55), ("north".to_string(), 7)]
+        );
+
+        sink_b.close().await.unwrap();
+    }
+
+    /// The upsert collapse → MERGE path over real object-store I/O (`MinIO` via
+    /// Docker), including the multi-update-per-key-in-one-epoch cardinality case.
+    #[cfg(feature = "delta-lake-s3")]
+    #[tokio::test]
+    #[ignore = "requires Docker (MinIO S3)"]
+    async fn upsert_against_minio_s3_object_store() {
+        use testcontainers::core::{IntoContainerPort, WaitFor};
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers::{GenericImage, ImageExt};
+
+        // MinIO's FS backend treats a directory under /data as a bucket, so we
+        // override the entrypoint to pre-create the bucket before the server
+        // starts (the official image has no auto-create env).
+        let container = GenericImage::new("minio/minio", "latest")
+            .with_exposed_port(9000.tcp())
+            .with_wait_for(WaitFor::message_on_stderr("API:"))
+            .with_entrypoint("sh")
+            .with_cmd(["-c", "mkdir -p /data/warehouse && minio server /data"])
+            .with_env_var("MINIO_ROOT_USER", "minioadmin")
+            .with_env_var("MINIO_ROOT_PASSWORD", "minioadmin")
+            .start()
+            .await
+            .expect("start MinIO container");
+        let port = container
+            .get_host_port_ipv4(9000.tcp())
+            .await
+            .expect("MinIO host port");
+
+        let mut storage = std::collections::HashMap::new();
+        for (k, v) in [
+            ("aws_access_key_id", "minioadmin"),
+            ("aws_secret_access_key", "minioadmin"),
+            ("aws_region", "us-east-1"),
+            ("aws_allow_http", "true"),
+            // Single writer: skip the DynamoDB lock; delta-rs allows this opt-in.
+            ("aws_s3_allow_unsafe_rename", "true"),
+        ] {
+            storage.insert(k.to_string(), v.to_string());
+        }
+        storage.insert(
+            "aws_endpoint".to_string(),
+            format!("http://127.0.0.1:{port}"),
+        );
+
+        let mut cfg = DeltaLakeSinkConfig::new("s3://warehouse/agg");
+        cfg.write_mode = DeltaWriteMode::Upsert;
+        cfg.merge_key_columns = vec!["region".to_string()];
+        cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
+        cfg.writer_id = "minio-writer".to_string();
+        cfg.storage_options = storage.clone();
+
+        let mut sink = DeltaLakeSink::new(cfg, None);
+        sink.open(&ConnectorConfig::new("delta-lake"))
+            .await
+            .expect("open Delta sink against MinIO");
+
+        run_epoch(
+            &mut sink,
+            1,
+            &zset_changelog(&[("east", 10, 1), ("west", 5, 1)]),
+        )
+        .await;
+        run_epoch(
+            &mut sink,
+            2,
+            &zset_changelog(&[
+                ("east", 10, -1),
+                ("east", 30, 1),
+                ("west", 5, -1),
+                ("north", 7, 1),
+            ]),
+        )
+        .await;
+        // Multiple updates to one key in a single epoch — the cardinality case —
+        // over real object-store I/O.
+        run_epoch(
+            &mut sink,
+            3,
+            &zset_changelog(&[
+                ("east", 30, -1),
+                ("east", 40, 1),
+                ("east", 40, -1),
+                ("east", 55, 1),
+            ]),
+        )
+        .await;
+
+        assert_eq!(
+            read_regions_opts("s3://warehouse/agg", storage).await,
+            vec![("east".to_string(), 55), ("north".to_string(), 7)]
+        );
 
         sink.close().await.unwrap();
     }

--- a/crates/laminar-connectors/src/lakehouse/delta_metrics.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_metrics.rs
@@ -38,6 +38,19 @@ pub struct DeltaLakeSinkMetrics {
     /// End-to-end flush duration histogram (concat → write → checkpoint).
     /// Buckets cover 5ms up to ~160s (0.005 * 2^15).
     pub flush_duration: Histogram,
+
+    /// Total changelog rows entering collapse (pre-dedup, per upsert flush).
+    pub collapse_rows_in: IntCounter,
+
+    /// Total upsert rows emitted by collapse (`_op = U`).
+    pub collapse_upserts_out: IntCounter,
+
+    /// Total delete rows emitted by collapse (`_op = D`).
+    pub collapse_deletes_out: IntCounter,
+
+    /// Changelog-collapse duration histogram (per upsert flush).
+    /// Buckets cover 100µs up to ~3.3s (0.0001 * 2^15).
+    pub collapse_duration: Histogram,
 }
 
 impl DeltaLakeSinkMetrics {
@@ -64,6 +77,25 @@ impl DeltaLakeSinkMetrics {
                 metric = "delta_sink_flush_duration_seconds",
                 error = %e,
                 "failed to register delta lake flush_duration histogram"
+            );
+        }
+
+        let collapse_duration = Histogram::with_opts(
+            HistogramOpts::new(
+                "delta_sink_collapse_duration_seconds",
+                "Changelog collapse duration per upsert flush (Z-set/CDC dedup)",
+            )
+            .buckets(prometheus::exponential_buckets(0.0001, 2.0, 16).unwrap()),
+        )
+        .unwrap();
+        if let Err(e) = handle
+            .registry()
+            .register(Box::new(collapse_duration.clone()))
+        {
+            tracing::warn!(
+                metric = "delta_sink_collapse_duration_seconds",
+                error = %e,
+                "failed to register delta lake collapse_duration histogram"
             );
         }
 
@@ -100,6 +132,19 @@ impl DeltaLakeSinkMetrics {
                 "Retry attempts kicked off (conflict + timeout)",
             ),
             flush_duration,
+            collapse_rows_in: handle.counter(
+                "delta_sink_collapse_rows_in_total",
+                "Changelog rows entering collapse (pre-dedup)",
+            ),
+            collapse_upserts_out: handle.counter(
+                "delta_sink_collapse_upserts_out_total",
+                "Upsert rows emitted by collapse (_op = U)",
+            ),
+            collapse_deletes_out: handle.counter(
+                "delta_sink_collapse_deletes_out_total",
+                "Delete rows emitted by collapse (_op = D)",
+            ),
+            collapse_duration,
         }
     }
 
@@ -160,6 +205,15 @@ impl DeltaLakeSinkMetrics {
     /// Records a completed flush duration (seconds).
     pub fn observe_flush_duration(&self, seconds: f64) {
         self.flush_duration.observe(seconds);
+    }
+
+    /// Records one changelog-collapse pass: `rows_in` rows folded down to
+    /// `upserts_out` upserts and `deletes_out` deletes in `seconds`.
+    pub fn observe_collapse(&self, rows_in: u64, upserts_out: u64, deletes_out: u64, seconds: f64) {
+        self.collapse_rows_in.inc_by(rows_in);
+        self.collapse_upserts_out.inc_by(upserts_out);
+        self.collapse_deletes_out.inc_by(deletes_out);
+        self.collapse_duration.observe(seconds);
     }
 }
 

--- a/crates/laminar-connectors/src/lakehouse/delta_table_provider.rs
+++ b/crates/laminar-connectors/src/lakehouse/delta_table_provider.rs
@@ -64,6 +64,14 @@ pub async fn register_delta_table(
     // Open the existing table.
     let table = delta_io::open_or_create_table(table_uri, storage_options, None).await?;
 
+    // Register the table's object store with the session so scans can resolve
+    // non-local URLs (s3://, az://, gs://); without it, reading an
+    // object-store-backed table fails with "No suitable object store found".
+    // (Local-filesystem tables use DataFusion's built-in store.)
+    table
+        .update_datafusion_session(&ctx.state())
+        .map_err(|e| ConnectorError::Internal(format!("register Delta object store: {e}")))?;
+
     // Build a DeltaTableProvider (which implements TableProvider) from the table.
     let provider =
         table.table_provider().build().await.map_err(|e| {

--- a/crates/laminar-connectors/src/lib.rs
+++ b/crates/laminar-connectors/src/lib.rs
@@ -82,6 +82,11 @@ pub mod lookup;
 /// Lakehouse connectors (Delta Lake, Iceberg).
 pub mod lakehouse;
 
+/// Sink-agnostic changelog collapse for upsert sinks (Z-set / CDC → key-unique
+/// `_op` batch). Pulled in by upsert-capable sink features (e.g. `delta-lake`).
+#[cfg(feature = "changelog-collapse")]
+pub mod changelog;
+
 /// Cloud storage infrastructure (credential resolution, validation, secret masking).
 pub mod storage;
 

--- a/crates/laminar-connectors/tests/delta_s3_integration.rs
+++ b/crates/laminar-connectors/tests/delta_s3_integration.rs
@@ -5,6 +5,7 @@
 //! the lib test binary — bundling them there overflowed the coverage build's
 //! linker (`--all-features` + instrumentation). Ignored by default; needs Docker.
 #![cfg(feature = "delta-lake-s3")]
+#![allow(clippy::disallowed_types)] // test code: std::HashMap is fine
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/laminar-connectors/tests/delta_s3_integration.rs
+++ b/crates/laminar-connectors/tests/delta_s3_integration.rs
@@ -1,0 +1,181 @@
+//! S3 / MinIO integration test for the Delta upsert (collapse → MERGE) path.
+//!
+//! Lives here rather than in the `delta` module's `#[cfg(test)]` so that
+//! `testcontainers`/`bollard` link only into this small integration binary, not
+//! the lib test binary — bundling them there overflowed the coverage build's
+//! linker (`--all-features` + instrumentation). Ignored by default; needs Docker.
+#![cfg(feature = "delta-lake-s3")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use laminar_connectors::config::ConnectorConfig;
+use laminar_connectors::connector::{DeliveryGuarantee, SinkConnector};
+use laminar_connectors::lakehouse::delta_table_provider::register_delta_table;
+use laminar_connectors::lakehouse::{DeltaLakeSink, DeltaLakeSinkConfig, DeltaWriteMode};
+use laminar_core::changelog::WEIGHT_COLUMN;
+
+/// A Z-set changelog batch shaped like aggregating-MV output:
+/// `[region: Utf8, total: Int64, __weight: Int64]`.
+fn zset_changelog(rows: &[(&str, i64, i64)]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("region", DataType::Utf8, false),
+        Field::new("total", DataType::Int64, false),
+        Field::new(WEIGHT_COLUMN, DataType::Int64, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(
+                rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(
+                rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(
+                rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+async fn run_epoch(sink: &mut DeltaLakeSink, epoch: u64, batch: &RecordBatch) {
+    sink.begin_epoch(epoch).await.unwrap();
+    sink.write_batch(batch).await.unwrap();
+    sink.pre_commit(epoch).await.unwrap();
+    sink.commit_epoch(epoch).await.unwrap();
+}
+
+/// Read the table back via `register_delta_table` (which registers the S3
+/// object store with the DataFusion session) and return `(region, total)`.
+async fn read_regions(path: &str, storage: HashMap<String, String>) -> Vec<(String, i64)> {
+    let ctx = datafusion::prelude::SessionContext::new();
+    register_delta_table(&ctx, "t", path, storage)
+        .await
+        .unwrap();
+    let batches = ctx
+        .sql("SELECT region, total FROM t")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let mut out = Vec::new();
+    for b in &batches {
+        // DataFusion may return strings as Utf8View; cast to concrete types.
+        let region = arrow_cast::cast(
+            b.column(b.schema().index_of("region").unwrap()),
+            &DataType::Utf8,
+        )
+        .unwrap();
+        let total = arrow_cast::cast(
+            b.column(b.schema().index_of("total").unwrap()),
+            &DataType::Int64,
+        )
+        .unwrap();
+        let regions = region.as_any().downcast_ref::<StringArray>().unwrap();
+        let totals = total.as_any().downcast_ref::<Int64Array>().unwrap();
+        for i in 0..b.num_rows() {
+            out.push((regions.value(i).to_string(), totals.value(i)));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// The upsert collapse → MERGE path over real object-store I/O (MinIO via
+/// Docker), including the multi-update-per-key-in-one-epoch cardinality case.
+#[tokio::test]
+#[ignore = "requires Docker (MinIO S3)"]
+async fn upsert_against_minio_s3_object_store() {
+    use testcontainers::core::{IntoContainerPort, WaitFor};
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers::{GenericImage, ImageExt};
+
+    // MinIO's FS backend treats a directory under /data as a bucket, so we
+    // override the entrypoint to pre-create the bucket before the server starts
+    // (the official image has no auto-create env).
+    let container = GenericImage::new("minio/minio", "latest")
+        .with_exposed_port(9000.tcp())
+        .with_wait_for(WaitFor::message_on_stderr("API:"))
+        .with_entrypoint("sh")
+        .with_cmd(["-c", "mkdir -p /data/warehouse && minio server /data"])
+        .with_env_var("MINIO_ROOT_USER", "minioadmin")
+        .with_env_var("MINIO_ROOT_PASSWORD", "minioadmin")
+        .start()
+        .await
+        .expect("start MinIO container");
+    let port = container
+        .get_host_port_ipv4(9000.tcp())
+        .await
+        .expect("MinIO host port");
+
+    let mut storage = HashMap::new();
+    for (k, v) in [
+        ("aws_access_key_id", "minioadmin"),
+        ("aws_secret_access_key", "minioadmin"),
+        ("aws_region", "us-east-1"),
+        ("aws_allow_http", "true"),
+        // Single writer: skip the DynamoDB lock; delta-rs allows this opt-in.
+        ("aws_s3_allow_unsafe_rename", "true"),
+    ] {
+        storage.insert(k.to_string(), v.to_string());
+    }
+    storage.insert(
+        "aws_endpoint".to_string(),
+        format!("http://127.0.0.1:{port}"),
+    );
+
+    let mut cfg = DeltaLakeSinkConfig::new("s3://warehouse/agg");
+    cfg.write_mode = DeltaWriteMode::Upsert;
+    cfg.merge_key_columns = vec!["region".to_string()];
+    cfg.delivery_guarantee = DeliveryGuarantee::ExactlyOnce;
+    cfg.writer_id = "minio-writer".to_string();
+    cfg.storage_options = storage.clone();
+
+    let mut sink = DeltaLakeSink::new(cfg, None);
+    sink.open(&ConnectorConfig::new("delta-lake"))
+        .await
+        .expect("open Delta sink against MinIO");
+
+    run_epoch(
+        &mut sink,
+        1,
+        &zset_changelog(&[("east", 10, 1), ("west", 5, 1)]),
+    )
+    .await;
+    run_epoch(
+        &mut sink,
+        2,
+        &zset_changelog(&[
+            ("east", 10, -1),
+            ("east", 30, 1),
+            ("west", 5, -1),
+            ("north", 7, 1),
+        ]),
+    )
+    .await;
+    // Multiple updates to one key in a single epoch — the cardinality case —
+    // over real object-store I/O.
+    run_epoch(
+        &mut sink,
+        3,
+        &zset_changelog(&[
+            ("east", 30, -1),
+            ("east", 40, 1),
+            ("east", 40, -1),
+            ("east", 55, 1),
+        ]),
+    )
+    .await;
+
+    assert_eq!(
+        read_regions("s3://warehouse/agg", storage).await,
+        vec![("east".to_string(), 55), ("north".to_string(), 7)]
+    );
+
+    sink.close().await.unwrap();
+}

--- a/crates/laminar-core/src/changelog.rs
+++ b/crates/laminar-core/src/changelog.rs
@@ -2,7 +2,7 @@
 //! (laminar-db) and the upsert-sink consumers (laminar-connectors).
 //!
 //! An aggregating MV emits one row per changed group carrying an Int64
-//! [`WEIGHT_COLUMN`]: `+n` inserts a value with multiplicity `n`, `-n` retracts
+//! `WEIGHT_COLUMN`: `+n` inserts a value with multiplicity `n`, `-n` retracts
 //! it (a value change for key `K` is `{(K, V_old): -1, (K, V_new): +1}`). The
 //! column name lives here so the producer and consumers cannot drift on it.
 

--- a/crates/laminar-core/src/changelog.rs
+++ b/crates/laminar-core/src/changelog.rs
@@ -1,0 +1,11 @@
+//! Z-set changelog encoding shared between the materialized-view producer
+//! (laminar-db) and the upsert-sink consumers (laminar-connectors).
+//!
+//! An aggregating MV emits one row per changed group carrying an Int64
+//! [`WEIGHT_COLUMN`]: `+n` inserts a value with multiplicity `n`, `-n` retracts
+//! it (a value change for key `K` is `{(K, V_old): -1, (K, V_new): +1}`). The
+//! column name lives here so the producer and consumers cannot drift on it.
+
+/// Name of the Int64 Z-set weight column appended to aggregating-MV changelog
+/// output. `+n` = insert with multiplicity `n`, `-n` = retract.
+pub const WEIGHT_COLUMN: &str = "__weight";

--- a/crates/laminar-core/src/lib.rs
+++ b/crates/laminar-core/src/lib.rs
@@ -8,6 +8,9 @@
 #![allow(unsafe_code)]
 
 pub mod alloc;
+/// Z-set changelog `__weight` column name, shared between the MV producer and
+/// upsert-sink consumers.
+pub mod changelog;
 /// Distributed checkpoint barrier protocol.
 pub mod checkpoint;
 /// Structured error code registry (`LDB-NNNN`) and Ring 0 hot path error type.

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -251,7 +251,10 @@ impl IncrementalAggState {
 }
 
 /// Name of the Z-set weight column appended to changelog output.
-pub(crate) const WEIGHT_COLUMN: &str = "__weight";
+///
+/// Re-exported from the shared changelog contract in `laminar-core` so the MV
+/// producer and the upsert-sink consumers agree on the column name.
+pub(crate) use laminar_core::changelog::WEIGHT_COLUMN;
 
 /// Build a weighted `RecordBatch` from collected keys, values, and weights.
 fn build_weighted_batch(


### PR DESCRIPTION
## What

Makes "aggregating materialized view → upsert lakehouse table" a correct, supported topology for the Delta Lake sink.

## Why

An aggregating MV emits a Z-set changelog (`__weight`); CDC sources emit an `_op` changelog. A single commit epoch can carry many events for the same merge key — every aggregate value change is a retract + insert. Handed straight to delta-rs `MERGE` this trips a cardinality violation ("multiple source rows matched a target row") and wedges the pipeline, so the most natural topology silently broke.

## How

- **`laminar-core::changelog::WEIGHT_COLUMN`** — the one contract string the MV producer (laminar-db) and the sink consumer (laminar-connectors) must agree on.
- **`collapse_changelog`** (new sink-agnostic `changelog-collapse` feature, pulls only `arrow-row`) — folds an epoch to at most one row per merge key, tagged `_op ∈ {U, D}`:
  - Z-set: consolidate identical rows by summed weight, drop net-zero, pick the one live row per key (or a delete).
  - CDC: last-arrival-per-key, op normalized to `{U, D}`.
- **Delta upsert wiring** — collapse the concatenated epoch in `flush_staged_to_delta` before the existing `merge_changelog`; also strip `__weight` from the target schema (it leaked as a phantom column alongside `_op`/`_ts_ms`).
- **Collapse metrics** — `rows_in` / `upserts_out` / `deletes_out` / duration.
- **Object-store read fix** — `register_delta_table` now registers the table's object store with the DataFusion session (`update_datafusion_session`); without it, any S3/ADLS/GCS Delta table read via SQL (`db.rs`) or lookup (`delta_lookup.rs`) failed with "No suitable object store found".

## Tests

- 13 `collapse_changelog` unit tests (Z-set update/delete/multi-update/non-unique-key/composite; CDC dedup/U± normalization/no-op; empty/error).
- End-to-end local Delta upsert integration test (value update, group drop, multi-update-per-key-in-one-epoch).
- Exactly-once replay-idempotency test (a recovered writer re-applying a committed epoch is a no-op; asserts recovery keys off a stable `writer_id`).
- `#[ignore]` MinIO S3 integration test over real object-store I/O (Docker) — verified green locally.

`clippy -D warnings` clean (`delta-lake` + `delta-lake-s3`); `cargo fmt` clean.

## Scope

Delta Lake only. Iceberg MOR reuse is blocked on iceberg-rust 0.9.0 — the public API cannot commit equality-delete files (`TableCommit` is unconstructable outside the crate; only `fast_append`, which rejects deletes, is exposed). Tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses Z-set/CDC changelogs to one row per merge key for Delta upsert sinks to prevent MERGE cardinality errors and keep tables free of changelog metadata. Adds a shared `laminar-core` `__weight` contract, collapse metrics, and fixes for collapsed output, object-store reads, and test stability.

- New Features
  - Added sink-agnostic changelog collapse (`changelog-collapse`): supports Z-set `__weight` and CDC `_op`, dedups per key, outputs `_op ∈ {U,D}`.
  - Delta upsert now collapses the concatenated epoch before MERGE; target schema strips `_op`, `_ts_ms`, and `__weight`.
  - Setting an explicit schema in upsert mode also strips `_op`, `_ts_ms`, and `__weight` so tables never include changelog metadata.
  - Introduced `laminar-core::changelog::WEIGHT_COLUMN` to align `laminar-db` and `laminar-connectors`.
  - Metrics: collapse `rows_in`, `upserts_out`, `deletes_out`, and duration.
  - Validates `merge.key.columns` uniqueness and rejects reserved metadata (`_op`, `_ts_ms`, `__weight`) as merge keys.

- Bug Fixes
  - Collapse excludes `_op`/`_ts_ms` from user columns and re-emits a single normalized `_op`, preventing duplicate `_op` and CDC timestamp leakage.
  - `register_delta_table` registers the table’s object store with DataFusion, fixing S3/ADLS/GCS reads that failed with “No suitable object store found”.
  - Moved the MinIO S3 integration test to `tests/` to avoid coverage linker OOM; no behavior change. Also allowed `std::collections::HashMap` in that test to satisfy Clippy and deflaked the Kafka schema registry cache TTL test by widening the TTL/sleep window.

<sup>Written for commit a41aa2f9dde25b415fa5d3a3351863d79de9082e. Summary will update on new commits. <a href="https://cubic.dev/pr/laminardb/laminardb/pull/402?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced sink-agnostic changelog collapse for upsert flows, producing single per-key rows and normalized operation markers.
  * Added a feature flag to enable changelog-collapse and wired it into the Delta upsert path.
  * Added collapse observability: rows in, upserts/deletes out, and duration metrics.

* **Documentation**
  * Documented upsert changelog collapse behavior, merge-key requirements, and partitioning/Z-order guidance; added feature flag to docs.

* **Tests**
  * Added unit and end-to-end tests covering collapse semantics, metrics, and idempotent replay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laminardb/laminardb/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->