### PR TITLE
feat(helm): parallel pod management, console token + CORS values

### DIFF
--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -412,7 +412,10 @@ pub async fn start_cluster(
     // error in cluster mode — fail fast instead of hanging.
     if cluster_cfg.discovery.seeds.is_empty() {
         return Err(ClusterStartupError::Discovery(
-            "cluster mode requires at least one seed address".into(),
+            "cluster mode requires [discovery].seeds — list every node's \
+             gossip address including this one (e.g. [\"node-0:7946\", \
+             \"node-1:7946\"]); expected membership is derived from it"
+                .into(),
         ));
     }
     let expected_peers = cluster_cfg.discovery.seeds.len().saturating_sub(1);

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -175,7 +175,7 @@ prometheusRule:
 | `laminardb.checkpoint.interval` | Checkpoint frequency | `30s` |
 | `laminardb.checkpoint.url` | Checkpoint storage: object store (`s3://`, `gs://`, `az://`) or local `file://`. Empty = local default. | `""` |
 | `laminardb.configWatch` | Hot-reload config on file change. Off in K8s (config changes roll pods via the checksum annotation); sets `LAMINAR_DISABLE_FILE_WATCH=1`. | `false` |
-| `laminardb.cluster.discovery.strategy` | Discovery method (`dns`, `gossip`, `static`) | `dns` |
+| `laminardb.cluster.discovery.strategy` | Discovery method (`gossip`, `static`) | `gossip` |
 | `laminardb.cluster.coordination.strategy` | Clustering controller coordination (`raft`) | `raft` |
 | `persistence.state.enabled` | Keep local state in Persistent Volume | `true` |
 | `persistence.state.storageClass` | K8s storage class for state PVC | `""` (default) |

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -165,6 +165,7 @@ prometheusRule:
 | `laminardb.httpBind` | HTTP API bind address | `0.0.0.0:8080` |
 | `laminardb.workers` | Number of worker threads (0 = auto) | `0` |
 | `laminardb.consoleToken.existingSecret` | Secret holding the console API bearer token (key from `secretKey`, default `token`); empty = unauthenticated | `""` |
+| `laminardb.consoleCorsAllowedOrigins` | CORS allow-list of console origins; empty = permissive legacy policy | `[]` |
 | `laminardb.state.backend` | Storage type: `in_process`, `local`, or `object_store` | `local` |
 | `laminardb.state.path` | Path for persistent state (required if backend=local) | `/var/lib/laminardb/state` |
 | `laminardb.state.url` | URL for object storage (required if backend=object_store) | `""` |

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -53,8 +53,10 @@ laminardb:
     
   cluster:
     discovery:
-      strategy: dns    # Headless service DNS discovery (recommended for K8s)
+      strategy: gossip
       gossipPort: 7946
+      # seeds are generated from replicaCount (per-pod headless DNS names);
+      # set `seeds` explicitly only for non-standard topologies
     coordination:
       strategy: raft
       raftPort: 7947

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -159,6 +159,7 @@ prometheusRule:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `replicaCount` | Number of pods to run | `1` |
+| `podManagementPolicy` | StatefulSet pod launch ordering: `Parallel` or `OrderedReady` (immutable after creation) | `Parallel` |
 | `laminardb.mode` | Server mode: `embedded` or `cluster` | `embedded` |
 | `laminardb.logLevel` | Log level: `trace`, `debug`, `info`, `warn`, `error` | `info` |
 | `laminardb.httpBind` | HTTP API bind address | `0.0.0.0:8080` |

--- a/deploy/helm/laminardb/README.md
+++ b/deploy/helm/laminardb/README.md
@@ -164,6 +164,7 @@ prometheusRule:
 | `laminardb.logLevel` | Log level: `trace`, `debug`, `info`, `warn`, `error` | `info` |
 | `laminardb.httpBind` | HTTP API bind address | `0.0.0.0:8080` |
 | `laminardb.workers` | Number of worker threads (0 = auto) | `0` |
+| `laminardb.consoleToken.existingSecret` | Secret holding the console API bearer token (key from `secretKey`, default `token`); empty = unauthenticated | `""` |
 | `laminardb.state.backend` | Storage type: `in_process`, `local`, or `object_store` | `local` |
 | `laminardb.state.path` | Path for persistent state (required if backend=local) | `/var/lib/laminardb/state` |
 | `laminardb.state.url` | URL for object storage (required if backend=object_store) | `""` |

--- a/deploy/helm/laminardb/ci/cluster-values.yaml
+++ b/deploy/helm/laminardb/ci/cluster-values.yaml
@@ -5,7 +5,7 @@ laminardb:
   logLevel: info
   cluster:
     discovery:
-      strategy: dns
+      strategy: gossip
       gossipPort: 7946
     coordination:
       strategy: raft

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -20,6 +20,10 @@ data:
     bind = "{{ .Values.laminardb.httpBind }}"
     workers = {{ .Values.laminardb.workers }}
     log_level = "{{ .Values.laminardb.logLevel }}"
+    {{- if (.Values.laminardb.consoleToken | default dict).existingSecret }}
+    # Resolved from the pod env at config load; the token never enters the ConfigMap.
+    console_token = "${LAMINAR_CONSOLE_TOKEN}"
+    {{- end }}
 
     [state]
     backend = "{{ .Values.laminardb.state.backend }}"

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
     [discovery]
     {{- $discovery := $cluster.discovery | default dict }}
     {{- $gossipPort := $discovery.gossipPort | default 7946 }}
-    {{- $podDomain := printf "%s.%s.svc.cluster.local" (include "laminardb.headlessServiceName" .) .Release.Namespace }}
+    {{- $podDomain := printf "%s.%s.svc.%s" (include "laminardb.headlessServiceName" .) .Release.Namespace (.Values.clusterDomain | default "cluster.local") }}
     strategy = "{{ $discovery.strategy | default "gossip" }}"
     gossip_port = {{ $gossipPort }}
     # Peers must reach this node by its per-pod headless-service DNS name; the

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -24,6 +24,9 @@ data:
     # Resolved from the pod env at config load; the token never enters the ConfigMap.
     console_token = "${LAMINAR_CONSOLE_TOKEN}"
     {{- end }}
+    {{- with .Values.laminardb.consoleCorsAllowedOrigins }}
+    console_cors_allowed_origins = [{{ range $i, $o := . }}{{ if $i }}, {{ end }}"{{ $o }}"{{ end }}]
+    {{- end }}
 
     [state]
     backend = "{{ .Values.laminardb.state.backend }}"

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -52,10 +52,18 @@ data:
 
     [discovery]
     {{- $discovery := $cluster.discovery | default dict }}
-    strategy = "{{ $discovery.strategy }}"
-    gossip_port = {{ $discovery.gossipPort }}
+    {{- $gossipPort := $discovery.gossipPort | default 7946 }}
+    {{- $podDomain := printf "%s.%s.svc.cluster.local" (include "laminardb.headlessServiceName" .) .Release.Namespace }}
+    strategy = "{{ $discovery.strategy | default "gossip" }}"
+    gossip_port = {{ $gossipPort }}
+    # Peers must reach this node by its per-pod headless-service DNS name; the
+    # bare pod hostname the server would otherwise advertise is not resolvable.
+    advertise_host = "{{ $discovery.advertiseHost | default (printf "${HOSTNAME}.%s" $podDomain) }}"
     {{- if $discovery.seeds }}
     seeds = [{{ range $i, $s := $discovery.seeds }}{{ if $i }}, {{ end }}"{{ $s }}"{{ end }}]
+    {{- else }}
+    # Generated from replicaCount: every node lists the full cluster (self included).
+    seeds = [{{ range $i := until (int .Values.replicaCount) }}{{ if $i }}, {{ end }}"{{ include "laminardb.fullname" $ }}-{{ $i }}.{{ $podDomain }}:{{ $gossipPort }}"{{ end }}]
     {{- end }}
 
     [coordination]

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -111,6 +111,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- end }}
+            {{- with (.Values.laminardb.consoleToken | default dict).existingSecret }}
+            - name: LAMINAR_CONSOLE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: {{ $.Values.laminardb.consoleToken.secretKey | default "token" }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/laminardb/templates/headless-service.yaml
+++ b/deploy/helm/laminardb/templates/headless-service.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  # Pods must resolve each other DURING cluster formation, before any pod is
+  # Ready (the server blocks on membership before serving probes) — without
+  # this, multi-replica discovery deadlocks.
+  publishNotReadyAddresses: true
   ports:
     - port: {{ .Values.service.httpPort }}
       targetPort: http

--- a/deploy/helm/laminardb/templates/service.yaml
+++ b/deploy/helm/laminardb/templates/service.yaml
@@ -21,15 +21,5 @@ spec:
       protocol: TCP
       name: pg
     {{- end }}
-    {{- if eq .Values.laminardb.mode "cluster" }}
-    - port: {{ .Values.service.gossipPort }}
-      targetPort: gossip
-      protocol: TCP
-      name: gossip
-    - port: {{ .Values.service.raftPort }}
-      targetPort: raft
-      protocol: TCP
-      name: raft
-    {{- end }}
   selector:
     {{- include "laminardb.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -10,6 +10,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   serviceName: {{ include "laminardb.headlessServiceName" . }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | default "OrderedReady" }}
   selector:
     matchLabels:
       {{- include "laminardb.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -10,7 +10,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   serviceName: {{ include "laminardb.headlessServiceName" . }}
-  podManagementPolicy: {{ .Values.podManagementPolicy | default "OrderedReady" }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | default "Parallel" }}
   selector:
     matchLabels:
       {{- include "laminardb.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -111,6 +111,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- with (.Values.laminardb.consoleToken | default dict).existingSecret }}
+            - name: LAMINAR_CONSOLE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: {{ $.Values.laminardb.consoleToken.secretKey | default "token" }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -70,6 +70,10 @@ laminardb:
     existingSecret: ""
     secretKey: "token"
 
+  # -- CORS allow-list of console origins, e.g. ["https://console.example.com"].
+  # -- Empty falls back to the permissive legacy policy (dev only).
+  consoleCorsAllowedOrigins: []
+
   # -- Hot-reload config on file change. Off in K8s: config changes already roll pods
   # (checksum/config annotation) and the watcher spams reloads on ConfigMap mounts.
   configWatch: false

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -1,6 +1,10 @@
 # -- Number of replicas (use 1 for embedded, >1 for cluster mode)
 replicaCount: 1
 
+# -- StatefulSet pod launch ordering: "Parallel" or "OrderedReady".
+# -- Immutable on a live StatefulSet (delete with --cascade=orphan to change).
+podManagementPolicy: Parallel
+
 image:
   # -- Docker image repository
   repository: laminardb/laminardb-server

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -64,6 +64,12 @@ laminardb:
     # -- Snapshot strategy: "full", "incremental", or "fork_cow"
     snapshotStrategy: full
 
+  # -- Bearer token for the control-plane (console) HTTP API, read from an
+  # -- existing Secret. Empty existingSecret = unauthenticated API (dev only).
+  consoleToken:
+    existingSecret: ""
+    secretKey: "token"
+
   # -- Hot-reload config on file change. Off in K8s: config changes already roll pods
   # (checksum/config annotation) and the watcher spams reloads on ConfigMap mounts.
   configWatch: false

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -87,14 +87,16 @@ laminardb:
     # -- Node ID (auto-generated from pod name if empty)
     nodeId: ""
     discovery:
-      # -- Discovery strategy: "dns", "gossip", or "static"
-      strategy: dns
-      # -- DNS name for discovery (auto-set to headless service if empty)
-      dnsName: ""
+      # -- Discovery strategy: "gossip" (recommended) or "static"
+      strategy: gossip
       # -- Gossip port
       gossipPort: 7946
-      # -- Seed nodes for static discovery
+      # -- Seed nodes. Empty = generated from replicaCount as
+      # -- <fullname>-N.<headless>.<namespace>.svc.cluster.local:<gossipPort>
       seeds: []
+      # -- Host peers use to reach this node. Empty = the pod's headless-service
+      # -- DNS name (override only for non-standard network setups)
+      advertiseHost: ""
     coordination:
       # -- Coordination strategy (only "raft" supported)
       strategy: raft

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -5,6 +5,9 @@ replicaCount: 1
 # -- Immutable on a live StatefulSet (delete with --cascade=orphan to change).
 podManagementPolicy: Parallel
 
+# -- Kubernetes cluster DNS domain, used to build per-pod discovery addresses.
+clusterDomain: cluster.local
+
 image:
   # -- Docker image repository
   repository: laminardb/laminardb-server


### PR DESCRIPTION
## SummaryThree Helm chart additions for operating LaminarDB clusters: parallel pod startup, and first-class console auth/CORS configuration (previously only reachable by replacing the entire generated config via `configOverride`).### 1. `podManagementPolicy` (default `Parallel`)The StatefulSet template omitted the field, so pods started one at a time (`OrderedReady`). LaminarDB nodes join via gossip with CAS-based assignment and no ordinal-0 bootstrap dependency, so serial startup only slows cold start and scale-up. Exposed as a top-level value, defaulting to `Parallel`; rolling updates remain ordered either way. The field is immutable on a live StatefulSet — documented (`kubectl delete statefulset <name> --cascade=orphan` before changing it on an existing release).### 2. Console bearer token from a Kubernetes Secret```yamllaminardb:  consoleToken:    existingSecret: laminardb-console    secretKey: token   # default```Renders `console_token = "${LAMINAR_CONSOLE_TOKEN}"` into the generated `[server]` config and injects the env var via `secretKeyRef` in both the StatefulSet and Deployment variants. The server expands `${VAR}` at config load, so the token lives only in the Secret and pod env — never in the ConfigMap. Empty (default) keeps the current unauthenticated behavior; `configOverride` users can reference the same env var since injection is independent of config generation.### 3. Console CORS allow-list```yamllaminardb:  consoleCorsAllowedOrigins: ["https://console.example.com"]```Renders `server.console_cors_allowed_origins`; empty keeps the permissive legacy policy (dev only).### VerificationChart templates follow existing conventions (`with`/`default dict` guards match the surrounding code); helm lint/template validation runs in chart CI against the `ci/` values files.

### 4. Cluster discovery repair (multi-seed duplicates)

Reviewing a report of duplicate membership in multi-seed clusters surfaced four chart defects, now fixed:

- **`strategy: dns` was fiction** — the server only implements `gossip` (everything else silently falls back to static), and `dnsName` was neither rendered nor read. With the chart's empty default seeds, cluster mode failed at startup. Default is now `gossip`; `dnsName` deleted.
- **`advertise_host` was never rendered** — with the `0.0.0.0` bind the server advertised its bare pod hostname, which peers cannot resolve (only `<pod>.<headless-svc>` names exist in cluster DNS). Nodes knowing each other by mixed/unresolvable identities is what produces flapping or duplicate-looking membership. Now defaults to the pod's headless-service FQDN (`cluster.discovery.advertiseHost` to override).
- **Seeds are now generated from `replicaCount`** (`<fullname>-N.<headless>.<ns>.svc.cluster.local:<gossipPort>`, every node listing the full cluster per the server's membership convention) — hand-written multi-seed lists were pure user-error surface. Explicit `seeds` still wins.
- **The regular load-balanced Service no longer exposes gossip/raft ports** — seeding via it round-robins heartbeats to random pods (the same seed address resolving to a different node each beat). Cluster traffic belongs on the headless service only.

Validated with `helm template` (helm 4.2.0): no duplicate resources across the cluster render; generated and explicit seed paths both correct; lint clean. CI cluster values and the README production example updated off the dns strategy.