### PR TITLE
ci: resolve benchmark build failures and update workflow configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,6 @@
 # SQL crate
 /crates/laminar-sql/ @laminardb/core-team
 
-# Storage crate
-/crates/laminar-storage/ @laminardb/core-team
 
 # Connectors
 /crates/laminar-connectors/ @laminardb/core-team @laminardb/integrations

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libelf-dev zlib1g-dev libcurl4-openssl-dev cmake pkg-config libsasl2-dev libudev-dev protobuf-compiler
 
       - name: Build all benchmarks
-        run: cargo build --release -p laminar-core -p laminar-storage --benches
+        run: cargo build --release -p laminar-core -p laminar-db --benches
 
   # Core latency-critical benchmarks
   bench-latency:
@@ -64,9 +64,8 @@ jobs:
 
       - name: Run latency benchmarks
         run: |
-          cargo bench -p laminar-core --bench state_bench -- $BENCH_ARGS 2>&1 | tee results.txt
-          cargo bench -p laminar-core --bench latency_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
-          cargo bench -p laminar-core --bench reactor_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
+          cargo bench -p laminar-core --bench latency_bench -- $BENCH_ARGS 2>&1 | tee results.txt
+          cargo bench -p laminar-core --bench cache_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4
@@ -96,8 +95,7 @@ jobs:
 
       - name: Run DAG benchmarks
         run: |
-          cargo bench -p laminar-core --bench dag_bench -- $BENCH_ARGS 2>&1 | tee results.txt
-          cargo bench -p laminar-core --bench dag_stress -- $BENCH_ARGS 2>&1 | tee -a results.txt
+          cargo bench -p laminar-db --bench stream_executor_bench -- $BENCH_ARGS 2>&1 | tee results.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4
@@ -128,9 +126,8 @@ jobs:
       - name: Run operator benchmarks
         run: |
           cargo bench -p laminar-core --bench window_bench -- $BENCH_ARGS 2>&1 | tee results.txt
-          cargo bench -p laminar-core --bench join_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
+          cargo bench -p laminar-core --bench lookup_join_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
           cargo bench -p laminar-core --bench streaming_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
-          cargo bench -p laminar-core --bench subscription_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4
@@ -160,8 +157,7 @@ jobs:
 
       - name: Run throughput benchmarks
         run: |
-          cargo bench -p laminar-core --bench throughput_bench -- $BENCH_ARGS 2>&1 | tee results.txt
-          cargo bench -p laminar-core --bench tpc_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
+          cargo bench -p laminar-db --bench hot_path_micro -- $BENCH_ARGS 2>&1 | tee results.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4
@@ -191,8 +187,7 @@ jobs:
 
       - name: Run storage benchmarks
         run: |
-          cargo bench -p laminar-storage --bench wal_bench -- $BENCH_ARGS 2>&1 | tee results.txt
-          cargo bench -p laminar-storage --bench checkpoint_bench -- $BENCH_ARGS 2>&1 | tee -a results.txt
+          cargo bench -p laminar-db --bench recovery_bench -- $BENCH_ARGS 2>&1 | tee results.txt
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,12 +358,6 @@ jobs:
       - name: Wait for index
         run: sleep 30
 
-      - name: Publish laminar-storage
-        run: cargo publish -p laminar-storage --registry crates-io --allow-dirty --no-verify
-        continue-on-error: true
-
-      - name: Wait for index
-        run: sleep 30
 
       - name: Publish laminar-connectors
         run: cargo publish -p laminar-connectors --registry crates-io --allow-dirty --no-verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,12 @@ sudo apt-get install cmake pkg-config libsasl2-dev
 
 ## How the project is organized
 
-LaminarDB is a Rust workspace with 7 crates. Here's what each one does:
+LaminarDB is a Rust workspace with 6 crates. Here's what each one does:
 
 | Crate | What it does |
 |-------|-------------|
-| **laminar-core** | The engine. Operators, window assigners, streaming channels (crossfire), checkpoint barrier protocol, lookup tables, time/watermarks, structured error codes. |
+| **laminar-core** | The engine. Operators, window assigners, streaming channels (crossfire), checkpoint barrier protocol, lookup tables, time/watermarks, structured error codes, checkpoint manifests, and object-store checkpoint persistence. |
 | **laminar-sql** | SQL parser with streaming extensions (EMIT, watermarks, windows, ASOF, temporal probe joins), query planner, DataFusion integration, custom UDFs, streaming physical optimizer. |
