### PR TITLE
Potential fix for code scanning alert no. 178: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/laminardb/laminardb/security/code-scanning/178](https://github.com/laminardb/laminardb/security/code-scanning/178)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, so all jobs (including `ci-success`) inherit least-privilege defaults. Since the shown jobs use checkout/build/test/doc/audit style operations and no write actions are visible, the safest non-breaking baseline is:

```yml
permissions:
  contents: read
```

Place this block near the top-level keys (e.g., after `concurrency`), so it applies globally unless a specific job later needs elevated scopes. No imports, methods, or extra definitions are required (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global `permissions` block at the workflow root in `.github/workflows/ci.yml` to resolve code scanning alert 178 and enforce least-privilege defaults across all jobs. Sets `contents: read` so all current and future jobs inherit read-only repo access and avoid unintended write scopes.

<sup>Written for commit 9f18e40fda009c702f85267742beffa9315043b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration of the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->