### PR TITLE
feat(cluster): failure-domain placement observability + MongoDB time-series sink

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -430,11 +431,14 @@ jobs:
           BRANCH_NAME="chore/update-compatibility-v${{ needs.verify.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH_NAME"
+          # -B + --force so re-running the release for the same version overwrites
+          # any stale branch instead of failing.
+          git checkout -B "$BRANCH_NAME"
           git add compatibility.json
           git commit -m "chore: update compatibility.json for v${{ needs.verify.outputs.version }}" || exit 0
-          git push -u origin "$BRANCH_NAME"
-          gh pr create \
+          git push -u origin "$BRANCH_NAME" --force
+          # Only open a PR if one doesn't already exist for this branch.
+          gh pr view "$BRANCH_NAME" > /dev/null 2>&1 || gh pr create \
             --title "chore: update compatibility.json for v${{ needs.verify.outputs.version }}" \
             --body "Auto-generated compatibility manifest update for release v${{ needs.verify.outputs.version }}." \
             --base main \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,7 +394,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Download checksums
         run: |
@@ -423,10 +423,19 @@ jobs:
           }
           EOF
 
-      - name: Commit and push
+      - name: Commit and create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH_NAME="chore/update-compatibility-v${{ needs.verify.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH_NAME"
           git add compatibility.json
           git commit -m "chore: update compatibility.json for v${{ needs.verify.outputs.version }}" || exit 0
-          git push
+          git push -u origin "$BRANCH_NAME"
+          gh pr create \
+            --title "chore: update compatibility.json for v${{ needs.verify.outputs.version }}" \
+            --body "Auto-generated compatibility manifest update for release v${{ needs.verify.outputs.version }}." \
+            --base main \
+            --head "$BRANCH_NAME"

--- a/crates/laminar-connectors/src/mongodb/config.rs
+++ b/crates/laminar-connectors/src/mongodb/config.rs
@@ -16,7 +16,7 @@ use crate::config::ConnectorConfig;
 use crate::error::ConnectorError;
 
 use super::resume_token::ResumeTokenStoreConfig;
-use super::timeseries::CollectionKind;
+use super::timeseries::{CollectionKind, TimeSeriesConfig, TimeSeriesGranularity};
 use super::write_model::WriteMode;
 
 /// Mode for requesting full documents on update events.
@@ -489,6 +489,41 @@ impl MongoDbSinkConfig {
             cfg.write_concern.timeout_ms = Some(timeout);
         }
 
+        if let Some(time_field) = config.get("timeseries.time_field") {
+            let meta_field = config.get("timeseries.meta_field").map(String::from);
+            let granularity = if let Some(gran_str) = config.get("timeseries.granularity") {
+                match gran_str.to_lowercase().as_str() {
+                    "seconds" => TimeSeriesGranularity::Seconds,
+                    "minutes" => TimeSeriesGranularity::Minutes,
+                    "hours" => TimeSeriesGranularity::Hours,
+                    "custom" => {
+                        let span =
+                            config.require_parsed::<u32>("timeseries.bucket_max_span_seconds")?;
+                        let rounding =
+                            config.require_parsed::<u32>("timeseries.bucket_rounding_seconds")?;
+                        TimeSeriesGranularity::custom(span, rounding)?
+                    }
+                    other => {
+                        return Err(ConnectorError::ConfigurationError(format!(
+                            "unknown timeseries granularity: {other}"
+                        )));
+                    }
+                }
+            } else {
+                TimeSeriesGranularity::Seconds
+            };
+
+            let expire_after_seconds =
+                config.get_parsed::<u64>("timeseries.expire_after_seconds")?;
+
+            cfg.collection_kind = CollectionKind::TimeSeries(TimeSeriesConfig {
+                time_field: time_field.to_string(),
+                meta_field,
+                granularity,
+                expire_after_seconds,
+            });
+        }
+
         cfg.validate()?;
         Ok(cfg)
     }
