### PR TITLE
refactor: replace foyer with quick_cache (ADR-006)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,15 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,12 +1700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmsketch"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ee2cfacbd29706479902b06d75ad8f1362900836aa32799eabc7e004bfd854"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,17 +1859,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core_affinity"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
-dependencies = [
- "libc",
- "num_cpus",
- "winapi",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -3571,16 +3545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastant"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
-dependencies = [
- "small_ctor",
- "web-time",
-]
-
-[[package]]
 name = "fastnum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,130 +3669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "foyer"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
-dependencies = [
- "anyhow",
- "equivalent",
- "foyer-common",
- "foyer-memory",
- "foyer-storage",
- "foyer-tokio",
- "futures-util",
- "mea",
- "mixtrics",
- "pin-project",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "foyer-common"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "cfg-if",
- "foyer-tokio",
- "mixtrics",
- "parking_lot 0.12.5",
- "pin-project",
- "serde",
- "twox-hash",
-]
-
-[[package]]
-name = "foyer-intrusive-collections"
-version = "0.10.0-dev"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4fee46bea69e0596130e3210e65d3424e0ac1e6df3bde6636304bdf1ca4a3b"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
-name = "foyer-memory"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
-dependencies = [
- "anyhow",
- "bitflags 2.10.0",
- "cmsketch",
- "equivalent",
- "foyer-common",
- "foyer-intrusive-collections",
- "foyer-tokio",
- "futures-util",
- "hashbrown 0.16.1",
- "itertools 0.14.0",
- "mea",
- "mixtrics",
- "parking_lot 0.12.5",
- "paste",
- "pin-project",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "foyer-storage"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
-dependencies = [
- "allocator-api2",
- "anyhow",
- "bytes",
- "core_affinity",
- "equivalent",
- "fastant",
- "foyer-common",
- "foyer-memory",
- "foyer-tokio",
- "fs4",
- "futures-core",
- "futures-util",
- "hashbrown 0.16.1",
- "io-uring",
- "itertools 0.14.0",
- "libc",
- "lz4",
- "mea",
- "parking_lot 0.12.5",
- "pin-project",
- "rand 0.9.4",
- "serde",
- "tracing",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "foyer-tokio"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
-dependencies = [
- "tokio",
-]
-
-[[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4769,17 +4609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5026,7 +4855,6 @@ dependencies = [
  "deadpool-postgres",
  "deltalake",
  "deltalake-catalog-glue",
- "foyer",
  "futures-util",
  "globset",
  "iceberg",
@@ -5045,6 +4873,7 @@ dependencies = [
  "pgwire-replication",
  "postgres-types",
  "prometheus",
+ "quick_cache",
  "rand 0.10.1",
  "rdkafka",
  "reqwest 0.13.2",
@@ -5091,13 +4920,13 @@ dependencies = [
  "criterion",
  "crossfire",
  "equivalent",
- "foyer",
  "futures",
  "gethostname",
  "object_store 0.13.2",
  "parking_lot 0.12.5",
  "prost",
  "protoc-bin-vendored",
+ "quick_cache",
  "rand 0.10.1",
  "rcgen",
  "rkyv 0.8.16",
@@ -5137,7 +4966,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-optimizer",
- "foyer",
  "futures",
  "futures-util",
  "governor",
@@ -5152,6 +4980,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "prometheus",
  "proptest",
+ "quick_cache",
  "rdkafka",
  "reqwest 0.13.2",
  "rkyv 0.8.16",
@@ -5498,25 +5327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
-dependencies = [
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,28 +5441,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
-name = "mea"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
-dependencies = [
- "slab",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mimalloc"
@@ -5695,16 +5487,6 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mixtrics"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb252c728b9d77c6ef9103f0c81524fa0a3d3b161d0a936295d7fbeff6e04c11"
-dependencies = [
- "itertools 0.14.0",
- "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -7286,6 +7068,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+dependencies = [
+ "ahash 0.8.12",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot 0.12.5",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8467,12 +8261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
-name = "small_ctor"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9469,9 +9257,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-dependencies = [
- "rand 0.9.4",
-]
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ memmap2 = "0.9"  # Memory-mapped files
 uuid = { version = "1.23", features = ["v4", "v7", "serde"] }  # Unique IDs
 gethostname = "0.5"  # Pure Rust hostname lookup
 ahash = "0.8"  # Fast hashing for state stores
-foyer = { version = "0.22", features = ["serde"] }  # High-performance cache (S3-FIFO eviction, serde for HybridCache)
+quick_cache = "0.6"  # Lightweight in-memory cache (S3-FIFO eviction, pure Rust, see ADR-006)
 sha2 = "0.10"  # SHA-256 for checkpoint integrity
 lz4_flex = "0.12"  # Pure Rust LZ4 compression (fastest decompression for recovery)
 zstd = "0.13"  # Zstd compression for archival storage tiers (warm/cold)

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ graph TD
         App["Application Logic"]:::appClass
         subgraph Engine["LaminarDB Engine (Embedded Profile)"]
             Coord["Streaming Coordinator<br/>('laminar-compute' thread)"]:::coordClass
-            InMemState["In-Memory State Store<br/>(foyer / FxHashMap)"]:::stateClass
+            InMemState["In-Memory State Store<br/>(quick_cache / FxHashMap)"]:::stateClass
             Checkpoint["Checkpoint Coordinator"]:::recoveryClass
             Recovery["Recovery Manager"]:::recoveryClass
             
@@ -537,7 +537,7 @@ graph TD
         
         subgraph Engine["LaminarDB Engine (Embedded Library)"]
             Coord["Streaming Coordinator<br/>('laminar-compute')"]:::coordClass
-            State["In-Memory State Store<br/>(foyer / FxHashMap)"]:::stateClass
+            State["In-Memory State Store<br/>(quick_cache / FxHashMap)"]:::stateClass
             Checkpoint["Checkpoint Coordinator"]:::checkpointClass
             Coord <--> State
             Checkpoint -.-> State

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { workspace = true }
 
 # Bytes (for cache value types)
 bytes = { workspace = true }
-foyer = { workspace = true }
+quick_cache = { workspace = true }
 
 # Common
 tokio = { workspace = true }

--- a/crates/laminar-connectors/src/kafka/schema_registry.rs
+++ b/crates/laminar-connectors/src/kafka/schema_registry.rs
@@ -6,7 +6,7 @@
 
 use std::time::{Duration, Instant};
 
-use foyer::{Cache, CacheBuilder};
+use quick_cache::sync::Cache;
 
 use arrow_schema::{DataType, SchemaRef};
 use reqwest::Client;
@@ -103,7 +103,7 @@ pub struct SchemaRegistryClient {
     client: Client,
     base_url: String,
     auth: Option<SrAuth>,
-    /// Cache by schema ID (foyer LRU with S3-FIFO eviction).
+    /// Cache by schema ID (`quick_cache`, S3-FIFO-style eviction).
     cache: Cache<i32, CachedSchema>,
     /// Cache by subject name (latest version).
     subject_cache: Cache<String, CachedSchema>,
@@ -247,10 +247,8 @@ impl SchemaRegistryClient {
         })?;
 
         let cache_config = SchemaRegistryCacheConfig::default();
-        let cache = CacheBuilder::new(cache_config.max_entries)
-            .with_shards(4)
-            .build();
-        let subject_cache = CacheBuilder::new(256).with_shards(4).build();
+        let cache = Cache::new(cache_config.max_entries);
+        let subject_cache = Cache::new(256);
         Ok(Self {
             client,
             base_url: base_url.into().trim_end_matches('/').to_string(),
@@ -268,11 +266,9 @@ impl SchemaRegistryClient {
         auth: Option<SrAuth>,
         cache_config: SchemaRegistryCacheConfig,
     ) -> Self {
-        let cache = CacheBuilder::new(cache_config.max_entries)
-            .with_shards(4)
-            .build();
+        let cache = Cache::new(cache_config.max_entries);
         // Subject cache is small — one entry per subject
-        let subject_cache = CacheBuilder::new(256).with_shards(4).build();
+        let subject_cache = Cache::new(256);
         Self {
             client: Client::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
@@ -303,7 +299,7 @@ impl SchemaRegistryClient {
 
     /// Inserts a schema into the cache.
     ///
-    /// foyer handles LRU eviction internally with S3-FIFO.
+    /// `quick_cache` handles eviction internally (S3-FIFO-style).
     fn cache_insert(&self, id: i32, mut schema: CachedSchema) {
         schema.inserted_at = Instant::now();
         self.cache.insert(id, schema);
@@ -314,17 +310,15 @@ impl SchemaRegistryClient {
     /// TTL is checked lazily on access — expired entries are removed
     /// and treated as cache misses.
     fn cache_get(&self, id: i32) -> Option<CachedSchema> {
-        let entry = self.cache.get(&id)?;
-        let schema = entry.value();
+        let schema = self.cache.get(&id)?;
         if let Some(ttl) = self.cache_config.ttl {
             if schema.inserted_at.elapsed() > ttl {
-                drop(entry);
                 self.cache.remove(&id);
                 return None;
             }
         }
-        // foyer's get() already promotes the entry in the eviction policy
-        Some(schema.clone())
+        // quick_cache's get() already promotes the entry in the eviction policy
+        Some(schema)
     }
 
     /// Fetches a schema by its global ID.
@@ -542,9 +536,9 @@ impl SchemaRegistryClient {
         schema_type: SchemaType,
     ) -> Result<i32, ConnectorError> {
         // Check subject cache — only return cached ID if schema hasn't changed.
-        if let Some(entry) = self.subject_cache.get(subject) {
-            if entry.value().schema_str == schema_str {
-                return Ok(entry.value().id);
+        if let Some(cached) = self.subject_cache.get(subject) {
+            if cached.schema_str == schema_str {
+                return Ok(cached.id);
             }
         }
 
@@ -634,13 +628,13 @@ impl SchemaRegistryClient {
     /// Returns `true` if the schema ID is in the local cache.
     #[must_use]
     pub fn is_cached(&self, id: i32) -> bool {
-        self.cache.contains(&id)
+        self.cache.contains_key(&id)
     }
 
     /// Returns the number of cached schemas.
     #[must_use]
     pub fn cache_size(&self) -> usize {
-        self.cache.usage()
+        self.cache.len()
     }
 
     /// Helper to perform a GET request and deserialize JSON.
@@ -725,8 +719,8 @@ impl std::fmt::Debug for SchemaRegistryClient {
         f.debug_struct("SchemaRegistryClient")
             .field("base_url", &self.base_url)
             .field("has_auth", &self.auth.is_some())
-            .field("cached_schemas", &self.cache.usage())
-            .field("cached_subjects", &self.subject_cache.usage())
+            .field("cached_schemas", &self.cache.len())
+            .field("cached_subjects", &self.subject_cache.len())
             .finish_non_exhaustive()
     }
 }
@@ -1436,7 +1430,7 @@ mod tests {
         client.cache_insert(3, make_cached_schema(3));
         assert_eq!(client.cache_size(), 3);
 
-        // Insert a 4th — should evict one entry (foyer S3-FIFO eviction).
+        // Insert a 4th — should evict one entry (S3-FIFO-style eviction).
         client.cache_insert(4, make_cached_schema(4));
         assert!(client.cache_size() <= 3);
         // The most recently inserted should always be present.

--- a/crates/laminar-core/Cargo.toml
+++ b/crates/laminar-core/Cargo.toml
@@ -27,7 +27,7 @@ rustc-hash = { workspace = true }
 xorf = { workspace = true }
 parking_lot = { workspace = true }
 bytes = { workspace = true }
-foyer = { workspace = true }
+quick_cache = { workspace = true }
 object_store = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 equivalent = "1"

--- a/crates/laminar-core/README.md
+++ b/crates/laminar-core/README.md
@@ -10,7 +10,7 @@ Core streaming engine for LaminarDB: operators, checkpoint barriers, and streami
 | `time` | Event time extraction, watermark generators |
 | `streaming` | Source/Sink/Subscription API backed by crossfire channels |
 | `checkpoint` | Barrier protocol for consistent snapshots |
-| `lookup` | Lookup table trait, predicate pushdown, foyer cache |
+| `lookup` | Lookup table trait, predicate pushdown, in-memory cache |
 | `mv` | Cascading materialized views |
 | `alloc` | Priority-class enforcement (debug builds) |
 | `error_codes` | Structured `LDB-NNNN` error codes and `HotPathError` |
@@ -23,6 +23,6 @@ Core streaming engine for LaminarDB: operators, checkpoint barriers, and streami
 cargo bench -p laminar-core --bench streaming_bench    # Channel and source throughput
 cargo bench -p laminar-core --bench window_bench       # Window operations
 cargo bench -p laminar-core --bench lookup_join_bench  # Lookup join throughput
-cargo bench -p laminar-core --bench cache_bench        # foyer cache hit/miss
+cargo bench -p laminar-core --bench cache_bench        # lookup cache hit/miss
 cargo bench -p laminar-core --bench latency_bench      # End-to-end event latency
 ```

--- a/crates/laminar-core/benches/cache_bench.rs
+++ b/crates/laminar-core/benches/cache_bench.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_types)]
 //! Cache hit/miss ratio benchmarks
 //!
-//! Measures foyer cache performance under realistic workloads with
+//! Measures lookup cache performance under realistic workloads with
 //! Zipfian access patterns.
 //!
 //! Run with: cargo bench --bench cache_bench
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::RngExt;
 
-use laminar_core::lookup::foyer_cache::{FoyerMemoryCache, FoyerMemoryCacheConfig};
+use laminar_core::lookup::lookup_cache::{LookupMemoryCache, LookupMemoryCacheConfig};
 
 fn bench_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![Field::new("v", DataType::Utf8, false)]))
@@ -24,11 +24,11 @@ fn bench_batch(val: &str) -> RecordBatch {
     RecordBatch::try_new(bench_schema(), vec![Arc::new(StringArray::from(vec![val]))]).unwrap()
 }
 
-/// Build a FoyerMemoryCache pre-populated with `n` entries.
-fn populated_cache(n: usize) -> FoyerMemoryCache {
-    let cache = FoyerMemoryCache::new(
+/// Build a LookupMemoryCache pre-populated with `n` entries.
+fn populated_cache(n: usize) -> LookupMemoryCache {
+    let cache = LookupMemoryCache::new(
         1,
-        FoyerMemoryCacheConfig {
+        LookupMemoryCacheConfig {
             // Generous byte budget so the working set is never evicted mid-bench.
             capacity_bytes: n.saturating_mul(8 * 1024),
             shards: 16,

--- a/crates/laminar-core/benches/cache_bench.rs
+++ b/crates/laminar-core/benches/cache_bench.rs
@@ -31,7 +31,6 @@ fn populated_cache(n: usize) -> LookupMemoryCache {
         LookupMemoryCacheConfig {
             // Generous byte budget so the working set is never evicted mid-bench.
             capacity_bytes: n.saturating_mul(8 * 1024),
-            shards: 16,
             ttl: None,
         },
     );

--- a/crates/laminar-core/benches/lookup_join_bench.rs
+++ b/crates/laminar-core/benches/lookup_join_bench.rs
@@ -52,7 +52,6 @@ fn bench_lookup_join_throughput(c: &mut Criterion) {
         LookupMemoryCacheConfig {
             // Generous byte budget so the dimension set is never evicted mid-bench.
             capacity_bytes: dim_size.saturating_mul(8 * 1024),
-            shards: 16,
             ttl: None,
         },
     );
@@ -98,7 +97,6 @@ fn bench_lookup_join_miss_rate(c: &mut Criterion) {
         LookupMemoryCacheConfig {
             // Generous byte budget so the dimension set is never evicted mid-bench.
             capacity_bytes: dim_size.saturating_mul(8 * 1024),
-            shards: 16,
             ttl: None,
         },
     );

--- a/crates/laminar-core/benches/lookup_join_bench.rs
+++ b/crates/laminar-core/benches/lookup_join_bench.rs
@@ -14,7 +14,7 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::RngExt;
 
-use laminar_core::lookup::foyer_cache::{FoyerMemoryCache, FoyerMemoryCacheConfig};
+use laminar_core::lookup::lookup_cache::{LookupMemoryCache, LookupMemoryCacheConfig};
 
 fn bench_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![Field::new("v", DataType::Utf8, false)]))
@@ -47,9 +47,9 @@ fn bench_lookup_join_throughput(c: &mut Criterion) {
     let mut group = c.benchmark_group("lookup_join_throughput");
 
     let dim_size: usize = 10_000;
-    let cache = FoyerMemoryCache::new(
+    let cache = LookupMemoryCache::new(
         1,
-        FoyerMemoryCacheConfig {
+        LookupMemoryCacheConfig {
             // Generous byte budget so the dimension set is never evicted mid-bench.
             capacity_bytes: dim_size.saturating_mul(8 * 1024),
             shards: 16,
@@ -93,9 +93,9 @@ fn bench_lookup_join_miss_rate(c: &mut Criterion) {
     let mut group = c.benchmark_group("lookup_join_miss_rate");
 
     let dim_size: usize = 1_000;
-    let cache = FoyerMemoryCache::new(
+    let cache = LookupMemoryCache::new(
         1,
-        FoyerMemoryCacheConfig {
+        LookupMemoryCacheConfig {
             // Generous byte budget so the dimension set is never evicted mid-bench.
             capacity_bytes: dim_size.saturating_mul(8 * 1024),
             shards: 16,

--- a/crates/laminar-core/src/lookup/lookup_cache.rs
+++ b/crates/laminar-core/src/lookup/lookup_cache.rs
@@ -1,9 +1,10 @@
-//! foyer-backed in-memory cache for lookup tables.
+//! `quick_cache`-backed in-memory cache for lookup tables.
 //!
-//! ## Ring 0 — [`FoyerMemoryCache`]
+//! ## Ring 0 — [`LookupMemoryCache`]
 //!
-//! Synchronous [`foyer::Cache`] with S3-FIFO eviction. Checked per-event
-//! on the operator hot path — sub-microsecond latency.
+//! Synchronous [`quick_cache::sync::Cache`] with S3-FIFO-style (Clock-PRO)
+//! eviction. Checked per-event on the operator hot path — sub-microsecond
+//! latency.
 //!
 //! `RecordBatch` clone is Arc bumps only (~16-48ns), within Ring 0 budget.
 
@@ -13,14 +14,15 @@ use std::time::{Duration, Instant};
 
 use arrow_array::RecordBatch;
 use equivalent::Equivalent;
-use foyer::{Cache, CacheBuilder};
+use quick_cache::sync::{Cache, DefaultLifecycle};
+use quick_cache::{DefaultHashBuilder, OptionsBuilder, Weighter};
 
 use crate::lookup::table::LookupResult;
 
 /// Composite cache key: table ID + raw key bytes.
 ///
 /// The `table_id` ensures that caches for different lookup tables
-/// never collide, even if they share a `foyer::Cache` instance.
+/// never collide, even if they share a cache instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct LookupCacheKey {
     /// Lookup table identifier.
@@ -31,7 +33,7 @@ pub struct LookupCacheKey {
 
 /// Borrowed view of [`LookupCacheKey`] that avoids heap allocation.
 ///
-/// Used with foyer's `Cache::get<Q>()` where `Q: Hash + Equivalent<K>`.
+/// Used with `quick_cache`'s `Cache::get<Q>()` where `Q: Hash + Equivalent<K>`.
 /// Hashes identically to `LookupCacheKey` because `Vec<u8>` and `[u8]`
 /// produce the same hash output.
 pub(crate) struct LookupCacheKeyRef<'a> {
@@ -55,24 +57,26 @@ impl Equivalent<LookupCacheKey> for LookupCacheKeyRef<'_> {
     }
 }
 
-/// Configuration for [`FoyerMemoryCache`].
+/// Configuration for [`LookupMemoryCache`].
 #[derive(Debug, Clone, Copy)]
-pub struct FoyerMemoryCacheConfig {
+pub struct LookupMemoryCacheConfig {
     /// Memory budget in bytes. Entries are weighted by their `RecordBatch`
     /// array size, so a few wide rows can't blow the bound the way an
     /// entry-count limit would.
     pub capacity_bytes: usize,
     /// Number of shards for concurrent access (should be a power of 2).
+    /// Each shard holds `capacity_bytes / shards`; an entry larger than its
+    /// shard's budget is rejected rather than admitted.
     pub shards: usize,
     /// Optional time-to-live. An entry older than `ttl` is treated as a miss
-    /// on the next [`get`](FoyerMemoryCache::get) (lazy expiry) and dropped, so
+    /// on the next [`get`](LookupMemoryCache::get) (lazy expiry) and dropped, so
     /// the caller re-fetches from the source. `None` = entries live until the
     /// byte bound evicts them (eventual freshness via eviction + CDC
     /// invalidation only).
     pub ttl: Option<Duration>,
 }
 
-impl Default for FoyerMemoryCacheConfig {
+impl Default for LookupMemoryCacheConfig {
     fn default() -> Self {
         Self {
             capacity_bytes: 64 * 1024 * 1024, // 64 MiB
@@ -90,35 +94,61 @@ struct CachedBatch {
     inserted_at: Instant,
 }
 
-/// foyer-backed in-memory lookup table cache.
+/// Weighs entries by payload bytes (min 1 so tombstones count) so the bound
+/// is memory, not entry count.
+#[derive(Debug, Clone)]
+struct BatchWeighter;
+
+impl Weighter<LookupCacheKey, CachedBatch> for BatchWeighter {
+    fn weight(&self, _key: &LookupCacheKey, val: &CachedBatch) -> u64 {
+        val.batch.get_array_memory_size().max(1) as u64
+    }
+}
+
+type BatchCache = Cache<LookupCacheKey, CachedBatch, BatchWeighter>;
+
+/// `quick_cache`-backed in-memory lookup table cache.
 ///
-/// Wraps [`foyer::Cache`] with hit/miss counters and lookup-table
+/// Wraps [`quick_cache::sync::Cache`] with hit/miss counters and lookup-table
 /// semantics. Designed for Ring 0 (< 500ns per operation).
 ///
 /// # Thread safety
 ///
-/// `foyer::Cache` is internally sharded and lock-free on the read path.
-/// `FoyerMemoryCache` is `Send + Sync`.
-pub struct FoyerMemoryCache {
-    cache: Cache<LookupCacheKey, CachedBatch>,
+/// `quick_cache::sync::Cache` is internally sharded with per-shard locks held
+/// only for the duration of a map operation. `LookupMemoryCache` is
+/// `Send + Sync`.
+pub struct LookupMemoryCache {
+    cache: BatchCache,
     table_id: u32,
     ttl: Option<Duration>,
     hits: AtomicU64,
     misses: AtomicU64,
 }
 
-impl FoyerMemoryCache {
+impl LookupMemoryCache {
     /// Create a new cache with the given configuration.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the options builder only errors when a capacity
+    /// field is left unset, and both are always set here.
     #[must_use]
-    pub fn new(table_id: u32, config: FoyerMemoryCacheConfig) -> Self {
-        let cache = CacheBuilder::new(config.capacity_bytes)
-            .with_shards(config.shards)
-            // Weigh entries by payload bytes (min 1 so tombstones count) so the
-            // bound is memory, not entry count.
-            .with_weighter(|_k: &LookupCacheKey, v: &CachedBatch| {
-                v.batch.get_array_memory_size().max(1)
-            })
-            .build();
+    pub fn new(table_id: u32, config: LookupMemoryCacheConfig) -> Self {
+        // Estimated entry count only sizes internal tables (ghost set, shard
+        // count); within an order of magnitude is fine. Assume ~1 KiB/entry.
+        let estimated_items = (config.capacity_bytes / 1024).max(64);
+        let options = OptionsBuilder::new()
+            .shards(config.shards)
+            .estimated_items_capacity(estimated_items)
+            .weight_capacity(config.capacity_bytes as u64)
+            .build()
+            .expect("both capacities are set");
+        let cache = BatchCache::with_options(
+            options,
+            BatchWeighter,
+            DefaultHashBuilder::default(),
+            DefaultLifecycle::default(),
+        );
 
         Self {
             cache,
@@ -132,7 +162,7 @@ impl FoyerMemoryCache {
     /// Create a cache with default configuration.
     #[must_use]
     pub fn with_defaults(table_id: u32) -> Self {
-        Self::new(table_id, FoyerMemoryCacheConfig::default())
+        Self::new(table_id, LookupMemoryCacheConfig::default())
     }
 
     /// Total cache hits since creation.
@@ -185,25 +215,23 @@ impl FoyerMemoryCache {
             table_id: self.table_id,
             key,
         };
-        if let Some(entry) = self.cache.get(&ref_key) {
+        if let Some(cached) = self.cache.get(&ref_key) {
             if self
                 .ttl
-                .is_some_and(|ttl| entry.value().inserted_at.elapsed() >= ttl)
+                .is_some_and(|ttl| cached.inserted_at.elapsed() >= ttl)
             {
-                let inserted_at = entry.value().inserted_at;
-                drop(entry);
-                if let Some(new_entry) = self.cache.get(&ref_key) {
-                    if new_entry.value().inserted_at == inserted_at {
-                        drop(new_entry);
-                        self.cache.remove(&ref_key);
+                // Lazy expiry. If a fresh value raced in between the get and
+                // the remove, put it back rather than dropping it.
+                if let Some((k, v)) = self.cache.remove(&ref_key) {
+                    if v.inserted_at != cached.inserted_at {
+                        self.cache.insert(k, v);
                     }
                 }
                 self.misses.fetch_add(1, Ordering::Relaxed);
                 return LookupResult::NotFound;
             }
-            let value = entry.value().batch.clone();
             self.hits.fetch_add(1, Ordering::Relaxed);
-            LookupResult::Hit(value)
+            LookupResult::Hit(cached.batch)
         } else {
             self.misses.fetch_add(1, Ordering::Relaxed);
             LookupResult::NotFound
@@ -238,22 +266,22 @@ impl FoyerMemoryCache {
 
     /// Number of entries currently in the cache.
     pub fn len(&self) -> usize {
-        self.cache.entries()
+        self.cache.len()
     }
 
     /// Whether the cache is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.cache.is_empty()
     }
 }
 
-impl std::fmt::Debug for FoyerMemoryCache {
+impl std::fmt::Debug for LookupMemoryCache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FoyerMemoryCache")
+        f.debug_struct("LookupMemoryCache")
             .field("table_id", &self.table_id)
             .field("ttl", &self.ttl)
-            .field("entries", &self.cache.entries())
+            .field("entries", &self.cache.len())
             .field("hits", &self.hits.load(Ordering::Relaxed))
             .field("misses", &self.misses.load(Ordering::Relaxed))
             .finish()
@@ -272,10 +300,10 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec![val]))]).unwrap()
     }
 
-    fn small_cache(table_id: u32) -> FoyerMemoryCache {
-        FoyerMemoryCache::new(
+    fn small_cache(table_id: u32) -> LookupMemoryCache {
+        LookupMemoryCache::new(
             table_id,
-            FoyerMemoryCacheConfig {
+            LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
                 shards: 4,
                 ttl: None,
@@ -284,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_hit_miss() {
+    fn test_lookup_cache_hit_miss() {
         let cache = small_cache(1);
 
         let result = cache.get_cached(b"key1");
@@ -300,12 +328,12 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_eviction() {
+    fn test_lookup_cache_eviction() {
         // Tiny byte budget: inserting many batches must evict (the bound is
         // bytes, so the cache can't hold all 200 entries).
-        let cache = FoyerMemoryCache::new(
+        let cache = LookupMemoryCache::new(
             1,
-            FoyerMemoryCacheConfig {
+            LookupMemoryCacheConfig {
                 capacity_bytes: 512,
                 shards: 1,
                 ttl: None,
@@ -324,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_invalidation() {
+    fn test_lookup_cache_invalidation() {
         let cache = small_cache(1);
 
         cache.insert(b"key1", test_batch("value1"));
@@ -335,7 +363,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_table_id_isolation() {
+    fn test_lookup_cache_table_id_isolation() {
         let cache_a = small_cache(1);
         let cache_b = small_cache(2);
 
@@ -351,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_lookup_methods() {
+    fn test_lookup_cache_methods() {
         let cache = small_cache(1);
 
         cache.insert(b"k", test_batch("v"));
@@ -360,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_hit_ratio() {
+    fn test_lookup_cache_hit_ratio() {
         let cache = small_cache(1);
         cache.insert(b"k1", test_batch("v1"));
 
@@ -373,25 +401,25 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_debug() {
+    fn test_lookup_cache_debug() {
         let cache = small_cache(42);
         let debug = format!("{cache:?}");
-        assert!(debug.contains("FoyerMemoryCache"));
+        assert!(debug.contains("LookupMemoryCache"));
         assert!(debug.contains("table_id: 42"));
     }
 
     #[test]
-    fn test_foyer_cache_default_config() {
-        let config = FoyerMemoryCacheConfig::default();
+    fn test_lookup_cache_default_config() {
+        let config = LookupMemoryCacheConfig::default();
         assert_eq!(config.capacity_bytes, 64 * 1024 * 1024);
         assert_eq!(config.shards, 16);
         assert!(config.ttl.is_none());
     }
 
-    fn ttl_cache(ttl: Duration) -> FoyerMemoryCache {
-        FoyerMemoryCache::new(
+    fn ttl_cache(ttl: Duration) -> LookupMemoryCache {
+        LookupMemoryCache::new(
             1,
-            FoyerMemoryCacheConfig {
+            LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
                 shards: 4,
                 ttl: Some(ttl),
@@ -432,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn test_foyer_cache_recordbatch_clone_is_cheap() {
+    fn test_lookup_cache_recordbatch_clone_is_cheap() {
         let cache = small_cache(1);
         let batch = test_batch("value");
         cache.insert(b"k", batch.clone());

--- a/crates/laminar-core/src/lookup/lookup_cache.rs
+++ b/crates/laminar-core/src/lookup/lookup_cache.rs
@@ -166,9 +166,9 @@ impl LookupMemoryCache {
     ///
     /// When a TTL is configured, an entry older than the TTL is dropped and
     /// reported as a miss (lazy expiry), so the caller re-fetches a fresh value
-    /// from the source. The drop is best-effort: a fresh value racing in
-    /// between the get and the remove may be dropped too, costing one
-    /// redundant re-fetch.
+    /// from the source. The removal re-checks expiry under the shard lock
+    /// (`remove_if`), so a fresh value racing in between the read and the
+    /// removal is preserved.
     #[must_use]
     pub fn get_cached(&self, key: &[u8]) -> LookupResult {
         let ref_key = LookupCacheKeyRef {
@@ -176,17 +176,19 @@ impl LookupMemoryCache {
             key,
         };
         match self.cache.get(&ref_key) {
-            Some(cached)
-                if self
-                    .ttl
-                    .is_some_and(|ttl| cached.inserted_at.elapsed() >= ttl) =>
-            {
-                self.cache.remove(&ref_key);
+            Some(cached) if self.is_expired(&cached) => {
+                self.cache.remove_if(&ref_key, |v| self.is_expired(v));
                 LookupResult::NotFound
             }
             Some(cached) => LookupResult::Hit(cached.batch),
             None => LookupResult::NotFound,
         }
+    }
+
+    /// Whether an entry is past the configured TTL. `None` = never expires.
+    fn is_expired(&self, entry: &CachedBatch) -> bool {
+        self.ttl
+            .is_some_and(|ttl| entry.inserted_at.elapsed() >= ttl)
     }
 
     /// Insert or update a cached entry. The TTL clock starts now.

--- a/crates/laminar-core/src/lookup/lookup_cache.rs
+++ b/crates/laminar-core/src/lookup/lookup_cache.rs
@@ -9,13 +9,12 @@
 //! `RecordBatch` clone is Arc bumps only (~16-48ns), within Ring 0 budget.
 
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use arrow_array::RecordBatch;
 use equivalent::Equivalent;
 use quick_cache::sync::{Cache, DefaultLifecycle};
-use quick_cache::{DefaultHashBuilder, OptionsBuilder, Weighter};
+use quick_cache::{DefaultHashBuilder, Weighter};
 
 use crate::lookup::table::LookupResult;
 
@@ -62,17 +61,15 @@ impl Equivalent<LookupCacheKey> for LookupCacheKeyRef<'_> {
 pub struct LookupMemoryCacheConfig {
     /// Memory budget in bytes. Entries are weighted by their `RecordBatch`
     /// array size, so a few wide rows can't blow the bound the way an
-    /// entry-count limit would.
+    /// entry-count limit would. The budget is split across internal shards;
+    /// an entry larger than a shard's slice is rejected rather than admitted
+    /// (it degrades to a re-fetch, never an error).
     pub capacity_bytes: usize,
-    /// Number of shards for concurrent access (should be a power of 2).
-    /// Each shard holds `capacity_bytes / shards`; an entry larger than its
-    /// shard's budget is rejected rather than admitted.
-    pub shards: usize,
     /// Optional time-to-live. An entry older than `ttl` is treated as a miss
-    /// on the next [`get`](LookupMemoryCache::get) (lazy expiry) and dropped, so
-    /// the caller re-fetches from the source. `None` = entries live until the
-    /// byte bound evicts them (eventual freshness via eviction + CDC
-    /// invalidation only).
+    /// on the next [`get_cached`](LookupMemoryCache::get_cached) (lazy expiry)
+    /// and dropped, so the caller re-fetches from the source. `None` = entries
+    /// live until the byte bound evicts them (eventual freshness via eviction
+    /// + CDC invalidation only).
     pub ttl: Option<Duration>,
 }
 
@@ -80,7 +77,6 @@ impl Default for LookupMemoryCacheConfig {
     fn default() -> Self {
         Self {
             capacity_bytes: 64 * 1024 * 1024, // 64 MiB
-            shards: 16,
             ttl: None,
         }
     }
@@ -109,8 +105,9 @@ type BatchCache = Cache<LookupCacheKey, CachedBatch, BatchWeighter>;
 
 /// `quick_cache`-backed in-memory lookup table cache.
 ///
-/// Wraps [`quick_cache::sync::Cache`] with hit/miss counters and lookup-table
-/// semantics. Designed for Ring 0 (< 500ns per operation).
+/// Wraps [`quick_cache::sync::Cache`] with lookup-table semantics (composite
+/// table-scoped keys, lazy TTL expiry). Designed for Ring 0 (< 500ns per
+/// operation).
 ///
 /// # Thread safety
 ///
@@ -121,30 +118,18 @@ pub struct LookupMemoryCache {
     cache: BatchCache,
     table_id: u32,
     ttl: Option<Duration>,
-    hits: AtomicU64,
-    misses: AtomicU64,
 }
 
 impl LookupMemoryCache {
     /// Create a new cache with the given configuration.
-    ///
-    /// # Panics
-    ///
-    /// Never in practice: the options builder only errors when a capacity
-    /// field is left unset, and both are always set here.
     #[must_use]
     pub fn new(table_id: u32, config: LookupMemoryCacheConfig) -> Self {
         // Estimated entry count only sizes internal tables (ghost set, shard
         // count); within an order of magnitude is fine. Assume ~1 KiB/entry.
         let estimated_items = (config.capacity_bytes / 1024).max(64);
-        let options = OptionsBuilder::new()
-            .shards(config.shards)
-            .estimated_items_capacity(estimated_items)
-            .weight_capacity(config.capacity_bytes as u64)
-            .build()
-            .expect("both capacities are set");
-        let cache = BatchCache::with_options(
-            options,
+        let cache = BatchCache::with(
+            estimated_items,
+            config.capacity_bytes as u64,
             BatchWeighter,
             DefaultHashBuilder::default(),
             DefaultLifecycle::default(),
@@ -154,8 +139,6 @@ impl LookupMemoryCache {
             cache,
             table_id,
             ttl: config.ttl,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
         }
     }
 
@@ -163,32 +146,6 @@ impl LookupMemoryCache {
     #[must_use]
     pub fn with_defaults(table_id: u32) -> Self {
         Self::new(table_id, LookupMemoryCacheConfig::default())
-    }
-
-    /// Total cache hits since creation.
-    #[must_use]
-    pub fn hit_count(&self) -> u64 {
-        self.hits.load(Ordering::Relaxed)
-    }
-
-    /// Total cache misses since creation.
-    #[must_use]
-    pub fn miss_count(&self) -> u64 {
-        self.misses.load(Ordering::Relaxed)
-    }
-
-    /// Cache hit ratio (0.0 – 1.0).
-    #[must_use]
-    #[allow(clippy::cast_precision_loss)]
-    pub fn hit_ratio(&self) -> f64 {
-        let hits = self.hits.load(Ordering::Relaxed);
-        let misses = self.misses.load(Ordering::Relaxed);
-        let total = hits + misses;
-        if total == 0 {
-            0.0
-        } else {
-            hits as f64 / total as f64
-        }
     }
 
     /// The table ID this cache is associated with.
@@ -209,38 +166,27 @@ impl LookupMemoryCache {
     ///
     /// When a TTL is configured, an entry older than the TTL is dropped and
     /// reported as a miss (lazy expiry), so the caller re-fetches a fresh value
-    /// from the source.
+    /// from the source. The drop is best-effort: a fresh value racing in
+    /// between the get and the remove may be dropped too, costing one
+    /// redundant re-fetch.
+    #[must_use]
     pub fn get_cached(&self, key: &[u8]) -> LookupResult {
         let ref_key = LookupCacheKeyRef {
             table_id: self.table_id,
             key,
         };
-        if let Some(cached) = self.cache.get(&ref_key) {
-            if self
-                .ttl
-                .is_some_and(|ttl| cached.inserted_at.elapsed() >= ttl)
+        match self.cache.get(&ref_key) {
+            Some(cached)
+                if self
+                    .ttl
+                    .is_some_and(|ttl| cached.inserted_at.elapsed() >= ttl) =>
             {
-                // Lazy expiry. If a fresh value raced in between the get and
-                // the remove, put it back rather than dropping it.
-                if let Some((k, v)) = self.cache.remove(&ref_key) {
-                    if v.inserted_at != cached.inserted_at {
-                        self.cache.insert(k, v);
-                    }
-                }
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                return LookupResult::NotFound;
+                self.cache.remove(&ref_key);
+                LookupResult::NotFound
             }
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            LookupResult::Hit(cached.batch)
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-            LookupResult::NotFound
+            Some(cached) => LookupResult::Hit(cached.batch),
+            None => LookupResult::NotFound,
         }
-    }
-
-    /// Alias for [`get_cached`](Self::get_cached). No slower storage tiers are wired yet.
-    pub fn get(&self, key: &[u8]) -> LookupResult {
-        self.get_cached(key)
     }
 
     /// Insert or update a cached entry. The TTL clock starts now.
@@ -265,6 +211,7 @@ impl LookupMemoryCache {
     }
 
     /// Number of entries currently in the cache.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.cache.len()
     }
@@ -282,8 +229,6 @@ impl std::fmt::Debug for LookupMemoryCache {
             .field("table_id", &self.table_id)
             .field("ttl", &self.ttl)
             .field("entries", &self.cache.len())
-            .field("hits", &self.hits.load(Ordering::Relaxed))
-            .field("misses", &self.misses.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -305,7 +250,6 @@ mod tests {
             table_id,
             LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
-                shards: 4,
                 ttl: None,
             },
         )
@@ -315,27 +259,22 @@ mod tests {
     fn test_lookup_cache_hit_miss() {
         let cache = small_cache(1);
 
-        let result = cache.get_cached(b"key1");
-        assert!(result.is_not_found());
-        assert_eq!(cache.miss_count(), 1);
+        assert!(cache.get_cached(b"key1").is_not_found());
 
         cache.insert(b"key1", test_batch("value1"));
         let result = cache.get_cached(b"key1");
         assert!(result.is_hit());
-        let batch = result.into_batch().unwrap();
-        assert_eq!(batch.num_rows(), 1);
-        assert_eq!(cache.hit_count(), 1);
+        assert_eq!(result.into_batch().unwrap().num_rows(), 1);
     }
 
     #[test]
     fn test_lookup_cache_eviction() {
-        // Tiny byte budget: inserting many batches must evict (the bound is
-        // bytes, so the cache can't hold all 200 entries).
+        // Tiny byte budget: inserting many batches must evict or reject (the
+        // bound is bytes, so the cache can't hold all 200 entries).
         let cache = LookupMemoryCache::new(
             1,
             LookupMemoryCacheConfig {
                 capacity_bytes: 512,
-                shards: 1,
                 ttl: None,
             },
         );
@@ -378,50 +317,11 @@ mod tests {
         assert_ne!(batch_a, batch_b);
     }
 
-    #[test]
-    fn test_lookup_cache_methods() {
-        let cache = small_cache(1);
-
-        cache.insert(b"k", test_batch("v"));
-        assert!(!cache.is_empty());
-        assert!(cache.get(b"k").is_hit());
-    }
-
-    #[test]
-    fn test_lookup_cache_hit_ratio() {
-        let cache = small_cache(1);
-        cache.insert(b"k1", test_batch("v1"));
-
-        // 1 hit
-        cache.get_cached(b"k1");
-        // 1 miss
-        cache.get_cached(b"k2");
-
-        assert!((cache.hit_ratio() - 0.5).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_lookup_cache_debug() {
-        let cache = small_cache(42);
-        let debug = format!("{cache:?}");
-        assert!(debug.contains("LookupMemoryCache"));
-        assert!(debug.contains("table_id: 42"));
-    }
-
-    #[test]
-    fn test_lookup_cache_default_config() {
-        let config = LookupMemoryCacheConfig::default();
-        assert_eq!(config.capacity_bytes, 64 * 1024 * 1024);
-        assert_eq!(config.shards, 16);
-        assert!(config.ttl.is_none());
-    }
-
     fn ttl_cache(ttl: Duration) -> LookupMemoryCache {
         LookupMemoryCache::new(
             1,
             LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
-                shards: 4,
                 ttl: Some(ttl),
             },
         )
@@ -435,7 +335,6 @@ mod tests {
         assert!(cache.get_cached(b"k").is_not_found());
         // The expired entry was evicted, not just skipped.
         assert!(cache.is_empty());
-        assert_eq!(cache.miss_count(), 1);
     }
 
     #[test]
@@ -457,17 +356,5 @@ mod tests {
         cache.insert(b"k", test_batch("v"));
         std::thread::sleep(Duration::from_millis(10));
         assert!(cache.get_cached(b"k").is_hit());
-    }
-
-    #[test]
-    fn test_lookup_cache_recordbatch_clone_is_cheap() {
-        let cache = small_cache(1);
-        let batch = test_batch("value");
-        cache.insert(b"k", batch.clone());
-
-        let hit1 = cache.get_cached(b"k").into_batch().unwrap();
-        let hit2 = cache.get_cached(b"k").into_batch().unwrap();
-        assert_eq!(hit1, hit2);
-        assert_eq!(hit1.num_rows(), 1);
     }
 }

--- a/crates/laminar-core/src/lookup/mod.rs
+++ b/crates/laminar-core/src/lookup/mod.rs
@@ -1,12 +1,12 @@
 //! Lookup table traits, predicate pushdown, and caching.
 
 pub mod align;
-pub mod foyer_cache;
+pub mod lookup_cache;
 pub mod predicate;
 pub mod source;
 
 pub use align::KeyAligner;
-pub use foyer_cache::{FoyerMemoryCache, FoyerMemoryCacheConfig, LookupCacheKey};
+pub use lookup_cache::{LookupCacheKey, LookupMemoryCache, LookupMemoryCacheConfig};
 pub use predicate::{
     predicate_to_sql, split_predicates, Predicate, ScalarValue, SourceCapabilities, SplitPredicates,
 };

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -57,7 +57,7 @@ laminar-sql = { path = "../laminar-sql", version = "0.25.1" }
 laminar-connectors = { path = "../laminar-connectors", version = "0.25.1" }
 
 # AI Inference Dependencies (Consolidated from laminar-ai)
-foyer = { workspace = true }
+quick_cache = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 governor = { version = "0.8", optional = true }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["load-dynamic", "api-24"], optional = true }

--- a/crates/laminar-db/src/ai/cache.rs
+++ b/crates/laminar-db/src/ai/cache.rs
@@ -12,10 +12,8 @@
 //! is a memory op: cheap enough to gate the inference worker from the operator
 //! without doing the model call inline.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use quick_cache::sync::{Cache, DefaultLifecycle};
-use quick_cache::{DefaultHashBuilder, OptionsBuilder, Weighter};
+use quick_cache::{DefaultHashBuilder, Weighter};
 
 use crate::ai::provider::InferenceParams;
 use crate::ai::registry::Task;
@@ -84,15 +82,12 @@ pub struct AiResultCacheConfig {
     /// bounds memory directly — an entry count would not, since an embedding
     /// vector is orders of magnitude larger than a one-word label.
     pub capacity_bytes: usize,
-    /// Number of shards for concurrent access (power of 2).
-    pub shards: usize,
 }
 
 impl Default for AiResultCacheConfig {
     fn default() -> Self {
         Self {
             capacity_bytes: 64 * 1024 * 1024,
-            shards: 16,
         }
     }
 }
@@ -120,40 +115,24 @@ impl Weighter<AiCacheKey, CachedOutput> for OutputWeighter {
 /// `Send + Sync`.
 pub struct AiResultCache {
     cache: Cache<AiCacheKey, CachedOutput, OutputWeighter>,
-    hits: AtomicU64,
-    misses: AtomicU64,
 }
 
 impl AiResultCache {
     /// Create a cache with the given configuration.
-    ///
-    /// # Panics
-    ///
-    /// Never in practice: the options builder only errors when a capacity
-    /// field is left unset, and both are always set here.
     #[must_use]
     pub fn new(config: AiResultCacheConfig) -> Self {
         // Estimated entry count only sizes internal tables; within an order
         // of magnitude is fine. Assume ~256 B/entry (labels are small,
         // embeddings large; the byte weighter enforces the real bound).
         let estimated_items = (config.capacity_bytes / 256).max(64);
-        let options = OptionsBuilder::new()
-            .shards(config.shards)
-            .estimated_items_capacity(estimated_items)
-            .weight_capacity(config.capacity_bytes as u64)
-            .build()
-            .expect("both capacities are set");
-        let cache = Cache::with_options(
-            options,
+        let cache = Cache::with(
+            estimated_items,
+            config.capacity_bytes as u64,
             OutputWeighter,
             DefaultHashBuilder::default(),
             DefaultLifecycle::default(),
         );
-        Self {
-            cache,
-            hits: AtomicU64::new(0),
-            misses: AtomicU64::new(0),
-        }
+        Self { cache }
     }
 
     /// Create a cache with default configuration.
@@ -162,33 +141,15 @@ impl AiResultCache {
         Self::new(AiResultCacheConfig::default())
     }
 
-    /// Look up a cached result, recording a hit or miss.
+    /// Look up a cached result.
     #[must_use]
     pub fn get(&self, key: &AiCacheKey) -> Option<CachedOutput> {
-        if let Some(value) = self.cache.get(key) {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            Some(value)
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-            None
-        }
+        self.cache.get(key)
     }
 
     /// Insert or update a cached result.
     pub fn insert(&self, key: AiCacheKey, value: CachedOutput) {
         self.cache.insert(key, value);
-    }
-
-    /// Total cache hits since creation.
-    #[must_use]
-    pub fn hit_count(&self) -> u64 {
-        self.hits.load(Ordering::Relaxed)
-    }
-
-    /// Total cache misses since creation.
-    #[must_use]
-    pub fn miss_count(&self) -> u64 {
-        self.misses.load(Ordering::Relaxed)
     }
 
     /// Number of entries currently cached.
@@ -208,8 +169,6 @@ impl std::fmt::Debug for AiResultCache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AiResultCache")
             .field("len", &self.len())
-            .field("hits", &self.hit_count())
-            .field("misses", &self.miss_count())
             .finish()
     }
 }
@@ -259,6 +218,5 @@ mod tests {
             cache.get(&remote),
             Some(CachedOutput::Text("negative".into()))
         );
-        assert_eq!(cache.hit_count(), 2);
     }
 }

--- a/crates/laminar-db/src/ai/cache.rs
+++ b/crates/laminar-db/src/ai/cache.rs
@@ -7,14 +7,15 @@
 //! permanently for correctness; remote results are cached as a cost-saver. The
 //! cache itself does not distinguish the two — that policy lives in the caller.
 //!
-//! The cache is an in-memory [`foyer::Cache`] with S3-FIFO eviction, the same
-//! crate the lookup and schema-registry caches use. A lookup is a memory op:
-//! cheap enough to gate the inference worker from the operator without doing the
-//! model call inline.
+//! The cache is an in-memory [`quick_cache::sync::Cache`] with S3-FIFO-style
+//! eviction, the same crate the lookup and schema-registry caches use. A lookup
+//! is a memory op: cheap enough to gate the inference worker from the operator
+//! without doing the model call inline.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use foyer::{Cache, CacheBuilder};
+use quick_cache::sync::{Cache, DefaultLifecycle};
+use quick_cache::{DefaultHashBuilder, OptionsBuilder, Weighter};
 
 use crate::ai::provider::InferenceParams;
 use crate::ai::registry::Task;
@@ -98,33 +99,56 @@ impl Default for AiResultCacheConfig {
 
 /// Weight of one cache entry: its payload bytes plus fixed key/bookkeeping
 /// overhead, so tiny entries still count against the budget.
-fn entry_weight(_key: &AiCacheKey, value: &CachedOutput) -> usize {
-    let payload = match value {
-        CachedOutput::Text(s) => s.len(),
-        CachedOutput::Vector(v) => v.len() * std::mem::size_of::<f32>(),
-        CachedOutput::Score(_) => std::mem::size_of::<f64>(),
-    };
-    payload + std::mem::size_of::<AiCacheKey>() + 32
+#[derive(Debug, Clone)]
+struct OutputWeighter;
+
+impl Weighter<AiCacheKey, CachedOutput> for OutputWeighter {
+    fn weight(&self, _key: &AiCacheKey, value: &CachedOutput) -> u64 {
+        let payload = match value {
+            CachedOutput::Text(s) => s.len(),
+            CachedOutput::Vector(v) => v.len() * std::mem::size_of::<f32>(),
+            CachedOutput::Score(_) => std::mem::size_of::<f64>(),
+        };
+        (payload + std::mem::size_of::<AiCacheKey>() + 32) as u64
+    }
 }
 
-/// foyer-backed in-memory cache of per-row inference results.
+/// `quick_cache`-backed in-memory cache of per-row inference results.
 ///
-/// `foyer::Cache` is internally sharded and lock-free on the read path, so
-/// [`AiResultCache`] is `Send + Sync`.
+/// `quick_cache::sync::Cache` is internally sharded with per-shard locks held
+/// only for the duration of a map operation, so [`AiResultCache`] is
+/// `Send + Sync`.
 pub struct AiResultCache {
-    cache: Cache<AiCacheKey, CachedOutput>,
+    cache: Cache<AiCacheKey, CachedOutput, OutputWeighter>,
     hits: AtomicU64,
     misses: AtomicU64,
 }
 
 impl AiResultCache {
     /// Create a cache with the given configuration.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the options builder only errors when a capacity
+    /// field is left unset, and both are always set here.
     #[must_use]
     pub fn new(config: AiResultCacheConfig) -> Self {
-        let cache = CacheBuilder::new(config.capacity_bytes)
-            .with_shards(config.shards)
-            .with_weighter(entry_weight)
-            .build();
+        // Estimated entry count only sizes internal tables; within an order
+        // of magnitude is fine. Assume ~256 B/entry (labels are small,
+        // embeddings large; the byte weighter enforces the real bound).
+        let estimated_items = (config.capacity_bytes / 256).max(64);
+        let options = OptionsBuilder::new()
+            .shards(config.shards)
+            .estimated_items_capacity(estimated_items)
+            .weight_capacity(config.capacity_bytes as u64)
+            .build()
+            .expect("both capacities are set");
+        let cache = Cache::with_options(
+            options,
+            OutputWeighter,
+            DefaultHashBuilder::default(),
+            DefaultLifecycle::default(),
+        );
         Self {
             cache,
             hits: AtomicU64::new(0),
@@ -141,9 +165,9 @@ impl AiResultCache {
     /// Look up a cached result, recording a hit or miss.
     #[must_use]
     pub fn get(&self, key: &AiCacheKey) -> Option<CachedOutput> {
-        if let Some(entry) = self.cache.get(key) {
+        if let Some(value) = self.cache.get(key) {
             self.hits.fetch_add(1, Ordering::Relaxed);
-            Some(entry.value().clone())
+            Some(value)
         } else {
             self.misses.fetch_add(1, Ordering::Relaxed);
             None
@@ -170,7 +194,7 @@ impl AiResultCache {
     /// Number of entries currently cached.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.cache.entries()
+        self.cache.len()
     }
 
     /// Whether the cache is empty.

--- a/crates/laminar-db/src/connector_manager.rs
+++ b/crates/laminar-db/src/connector_manager.rs
@@ -55,7 +55,7 @@ pub(crate) struct TableRegistration {
     pub format: Option<String>,
     pub format_options: HashMap<String, String>,
     pub refresh: Option<RefreshMode>,
-    /// Byte budget for the on-demand lookup `FoyerMemoryCache` (partial mode).
+    /// Byte budget for the on-demand lookup `LookupMemoryCache` (partial mode).
     /// `None` falls back to the cache's default.
     pub cache_max_bytes: Option<usize>,
     /// Time-to-live for on-demand lookup cache entries (partial mode). After

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -483,7 +483,7 @@ impl LaminarDB {
 
             if is_persistent {
                 return Err(DbError::InvalidOperation(
-                    "storage = 'persistent' is no longer supported; use in-memory tables with foyer caching instead".to_string(),
+                    "storage = 'persistent' is no longer supported; use in-memory tables with in-memory caching instead".to_string(),
                 ));
             } else if resolved_cache_mode.is_some() {
                 let mut ts = self.table_store.write();

--- a/crates/laminar-db/src/operator/lookup_enrich.rs
+++ b/crates/laminar-db/src/operator/lookup_enrich.rs
@@ -387,7 +387,7 @@ impl LookupEnrichOperator {
                 continue;
             }
             let key = rows.row(row);
-            match resolved.cache.get(key.as_ref()).into_batch() {
+            match resolved.cache.get_cached(key.as_ref()).into_batch() {
                 // Zero-row batch = negative-cache tombstone (known miss).
                 Some(b) if b.num_rows() == 0 => {
                     hits += 1;

--- a/crates/laminar-db/src/operator/lookup_enrich.rs
+++ b/crates/laminar-db/src/operator/lookup_enrich.rs
@@ -23,7 +23,7 @@ use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use laminar_core::lookup::foyer_cache::FoyerMemoryCache;
+use laminar_core::lookup::lookup_cache::LookupMemoryCache;
 use laminar_core::lookup::source::{ColumnId, LookupSourceDyn};
 use laminar_core::serialization::{deserialize_batch_stream, serialize_batch_stream};
 use laminar_sql::datafusion::lookup_join::LookupJoinType;
@@ -127,7 +127,7 @@ struct PendingBatch {
 /// Registry-resolved state, materialised on the first `process` (the
 /// `PartialLookupState` is only registered at pipeline start).
 struct Resolved {
-    cache: Arc<FoyerMemoryCache>,
+    cache: Arc<LookupMemoryCache>,
     converter: RowConverter,
     key_indices: Vec<usize>,
     /// `(lookup key column, expected type)` per key, used to fail fast with a
@@ -249,7 +249,7 @@ impl LookupEnrichOperator {
             )));
         };
         let PartialLookupState {
-            foyer_cache,
+            lookup_cache,
             schema,
             key_columns,
             key_sort_fields,
@@ -299,7 +299,7 @@ impl LookupEnrichOperator {
         };
 
         self.resolved = Some(Resolved {
-            cache: Arc::clone(foyer_cache),
+            cache: Arc::clone(lookup_cache),
             converter,
             key_indices: Vec::new(),
             key_checks,
@@ -922,7 +922,7 @@ mod tests {
         registry.register_partial(
             "customers",
             PartialLookupState {
-                foyer_cache: Arc::new(FoyerMemoryCache::with_defaults(0)),
+                lookup_cache: Arc::new(LookupMemoryCache::with_defaults(0)),
                 schema: lookup_schema(),
                 key_columns: vec!["id".into()],
                 key_sort_fields: vec![SortField::new(DataType::Int64)],
@@ -1072,7 +1072,7 @@ mod tests {
         registry.register_partial(
             "customers",
             PartialLookupState {
-                foyer_cache: Arc::new(FoyerMemoryCache::with_defaults(0)),
+                lookup_cache: Arc::new(LookupMemoryCache::with_defaults(0)),
                 schema: lookup_schema(), // id, name
                 key_columns: vec!["id".into()],
                 key_sort_fields: vec![SortField::new(DataType::Int64)],
@@ -1150,7 +1150,7 @@ mod tests {
         lookups.register_partial(
             "customers",
             PartialLookupState {
-                foyer_cache: Arc::new(FoyerMemoryCache::with_defaults(0)),
+                lookup_cache: Arc::new(LookupMemoryCache::with_defaults(0)),
                 schema: lookup_schema(),
                 key_columns: vec!["id".into()],
                 key_sort_fields: vec![SortField::new(DataType::Int64)],

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1727,7 +1727,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 }
 
-/// Update a partial foyer cache from a CDC batch by inserting or deleting
+/// Update a partial lookup cache from a CDC batch by inserting or deleting
 /// each row keyed by the primary key column(s).
 ///
 /// CDC delete detection: if the batch has a column named `__op`, `__operation`,
@@ -1788,10 +1788,10 @@ fn update_partial_cache_from_batch(
         });
 
         if is_delete {
-            partial.foyer_cache.invalidate(key.as_ref());
+            partial.lookup_cache.invalidate(key.as_ref());
         } else {
             let row_batch = batch.slice(row, 1);
-            partial.foyer_cache.insert(key.as_ref(), row_batch);
+            partial.lookup_cache.insert(key.as_ref(), row_batch);
         }
     }
 }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1152,7 +1152,7 @@ impl LaminarDB {
         }
 
         // On-demand (Manual) tables: register as Partial in the lookup
-        // registry so lookup joins use the foyer cache + source fallback path,
+        // registry so lookup joins use the lookup cache + source fallback path,
         // then promote to SnapshotPlusCdc so poll_tables() calls poll_changes().
         for (name, _source, mode) in &mut table_sources {
             if !matches!(mode, RefreshMode::Manual) {
@@ -1182,9 +1182,9 @@ impl LaminarDB {
                 })
                 .collect();
 
-            let cache = Arc::new(laminar_core::lookup::foyer_cache::FoyerMemoryCache::new(
+            let cache = Arc::new(laminar_core::lookup::lookup_cache::LookupMemoryCache::new(
                 0,
-                laminar_core::lookup::foyer_cache::FoyerMemoryCacheConfig {
+                laminar_core::lookup::lookup_cache::LookupMemoryCacheConfig {
                     capacity_bytes,
                     shards: 16,
                     ttl: reg.cache_ttl,
@@ -1225,7 +1225,7 @@ impl LaminarDB {
             self.lookup_registry.register_partial(
                 name,
                 laminar_sql::datafusion::PartialLookupState {
-                    foyer_cache: cache,
+                    lookup_cache: cache,
                     schema,
                     key_columns: pk_cols,
                     key_sort_fields,

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1186,7 +1186,6 @@ impl LaminarDB {
                 0,
                 laminar_core::lookup::lookup_cache::LookupMemoryCacheConfig {
                     capacity_bytes,
-                    shards: 16,
                     ttl: reg.cache_ttl,
                 },
             ));

--- a/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
+++ b/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
@@ -2089,7 +2089,6 @@ mod tests {
             1,
             LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
-                shards: 4,
                 ttl: None,
             },
         ))

--- a/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
+++ b/crates/laminar-sql/src/datafusion/lookup_join_exec.rs
@@ -37,7 +37,7 @@ use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::Expr;
 use futures::StreamExt;
-use laminar_core::lookup::foyer_cache::FoyerMemoryCache;
+use laminar_core::lookup::lookup_cache::LookupMemoryCache;
 use laminar_core::lookup::source::{ColumnId, LookupSourceDyn};
 use tokio::sync::Semaphore;
 
@@ -63,7 +63,7 @@ pub struct LookupTableRegistry {
 pub enum RegisteredLookup {
     /// Full snapshot: all rows pre-loaded in a single batch.
     Snapshot(Arc<LookupSnapshot>),
-    /// Partial (on-demand): bounded foyer cache with S3-FIFO eviction.
+    /// Partial (on-demand): bounded lookup cache with S3-FIFO eviction.
     Partial(Arc<PartialLookupState>),
     /// Versioned: all versions of all keys for temporal joins.
     Versioned(Arc<VersionedLookupState>),
@@ -98,8 +98,8 @@ pub struct VersionedLookupState {
 
 /// State for a partial (on-demand) lookup table.
 pub struct PartialLookupState {
-    /// Bounded foyer memory cache with S3-FIFO eviction.
-    pub foyer_cache: Arc<FoyerMemoryCache>,
+    /// Bounded in-memory cache with S3-FIFO eviction.
+    pub lookup_cache: Arc<LookupMemoryCache>,
     /// Schema of the lookup table.
     pub schema: SchemaRef,
     /// Key column names for row encoding.
@@ -999,12 +999,12 @@ fn probe_versioned_batch(
 
 // ── Partial Lookup Join Exec ──────────────────────────────────────
 
-/// Physical plan that probes a bounded foyer cache per key for each
+/// Physical plan that probes a bounded lookup cache per key for each
 /// batch from the streaming input. Used for on-demand/partial tables
 /// where the full dataset does not fit in memory.
 pub struct PartialLookupJoinExec {
     input: Arc<dyn ExecutionPlan>,
-    foyer_cache: Arc<FoyerMemoryCache>,
+    lookup_cache: Arc<LookupMemoryCache>,
     stream_key_indices: Vec<usize>,
     join_type: LookupJoinType,
     schema: SchemaRef,
@@ -1027,7 +1027,7 @@ impl PartialLookupJoinExec {
     /// Returns an error if the output schema cannot be constructed.
     pub fn try_new(
         input: Arc<dyn ExecutionPlan>,
-        foyer_cache: Arc<FoyerMemoryCache>,
+        lookup_cache: Arc<LookupMemoryCache>,
         stream_key_indices: Vec<usize>,
         key_sort_fields: Vec<SortField>,
         join_type: LookupJoinType,
@@ -1036,7 +1036,7 @@ impl PartialLookupJoinExec {
     ) -> Result<Self> {
         Self::try_new_with_source(
             input,
-            foyer_cache,
+            lookup_cache,
             stream_key_indices,
             key_sort_fields,
             join_type,
@@ -1056,7 +1056,7 @@ impl PartialLookupJoinExec {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new_with_source(
         input: Arc<dyn ExecutionPlan>,
-        foyer_cache: Arc<FoyerMemoryCache>,
+        lookup_cache: Arc<LookupMemoryCache>,
         stream_key_indices: Vec<usize>,
         key_sort_fields: Vec<SortField>,
         join_type: LookupJoinType,
@@ -1096,7 +1096,7 @@ impl PartialLookupJoinExec {
 
         Ok(Self {
             input,
-            foyer_cache,
+            lookup_cache,
             stream_key_indices,
             join_type,
             schema: output_schema,
@@ -1116,7 +1116,7 @@ impl Debug for PartialLookupJoinExec {
         f.debug_struct("PartialLookupJoinExec")
             .field("join_type", &self.join_type)
             .field("stream_keys", &self.stream_key_indices)
-            .field("cache_table_id", &self.foyer_cache.table_id())
+            .field("cache_table_id", &self.lookup_cache.table_id())
             .finish_non_exhaustive()
     }
 }
@@ -1130,7 +1130,7 @@ impl DisplayAs for PartialLookupJoinExec {
                     "PartialLookupJoinExec: type={}, stream_keys={:?}, cache_entries={}",
                     self.join_type,
                     self.stream_key_indices,
-                    self.foyer_cache.len(),
+                    self.lookup_cache.len(),
                 )
             }
             DisplayFormatType::TreeRender => write!(f, "PartialLookupJoinExec"),
@@ -1170,7 +1170,7 @@ impl ExecutionPlan for PartialLookupJoinExec {
         }
         Ok(Arc::new(Self {
             input: children.swap_remove(0),
-            foyer_cache: Arc::clone(&self.foyer_cache),
+            lookup_cache: Arc::clone(&self.lookup_cache),
             stream_key_indices: self.stream_key_indices.clone(),
             join_type: self.join_type,
             schema: Arc::clone(&self.schema),
@@ -1191,7 +1191,7 @@ impl ExecutionPlan for PartialLookupJoinExec {
     ) -> Result<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
         let converter = Arc::clone(&self.converter);
-        let foyer_cache = Arc::clone(&self.foyer_cache);
+        let lookup_cache = Arc::clone(&self.lookup_cache);
         let stream_key_indices = self.stream_key_indices.clone();
         let join_type = self.join_type;
         let schema = self.schema();
@@ -1202,7 +1202,7 @@ impl ExecutionPlan for PartialLookupJoinExec {
         let projection = self.projection.clone();
 
         let output = input_stream.then(move |result| {
-            let foyer_cache = Arc::clone(&foyer_cache);
+            let lookup_cache = Arc::clone(&lookup_cache);
             let converter = Arc::clone(&converter);
             let stream_key_indices = stream_key_indices.clone();
             let schema = Arc::clone(&schema);
@@ -1218,7 +1218,7 @@ impl ExecutionPlan for PartialLookupJoinExec {
                 probe_partial_batch_with_fallback(
                     &batch,
                     &converter,
-                    &foyer_cache,
+                    &lookup_cache,
                     &stream_key_indices,
                     join_type,
                     &schema,
@@ -1263,14 +1263,14 @@ impl datafusion::physical_plan::ExecutionPlanProperties for PartialLookupJoinExe
     }
 }
 
-/// Probes the foyer cache for each row in `stream_batch`, falling back
+/// Probes the lookup cache for each row in `stream_batch`, falling back
 /// to the async source for cache misses. Inserts source results into
 /// the cache before building the output.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 async fn probe_partial_batch_with_fallback(
     stream_batch: &RecordBatch,
     converter: &RowConverter,
-    foyer_cache: &FoyerMemoryCache,
+    lookup_cache: &LookupMemoryCache,
     stream_key_indices: &[usize],
     join_type: LookupJoinType,
     output_schema: &SchemaRef,
@@ -1303,7 +1303,7 @@ async fn probe_partial_batch_with_fallback(
         }
 
         let key = rows.row(row);
-        let result = foyer_cache.get_cached(key.as_ref());
+        let result = lookup_cache.get_cached(key.as_ref());
         if let Some(batch) = result.into_batch() {
             stream_indices.push(row as u32);
             lookup_batches.push(Some(batch));
@@ -1361,7 +1361,7 @@ async fn probe_partial_batch_with_fallback(
 
             for ((idx, key_bytes), maybe_batch) in miss_keys.iter().zip(results) {
                 if let Some(batch) = maybe_batch {
-                    foyer_cache.insert(key_bytes, batch.clone());
+                    lookup_cache.insert(key_bytes, batch.clone());
                     lookup_batches[*idx] = Some(batch);
                 }
             }
@@ -1516,7 +1516,7 @@ impl ExtensionPlanner for LookupJoinExtensionPlanner {
 
                 let exec = PartialLookupJoinExec::try_new_with_source(
                     input,
-                    Arc::clone(&partial_state.foyer_cache),
+                    Arc::clone(&partial_state.lookup_cache),
                     stream_key_indices,
                     partial_state.key_sort_fields.clone(),
                     lookup_node.join_type(),
@@ -2082,12 +2082,12 @@ mod tests {
 
     // ── PartialLookupJoinExec Tests ──────────────────────────────
 
-    use laminar_core::lookup::foyer_cache::FoyerMemoryCacheConfig;
+    use laminar_core::lookup::lookup_cache::LookupMemoryCacheConfig;
 
-    fn make_foyer_cache() -> Arc<FoyerMemoryCache> {
-        Arc::new(FoyerMemoryCache::new(
+    fn make_lookup_cache() -> Arc<LookupMemoryCache> {
+        Arc::new(LookupMemoryCache::new(
             1,
-            FoyerMemoryCacheConfig {
+            LookupMemoryCacheConfig {
                 capacity_bytes: 64 * 1024,
                 shards: 4,
                 ttl: None,
@@ -2106,7 +2106,7 @@ mod tests {
         .unwrap()
     }
 
-    fn warm_cache(cache: &FoyerMemoryCache) {
+    fn warm_cache(cache: &LookupMemoryCache) {
         let converter = RowConverter::new(vec![SortField::new(DataType::Int64)]).unwrap();
 
         for (id, name) in [(1, "Alice"), (2, "Bob"), (3, "Charlie")] {
@@ -2118,7 +2118,7 @@ mod tests {
     }
 
     fn make_partial_exec(join_type: LookupJoinType) -> PartialLookupJoinExec {
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         warm_cache(&cache);
 
         let input = batch_exec(orders_batch());
@@ -2176,7 +2176,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_empty_cache_inner_produces_no_rows() {
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         let input = batch_exec(orders_batch());
         let key_sort_fields = vec![SortField::new(DataType::Int64)];
 
@@ -2199,7 +2199,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_empty_cache_left_outer_preserves_all() {
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         let input = batch_exec(orders_batch());
         let key_sort_fields = vec![SortField::new(DataType::Int64)];
 
@@ -2241,13 +2241,13 @@ mod tests {
     #[test]
     fn registry_partial_entry() {
         let reg = LookupTableRegistry::new();
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         let key_sort_fields = vec![SortField::new(DataType::Int64)];
 
         reg.register_partial(
             "customers",
             PartialLookupState {
-                foyer_cache: cache,
+                lookup_cache: cache,
                 schema: customers_schema(),
                 key_columns: vec!["id".into()],
                 key_sort_fields,
@@ -2290,7 +2290,7 @@ mod tests {
             }
         }
 
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         // Only warm id=1 in cache, id=99 will miss and go to source
         warm_cache(&cache);
 
@@ -2358,7 +2358,7 @@ mod tests {
             }
         }
 
-        let cache = make_foyer_cache();
+        let cache = make_lookup_cache();
         let input = batch_exec(orders_batch());
         let key_sort_fields = vec![SortField::new(DataType::Int64)];
         let source: Arc<dyn LookupSourceDyn> = Arc::new(FailingSource);

--- a/examples/demos/crypto_sentiment/README.md
+++ b/examples/demos/crypto_sentiment/README.md
@@ -10,7 +10,7 @@ What the engine does, end to end, from one [`pipeline.toml`](pipeline.toml):
   skew to tune): Binance `btcusdt@trade` and the Bluesky Jetstream.
 - **`ai_sentiment(text) → DOUBLE`** scored inline on a stream by **FinBERT**, a
   finance-tuned BERT running locally (ONNX) on Ring 1 (never blocking the hot
-  path), batched and deduped through the foyer cache, every call in `laminar.ai_calls`.
+  path), batched and deduped through the result cache, every call in `laminar.ai_calls`.
 - **1-minute tumbling windows** on each side (price OHLC-ish; mean sentiment + post count).
 - **An MV-to-MV join** on `bucket_start`, emitting as both minutes close.
 - **A rolling `CORR(price, mean_sentiment)` over 30 buckets**, computed in-engine

--- a/examples/demos/crypto_sentiment/pipeline.toml
+++ b/examples/demos/crypto_sentiment/pipeline.toml
@@ -64,7 +64,7 @@ WHERE operation = 'create'
 
 -- ── Sentiment scored inline (Ring 1), returns a DOUBLE in [-1, 1] ─────────
 -- One ai_sentiment call per row, batched + deduped through the AI operator and
--- the foyer cache; every call is visible in laminar.ai_calls.
+-- the result cache; every call is visible in laminar.ai_calls.
 CREATE STREAM bsky_crypto AS
 SELECT did, text, ts, ai_sentiment(text) AS sentiment
 FROM bsky_crypto_raw;

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1379,7 +1379,7 @@ max_out_of_orderness = "5s"</code></pre>
             <td class="field-name">cache.hybrid</td>
             <td class="field-type">bool</td>
             <td class="field-default">false</td>
-            <td>Enable memory + disk caching via foyer</td>
+            <td>Enable in-memory caching via quick_cache</td>
           </tr>
         </tbody>
       </table>
@@ -2025,7 +2025,7 @@ LEFT JOIN products p
       </div>
 
       <p style="font-size: 0.82rem;">
-        <strong>Cache:</strong> Foyer-backed memory/hybrid cache. Configure via
+        <strong>Cache:</strong> quick_cache-backed in-memory cache. Configure via
         <code>[[lookup]]</code> section: <code>cache.size_bytes</code>,
         <code>cache.ttl</code>, <code>cache.hybrid</code>.
         Supports predicate pushdown to the lookup connector.

--- a/site/index.html
+++ b/site/index.html
@@ -406,7 +406,7 @@
             <div class="card-content">
               <h3>ON-DEMAND LOOKUP SOURCES</h3>
               <p>
-                Query slowly-changing reference tables (Postgres, CDC, Delta Lake, Iceberg) directly with foyer-backed hybrid caching and pushdown predicates.
+                Query slowly-changing reference tables (Postgres, CDC, Delta Lake, Iceberg) directly with in-memory caching (S3-FIFO eviction) and pushdown predicates.
               </p>
             </div>
             <div class="card-illustration">


### PR DESCRIPTION
## SummaryReplaces the `foyer` cache crate with `quick_cache` 0.6 in all three in-process cache sites (Ring 0 lookup-table cache, AI result cache, Schema Registry cache), plus a review cleanup pass that deletes dead instrumentation the migration surfaced.### WhyNothing used foyer beyond its sync in-memory tier — no HybridCache, no async `fetch`, no event listeners — but the `foyer` facade unconditionally pulls `foyer-storage` and ~15 transitive crates including the C-binding `lz4` and `zstd`, `io-uring`, `fs4`, `core_affinity`, and `mixtrics`. quick_cache is pure Rust (essentially `hashbrown` + `equivalent`) with Clock-PRO/S3-FIFO-family eviction, so the existing scan-resistance and negative-caching assumptions carry over. Full rationale in ADR-006.### Changes- `FoyerMemoryCache` → `LookupMemoryCache` (module `lookup::foyer_cache` → `lookup::lookup_cache`); byte-weighting via the `Weighter` trait, zero-allocation borrowed-key lookup via `equivalent` unchanged- AI result cache and Schema Registry cache rewritten on `quick_cache::sync::Cache`- TTL lazy expiry kept (wrapper-level, plain `remove()` on expired read)- Review cleanup (`08cfd061`): deleted unconsumed `hit_count`/`miss_count`/`hit_ratio` counters (two atomics per Ring 0 get; Prometheus metrics are counted by the operator), the speculative `get()` alias, the hardcoded `shards` config knob (constructors now infallible), and five low-value tests### Dependency impactfoyer and its entire subtree removed from `Cargo.lock`: `io-uring`, C `lz4`, `zstd`-via-foyer, `fs4`, `core_affinity`, `fastant`, `mixtrics`, `cmsketch`, `mea`. (`zstd` remains as a direct workspace dep for archival tiers; `lz4_flex` remains the intended pure-Rust LZ4.)### Verification- `cargo clippy --all --all-targets -- -D warnings` clean- Full lib test suite green (laminar-core 324, laminar-db 741, laminar-sql 872 after cleanup)- `cache_bench` vs the stored foyer baseline: lookup gets **36-41% faster** (p < 0.05), ~61ns/get — well inside the 500ns Ring 0 budget- Behavioral note: quick_cache rejects an entry heavier than a single shard''s byte budget instead of admitting it (degrades to a re-fetch); per-key lookup batches, AI outputs, and schemas are orders of magnitude below that ceiling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `foyer` with `quick_cache` 0.6 for all in-memory caches (lookup, AI results, Schema Registry) to drop native deps and make gets 36–41% faster. Also fixes a TTL expiry race in the lookup cache with shard-safe `remove_if`.

- **Refactors**
  - `FoyerMemoryCache` → `LookupMemoryCache` (`lookup::foyer_cache` → `lookup::lookup_cache`); byte-weighted via `Weighter`, borrowed-key lookups kept with `equivalent`.
  - TTL lazy expiry now uses `remove_if` to avoid deleting fresh inserts; negative-caching unchanged.
  - AI result and Schema Registry caches now use `quick_cache::sync::Cache` (e.g., `contains_key`, `len`).
  - Removed unused hit/miss counters, the `get()` alias, and the `shards` knob; constructors are infallible.
  - Removed `foyer` and its transitive subtree; `quick_cache` is pure Rust.

- **Migration**
  - Imports: `lookup::foyer_cache` → `lookup::lookup_cache`.
  - Types/calls: `FoyerMemoryCache` → `LookupMemoryCache`; use `get_cached(...)` instead of `get(...)`.
  - DataFusion: `PartialLookupState` field is now `lookup_cache` (was `foyer_cache`).
  - Schema Registry: construct with `Cache::new(...)`; use `.contains_key()` and `.len()`.
  - Config: keep `capacity_bytes` and optional `ttl`; no `shards`. Behavioral note: entries larger than a shard’s byte slice are rejected and re-fetched.

<sup>Written for commit 914d231a14e35c0f07c70bf840bc05eea2721e8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the in-memory cache backend across lookup joins and AI result caching with a new cache implementation.
  * Simplified cache configuration to a byte-capacity + optional TTL; removed shard tuning.
  * Updated docs, diagrams, examples, and benchmarks to reflect the new cache and S3‑FIFO-style eviction.
  * Removed built-in cache hit/miss counters and related telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->