-| **laminar-storage** | Checkpoint manifests, filesystem/object-store checkpoint persistence, object-store builder. |
 | **laminar-connectors** | All external connectors: Kafka, PostgreSQL CDC, MySQL CDC, MongoDB CDC, Delta Lake, Iceberg, WebSocket, OpenTelemetry (OTLP/gRPC), files, Postgres/Parquet lookup. Also the schema framework and serde layer. |
 | **laminar-db** | The main entry point. Ties everything together -- `StreamingCoordinator` pipeline, checkpoint coordination, recovery, FFI API. |
 | **laminar-derive** | Proc macros: `Record`, `FromRecordBatch`, `FromRow`, `ConnectorConfig`. |

--- a/README.md
+++ b/README.md
@@ -567,9 +567,8 @@ cargo run -p binance-ws
 
 ```text
 crates/
-  laminar-core/        Core engine: operators, windows, streaming channels, checkpoint barriers, error codes
+  laminar-core/        Core engine: operators, windows, streaming channels, checkpoint barriers, error codes, storage/checkpoint stores
   laminar-sql/         SQL parser, planner, DataFusion integration, streaming optimizer, watermark pushdown
-  laminar-storage/     Checkpoint manifest and store (filesystem + object store)
   laminar-connectors/  Kafka, CDC (PG/MySQL/Mongo), WebSocket, Files, Delta Lake, Iceberg, OTEL
   laminar-db/          Unified database facade, StreamingCoordinator, checkpoint coordination, recovery, FFI
   laminar-derive/      Derive macros: Record, FromRecordBatch, FromRow, ConnectorConfig

--- a/crates/laminar-connectors/README.md
+++ b/crates/laminar-connectors/README.md
@@ -142,6 +142,5 @@ registry.register_source("my-source", info, factory_fn);
 
 ## Related Crates
 
-- [`laminar-core`](../laminar-core) -- Streaming channels and sink abstractions
-- [`laminar-storage`](../laminar-storage) -- Checkpoint manifest types
+- [`laminar-core`](../laminar-core) -- Streaming channels, sink abstractions, and checkpoint manifest types
 - [`laminar-db`](../laminar-db) -- Connector manager and checkpoint coordinator

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -286,11 +286,8 @@ impl ConnectorPipelineCallback {
             Ok(Some(a)) if a.phase == Phase::Prepare => a,
             _ => return None,
         };
-        if Self::follower_should_skip(
-            self.last_follower_epoch,
-            self.pending_follower_checkpoint.as_ref().map(|p| p.epoch),
-            ann.epoch,
-        ) {
+        let in_flight = self.pending_follower_checkpoint.as_ref().map(|p| p.epoch);
+        if Self::follower_should_skip(self.last_follower_epoch, in_flight, ann.epoch) {
             return None;
         }
 

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -126,8 +126,10 @@ pub(crate) struct ConnectorPipelineCallback {
     /// non-leaders.
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
-    /// Highest epoch a non-leader has already prepared for. Prevents
-    /// re-running `follower_checkpoint` on the same announcement.
+    /// Highest epoch this non-leader has successfully committed; dedups the
+    /// leader's idempotent `Prepare` re-announcements. Advanced only on commit
+    /// (see [`Self::follower_should_skip`]). In-flight deferred epochs are
+    /// tracked by [`Self::pending_follower_checkpoint`].
     #[cfg(feature = "cluster")]
     pub(crate) last_follower_epoch: Option<u64>,
     /// Local source barrier injectors to trigger follower-side checkpoints.
@@ -257,6 +259,20 @@ impl ConnectorPipelineCallback {
         Ok(result)
     }
 
+    /// Skip a follower `Prepare` for `ann_epoch` only if it is already
+    /// committed (`last_committed`) or already in flight as a deferred
+    /// checkpoint (`in_flight`). A failed checkpoint does not advance
+    /// `last_committed`, and the leader retries the same epoch (it advances
+    /// only on success), so the retry must be reprocessed, not deduped.
+    #[cfg(feature = "cluster")]
+    fn follower_should_skip(
+        last_committed: Option<u64>,
+        in_flight: Option<u64>,
+        ann_epoch: u64,
+    ) -> bool {
+        last_committed.is_some_and(|e| e >= ann_epoch) || in_flight.is_some_and(|e| e >= ann_epoch)
+    }
+
     #[cfg(feature = "cluster")]
     async fn maybe_follower_checkpoint(
         &mut self,
@@ -270,10 +286,13 @@ impl ConnectorPipelineCallback {
             Ok(Some(a)) if a.phase == Phase::Prepare => a,
             _ => return None,
         };
-        if self.last_follower_epoch.is_some_and(|e| e >= ann.epoch) {
+        if Self::follower_should_skip(
+            self.last_follower_epoch,
+            self.pending_follower_checkpoint.as_ref().map(|p| p.epoch),
+            ann.epoch,
+        ) {
             return None;
         }
-        self.last_follower_epoch = Some(ann.epoch);
 
         // Inject barriers into local sources so they flow through this node's
         // streaming tasks and emit the shuffle barriers required for alignment.
@@ -360,6 +379,8 @@ impl ConnectorPipelineCallback {
             Ok(true) => {
                 tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
                 self.last_checkpoint = std::time::Instant::now();
+                // Record only on commit so a failed-then-retried epoch is not deduped.
+                self.last_follower_epoch = Some(follower_epoch);
                 Some(follower_epoch)
             }
             Ok(false) => {
@@ -460,6 +481,10 @@ impl ConnectorPipelineCallback {
             Ok(true) => {
                 tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
                 self.last_checkpoint = std::time::Instant::now();
+                // Record only on commit; the caller already took
+                // `pending_follower_checkpoint`, so a failed deferred checkpoint
+                // leaves no dedup state and the leader's retry is reprocessed.
+                self.last_follower_epoch = Some(follower_epoch);
                 BarrierOutcome::Committed(follower_epoch)
             }
             Ok(false) => {
@@ -1756,5 +1781,67 @@ mod tests {
             Some(800),
             "source below cluster min must NOT be advanced by the cap",
         );
+    }
+
+    /// A committed (or older) epoch re-announced by the leader is deduped.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_skips_already_committed_or_older_epoch() {
+        assert!(ConnectorPipelineCallback::follower_should_skip(
+            Some(5),
+            None,
+            5
+        ));
+        assert!(ConnectorPipelineCallback::follower_should_skip(
+            Some(5),
+            None,
+            3
+        ));
+    }
+
+    /// A deferred epoch awaiting local barriers (tracked via the in-flight
+    /// arg) is deduped so its injectors aren't re-triggered each cycle.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_skips_in_flight_deferred_epoch() {
+        assert!(ConnectorPipelineCallback::follower_should_skip(
+            Some(4),
+            Some(5),
+            5
+        ));
+    }
+
+    /// Regression: a failed checkpoint doesn't advance the committed epoch, and
+    /// the leader retries the same epoch, so the retry must be reprocessed —
+    /// not deduped. The old code recorded the epoch before commit and wedged.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_reprocesses_retry_of_failed_epoch() {
+        // Epoch 5 failed: committed is still 4, nothing in flight, leader retries 5.
+        assert!(!ConnectorPipelineCallback::follower_should_skip(
+            Some(4),
+            None,
+            5
+        ));
+        // Same on a fresh follower whose first epoch failed.
+        assert!(!ConnectorPipelineCallback::follower_should_skip(
+            None, None, 5
+        ));
+    }
+
+    /// A higher epoch is always processed.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_processes_newer_epoch() {
+        assert!(!ConnectorPipelineCallback::follower_should_skip(
+            Some(5),
+            None,
+            6
+        ));
+        assert!(!ConnectorPipelineCallback::follower_should_skip(
+            Some(5),
+            Some(5),
+            6
+        ));
     }
 }

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -302,5 +302,4 @@ See [deploy/README.md](../../deploy/README.md) for binary downloads, Docker, and
 
 - [`laminar-db`](../laminar-db) -- Database facade
 - [`laminar-connectors`](../laminar-connectors) -- External system connectors
-- [`laminar-core`](../laminar-core) -- Streaming engine
-- [`laminar-storage`](../laminar-storage) -- Checkpoint storage
+- [`laminar-core`](../laminar-core) -- Streaming engine and checkpoint storage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ and injects/aligns checkpoint barriers (Chandy-Lamport protocol).
 Durability and I/O, runs on the main tokio async runtime (not the compute thread).
 
 **Components:**
-- **Checkpoint Coordinator** -- Orchestrates periodic full-state snapshots with manifest-based persistence via two-phase commit across exactly-once sinks (`laminar-db/src/checkpoint_coordinator.rs`). Manifests are written via filesystem or object store (`laminar-storage/src/checkpoint_store.rs`).
+- **Checkpoint Coordinator** -- Orchestrates periodic full-state snapshots with manifest-based persistence via two-phase commit across exactly-once sinks (`laminar-db/src/checkpoint_coordinator.rs`). Manifests are written via filesystem or object store (`crates/laminar-core/src/checkpoint/checkpoint_store.rs`).
 - **Recovery Manager** -- Loads the latest checkpoint manifest and restores operator state, connector offsets, and watermarks on startup (`laminar-db/src/recovery_manager.rs`).
 - **Connectors** -- External source/sink connectors (Kafka, CDC, Delta Lake, Iceberg, WebSocket, OTEL, Files) run as tokio tasks on the main runtime.
 
@@ -130,16 +130,15 @@ How an event moves through the system:
 ```text
 laminar-core          Core: operators, window assigners, time/watermarks,
                       streaming channels (crossfire), subscriptions,