@@ -749,6 +784,53 @@ mod tests {
         let cfg = MongoDbSinkConfig::from_config(&config).unwrap();
         assert_eq!(cfg.batch_size, 1000);
         assert!(!cfg.ordered);
+    }
+
+    #[test]
+    fn test_sink_config_timeseries_parsing() {
+        // Test standard granularity with metadata and TTL
+        let mut config = ConnectorConfig::new("mongodb-sink");
+        config.set("connection.uri", "mongodb://host:27017");
+        config.set("database", "testdb");
+        config.set("collection", "ts_out");
+        config.set("timeseries.time_field", "timestamp");
+        config.set("timeseries.meta_field", "sensor_id");
+        config.set("timeseries.granularity", "minutes");
+        config.set("timeseries.expire_after_seconds", "86400");
+
+        let cfg = MongoDbSinkConfig::from_config(&config).unwrap();
+        if let CollectionKind::TimeSeries(ts) = cfg.collection_kind {
+            assert_eq!(ts.time_field, "timestamp");
+            assert_eq!(ts.meta_field.as_deref(), Some("sensor_id"));
+            assert_eq!(ts.granularity, TimeSeriesGranularity::Minutes);
+            assert_eq!(ts.expire_after_seconds, Some(86400));
+        } else {
+            panic!("Expected TimeSeries collection kind");
+        }
+
+        // Test custom granularity
+        let mut config_custom = ConnectorConfig::new("mongodb-sink");
+        config_custom.set("connection.uri", "mongodb://host:27017");
+        config_custom.set("database", "testdb");
+        config_custom.set("collection", "ts_custom");
+        config_custom.set("timeseries.time_field", "timestamp");
+        config_custom.set("timeseries.granularity", "custom");
+        config_custom.set("timeseries.bucket_max_span_seconds", "3600");
+        config_custom.set("timeseries.bucket_rounding_seconds", "3600");
+
+        let cfg_custom = MongoDbSinkConfig::from_config(&config_custom).unwrap();
+        if let CollectionKind::TimeSeries(ts) = cfg_custom.collection_kind {
+            assert_eq!(ts.time_field, "timestamp");
+            assert_eq!(
+                ts.granularity,
+                TimeSeriesGranularity::Custom {
+                    bucket_max_span_seconds: 3600,
+                    bucket_rounding_seconds: 3600,
+                }
+            );
+        } else {
+            panic!("Expected TimeSeries collection kind");
+        }
     }
 
     #[test]

