### PR TITLE
feat(server,helm): default object-store checkpoints; fix Helm config-watch spam and double PVC

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,8 @@ jobs:
         run: |
           set -euo pipefail
           APP_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          # Chart version must change per publish or clients never see updates.
+          sed -i "s/^version:.*/version: ${APP_VERSION}/" deploy/helm/laminardb/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${APP_VERSION}\"/" deploy/helm/laminardb/Chart.yaml
           mkdir -p _site/charts
           helm package deploy/helm/laminardb -d _site/charts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow",
  "laminar-connectors",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.95"

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,7 +11,7 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.25.0" }
+laminar-core = { path = "../laminar-core", version = "0.25.1" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -52,9 +52,9 @@ remote = ["dep:reqwest", "dep:governor"]
 local = ["dep:ort", "dep:tokenizers", "dep:reqwest", "dep:hf-hub"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.25.0" }
-laminar-sql = { path = "../laminar-sql", version = "0.25.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.0" }
+laminar-core = { path = "../laminar-core", version = "0.25.1" }
+laminar-sql = { path = "../laminar-sql", version = "0.25.1" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.25.1" }
 
 # AI Inference Dependencies (Consolidated from laminar-ai)
 foyer = { workspace = true }
@@ -138,8 +138,8 @@ tempfile = { workspace = true }
 # no openssl); the `remote` feature exposes the real AnthropicProvider so the
 # test drives the actual HTTP path (request build, 500/retry, response parse).
 wiremock = "0.6"
-laminar-derive = { path = "../laminar-derive", version = "0.25.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.0", features = ["testing"] }
+laminar-derive = { path = "../laminar-derive", version = "0.25.1" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.25.1", features = ["testing"] }
 criterion = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 arrow = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.25.0" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.0" }
+laminar-core = { path = "../laminar-core", version = "0.25.1" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.25.1" }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -23,9 +23,9 @@ required-features = ["cluster"]
 # LaminarDB crates. laminar-db re-exports the rest of the workspace; the
 # server only needs the unified facade plus laminar-core for things like
 # metrics types referenced directly.
-laminar-core = { path = "../laminar-core", version = "0.25.0" }
-laminar-db = { path = "../laminar-db", version = "0.25.0", features = ["api", "remote", "local"] }
-laminar-sql = { path = "../laminar-sql", version = "0.25.0" }
+laminar-core = { path = "../laminar-core", version = "0.25.1" }
+laminar-db = { path = "../laminar-db", version = "0.25.1", features = ["api", "remote", "local"] }
+laminar-sql = { path = "../laminar-sql", version = "0.25.1" }
 
 # For pgwire dispatch on parsed AST
 sqlparser = { workspace = true }
@@ -142,6 +142,9 @@ default = [
     "parquet-lookup",
     "otel",
     "cluster",
+    "aws",
+    "gcs",
+    "azure",
 ]
 jemalloc = ["dep:tikv-jemallocator"]
 mimalloc = ["dep:mimalloc"]

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -71,7 +71,10 @@ backend = "local"           # "in_process", "local", or "object_store"
 path = "./data/state"       # required when backend = "local"
 
 [checkpoint]
-url = "file:///tmp/laminardb/checkpoints"  # file://, s3://, gs://
+# Local file://, or an object store: s3://, gs://, az://, abfs(s):// (the
+# AWS/GCS/Azure backends are in the default build). Credentials come from the
+# standard provider env vars, or set them under [checkpoint.storage].
+url = "file:///tmp/laminardb/checkpoints"
 interval = "30s"
 
 [[source]]

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -17,7 +17,7 @@ cluster = ["laminar-core/cluster"]
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.25.0" }
+laminar-core = { path = "../laminar-core", version = "0.25.1" }
 
 # Runtime glue for ClusterRepartitionExec's per-partition channels.
 tokio-stream = { workspace = true }

--- a/deploy/helm/laminardb/Chart.yaml
+++ b/deploy/helm/laminardb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: laminardb
 description: LaminarDB - Embedded Streaming SQL Database for stream processing
 type: application
-version: 0.1.0
-appVersion: "0.18.0"
+version: 0.25.1
+appVersion: "0.25.1"
 kubeVersion: ">=1.25.0-0"
 keywords:
   - streaming

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -48,7 +48,8 @@ laminardb:
     interval: "30s"
     mode: aligned
     snapshotStrategy: incremental
-    url: "file:///var/lib/laminardb/checkpoints"
+    # Object store so checkpoints are recoverable across nodes (credentials via extraEnv).
+    url: "az://laminardb-checkpoints/cluster"
     
   cluster:
     discovery:
@@ -65,10 +66,18 @@ persistence:
     enabled: true
     storageClass: "managed-csi" # Azure Disk CSI / local SSD on-prem
     size: 50Gi
+  # Checkpoints use the object store above — one (state) PVC per pod, not two.
   checkpoints:
-    enabled: true
-    storageClass: "azurefile-csi" # Shared Azure Files CSI / CephFS on-prem
-    size: 100Gi
+    enabled: false
+
+# Object-store credentials (example: Azure).
+extraEnv:
+  - name: AZURE_STORAGE_ACCOUNT_NAME
+    valueFrom:
+      secretKeyRef: { name: laminardb-azure, key: account }
+  - name: AZURE_STORAGE_ACCOUNT_KEY
+    valueFrom:
+      secretKeyRef: { name: laminardb-azure, key: key }
 
 guaranteedQoS: true
 
@@ -159,12 +168,13 @@ prometheusRule:
 | `laminardb.state.url` | URL for object storage (required if backend=object_store) | `""` |
 | `laminardb.checkpoint.enabled` | Enable checkpoint coordination | `true` |
 | `laminardb.checkpoint.interval` | Checkpoint frequency | `30s` |
-| `laminardb.checkpoint.url` | Storage endpoint (`file://` or `s3://`) | `file:///var/lib/laminardb/checkpoints` |
+| `laminardb.checkpoint.url` | Checkpoint storage: object store (`s3://`, `gs://`, `az://`) or local `file://`. Empty = local default. | `""` |
+| `laminardb.configWatch` | Hot-reload config on file change. Off in K8s (config changes roll pods via the checksum annotation); sets `LAMINAR_DISABLE_FILE_WATCH=1`. | `false` |
 | `laminardb.cluster.discovery.strategy` | Discovery method (`dns`, `gossip`, `static`) | `dns` |
 | `laminardb.cluster.coordination.strategy` | Clustering controller coordination (`raft`) | `raft` |
 | `persistence.state.enabled` | Keep local state in Persistent Volume | `true` |
 | `persistence.state.storageClass` | K8s storage class for state PVC | `""` (default) |
-| `persistence.checkpoints.enabled` | Keep checkpoints in Persistent Volume | `true` |
+| `persistence.checkpoints.enabled` | Provision a dedicated checkpoints PVC. Off by default — prefer an object store via `laminardb.checkpoint.url`. | `false` |
 | `guaranteedQoS` | Pin requests == limits for guaranteed CPU/Mem | `false` |
 | `extraEnvFrom` | Inject variables from ConfigMaps / Secrets | `[]` |
 | `extraVolumes` | Additional volumes to mount into pods | `[]` |

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
     {{- end }}
 
     [checkpoint]
-    url = "{{ .Values.laminardb.checkpoint.url }}"
+    url = "{{ .Values.laminardb.checkpoint.url | default "file:///var/lib/laminardb/checkpoints" }}"
     interval = "{{ .Values.laminardb.checkpoint.interval }}"
     mode = "{{ .Values.laminardb.checkpoint.mode }}"
     snapshot_strategy = "{{ .Values.laminardb.checkpoint.snapshotStrategy }}"

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -150,10 +150,7 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        # Always mounted: the default file:// checkpoint path must be writable
-        # under readOnlyRootFilesystem even with the checkpoints PVC disabled.
-        # (The Deployment never gets a PVC — durable checkpoints need the
-        # StatefulSet or an object-store laminardb.checkpoint.url.)
+        # Volatile; durable checkpoints need the StatefulSet PVC or an object store.
         - name: checkpoints
           emptyDir: {}
         {{- with .Values.extraVolumes }}

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -100,6 +100,11 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            {{- if not .Values.laminardb.configWatch }}
+            # Config changes roll pods via the checksum annotation; the in-pod watcher is redundant on ConfigMap mounts.
+            - name: LAMINAR_DISABLE_FILE_WATCH
+              value: "1"
+            {{- end }}
             {{- if eq .Values.laminardb.mode "cluster" }}
             - name: HOSTNAME
               valueFrom:

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -128,10 +128,8 @@ spec:
             - name: state
               mountPath: /var/lib/laminardb/state
             {{- end }}
-            {{- if .Values.persistence.checkpoints.enabled }}
             - name: checkpoints
               mountPath: /var/lib/laminardb/checkpoints
-            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -152,10 +150,12 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
-        {{- if .Values.persistence.checkpoints.enabled }}
+        # Always mounted: the default file:// checkpoint path must be writable
+        # under readOnlyRootFilesystem even with the checkpoints PVC disabled.
+        # (The Deployment never gets a PVC — durable checkpoints need the
+        # StatefulSet or an object-store laminardb.checkpoint.url.)
         - name: checkpoints
           emptyDir: {}
-        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -139,9 +139,7 @@ spec:
         - name: tmp
           emptyDir: {}
         {{- if not .Values.persistence.checkpoints.enabled }}
-        # Writable fallback for the default file:// checkpoint path; the root
-        # filesystem is read-only. Volatile — set laminardb.checkpoint.url to an
-        # object store (or enable the PVC) for durable checkpoints.
+        # Volatile fallback so the file:// checkpoint path stays writable.
         - name: checkpoints
           emptyDir: {}
         {{- end }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -127,10 +127,8 @@ spec:
             - name: state
               mountPath: /var/lib/laminardb/state
             {{- end }}
-            {{- if .Values.persistence.checkpoints.enabled }}
             - name: checkpoints
               mountPath: /var/lib/laminardb/checkpoints
-            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -140,6 +138,13 @@ spec:
             name: {{ include "laminardb.fullname" . }}
         - name: tmp
           emptyDir: {}
+        {{- if not .Values.persistence.checkpoints.enabled }}
+        # Writable fallback for the default file:// checkpoint path; the root
+        # filesystem is read-only. Volatile — set laminardb.checkpoint.url to an
+        # object store (or enable the PVC) for durable checkpoints.
+        - name: checkpoints
+          emptyDir: {}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -101,6 +101,11 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            {{- if not .Values.laminardb.configWatch }}
+            # Config changes roll pods via the checksum annotation; the in-pod watcher is redundant on ConfigMap mounts.
+            - name: LAMINAR_DISABLE_FILE_WATCH
+              value: "1"
+            {{- end }}
             - name: HOSTNAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -52,12 +52,17 @@ laminardb:
     enabled: true
     # -- Checkpoint interval (Go/humantime duration)
     interval: "30s"
-    # -- Checkpoint storage URL (file:// or s3://)
-    url: "file:///var/lib/laminardb/checkpoints"
+    # -- Checkpoint storage URL. Use an object store (s3://, gs://, az://) for durable
+    # checkpoints; empty falls back to a local path (non-durable unless checkpoints PVC enabled).
+    url: ""
     # -- Checkpoint mode: "aligned" or "unaligned"
     mode: aligned
     # -- Snapshot strategy: "full", "incremental", or "fork_cow"
     snapshotStrategy: full
+
+  # -- Hot-reload config on file change. Off in K8s: config changes already roll pods
+  # (checksum/config annotation) and the watcher spams reloads on ConfigMap mounts.
+  configWatch: false
 
   # -- Custom laminardb.toml configuration (overrides all above).
   # -- If set, this raw TOML string is used as the config file directly.
@@ -227,8 +232,9 @@ persistence:
     # -- emptyDir medium (set to "Memory" for tmpfs)
     emptyDirMedium: ""
   checkpoints:
-    # -- Enable persistent checkpoint storage
-    enabled: true
+    # -- Provision a dedicated checkpoints PVC. Off by default — prefer an object
+    # store (laminardb.checkpoint.url); a default install then creates one PVC, not two.
+    enabled: false
     # -- Storage class (empty = default)
     storageClass: ""
     # -- Access modes

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -233,9 +233,8 @@ persistence:
     emptyDirMedium: ""
   checkpoints:
     # -- Provision a dedicated checkpoints PVC. Off by default — prefer an object
-    # store (laminardb.checkpoint.url); a default install then creates one PVC, not
-    # two, and the local fallback path is backed by a volatile emptyDir so it stays
-    # writable under readOnlyRootFilesystem.
+    # store (laminardb.checkpoint.url); the local fallback path then uses a
+    # volatile emptyDir.
     enabled: false
     # -- Storage class (empty = default)
     storageClass: ""

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -233,7 +233,9 @@ persistence:
     emptyDirMedium: ""
   checkpoints:
     # -- Provision a dedicated checkpoints PVC. Off by default — prefer an object
-    # store (laminardb.checkpoint.url); a default install then creates one PVC, not two.
+    # store (laminardb.checkpoint.url); a default install then creates one PVC, not
+    # two, and the local fallback path is backed by a volatile emptyDir so it stays
+    # writable under readOnlyRootFilesystem.
     enabled: false
     # -- Storage class (empty = default)
     storageClass: ""

--- a/examples/laminardb.toml
+++ b/examples/laminardb.toml
@@ -14,6 +14,7 @@ log_level = "info"
 backend = "in_process"
 
 [checkpoint]
+# Local path, or an object store: s3://, gs://, az:// (in the default build).
 url = "file:///tmp/laminardb/checkpoints"
 interval = "10s"
 mode = "aligned"


### PR DESCRIPTION
## Summary

Three related changes around checkpoint storage in object stores and the Helm deployment.

### 1. Object-store checkpoint backends in the default server build
Adds `aws`, `gcs`, `azure` to `laminar-server`'s default features so `s3://`, `gs://`, `az://` (and `abfs(s)://`) checkpoint locations work out of the box — no custom `--features` build required.

- The feature chain (`server → db → core → object_store`), the URL-scheme builder, and `ObjectStoreCheckpointStore` already existed; this only flips the default feature set. No code changes.
- The cloud `object_store` backends use **rustls** (`rustls-tls-*`), so they add **no new OpenSSL/native-tls dependency**. The only `openssl-sys` in the tree is from `rdkafka` (already default, already handled by `vendored-openssl` in the musl release), so the cross-compiled release build is unaffected.
- The release workflow builds additively (no `--no-default-features`), so released binaries pick up the cloud backends automatically.

### 2. Helm: stop the "Config file change detected" log spam
The in-pod config file watcher misfires on Kubernetes ConfigMap volume mounts (the atomically-swapped symlink farm) and is **redundant** there: the chart's `checksum/config` annotation already rolls pods on config change.

- New `laminardb.configWatch` value (default `false`) injects `LAMINAR_DISABLE_FILE_WATCH=1` in both `deployment.yaml` and `statefulset.yaml`.
- Config changes still apply — via rolling restart. Set `configWatch: true` for true in-place reload.

### 3. Helm: single PVC by default (checkpoints → object store)
Two PVCs (`state` + `checkpoints`) were the intended default. A local RWO `checkpoints` PVC is the wrong default for a distributed system (checkpoints aren't recoverable on another node).

- `persistence.checkpoints.enabled` now defaults to `false`, so a default install provisions a **single (state) PVC**.
- Checkpoints are expected to go to an object store via `laminardb.checkpoint.url`; the local `file://` path is an inline default in the ConfigMap.
- CI values that set `checkpoints.enabled: true` are unchanged (still get the dedicated checkpoints PVC).

### Version
Bumps the workspace version to **0.25.1** (inter-crate path-dependency pins and `Cargo.lock` synced).

## Verification
- `cargo check -p laminar-server` with the new default feature set: clean (`object_store` cloud backends compile).
- Verified via `cargo tree` that the cloud backends pull rustls, not OpenSSL/native-tls.
- `cargo metadata` resolves; `Cargo.lock` updated for the six workspace crates only.
- `helm` is not available in the authoring environment — the chart templates were validated by inspection. A `helm template` render against the default and `ci/*` values is worth running in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables object-store checkpoints by default and streamlines the Helm chart. S3/GCS/Azure checkpoint URLs work out of the box; config-watch spam is disabled, the default install uses one PVC, a writable `file://` fallback is always mounted, and the chart version now tracks the app to avoid stale installs.

- **New Features**
  - `laminar-server` now enables `aws`, `gcs`, and `azure` backends by default; `s3://`, `gs://`, `az://`, and `abfs(s)://` checkpoint URLs work without custom features.
  - Uses `rustls`; no new OpenSSL/native-tls dependencies. Release builds are unchanged.

- **Migration**
  - Helm config watcher is off by default; set `laminardb.configWatch: true` to re-enable in-place reloads.
  - `persistence.checkpoints.enabled` now defaults to `false`. Prefer an object store via `laminardb.checkpoint.url`, or turn the PVC back on if needed.
  - If `laminardb.checkpoint.url` is empty, it falls back to `file:///var/lib/laminardb/checkpoints`. The chart always mounts this path writable: PVC when enabled (StatefulSet), `emptyDir` otherwise, so it works under `readOnlyRootFilesystem`.
  - Helm chart `version` and `appVersion` now follow the workspace version (stamped in CI) so clients receive updates.

<sup>Written for commit 4bf20c42b02540aeb2ea4468573d7e074586c97c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkpoints now support cloud object stores (AWS S3, Google Cloud Storage, Azure Blob Storage) alongside local filesystem storage.

* **Documentation**
  * Updated configuration examples and documentation for checkpoint URL schemes and storage backends.
  * Updated Helm chart defaults and configuration reference for checkpoint storage options.

* **Chores**
  * Version bumped to 0.25.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->