-                      lookup tables, checkpoint barrier protocol, error codes
+                      lookup tables, checkpoint barrier protocol, error codes,
+                      checkpoint persistence: manifest, checkpoint store
+                      (filesystem + object store), object store builder
                       |
 laminar-sql           SQL parser (streaming extensions), query planner,
                       DataFusion integration, operator config translators,
                       custom UDFs (tumble, hop, session, slide, first_value, last_value),
                       streaming physical optimizer, cooperative scheduling,
                       PROCTIME() UDF, temporal probe join translator
-                      |
-laminar-storage       Checkpoint persistence: manifest, checkpoint store
-                      (filesystem + object store), object store builder
                       |
 laminar-connectors    Kafka source/sink, PostgreSQL CDC/sink, MySQL CDC,
                       MongoDB CDC source/sink, WebSocket source/sink,

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -24,9 +24,8 @@ LaminarDB is pre-1.0. Single-node embedded and standalone server deployments are
 
 ## Crates
 
-- [laminar-core](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-core/README.md): Operators, windows, streaming channels, checkpoint barriers
+- [laminar-core](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-core/README.md): Operators, windows, streaming channels, checkpoint barriers, storage/checkpoint stores
 - [laminar-sql](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-sql/README.md): SQL parser, planner, DataFusion integration, temporal probe translator