--- a/crates/laminar-connectors/src/mongodb/config.rs
+++ b/crates/laminar-connectors/src/mongodb/config.rs
@@ -490,6 +490,11 @@ impl MongoDbSinkConfig {
         }
 
         if let Some(time_field) = config.get("timeseries.time_field") {
+            if time_field.trim().is_empty() {
+                return Err(ConnectorError::ConfigurationError(
+                    "timeseries.time_field must not be empty".to_string(),
+                ));
+            }
             let meta_field = config.get("timeseries.meta_field").map(String::from);
             let granularity = if let Some(gran_str) = config.get("timeseries.granularity") {
                 match gran_str.to_lowercase().as_str() {
@@ -831,6 +836,17 @@ mod tests {
         } else {
             panic!("Expected TimeSeries collection kind");
         }
+    }
+
+    #[test]
+    fn test_sink_config_timeseries_empty_time_field_rejected() {
+        let mut config = ConnectorConfig::new("mongodb-sink");
+        config.set("connection.uri", "mongodb://host:27017");
+        config.set("database", "testdb");
+        config.set("collection", "ts");
+        config.set("timeseries.time_field", "  ");
+        let err = MongoDbSinkConfig::from_config(&config).unwrap_err();
+        assert!(err.to_string().contains("time_field"));
     }
 
     #[test]

--- a/crates/laminar-connectors/src/mongodb/mod.rs
+++ b/crates/laminar-connectors/src/mongodb/mod.rs
@@ -171,6 +171,61 @@ fn mongodb_sink_config_keys() -> Vec<ConfigKeySpec> {
             "Ordered writes (fail-fast) vs unordered (higher throughput)",
             "true",
         ),
+        ConfigKeySpec::optional(
+            "write.mode",
+            "Write operation mode (insert, upsert, replace, cdc_replay)",
+            "insert",
+        ),
+        ConfigKeySpec::optional(
+            "write.mode.key_fields",
+            "Comma-separated key fields to match documents in upsert mode",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "write.mode.upsert_on_missing",
+            "Insert the document if not found in replace mode",
+            "false",
+        ),
+        ConfigKeySpec::optional(
+            "write_concern.journal",
+            "Request acknowledgment after the write has been journaled",
+            "true",
+        ),
+        ConfigKeySpec::optional(
+            "write_concern.timeout_ms",
+            "Timeout for the write concern to be satisfied",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.time_field",
+            "The field in each document containing the date",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.meta_field",
+            "An optional field labeling the data source",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.granularity",
+            "Bucketing granularity (seconds, minutes, hours, custom)",
+            "seconds",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.bucket_max_span_seconds",
+            "Max span of a single bucket in seconds (custom granularity)",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.bucket_rounding_seconds",
+            "Rounding boundary in seconds (custom granularity)",
+            "",
+        ),
+        ConfigKeySpec::optional(
+            "timeseries.expire_after_seconds",
+            "TTL in seconds (automatically delete documents after this span)",
+            "",
+        ),
     ]
 }
 

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -13,6 +13,7 @@ use super::barrier::{
 use super::leader::leader_of;
 use super::snapshot::AssignmentSnapshotStore;
 use crate::cluster::discovery::{assignable_node_ids, NodeId, NodeInfo, NodeState};
+use crate::state::Locality;
 
 /// Facade composing the cluster-control primitives.
 pub struct ClusterController {
@@ -33,6 +34,9 @@ pub struct ClusterController {
     draining: Arc<AtomicBool>,
     /// Whether this node has announced itself as Active.
     active: Arc<AtomicBool>,
+    /// This node's own failure-domain locality (peers carry theirs in
+    /// `members_rx`; self is only known by id). Set once at startup.
+    self_locality: parking_lot::RwLock<Locality>,
     /// Handler serving cross-node `RemoteScan`, shared with the query server.
     #[cfg(feature = "cluster")]
     query_handler: super::query::QueryHandlerSlot,
@@ -70,6 +74,7 @@ impl ClusterController {
             cluster_min_watermark: Arc::new(AtomicI64::new(i64::MIN)),
             draining: Arc::new(AtomicBool::new(false)),
             active: Arc::new(AtomicBool::new(true)),
+            self_locality: parking_lot::RwLock::new(Locality::default()),
             #[cfg(feature = "cluster")]
             query_handler: Arc::new(parking_lot::RwLock::new(None)),
             #[cfg(feature = "cluster")]
@@ -208,6 +213,34 @@ impl ClusterController {
         ids.sort_unstable();
         ids.dedup();
         ids
+    }
+
+    /// Record this node's own locality. Call once at startup.
+    pub fn set_self_locality(&self, locality: Locality) {
+        *self.self_locality.write() = locality;
+    }
+
+    /// [`Self::assignable_instances`] paired with each node's [`Locality`]
+    /// (peers' from `members_rx`, self's from [`Self::set_self_locality`]).
+    #[must_use]
+    pub fn assignable_with_locality(&self) -> Vec<(NodeId, Locality)> {
+        let members = self.members_rx.borrow();
+        self.assignable_instances()
+            .into_iter()
+            .map(|id| {
+                let locality = if id == self.instance_id {
+                    self.self_locality.read().clone()
+                } else {
+                    members
+                        .iter()
+                        .find(|m| m.id == id)
+                        .and_then(|m| m.metadata.failure_domain.as_deref())
+                        .map(Locality::parse)
+                        .unwrap_or_default()
+                };
+                (id, locality)
+            })
+            .collect()
     }
 
     /// Cloneable membership watch. Background tasks subscribe to
@@ -378,6 +411,34 @@ mod tests {
         c.begin_drain();
         assert!(c.is_draining());
         assert_eq!(c.assignable_instances(), vec![NodeId(3)]);
+    }
+
+    #[test]
+    fn assignable_with_locality_attaches_self_and_peer_domains() {
+        let mut peer = info(3);
+        peer.metadata.failure_domain = Some("region=r;zone=z2".to_string());
+        let c = ctl(1, vec![peer]);
+        c.set_self_locality(Locality::parse("region=r;zone=z1"));
+
+        let pairs = c.assignable_with_locality();
+        // Same set as assignable_instances (self + active peer), sorted by id.
+        let ids: Vec<NodeId> = pairs.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![NodeId(1), NodeId(3)]);
+        // Self's locality comes from set_self_locality; peer's from gossip.
+        let self_loc = &pairs.iter().find(|(id, _)| *id == NodeId(1)).unwrap().1;
+        let peer_loc = &pairs.iter().find(|(id, _)| *id == NodeId(3)).unwrap().1;
+        assert_eq!(self_loc.domain_at(1), "r;z1");
+        assert_eq!(peer_loc.domain_at(1), "r;z2");
+    }
+
+    #[test]
+    fn assignable_with_locality_defaults_unlabeled_to_empty_domain() {
+        // A peer with no failure_domain and unset self locality both collapse
+        // to the empty "unknown" domain — safe degradation, never a panic.
+        let c = ctl(1, vec![info(3)]);
+        let pairs = c.assignable_with_locality();
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs.iter().all(|(_, loc)| loc.domain_at(0).is_empty()));
     }
 
     #[tokio::test]

--- a/crates/laminar-core/src/state/mod.rs
+++ b/crates/laminar-core/src/state/mod.rs
@@ -16,6 +16,6 @@ pub use config::{
 pub use in_process::InProcessBackend;
 pub use object_store::ObjectStoreBackend;
 pub use vnode::{
-    key_hash, owned_vnodes, peer_owners, rendezvous_assignment, NodeId, VnodeLifecycleState,
-    VnodeRegistry,
+    key_hash, owned_vnodes, owners_per_domain, peer_owners, rendezvous_assignment, Locality,
+    NodeId, VnodeLifecycleState, VnodeRegistry,
 };

--- a/crates/laminar-core/src/state/vnode.rs
+++ b/crates/laminar-core/src/state/vnode.rs
@@ -13,6 +13,7 @@
 //! [`key_hash`] (xxh3) and modulo `vnode_count`. Connectors that
 //! need a vnode ID for an event call [`VnodeRegistry::vnode_for_key`].
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
@@ -341,6 +342,78 @@ pub fn rendezvous_assignment(vnode_count: u32, peers: &[NodeId]) -> Arc<[NodeId]
     assignment.into()
 }
 
+/// A node's failure-domain locality: ordered tier values, coarsest first
+/// (e.g. `["us-east-1", "us-east-1a", "r17"]`). Parsed from the node's
+/// `failure_domain` gossip string.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Locality {
+    tiers: Vec<String>,
+}
+
+impl Locality {
+    /// Build from ordered tier values, coarsest first.
+    #[must_use]
+    pub fn new(tiers: Vec<String>) -> Self {
+        Self { tiers }
+    }
+
+    /// Parse `"region=us-east-1;zone=us-east-1a;rack=r17"` (or a bare label
+    /// `"rack17"`) into its tier values. Tier names are ignored.
+    #[must_use]
+    pub fn parse(s: &str) -> Self {
+        let tiers = s
+            .split(';')
+            .map(str::trim)
+            .filter(|seg| !seg.is_empty())
+            .map(|seg| {
+                seg.split_once('=')
+                    .map_or(seg, |(_, v)| v.trim())
+                    .to_string()
+            })
+            .collect();
+        Self { tiers }
+    }
+
+    /// Failure-domain key at `tier`: the `;`-joined value prefix `0..=tier`.
+    /// Two nodes share a domain iff equal; an unlabeled node yields the empty key.
+    #[must_use]
+    pub fn domain_at(&self, tier: usize) -> String {
+        if self.tiers.is_empty() {
+            return String::new();
+        }
+        let end = tier.min(self.tiers.len() - 1);
+        self.tiers[..=end].join(";")
+    }
+}
+
+/// Resolve each node's failure-domain key at `isolation_tier`.
+fn resolve_domains(nodes: &[(NodeId, Locality)], isolation_tier: usize) -> Vec<(NodeId, String)> {
+    nodes
+        .iter()
+        .map(|(id, loc)| (*id, loc.domain_at(isolation_tier)))
+        .collect()
+}
+
+/// Owner counts per failure domain at `isolation_tier`. The largest value over
+/// `vnode_count` is the blast radius — the share of state that goes `Restoring`
+/// if that one domain fails at once.
+#[must_use]
+pub fn owners_per_domain(
+    owners: &[NodeId],
+    nodes: &[(NodeId, Locality)],
+    isolation_tier: usize,
+) -> BTreeMap<String, u32> {
+    let dom: BTreeMap<NodeId, String> =
+        resolve_domains(nodes, isolation_tier).into_iter().collect();
+    let mut counts = BTreeMap::new();
+    for &o in owners {
+        *counts
+            .entry(dom.get(&o).cloned().unwrap_or_default())
+            .or_default() += 1;
+    }
+    counts
+}
+
 /// Vnodes currently assigned to `owner`.
 ///
 /// Used by the checkpoint coordinator to decide which vnodes' durability
@@ -545,5 +618,39 @@ mod tests {
         r.mark_restoring(&[2]);
         r.set_assignment(vec![NodeId(1), NodeId(1), NodeId(1), NodeId(1)].into());
         assert!(r.is_restoring(2));
+    }
+
+    // -- Topology-aware placement --------------------------------------------
+
+    /// A node at (region, zone, rack).
+    fn node(id: u64, region: &str, zone: &str, rack: &str) -> (NodeId, Locality) {
+        (
+            NodeId(id),
+            Locality::new(vec![region.into(), zone.into(), rack.into()]),
+        )
+    }
+
+    const TIER_ZONE: usize = 1;
+
+    #[test]
+    fn locality_parse_and_domain_at() {
+        let l = Locality::parse("region=us-east-1;zone=us-east-1a;rack=r17");
+        assert_eq!(l.domain_at(0), "us-east-1");
+        assert_eq!(l.domain_at(1), "us-east-1;us-east-1a");
+        assert_eq!(l.domain_at(2), "us-east-1;us-east-1a;r17");
+        assert_eq!(l.domain_at(99), "us-east-1;us-east-1a;r17"); // clamps to finest
+        assert_eq!(Locality::parse("rack17").domain_at(0), "rack17"); // bare label
+        assert_eq!(Locality::parse("").domain_at(0), ""); // unknown → empty domain
+    }
+
+    #[test]
+    fn owners_per_domain_counts_by_zone() {
+        let nodes = vec![node(1, "r", "z1", "a"), node(2, "r", "z2", "a")];
+        // z1 owns 2, z2 owns 1, and an unassigned owner folds into the empty domain.
+        let owners = [NodeId(1), NodeId(1), NodeId(2), NodeId::UNASSIGNED];
+        let counts = owners_per_domain(&owners, &nodes, TIER_ZONE);
+        assert_eq!(counts["r;z1"], 2);
+        assert_eq!(counts["r;z2"], 1);
+        assert_eq!(counts[""], 1);
     }
 }

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -1,7 +1,8 @@
 //! Prometheus metrics for the streaming engine.
 
 use prometheus::{
-    Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+    Gauge, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+    Registry,
 };
 
 /// Pipeline metrics registered on an explicit prometheus `Registry`.
@@ -91,6 +92,10 @@ pub struct EngineMetrics {
     /// Output batches dropped when a remote subscriber's routing queue is full
     /// (cluster mode, best-effort delivery under backpressure).
     pub remote_subscription_batches_dropped: IntCounter,
+    /// Vnodes owned per failure domain (cluster mode). Label: `domain`.
+    pub placement_vnodes_per_domain: IntGaugeVec,
+    /// Largest single domain's share of all vnodes (`[0, 1]`) — the blast radius.
+    pub placement_blast_radius_ratio: Gauge,
 }
 
 impl EngineMetrics {
@@ -307,6 +312,19 @@ impl EngineMetrics {
             remote_subscription_batches_dropped: reg!(IntCounter::new(
                 "remote_subscription_batches_dropped_total",
                 "Output batches dropped under remote-subscriber backpressure"
+            )
+            .unwrap()),
+            placement_vnodes_per_domain: reg!(IntGaugeVec::new(
+                Opts::new(
+                    "placement_vnodes_per_domain",
+                    "Vnodes owned per failure domain (cluster mode)"
+                ),
+                &["domain"],
+            )
+            .unwrap()),
+            placement_blast_radius_ratio: reg!(Gauge::new(
+                "placement_blast_radius_ratio",
+                "Largest single domain's share of all vnodes (0-1); state that goes Restoring if it fails"
             )
             .unwrap()),
         }

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -9,13 +9,16 @@ use std::time::Duration;
 use laminar_core::cluster::control::{
     AssignmentSnapshot, AssignmentSnapshotStore, ClusterController, RotateOutcome,
 };
-use laminar_core::state::{rendezvous_assignment, NodeId, VnodeRegistry};
+use laminar_core::state::{
+    owners_per_domain, rendezvous_assignment, Locality, NodeId, VnodeRegistry,
+};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, info, warn};
 
 use crate::db::{LaminarDB, SnapshotAdoption};