-- [laminar-storage](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-storage/README.md): Checkpoint manifest and store, object store builder
 - [laminar-db](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-db/README.md): Unified facade, StreamingCoordinator, recovery, checkpoint coordinator
 - [laminar-server](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-server/README.md): HTTP and WebSocket server binary
 - [laminar-derive](https://raw.githubusercontent.com/laminardb/laminardb/main/crates/laminar-derive/README.md): Procedural macros for typed records


### PR DESCRIPTION
Removes references to the consolidated laminar-storage crate across CI workflows, CODEOWNERS, and documentation, and updates the benchmark configurations to run active benchmarks in laminar-core and laminar-db. Also adjusts the follower pipeline callback checkpointing to handle retry scenarios without deduping failed epochs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes benchmark CI by removing `laminar-storage` references and targeting active benches, and hardens follower checkpoint retries so failed epochs aren’t incorrectly deduped. This unblocks bench runs and makes follower checkpointing resilient to leader re-announcements.

- **Bug Fixes**
  - Advance follower dedupe state only on commit; retries of failed epochs are reprocessed.
  - Track in-flight deferred epochs to avoid double-injecting barriers.
  - Add `follower_should_skip` helper and tests for committed, in-flight, retry, and newer-epoch cases.

- **Refactors**
  - CI: Build benches for `laminar-core` and `laminar-db`; run active suites (`latency_bench`, `cache_bench`, `stream_executor_bench`, `lookup_join_bench`, `streaming_bench`, `hot_path_micro`, `recovery_bench`).
  - CI: Stop publishing the removed `laminar-storage` crate in `release.yml`.
  - Docs/metadata: Remove `laminar-storage`; consolidate checkpoint/manifest storage under `laminar-core`; update crate count and descriptions.

<sup>Written for commit a88f2e24dbb34a737688b2197b4efb57e202e383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