+use crate::engine_metrics::EngineMetrics;
 
 /// Tunables for the rebalance control plane.
 #[derive(Debug, Clone, Copy)]
@@ -28,6 +31,8 @@ pub struct RebalanceConfig {
     pub checkpoint_timeout: Duration,
     /// Delay before retrying a failed rotation.
     pub retry_delay: Duration,
+    /// Locality tier the placement metrics group by (0 = coarsest).
+    pub placement_isolation_tier: usize,
 }
 
 impl Default for RebalanceConfig {
@@ -37,6 +42,7 @@ impl Default for RebalanceConfig {
             rebalance_debounce: Duration::from_secs(5),
             checkpoint_timeout: Duration::from_secs(60),
             retry_delay: Duration::from_secs(10),
+            placement_isolation_tier: 0,
         }
     }
 }
@@ -51,6 +57,7 @@ impl RebalanceConfig {
             rebalance_debounce: Duration::from_millis(500),
             checkpoint_timeout: Duration::from_secs(30),
             retry_delay: Duration::from_millis(500),
+            placement_isolation_tier: 0,
         }
     }
 }
@@ -86,6 +93,7 @@ pub fn spawn_snapshot_watcher(
         let mut ticker = tokio::time::interval(config.watcher_poll);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         ticker.tick().await; // burn the immediate first tick
+        let mut published_version = 0;
         loop {
             tokio::select! {
                 biased;
@@ -114,8 +122,55 @@ pub fn spawn_snapshot_watcher(
                     Err(e) => warn!(error = %e, "snapshot watcher: load failed"),
                 }
             }
+
+            // Refresh placement metrics only when the assignment changed.
+            let version = registry.assignment_version();
+            if version != published_version {
+                published_version = version;
+                if let (Some(c), Some(metrics)) = (controller.as_ref(), db.engine_metrics()) {
+                    let nodes = c.assignable_with_locality();
+                    publish_placement_metrics(
+                        &metrics,
+                        &registry,
+                        &nodes,
+                        config.placement_isolation_tier,
+                    );
+                }
+            }
         }
     })
+}
+
+/// Publish per-domain owner counts and the blast-radius ratio. The gauge vector
+/// is reset so domains that disappear don't leave stale series.
+#[allow(clippy::cast_precision_loss)]
+fn publish_placement_metrics(
+    metrics: &EngineMetrics,
+    registry: &VnodeRegistry,
+    nodes: &[(NodeId, Locality)],
+    isolation_tier: usize,
+) {
+    let owners = registry.snapshot();
+    let total = owners.len().max(1);
+    let counts = owners_per_domain(&owners, nodes, isolation_tier);
+
+    metrics.placement_vnodes_per_domain.reset();
+    let mut max = 0u32;
+    for (domain, &count) in &counts {
+        let label = if domain.is_empty() {
+            "unknown"
+        } else {
+            domain.as_str()
+        };
+        metrics
+            .placement_vnodes_per_domain
+            .with_label_values(&[label])
+            .set(i64::from(count));
+        max = max.max(count);
+    }
+    metrics
+        .placement_blast_radius_ratio
+        .set(f64::from(max) / total as f64);
 }
 
 /// Spawn the leader-gated rebalance controller. Runs on every node;
@@ -234,6 +289,13 @@ async fn try_rebalance(
     live: &[NodeId],
     config: RebalanceConfig,
 ) -> Result<Option<u64>, String> {
+    // No assignable instances (whole cluster draining/joining) — nothing to
+    // rotate to. Hold the current assignment rather than panicking the
+    // placement call on an empty node set.
+    if live.is_empty() {
+        return Ok(None);
+    }
+
     let current = store
         .load()
         .await
@@ -303,6 +365,29 @@ mod tests {
     fn store() -> AssignmentSnapshotStore {
         let mem: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         AssignmentSnapshotStore::new(mem)
+    }
+
+    #[test]
+    fn publish_placement_metrics_labels_by_domain() {
+        let prom = prometheus::Registry::new();
+        let metrics = EngineMetrics::new(&prom);
+
+        // 4 vnodes: node 1 owns two, node 2 owns one, one is unassigned.
+        let vreg = VnodeRegistry::new(4);
+        vreg.set_assignment(vec![NodeId(1), NodeId(1), NodeId(2), NodeId::UNASSIGNED].into());
+        let nodes = vec![
+            (NodeId(1), Locality::parse("region=r;zone=z1")),
+            (NodeId(2), Locality::parse("region=r;zone=z2")),
+        ];
+
+        publish_placement_metrics(&metrics, &vreg, &nodes, 1); // isolation_tier 1 = zone
+
+        let g = &metrics.placement_vnodes_per_domain;
+        assert_eq!(g.with_label_values(&["r;z1"]).get(), 2);
+        assert_eq!(g.with_label_values(&["r;z2"]).get(), 1);
+        assert_eq!(g.with_label_values(&["unknown"]).get(), 1); // the unassigned vnode
+                                                                // Blast radius = largest domain (2) / total vnodes (4).
+        assert!((metrics.placement_blast_radius_ratio.get() - 0.5).abs() < 1e-9);
     }
 
     #[tokio::test]

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -242,6 +242,20 @@ The server watches `pgwire_tls_cert`, `pgwire_tls_key`, and `pgwire_tls_client_c
 psql "host=127.0.0.1 port=5433 dbname=laminardb user=any" -c "SUBSCRIBE avg_price WHERE symbol = 'AAPL'"
 ```
 
+## Failure-Domain Placement (rack/zone awareness)
+
+In `mode = "cluster"`, advertise each node's physical topology with `failure_domain` (a flat label, or hierarchical coarsest-first `;`-separated tiers). It is gossiped to peers and exported as blast-radius metrics so you can see how vnode ownership is spread across racks/zones.
+
+```toml
+[discovery]
+strategy = "gossip"
+seeds = ["node-1:7946", "node-2:7946"]
+failure_domain = "region=us-east-1;zone=us-east-1a;rack=r17"
+placement_isolation_tier = 1     # 0=region, 1=zone, 2=rack — what counts as a "domain"
+```
+
+`placement_vnodes_per_domain{domain}` and `placement_blast_radius_ratio` (the largest domain's share of vnodes — the state that goes into recovery if that domain fails at once) are exported; see the "Failure-Domain Placement" row in the cluster Grafana dashboard. Unlabeled nodes collapse into one shared `unknown` domain. Placement itself is plain rendezvous hashing — this surfaces the blast radius, it does not yet act on it.
+
 ## Cluster Control-Plane TLS (mTLS)
 
 In `mode = "cluster"`, the inter-node control plane (barrier sync, the distributed-query `RemoteScan` service, and the row shuffle) is plaintext and unauthenticated by default — run it on a trusted/isolated network. To require mutual TLS between nodes, set all four `[discovery]` keys together (omit them for plaintext):

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -353,7 +353,7 @@ pub async fn start_cluster(
         metadata: NodeMetadata {
             cores: num_cpus(),
             memory_bytes: 0,
-            failure_domain: None,
+            failure_domain: cluster_cfg.discovery.failure_domain.clone(),
             tags: std::collections::HashMap::new(),
             owned_partitions: Vec::new(),
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -503,6 +503,12 @@ pub async fn start_cluster(
                 &advertise_host,
             )
             .await?;
+            // Hand the controller this node's own locality so the topology-
+            // aware rebalancer can place self correctly (peers' localities
+            // arrive via gossip; self is folded in by id only).
+            controller.set_self_locality(laminar_core::state::Locality::parse(
+                local_node.metadata.failure_domain.as_deref().unwrap_or(""),
+            ));
             builder = builder.cluster_controller(Arc::clone(&controller));
             Some(controller)
         }
@@ -611,7 +617,10 @@ pub async fn start_cluster(
     if let (Some(snap_store), Some(controller)) =
         (snapshot_store.clone(), cluster_controller.as_ref())
     {
-        let cfg = laminar_db::rebalance::RebalanceConfig::default();
+        let cfg = laminar_db::rebalance::RebalanceConfig {
+            placement_isolation_tier: cluster_cfg.discovery.placement_isolation_tier,
+            ..laminar_db::rebalance::RebalanceConfig::default()
+        };
         rebalance_tasks.push(laminar_db::rebalance::spawn_snapshot_watcher(
             Arc::clone(&db),
             Arc::clone(&snap_store),

--- a/crates/laminar-server/src/cluster_config.rs
+++ b/crates/laminar-server/src/cluster_config.rs
@@ -146,6 +146,8 @@ mod tests {
             seeds: vec!["node-1:7946".to_string(), "node-2:7946".to_string()],
             gossip_port: 7946,
             advertise_host: None,
+            failure_domain: None,
+            placement_isolation_tier: 0,
             cluster_tls_cert: None,
             cluster_tls_key: None,
             cluster_tls_client_ca: None,

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -688,6 +688,13 @@ pub struct DiscoverySection {
     pub gossip_port: u16,
     #[serde(default)]
     pub advertise_host: Option<String>,
+    /// Failure-domain locality, gossiped to peers. A flat label (`"rack17"`)
+    /// or coarsest-first `;`-separated tiers (`"region=...;zone=...;rack=..."`).
+    #[serde(default)]
+    pub failure_domain: Option<String>,
+    /// Locality tier the placement/blast-radius metrics group by (0 = coarsest).
+    #[serde(default)]
+    pub placement_isolation_tier: usize,
     /// PEM cert for control-plane (barrier/query/shuffle) mTLS; enable by
     /// setting cert + key + client_ca + server_name together.
     #[serde(default)]
@@ -1012,6 +1019,8 @@ snapshot_strategy = "fork_cow"
 strategy = "static"
 seeds = ["node-1:7946", "node-2:7946"]
 gossip_port = 7946
+failure_domain = "region=us-east-1;zone=us-east-1a;rack=r17"
+placement_isolation_tier = 1
 
 [coordination]
 strategy = "raft"
@@ -1042,6 +1051,13 @@ delivery = "exactly_once"
         assert!(matches!(config.state, StateBackendConfig::Local { .. }));
         assert!(config.discovery.is_some());
         assert!(config.coordination.is_some());
+
+        let disc = config.discovery.as_ref().unwrap();
+        assert_eq!(
+            disc.failure_domain.as_deref(),
+            Some("region=us-east-1;zone=us-east-1a;rack=r17")
+        );
+        assert_eq!(disc.placement_isolation_tier, 1);
 
         let coord = config.coordination.as_ref().unwrap();
         assert_eq!(coord.election_timeout, Duration::from_millis(1500));

--- a/grafana/laminardb-cluster.json
+++ b/grafana/laminardb-cluster.json
@@ -375,6 +375,63 @@
           }
         }
       ]
+    },
+    {
+      "title": "Failure-Domain Placement",
+      "type": "row",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "collapsed": true,
+      "panels": [
+        {
+          "title": "Blast Radius (max domain share)",
+          "type": "stat",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 52 },
+          "targets": [
+            { "expr": "max(laminardb_placement_blast_radius_ratio)", "legendFormat": "Blast radius" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 0.5 },
+                  { "color": "red", "value": 0.7 }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "title": "Failure Domains",
+          "type": "stat",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 52 },
+          "targets": [
+            { "expr": "count(laminardb_placement_vnodes_per_domain)", "legendFormat": "Domains" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" } }
+        },
+        {
+          "title": "Vnodes per Failure Domain",
+          "type": "timeseries",
+          "datasource": "${DS_PROMETHEUS}",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
+          "targets": [
+            { "expr": "max(laminardb_placement_vnodes_per_domain) by (domain)", "legendFormat": "{{domain}}" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal" } }
+            }
+          }
+        }
+      ]
     }
   ],
   "schemaVersion": 39,

--- a/grafana/laminardb-cluster.json
+++ b/grafana/laminardb-cluster.json
@@ -412,7 +412,7 @@
           "datasource": "${DS_PROMETHEUS}",
           "gridPos": { "h": 4, "w": 6, "x": 6, "y": 52 },
           "targets": [
-            { "expr": "count(laminardb_placement_vnodes_per_domain)", "legendFormat": "Domains" }
+            { "expr": "count(max(laminardb_placement_vnodes_per_domain) by (domain))", "legendFormat": "Domains" }
           ],
           "fieldConfig": { "defaults": { "unit": "short" } }
         },


### PR DESCRIPTION
Bundles three independent changes (per request).

## 1. Cluster failure-domain observability
Surface how vnode ownership is spread across racks/zones, so an operator can see their blast radius. **Placement itself is unchanged — plain rendezvous hashing.** This is plumbing + metrics only.

- `[discovery] failure_domain` (flat label or coarsest-first `region=…;zone=…;rack=…` tiers) is gossiped to peers and resolved via a new `Locality` type.
- `ClusterController::set_self_locality()` + `assignable_with_locality()` thread locality to the rebalancer (peers carry it in `members_rx`; self is folded in by id).
- New metrics `placement_vnodes_per_domain{domain}` and `placement_blast_radius_ratio` (largest domain's share of vnodes — the state that goes `Restoring` if that domain fails), published by the snapshot watcher, version-gated. Grafana cluster dashboard gains a "Failure-Domain Placement" row.

An earlier iteration also had a capacity-aware blast-radius *balancer*; it was cut as speculative/off-by-default and unverified — only the observability is kept.

## 2. MongoDB time-series sink
- Parse `timeseries.*` sink config into `CollectionKind::TimeSeries`, **activating the existing (previously unreachable) time-series support** — `collection_kind` was always `Standard`, so `ensure_timeseries_collection` could never run. Insert-only constraint enforced in `validate()`.
- Register the missing sink `ConfigKeySpec` entries (`write.mode*`, `write_concern.*`, `timeseries.*`).

## 3. CI: release workflow
- The release job's direct `git push` of `compatibility.json` fails against protected `main`; it now opens a PR via `gh` (using `GH_PAT`, falling back to `GITHUB_TOKEN`).

## Verification
- clippy `-D warnings` + fmt clean across laminar-core / laminar-db (cluster) / laminar-server / laminar-connectors (mongodb-cdc).
- Unit: vnode, controller, rebalance (incl. `publish_placement_metrics_labels_by_domain`), server config, mongodb config.
- Integration: `cluster_integration` 16/16 + `cluster_repartition_integration` 1/1.
- Real binary: single-node cluster booted from config with `failure_domain` set; `/metrics` returned `placement_vnodes_per_domain{domain="us-east-1;us-east-1a"} 16` and `placement_blast_radius_ratio 1`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds failure-domain placement observability (blast-radius metrics + Grafana) and activates the MongoDB time-series sink with granularity/TTL support. Also updates the release workflow to open/update a PR instead of pushing to `main`.

- **New Features**
  - Cluster observability: gossips `[discovery] failure_domain`, introduces `Locality`, and exposes `placement_vnodes_per_domain{domain}` and `placement_blast_radius_ratio`; configurable with `[discovery] placement_isolation_tier`. Grafana adds a “Failure-Domain Placement” row. Placement remains plain rendezvous hashing (metrics only).
  - MongoDB sink: parses `timeseries.*` into `CollectionKind::TimeSeries` with `granularity` (seconds/minutes/hours/custom with bucket span/rounding) and optional TTL via `expire_after_seconds`; insert-only enforced. Registers missing sink config keys: `write.*`, `write_concern.*`, `timeseries.*`.

- **Bug Fixes**
  - CI release: idempotent PR flow — force-updates the branch, only creates a PR if missing, uses `GH_PAT` (fallback to `GITHUB_TOKEN`), and grants `pull-requests: write`.
  - Grafana: counts distinct failure domains correctly in the dashboard.
  - MongoDB time-series: rejects empty `timeseries.time_field`.

<sup>Written for commit 5c2e281ab963bef235060b207c36b5eb57d13709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure-domain topology awareness for vnode placement with configurable isolation tiers (region/zone/rack)
  * Time-series collection settings for the MongoDB connector (including custom granularity and TTL)
  * New placement metrics: per-domain vnode counts and blast-radius ratio

* **Documentation**
  * Added failure-domain placement configuration and monitoring docs
  * Grafana dashboard panels for failure-domain placement visualization

* **Bug Fixes / Behavior**
  * Placement metrics updated only on assignment changes to avoid stale reports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->