### PR TITLE
Sub-second checkpointing: two-level completion, pipelined epochs, incremental snapshots (ADR-003)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe"

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ agent_handoff.json
 agent_rules.md
 .subtask3-report.md
 /target_new
+
+# Machine-local cargo config (linker overrides etc.)
+/.cargo/config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,6 +5047,7 @@ dependencies = [
  "prometheus",
  "rand 0.10.1",
  "rcgen",
+ "rdkafka",
  "regex",
  "reqwest 0.13.2",
  "rustls-pemfile",

--- a/crates/laminar-connectors/src/connector.rs
+++ b/crates/laminar-connectors/src/connector.rs
@@ -208,6 +208,15 @@ pub struct SinkConnectorCapabilities {
     /// Whether the sink supports partitioned writes.
     pub partitioned: bool,
 
+    /// Whether output pending in an abandoned epoch survives into the
+    /// next epoch's commit WITHOUT a connector rollback (e.g. a Kafka
+    /// transactional producer's single open transaction). When set, a
+    /// live coordination failure skips the connector rollback so the
+    /// pending rows are not discarded — sources only rewind on
+    /// restart, never on a live abort. When unset, live failures roll
+    /// the connector back.
+    pub preserves_pending_on_abandon: bool,
+
     /// Default per-call `write_batch` I/O timeout. Users can override via
     /// the `sink.write.timeout.ms` connector property.
     pub suggested_write_timeout: std::time::Duration,
@@ -226,8 +235,17 @@ impl SinkConnectorCapabilities {
             two_phase_commit: false,
             schema_evolution: false,
             partitioned: false,
+            preserves_pending_on_abandon: false,
             suggested_write_timeout,
         }
+    }
+
+    /// Declare that pending output survives an abandoned epoch into the
+    /// next commit without a rollback (see the field docs).
+    #[must_use]
+    pub fn with_preserves_pending_on_abandon(mut self) -> Self {
+        self.preserves_pending_on_abandon = true;
+        self
     }
 
     /// Enable exactly-once semantics (requires epoch + 2PC impl).

--- a/crates/laminar-connectors/src/generator.rs
+++ b/crates/laminar-connectors/src/generator.rs
@@ -1,0 +1,243 @@
+//! Synthetic data generator source — no external infrastructure.
+//!
+//! Emits a deterministic sequence at a configured rate: row `i` is
+//! always `(seq = i, ts_ms = i * 1000 / rows_per_second, value = "v{i}")`,
+//! so output is a pure function of the offset. That makes the source
+//! fully replayable (exactly-once capable) and lets harnesses verify
+//! sink completeness by recomputing the expected rows — its primary
+//! consumer is the cluster soak test, but it works anywhere a
+//! self-driving source is needed (demos, benchmarks).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::{Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+
+use crate::checkpoint::SourceCheckpoint;
+use crate::config::{ConfigKeySpec, ConnectorConfig, ConnectorInfo};
+use crate::connector::{SourceBatch, SourceConnector};
+use crate::error::ConnectorError;
+use crate::registry::ConnectorRegistry;
+
+/// Deterministic rate-limited source. See module docs.
+pub struct GeneratorSource {
+    schema: SchemaRef,
+    rows_per_second: u64,
+    batch_max: usize,
+    max_rows: Option<u64>,
+    /// Next sequence number to emit (== rows emitted so far across
+    /// restarts; restored from the checkpoint).
+    next_seq: u64,
+    /// Rate-limit anchor: emission is allowed up to
+    /// `anchor_seq + elapsed_since(anchor) * rows_per_second`.
+    /// Re-anchored on open/restore so a restart doesn't burst or stall.
+    anchor: Option<(Instant, u64)>,
+}
+
+impl GeneratorSource {
+    fn generator_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("seq", DataType::Int64, false),
+            Field::new("ts_ms", DataType::Int64, false),
+            Field::new("value", DataType::Utf8, false),
+        ]))
+    }
+
+    /// Build rows `[start, start + n)` — a pure function of `start`,
+    /// which is what makes the source replayable.
+    // Cast lints: seq is a monotonic generator counter and rates are
+    // operator-supplied config — both far below the 2^52/2^63 edges.
+    #[allow(
+        clippy::cast_possible_wrap,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss
+    )]
+    fn build_batch(&self, start: u64, n: usize) -> Result<RecordBatch, ConnectorError> {
+        let seqs: Vec<i64> = (0..n as u64).map(|i| (start + i) as i64).collect();
+        let ts: Vec<i64> = seqs
+            .iter()
+            .map(|&s| {
+                (s as u64)
+                    .saturating_mul(1000)
+                    .wrapping_div(self.rows_per_second) as i64
+            })
+            .collect();
+        let values: Vec<String> = seqs.iter().map(|s| format!("v{s}")).collect();
+        RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(Int64Array::from(seqs)),
+                Arc::new(Int64Array::from(ts)),
+                Arc::new(StringArray::from(values)),
+            ],
+        )
+        .map_err(|e| ConnectorError::ReadError(e.to_string()))
+    }
+}
+
+impl Default for GeneratorSource {
+    fn default() -> Self {
+        Self {
+            schema: Self::generator_schema(),
+            rows_per_second: 1000,
+            batch_max: 1024,
+            max_rows: None,
+            next_seq: 0,
+            anchor: None,
+        }
+    }
+}
+
+#[async_trait]
+impl SourceConnector for GeneratorSource {
+    async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
+        if let Some(rps) = config.get_parsed::<u64>("rows.per.second")? {
+            if rps == 0 {
+                return Err(ConnectorError::ConfigurationError(
+                    "rows.per.second must be > 0".into(),
+                ));
+            }
+            self.rows_per_second = rps;
+        }
+        if let Some(n) = config.get_parsed::<usize>("batch.max.size")? {
+            self.batch_max = n.max(1);
+        }
+        self.max_rows = config.get_parsed::<u64>("max.rows")?;
+        self.anchor = None;
+        Ok(())
+    }
+
+    // Cast lints: see build_batch.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    async fn poll_batch(
+        &mut self,
+        max_records: usize,
+    ) -> Result<Option<SourceBatch>, ConnectorError> {
+        let (anchored_at, anchor_seq) = *self
+            .anchor
+            .get_or_insert_with(|| (Instant::now(), self.next_seq));
+        let mut allowed = anchor_seq.saturating_add(
+            (anchored_at.elapsed().as_secs_f64() * self.rows_per_second as f64) as u64,
+        );
+        if let Some(max) = self.max_rows {
+            allowed = allowed.min(max);
+        }
+        let pending = allowed.saturating_sub(self.next_seq);
+        let n = (pending as usize).min(max_records).min(self.batch_max);
+        if n == 0 {
+            return Ok(None);
+        }
+        let batch = self.build_batch(self.next_seq, n)?;
+        self.next_seq += n as u64;
+        Ok(Some(SourceBatch::new(batch)))
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn checkpoint(&self) -> SourceCheckpoint {
+        let mut cp = SourceCheckpoint::new(0);
+        cp.set_offset("seq", self.next_seq.to_string());
+        cp
+    }
+
+    async fn restore(&mut self, checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
+        if let Some(seq) = checkpoint.get_offset("seq") {
+            self.next_seq = seq.parse().map_err(|e| {
+                ConnectorError::ConfigurationError(format!("bad generator offset '{seq}': {e}"))
+            })?;
+        }
+        // Re-anchor so the rate limit resumes from here rather than
+        // bursting to "catch up" with pre-restart wall-clock time.
+        self.anchor = None;
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    /// Output is a pure function of the offset — replay is exact.
+    fn supports_replay(&self) -> bool {
+        true
+    }
+}
+
+/// Registers the generator source so
+/// `CREATE SOURCE ... WITH (connector = 'generator')` resolves.
+pub fn register_generator_source(registry: &ConnectorRegistry) {
+    let info = ConnectorInfo {
+        name: "generator".to_string(),
+        display_name: "Synthetic Data Generator".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        is_source: true,
+        is_sink: false,
+        config_keys: vec![
+            ConfigKeySpec::optional("rows.per.second", "Emission rate", "1000"),
+            ConfigKeySpec::optional("batch.max.size", "Max rows per batch", "1024"),
+            ConfigKeySpec::optional(
+                "max.rows",
+                "Stop after this many rows (unbounded if unset)",
+                "",
+            ),
+        ],
+    };
+    registry.register_source(
+        "generator",
+        info,
+        Arc::new(|_registry: Option<&prometheus::Registry>| Box::new(GeneratorSource::default())),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn deterministic_and_replayable_across_restore() {
+        let mut config = ConnectorConfig::new("generator");
+        config.set("rows.per.second", "1000000"); // effectively unthrottled
+        let mut a = GeneratorSource::default();
+        a.open(&config).await.unwrap();
+        // First poll anchors the rate limit (no tokens accrue before
+        // polling starts); rows become available after it.
+        let _ = a.poll_batch(8).await.unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let first = a.poll_batch(8).await.unwrap().expect("rows");
+        assert_eq!(first.num_rows(), 8);
+
+        // Restore a fresh instance from a's checkpoint at seq=8 and
+        // verify the next rows equal what `a` produces next.
+        let cp = a.checkpoint();
+        let mut b = GeneratorSource::default();
+        b.open(&config).await.unwrap();
+        b.restore(&cp).await.unwrap();
+        let _ = b.poll_batch(4).await.unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let from_a = a.poll_batch(4).await.unwrap().expect("rows").records;
+        let from_b = b.poll_batch(4).await.unwrap().expect("rows").records;
+        assert_eq!(from_a, from_b, "replay from offset must be byte-identical");
+    }
+
+    #[tokio::test]
+    async fn rate_limit_and_max_rows_bound_emission() {
+        let mut config = ConnectorConfig::new("generator");
+        config.set("rows.per.second", "1000");
+        config.set("max.rows", "3");
+        let mut g = GeneratorSource::default();
+        g.open(&config).await.unwrap();
+        let _ = g.poll_batch(100).await.unwrap(); // anchor
+        std::thread::sleep(std::time::Duration::from_millis(50)); // ~50 tokens
+        let batch = g.poll_batch(100).await.unwrap().expect("rows");
+        assert_eq!(batch.num_rows(), 3, "max.rows caps emission");
+        assert!(g.poll_batch(100).await.unwrap().is_none(), "exhausted");
+    }
+}

--- a/crates/laminar-connectors/src/kafka/sink.rs
+++ b/crates/laminar-connectors/src/kafka/sink.rs
@@ -728,17 +728,17 @@ impl SinkConnector for KafkaSink {
                     actual: self.state.to_string(),
                 })?;
 
+            // An already-open transaction is the CONTINUATION case: a
+            // coordination-failed epoch keeps its pending rows (sources
+            // do not rewind on a live abort), and the next epoch's
+            // commit covers them. Aborting here would lose them.
             if self.transaction_active {
-                warn!(epoch, "aborting stale transaction before new epoch");
-                let txn_timeout = self.config.transaction_timeout;
-                Self::producer_blocking(producer, move |p| p.abort_transaction(txn_timeout))
-                    .await
-                    .map_err(|e| {
-                        ConnectorError::TransactionError(format!(
-                            "cannot begin epoch {epoch}: abort of stale transaction failed: {e}"
-                        ))
-                    })?;
-                self.transaction_active = false;
+                debug!(
+                    epoch,
+                    "transaction already open — pending rows ride into this epoch"
+                );
+                self.partitioner.reset();
+                return Ok(());
             }
 
             Self::producer_blocking(producer, FutureProducer::begin_transaction)
@@ -758,12 +758,19 @@ impl SinkConnector for KafkaSink {
     }
 
     async fn pre_commit(&mut self, epoch: u64) -> Result<(), ConnectorError> {
-        if epoch != self.current_epoch {
+        // Monotonic, not strict equality: the coordinator abandons
+        // failed epochs (ids are never reused), so the epoch sealing
+        // the currently open transaction may skip past the one
+        // `begin_epoch` was called with. Only a STALE epoch is an
+        // error — there is one open transaction and it always holds
+        // the rows since the last barrier.
+        if epoch < self.current_epoch {
             return Err(ConnectorError::TransactionError(format!(
-                "epoch mismatch in pre_commit: expected {}, got {epoch}",
+                "stale epoch in pre_commit: current {}, got {epoch}",
                 self.current_epoch
             )));
         }
+        self.current_epoch = epoch;
 
         // Flush all pending messages to Kafka brokers (phase 1).
         if let Some(ref producer) = self.producer {
@@ -781,12 +788,14 @@ impl SinkConnector for KafkaSink {
     }
 
     async fn commit_epoch(&mut self, epoch: u64) -> Result<(), ConnectorError> {
-        if epoch != self.current_epoch {
+        // Monotonic for the same reason as `pre_commit`.
+        if epoch < self.current_epoch {
             return Err(ConnectorError::TransactionError(format!(
-                "epoch mismatch: expected {}, got {epoch}",
+                "stale epoch in commit: current {}, got {epoch}",
                 self.current_epoch
             )));
         }
+        self.current_epoch = epoch;
 
         if self.config.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
             let producer = self

--- a/crates/laminar-connectors/src/kafka/sink.rs
+++ b/crates/laminar-connectors/src/kafka/sink.rs
@@ -728,10 +728,10 @@ impl SinkConnector for KafkaSink {
                     actual: self.state.to_string(),
                 })?;
 
-            // An already-open transaction is the CONTINUATION case: a
-            // coordination-failed epoch keeps its pending rows (sources
-            // do not rewind on a live abort), and the next epoch's
-            // commit covers them. Aborting here would lose them.
+            // An already-open transaction is the continuation case: an
+            // abandoned epoch keeps its pending rows and the next
+            // epoch's commit covers them. Aborting here would lose them
+            // (a live abort is never replayed).
             if self.transaction_active {
                 debug!(
                     epoch,

--- a/crates/laminar-connectors/src/kafka/sink.rs
+++ b/crates/laminar-connectors/src/kafka/sink.rs
@@ -878,7 +878,14 @@ impl SinkConnector for KafkaSink {
             .with_partitioned();
 
         if self.config.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
-            caps = caps.with_exactly_once().with_two_phase_commit();
+            // The single open transaction holds all rows since the last
+            // commit, so an abandoned epoch's rows ride into the next
+            // epoch's commit — no rollback needed (or wanted) on a live
+            // coordination failure.
+            caps = caps
+                .with_exactly_once()
+                .with_two_phase_commit()
+                .with_preserves_pending_on_abandon();
         }
 
         if self.schema_registry.is_some() {

--- a/crates/laminar-connectors/src/kafka/sink_config.rs
+++ b/crates/laminar-connectors/src/kafka/sink_config.rs
@@ -453,6 +453,30 @@ impl KafkaSinkConfig {
             config.set(key, value);
         }
 
+        // Re-apply the transactional invariant AFTER pass-throughs: a
+        // user override of either timeout must not reintroduce
+        // message.timeout.ms > transaction.timeout.ms, which librdkafka
+        // rejects at producer creation.
+        if self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+            let get_ms = |cfg: &ClientConfig, key: &str| -> Option<u64> {
+                cfg.get(key).and_then(|v| v.parse().ok())
+            };
+            if let (Some(msg), Some(txn)) = (
+                get_ms(&config, "message.timeout.ms"),
+                get_ms(&config, "transaction.timeout.ms"),
+            ) {
+                if msg > txn {
+                    tracing::warn!(
+                        msg,
+                        txn,
+                        "clamping message.timeout.ms to transaction.timeout.ms \
+                         (librdkafka rejects transactional producers otherwise)"
+                    );
+                    config.set("message.timeout.ms", txn.to_string());
+                }
+            }
+        }
+
         config
     }
 

--- a/crates/laminar-connectors/src/kafka/sink_config.rs
+++ b/crates/laminar-connectors/src/kafka/sink_config.rs
@@ -398,6 +398,17 @@ impl KafkaSinkConfig {
             config.set("ssl.key.password", key_pass);
         }
 
+        // librdkafka rejects a transactional producer whose
+        // message.timeout.ms exceeds transaction.timeout.ms (a message
+        // outliving its transaction could never commit) — and the
+        // defaults conflict (delivery 120s > transaction 60s), so an
+        // unclamped exactly-once config fails producer creation.
+        let message_timeout = if self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce {
+            self.delivery_timeout.min(self.transaction_timeout)
+        } else {
+            self.delivery_timeout
+        };
+
         config
             .set("enable.idempotence", "true")
             .set("acks", self.acks.as_rdkafka_str())
@@ -410,7 +421,7 @@ impl KafkaSinkConfig {
             )
             .set(
                 "message.timeout.ms",
-                self.delivery_timeout.as_millis().to_string(),
+                message_timeout.as_millis().to_string(),
             );
 
         if let Some(num_msgs) = self.batch_num_messages {
@@ -809,6 +820,11 @@ mod tests {
         let rdk = cfg.to_rdkafka_config();
         assert_eq!(rdk.get("enable.idempotence"), Some("true"));
         assert!(rdk.get("transactional.id").is_some());
+        // librdkafka rejects message.timeout.ms > transaction.timeout.ms;
+        // the default 120s delivery timeout must clamp to the 60s
+        // transaction timeout or producer creation fails outright.
+        assert_eq!(rdk.get("message.timeout.ms"), Some("60000"));
+        assert_eq!(rdk.get("transaction.timeout.ms"), Some("60000"));
     }
 
     #[test]

--- a/crates/laminar-connectors/src/lib.rs
+++ b/crates/laminar-connectors/src/lib.rs
@@ -39,6 +39,7 @@ pub mod config;
 
 /// Core connector traits (`SourceConnector`, `SinkConnector`).
 pub mod connector;
+pub mod generator;
 
 /// Connector checkpoint types.
 pub mod checkpoint;

--- a/crates/laminar-core/proto/barrier.proto
+++ b/crates/laminar-core/proto/barrier.proto
@@ -43,8 +43,6 @@ message PrepareRequest {
   // Reserved for unaligned / other barrier flags (mirrors
   // `BarrierAnnouncement.flags`).
   uint64 flags = 3;
-  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
-  uint64 seq = 4;
 }
 
 message AlignedRequest {
@@ -55,8 +53,6 @@ message AlignedRequest {
   // followers see cluster-wide event-time progress at resume rather
   // than waiting for the (upload-gated) Commit.
   optional int64 min_watermark_ms = 4;
-  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
-  uint64 seq = 5;
 }
 
 message CommitRequest {
@@ -67,16 +63,12 @@ message CommitRequest {
   // leader from the Prepare acks. Absent when no node has a watermark
   // yet (treated as +infinity).
   optional int64 min_watermark_ms = 4;
-  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
-  uint64 seq = 5;
 }
 
 message AbortRequest {
   uint64 epoch = 1;
   uint64 checkpoint_id = 2;
   uint64 flags = 3;
-  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
-  uint64 seq = 4;
 }
 
 // Follower reply to any phase. Mirrors `BarrierAck`.

--- a/crates/laminar-core/proto/barrier.proto
+++ b/crates/laminar-core/proto/barrier.proto
@@ -17,8 +17,7 @@ service BarrierSync {
   // The follower returns its local watermark so the leader can fold a
   // cluster-wide minimum for the matching Aligned/Commit. The durable
   // tail (sink pre-commit, manifest, state uploads) runs after the ack
-  // — the ack means "captured", not "durable" (ADR-003 two-level
-  // completion).
+  // — the ack means "captured", not "durable".
   rpc Prepare(PrepareRequest) returns (Ack);
 
   // Intermediate (success). Every node has aligned the shuffle and

--- a/crates/laminar-core/proto/barrier.proto
+++ b/crates/laminar-core/proto/barrier.proto
@@ -13,10 +13,20 @@ syntax = "proto3";
 package laminar.barrier.v1;
 
 service BarrierSync {
-  // Phase 1. Snapshot state and pre-commit sinks, then report
-  // readiness. The follower returns its local watermark so the leader
-  // can fold a cluster-wide minimum for the matching Commit.
+  // Phase 1. Align + capture state locally, then report readiness.
+  // The follower returns its local watermark so the leader can fold a
+  // cluster-wide minimum for the matching Aligned/Commit. The durable
+  // tail (sink pre-commit, manifest, state uploads) runs after the ack
+  // — the ack means "captured", not "durable" (ADR-003 two-level
+  // completion).
   rpc Prepare(PrepareRequest) returns (Ack);
+
+  // Intermediate (success). Every node has aligned the shuffle and
+  // captured the epoch locally; pipelines may resume the next epoch.
+  // The epoch is NOT yet restorable — Commit follows once the
+  // durability gate passes. Carries the cluster-wide minimum
+  // watermark computed from the Prepare acks.
+  rpc Aligned(AlignedRequest) returns (Ack);
 
   // Phase 2 (success). The durability gate passed cluster-wide; commit
   // sinks. Carries the cluster-wide minimum watermark.
@@ -33,6 +43,20 @@ message PrepareRequest {
   // Reserved for unaligned / other barrier flags (mirrors
   // `BarrierAnnouncement.flags`).
   uint64 flags = 3;
+  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
+  uint64 seq = 4;
+}
+
+message AlignedRequest {
+  uint64 epoch = 1;
+  uint64 checkpoint_id = 2;
+  uint64 flags = 3;
+  // Cluster-wide minimum watermark folded from the Prepare acks, so
+  // followers see cluster-wide event-time progress at resume rather
+  // than waiting for the (upload-gated) Commit.
+  optional int64 min_watermark_ms = 4;
+  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
+  uint64 seq = 5;
 }
 
 message CommitRequest {
@@ -43,12 +67,16 @@ message CommitRequest {
   // leader from the Prepare acks. Absent when no node has a watermark
   // yet (treated as +infinity).
   optional int64 min_watermark_ms = 4;
+  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
+  uint64 seq = 5;
 }
 
 message AbortRequest {
   uint64 epoch = 1;
   uint64 checkpoint_id = 2;
   uint64 flags = 3;
+  // Leader-stamped announce sequence (see `BarrierAnnouncement.seq`).
+  uint64 seq = 4;
 }
 
 // Follower reply to any phase. Mirrors `BarrierAck`.

--- a/crates/laminar-core/src/checkpoint/object_store_builder.rs
+++ b/crates/laminar-core/src/checkpoint/object_store_builder.rs
@@ -107,23 +107,27 @@ fn url_path_prefix(url: &str) -> &str {
         .map_or("", |i| after_scheme[i + 1..].trim_matches('/'))
 }
 
-/// Extract the local path from a `file://` URL and create a `LocalFileSystem`.
-fn build_local_file_system(url: &str) -> Result<Arc<dyn ObjectStore>, ObjectStoreBuilderError> {
-    // file:///path/to/dir → /path/to/dir
+/// Normalized filesystem path from a `file://` URL: scheme stripped and
+/// the Windows drive-letter slash removed (`file:///C:/x` → `C:/x`).
+///
+/// # Errors
+/// Returns [`ObjectStoreBuilderError::InvalidUrl`] when the scheme is
+/// missing or the path is empty.
+pub fn file_url_path(url: &str) -> Result<&str, ObjectStoreBuilderError> {
     let path = url
         .strip_prefix("file://")
         .ok_or_else(|| ObjectStoreBuilderError::InvalidUrl(url.to_string()))?;
-
     if path.is_empty() {
         return Err(ObjectStoreBuilderError::InvalidUrl(
             "file:// URL has empty path".to_string(),
         ));
     }
+    Ok(strip_windows_leading_slash(path))
+}
 
-    // On Windows, file:///C:/path yields "/C:/path" after stripping the
-    // scheme. The leading slash before the drive letter is invalid — strip
-    // it so `LocalFileSystem::new_with_prefix` receives "C:/path".
-    let path = strip_windows_leading_slash(path);
+/// Extract the local path from a `file://` URL and create a `LocalFileSystem`.
+fn build_local_file_system(url: &str) -> Result<Arc<dyn ObjectStore>, ObjectStoreBuilderError> {
+    let path = file_url_path(url)?;
 
     // Ensure the directory exists — LocalFileSystem doesn't create it.
     std::fs::create_dir_all(path).map_err(|e| {

--- a/crates/laminar-core/src/checkpoint/object_store_builder.rs
+++ b/crates/laminar-core/src/checkpoint/object_store_builder.rs
@@ -57,6 +57,13 @@ impl From<object_store::Error> for ObjectStoreBuilderError {
 /// | `gs://` | `gcs` | `GoogleCloudStorageBuilder` |
 /// | `az://`, `abfs://` | `azure` | `MicrosoftAzureBuilder` |
 ///
+/// The URL's path (everything after the bucket/container) is applied as a
+/// key prefix on the returned store, so every consumer — checkpoint
+/// manifests, decision markers, control plane, state partials — is rooted
+/// under it. The cloud builders themselves only consume the bucket from the
+/// URL; without the wrapper, two clusters sharing a bucket with different
+/// path prefixes would silently collide at the bucket root.
+///
 /// # Errors
 ///
 /// Returns [`ObjectStoreBuilderError`] if the scheme is unsupported, requires
@@ -71,15 +78,33 @@ pub fn build_object_store(
         .map(|i| &url[..i])
         .ok_or_else(|| ObjectStoreBuilderError::InvalidUrl(format!("no scheme in '{url}'")))?;
 
-    match scheme {
-        "file" => build_local_file_system(url),
+    let store = match scheme {
+        // file:// uses the whole path as the filesystem root — already rooted.
+        "file" => return build_local_file_system(url),
         "s3" => build_s3(url, options),
         "gs" => build_gcs(url, options),
         "az" | "abfs" | "abfss" => build_azure(url, options),
         other => Err(ObjectStoreBuilderError::UnsupportedScheme(
             other.to_string(),
         )),
-    }
+    }?;
+
+    Ok(match url_path_prefix(url) {
+        "" => store,
+        prefix => Arc::new(object_store::prefix::PrefixStore::new(
+            store,
+            object_store::path::Path::from(prefix),
+        )),
+    })
+}
+
+/// The key prefix encoded in a cloud URL's path: everything after the
+/// bucket/container authority, e.g. `s3://bucket/a/b/` → `a/b`.
+fn url_path_prefix(url: &str) -> &str {
+    let after_scheme = url.find("://").map_or(url, |i| &url[i + 3..]);
+    after_scheme
+        .find('/')
+        .map_or("", |i| after_scheme[i + 1..].trim_matches('/'))
 }
 
 /// Extract the local path from a `file://` URL and create a `LocalFileSystem`.
@@ -305,6 +330,22 @@ mod tests {
             let err = result.unwrap_err().to_string();
             assert!(err.contains("azure"), "got: {err}");
         }
+    }
+
+    /// The URL path roots ALL consumers of the store (manifests,
+    /// decision markers, control plane, state partials) — two clusters
+    /// sharing a bucket must not collide at the root.
+    #[test]
+    fn url_path_prefix_extraction() {
+        assert_eq!(url_path_prefix("s3://bucket"), "");
+        assert_eq!(url_path_prefix("s3://bucket/"), "");
+        assert_eq!(url_path_prefix("s3://bucket/a"), "a");
+        assert_eq!(url_path_prefix("s3://bucket/a/b/"), "a/b");
+        assert_eq!(url_path_prefix("gs://bucket/x"), "x");
+        assert_eq!(
+            url_path_prefix("abfss://container@account.dfs.core.windows.net/p/q"),
+            "p/q"
+        );
     }
 
     #[test]

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -812,6 +812,16 @@ impl BarrierCoordinator {
         Ok(())
     }
 
+    /// Watch over gRPC-delivered announcements, for push-driven waits
+    /// (the decision wait and the Aligned resume gate). `None` until
+    /// the gRPC server is started — gossip-KV-only deployments fall
+    /// back to polling [`observe`](Self::observe).
+    #[cfg(feature = "cluster")]
+    #[must_use]
+    pub fn announcement_watch(&self) -> Option<watch::Receiver<Option<BarrierAnnouncement>>> {
+        self.grpc.lock().as_ref().map(|s| s.latest_rx.clone())
+    }
+
     /// Follower-side observe — returns the *latest* announcement
     /// (non-destructive; repeated calls return the same value until a
     /// newer one arrives, matching the gossip-KV fallback). Callers

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -33,7 +33,7 @@ pub enum Phase {
     Prepare,
     /// Every node has aligned + captured this epoch (full-membership
     /// capture quorum). Pipelines may resume the next epoch; the epoch
-    /// is NOT yet restorable (ADR-003 two-level completion).
+    /// is NOT yet restorable.
     Aligned,
     /// Durability gate passed; commit sinks. The epoch is restorable.
     Commit,

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -28,9 +28,14 @@ pub const BARRIER_ADDR_KEY: &str = "barrier:addr";
 /// Barrier phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Phase {
-    /// Snapshot state and pre-commit sinks.
+    /// Align the shuffle, capture state locally, ack. The durable tail
+    /// (sink pre-commit, manifest, uploads) runs after the ack.
     Prepare,
-    /// Durability gate passed; commit sinks.
+    /// Every node has aligned + captured this epoch (full-membership
+    /// capture quorum). Pipelines may resume the next epoch; the epoch
+    /// is NOT yet restorable (ADR-003 two-level completion).
+    Aligned,
+    /// Durability gate passed; commit sinks. The epoch is restorable.
     Commit,
     /// Prepare failed; roll back.
     Abort,
@@ -61,6 +66,18 @@ pub struct BarrierAnnouncement {
     /// node is still processing earlier events.
     #[serde(default)]
     pub min_watermark_ms: Option<i64>,
+    /// Leader-stamped monotonic announce sequence, assigned by
+    /// [`BarrierCoordinator::announce`] (caller-set values are
+    /// overwritten). Observation is latest-wins across two channels
+    /// (gRPC push + gossip KV), and a retry of an aborted epoch reuses
+    /// the same epoch/checkpoint id — within an epoch only this
+    /// sequence distinguishes `Abort(attempt 1)` from the retry's
+    /// `Prepare(attempt 2)`. Resets on leader change/restart; epoch
+    /// ordering dominates across leaders, and the gRPC push physically
+    /// overwriting the watch self-heals same-epoch staleness.
+    /// `0` on legacy payloads via `#[serde(default)]`.
+    #[serde(default)]
+    pub seq: u64,
 }
 
 /// Follower ack. `ok = false` forces the leader to abort instead of wait.
@@ -214,14 +231,19 @@ type BarrierClientPool = Arc<
 
 #[cfg(feature = "cluster")]
 struct GrpcState {
-    incoming_rx: parking_lot::Mutex<Option<crossfire::AsyncRx<BarrierFlavor>>>,
-    incoming_rx_returned: Arc<tokio::sync::Notify>,
+    /// Latest gRPC-delivered announcement, fed in arrival order by the
+    /// relay task draining the incoming queue. Latest-wins semantics
+    /// (matching the gossip-KV fallback) so concurrent observers — the
+    /// pipeline's resume gate and the background durable tail — never
+    /// steal announcements from each other.
+    latest_rx: watch::Receiver<Option<BarrierAnnouncement>>,
     #[allow(dead_code)]
     incoming_tx: crossfire::MAsyncTx<BarrierFlavor>,
     pending_acks: Arc<parking_lot::Mutex<FxHashMap<u64, tokio::sync::oneshot::Sender<BarrierAck>>>>,
     completed_acks: Arc<parking_lot::Mutex<FxHashMap<u64, BarrierAck>>>,
     clients: BarrierClientPool,
     server_handle: Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    relay_handle: Arc<parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>>,
     advertise_addr: String,
 }
 
@@ -326,6 +348,7 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Prepare,
             flags: req.flags,
             min_watermark_ms: None,
+            seq: req.seq,
         };
 
         if self.incoming_tx.send(ann).await.is_err() {
@@ -352,6 +375,35 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
         }
     }
 
+    async fn aligned(
+        &self,
+        request: tonic::Request<barrier_v1::AlignedRequest>,
+    ) -> Result<tonic::Response<barrier_v1::Ack>, tonic::Status> {
+        self.validate_leader(request.metadata()).await?;
+        let req = request.into_inner();
+
+        // Unlike Commit/Abort, Aligned is mid-protocol: the epoch's ack
+        // bookkeeping stays untouched — only the announcement is relayed
+        // so the pipeline's resume gate can release.
+        let ann = BarrierAnnouncement {
+            epoch: req.epoch,
+            checkpoint_id: req.checkpoint_id,
+            phase: Phase::Aligned,
+            flags: req.flags,
+            min_watermark_ms: req.min_watermark_ms,
+            seq: req.seq,
+        };
+        if self.incoming_tx.send(ann).await.is_err() {
+            return Err(tonic::Status::aborted("Follower coordinator shutdown"));
+        }
+        Ok(tonic::Response::new(barrier_v1::Ack {
+            epoch: req.epoch,
+            ok: true,
+            error: None,
+            local_watermark_ms: None,
+        }))
+    }
+
     async fn commit(
         &self,
         request: tonic::Request<barrier_v1::CommitRequest>,
@@ -371,6 +423,7 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Commit,
             flags: req.flags,
             min_watermark_ms: req.min_watermark_ms,
+            seq: req.seq,
         };
         if self.incoming_tx.send(ann).await.is_err() {
             return Err(tonic::Status::aborted("Follower coordinator shutdown"));
@@ -402,6 +455,7 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Abort,
             flags: req.flags,
             min_watermark_ms: None,
+            seq: req.seq,
         };
         if self.incoming_tx.send(ann).await.is_err() {
             return Err(tonic::Status::aborted("Follower coordinator shutdown"));
@@ -434,9 +488,91 @@ async fn get_barrier_client(
     Some(client)
 }
 
+/// Stamp the leader's identity into the request metadata so the
+/// follower's `validate_leader` check can reject impostors.
+#[cfg(feature = "cluster")]
+fn stamp_leader_id<T>(req: &mut tonic::Request<T>, local_id: Option<NodeId>) {
+    if let Some(lid) = local_id {
+        if let Ok(val) = lid.0.to_string().parse() {
+            req.metadata_mut().insert("x-leader-id", val);
+        }
+    }
+}
+
+/// Fan a non-Prepare phase announcement to one peer over gRPC. A failed
+/// RPC evicts the pooled client so the next round re-resolves the peer.
+#[cfg(feature = "cluster")]
+async fn send_phase_rpc(
+    peer: NodeId,
+    clients_pool: BarrierClientPool,
+    kv: Arc<dyn ClusterKv>,
+    ann: BarrierAnnouncement,
+    local_id: Option<NodeId>,
+) -> Result<(), String> {
+    let mut client = get_barrier_client(peer, &clients_pool, &kv)
+        .await
+        .ok_or_else(|| format!("failed to get client for peer {}", peer.0))?;
+    let result = match ann.phase {
+        Phase::Aligned => {
+            let mut req = tonic::Request::new(barrier_v1::AlignedRequest {
+                epoch: ann.epoch,
+                checkpoint_id: ann.checkpoint_id,
+                flags: ann.flags,
+                min_watermark_ms: ann.min_watermark_ms,
+                seq: ann.seq,
+            });
+            stamp_leader_id(&mut req, local_id);
+            client
+                .aligned(req)
+                .await
+                .map(|_| ())
+                .map_err(|e| ("aligned", e))
+        }
+        Phase::Commit => {
+            let mut req = tonic::Request::new(barrier_v1::CommitRequest {
+                epoch: ann.epoch,
+                checkpoint_id: ann.checkpoint_id,
+                flags: ann.flags,
+                min_watermark_ms: ann.min_watermark_ms,
+                seq: ann.seq,
+            });
+            stamp_leader_id(&mut req, local_id);
+            client
+                .commit(req)
+                .await
+                .map(|_| ())
+                .map_err(|e| ("commit", e))
+        }
+        Phase::Abort => {
+            let mut req = tonic::Request::new(barrier_v1::AbortRequest {
+                epoch: ann.epoch,
+                checkpoint_id: ann.checkpoint_id,
+                flags: ann.flags,
+                seq: ann.seq,
+            });
+            stamp_leader_id(&mut req, local_id);
+            client
+                .abort(req)
+                .await
+                .map(|_| ())
+                .map_err(|e| ("abort", e))
+        }
+        Phase::Prepare => Ok(()),
+    };
+    result.map_err(|(rpc, e)| {
+        clients_pool.lock().remove(&peer);
+        format!("{rpc} RPC to peer {} failed: {e}", peer.0)
+    })
+}
+
 /// Cross-instance barrier coordination.
 pub struct BarrierCoordinator {
     kv: Arc<dyn ClusterKv>,
+    /// Monotonic per-process announce sequence (see
+    /// [`BarrierAnnouncement::seq`]). Stamped on every announce and on
+    /// each `wait_for_quorum` Prepare round so observers can order
+    /// same-epoch announcements across retries.
+    announce_seq: std::sync::atomic::AtomicU64,
     #[cfg(feature = "cluster")]
     grpc: Arc<parking_lot::Mutex<Option<Arc<GrpcState>>>>,
     #[cfg(feature = "cluster")]
@@ -459,6 +595,10 @@ impl Drop for BarrierCoordinator {
                 if let Some(handle) = handle_opt {
                     handle.abort();
                 }
+                let relay_opt = state.relay_handle.lock().take();
+                if let Some(handle) = relay_opt {
+                    handle.abort();
+                }
             }
         }
     }
@@ -470,11 +610,20 @@ impl BarrierCoordinator {
     pub fn new(kv: Arc<dyn ClusterKv>) -> Self {
         Self {
             kv,
+            announce_seq: std::sync::atomic::AtomicU64::new(0),
             #[cfg(feature = "cluster")]
             grpc: Arc::new(parking_lot::Mutex::new(None)),
             #[cfg(feature = "cluster")]
             leader_election: Arc::new(parking_lot::Mutex::new(None)),
         }
+    }
+
+    /// Next announce sequence value (starts at 1 so `0` stays the
+    /// legacy/unset sentinel).
+    fn next_seq(&self) -> u64 {
+        self.announce_seq
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+            + 1
     }
 
     /// Configure the leader election state used to validate incoming leader identity.
@@ -568,14 +717,26 @@ impl BarrierCoordinator {
             local_addr.to_string()
         };
 
+        // Relay every gRPC-delivered announcement into a latest-wins
+        // watch in arrival order. Observation is then non-destructive,
+        // so the pipeline's resume gate and the background durable
+        // tail can watch concurrently (matching the gossip-KV
+        // fallback's read-latest semantics).
+        let (latest_tx, latest_rx) = watch::channel::<Option<BarrierAnnouncement>>(None);
+        let relay_task = tokio::spawn(async move {
+            while let Ok(ann) = incoming_rx.recv().await {
+                let _ = latest_tx.send(Some(ann));
+            }
+        });
+
         let grpc_state = Arc::new(GrpcState {
-            incoming_rx: parking_lot::Mutex::new(Some(incoming_rx)),
-            incoming_rx_returned: Arc::new(tokio::sync::Notify::new()),
+            latest_rx,
             incoming_tx,
             pending_acks,
             completed_acks,
             clients,
             server_handle: Arc::new(parking_lot::Mutex::new(Some(server_task))),
+            relay_handle: Arc::new(parking_lot::Mutex::new(Some(relay_task))),
             advertise_addr: advertise_addr.clone(),
         });
 
@@ -586,11 +747,18 @@ impl BarrierCoordinator {
         Ok(local_addr)
     }
 
-    /// Leader-side announce.
+    /// Leader-side announce. Stamps [`BarrierAnnouncement::seq`] from
+    /// this coordinator's monotonic counter (any caller-set value is
+    /// overwritten) so observers can order same-epoch announcements
+    /// across abort/retry sequences.
     ///
     /// # Errors
     /// Returns a string on JSON encode failure.
     pub async fn announce(&self, ann: &BarrierAnnouncement) -> Result<(), String> {
+        let ann = &BarrierAnnouncement {
+            seq: self.next_seq(),
+            ..ann.clone()
+        };
         #[cfg(feature = "cluster")]
         {
             let grpc_opt = self.grpc.lock().clone();
@@ -599,7 +767,7 @@ impl BarrierCoordinator {
                 if ann.phase == Phase::Prepare {
                     // Prepare gRPC calls are initiated by wait_for_quorum.
                     // Redundant calls here cause duplicate prepare executions and timeouts on followers.
-                } else if ann.phase == Phase::Commit || ann.phase == Phase::Abort {
+                } else {
                     let mut expected = Vec::new();
                     for (node_id, addr) in self.kv.scan(BARRIER_ADDR_KEY).await {
                         if addr == state.advertise_addr {
@@ -613,60 +781,26 @@ impl BarrierCoordinator {
                         let clients_pool = Arc::clone(&state.clients);
                         let kv = Arc::clone(&self.kv);
                         let ann_clone = ann.clone();
-                        futures.push(async move {
-                            let mut client = get_barrier_client(peer, &clients_pool, &kv)
-                                .await
-                                .ok_or_else(|| {
-                                    format!("failed to get client for peer {}", peer.0)
-                                })?;
-                            match ann_clone.phase {
-                                Phase::Commit => {
-                                    let mut req = tonic::Request::new(barrier_v1::CommitRequest {
-                                        epoch: ann_clone.epoch,
-                                        checkpoint_id: ann_clone.checkpoint_id,
-                                        flags: ann_clone.flags,
-                                        min_watermark_ms: ann_clone.min_watermark_ms,
-                                    });
-                                    if let Some(lid) = local_id {
-                                        if let Ok(val) = lid.0.to_string().parse() {
-                                            req.metadata_mut().insert("x-leader-id", val);
-                                        }
-                                    }
-                                    if let Err(e) = client.commit(req).await {
-                                        clients_pool.lock().remove(&peer);
-                                        return Err(format!(
-                                            "commit RPC to peer {} failed: {e}",
-                                            peer.0
-                                        ));
-                                    }
-                                }
-                                Phase::Abort => {
-                                    let mut req = tonic::Request::new(barrier_v1::AbortRequest {
-                                        epoch: ann_clone.epoch,
-                                        checkpoint_id: ann_clone.checkpoint_id,
-                                        flags: ann_clone.flags,
-                                    });
-                                    if let Some(lid) = local_id {
-                                        if let Ok(val) = lid.0.to_string().parse() {
-                                            req.metadata_mut().insert("x-leader-id", val);
-                                        }
-                                    }
-                                    if let Err(e) = client.abort(req).await {
-                                        clients_pool.lock().remove(&peer);
-                                        return Err(format!(
-                                            "abort RPC to peer {} failed: {e}",
-                                            peer.0
-                                        ));
-                                    }
-                                }
-                                Phase::Prepare => {}
-                            }
-                            Ok::<(), String>(())
-                        });
+                        futures.push(send_phase_rpc(peer, clients_pool, kv, ann_clone, local_id));
                     }
                     let results = futures::future::join_all(futures).await;
                     for res in results {
-                        res?;
+                        match res {
+                            Ok(()) => {}
+                            // Aligned is best-effort per peer: a missed
+                            // delivery only delays that peer's pipeline
+                            // resume until Commit (or its gate timeout) —
+                            // never fail the announce, and never skip the
+                            // KV write below.
+                            Err(e) if ann.phase == Phase::Aligned => {
+                                tracing::warn!(
+                                    epoch = ann.epoch,
+                                    error = %e,
+                                    "aligned announcement RPC failed; peer resumes on Commit"
+                                );
+                            }
+                            Err(e) => return Err(e),
+                        }
                     }
                 }
 
@@ -681,38 +815,47 @@ impl BarrierCoordinator {
         Ok(())
     }
 
-    /// Follower-side observe.
+    /// Follower-side observe — returns the *latest* announcement
+    /// (non-destructive; repeated calls return the same value until a
+    /// newer one arrives, matching the gossip-KV fallback). Callers
+    /// already dedup by epoch/phase. The gRPC-delivered value and the
+    /// gossip-KV value are merged by `(epoch, seq)` — within an epoch
+    /// only the leader's announce sequence distinguishes a retry's
+    /// `Prepare` from the previous attempt's `Abort`; on a full tie the
+    /// gRPC value wins (RPC arrival order is authoritative).
     ///
     /// # Errors
     /// Returns a string on JSON decode failure.
     pub async fn observe(&self, leader: NodeId) -> Result<Option<BarrierAnnouncement>, String> {
         #[cfg(feature = "cluster")]
-        {
+        let grpc_latest: Option<BarrierAnnouncement> = {
             let grpc_opt = self.grpc.lock().clone();
-            if let Some(state) = grpc_opt {
-                let taken = { state.incoming_rx.lock().take() };
-                if let Some(rx) = taken {
-                    let blocking_rx = rx.into_blocking();
-                    let res = blocking_rx.try_recv();
-                    let async_rx = blocking_rx.into_async();
-                    *state.incoming_rx.lock() = Some(async_rx);
-                    state.incoming_rx_returned.notify_one();
+            grpc_opt.and_then(|state| state.latest_rx.borrow().clone())
+        };
+        #[cfg(not(feature = "cluster"))]
+        let grpc_latest: Option<BarrierAnnouncement> = None;
 
-                    match res {
-                        Ok(ann) => return Ok(Some(ann)),
-                        Err(crossfire::TryRecvError::Disconnected) => return Ok(None),
-                        Err(crossfire::TryRecvError::Empty) => {} // fallback to KV check below
-                    }
+        let kv_latest: Option<BarrierAnnouncement> =
+            match self.kv.read_from(leader, ANNOUNCEMENT_KEY).await {
+                Some(json) => serde_json::from_str(&json).map(Some).map_err(|e| {
+                    // A decode failure on the KV path is fatal only when
+                    // there is no gRPC value to fall back on.
+                    e.to_string()
+                })?,
+                None => None,
+            };
+
+        Ok(match (grpc_latest, kv_latest) {
+            (Some(g), Some(k)) => {
+                if (k.epoch, k.seq) > (g.epoch, g.seq) {
+                    Some(k)
+                } else {
+                    Some(g)
                 }
             }
-        }
-
-        match self.kv.read_from(leader, ANNOUNCEMENT_KEY).await {
-            Some(json) => serde_json::from_str(&json)
-                .map(Some)
-                .map_err(|e| e.to_string()),
-            None => Ok(None),
-        }
+            (Some(g), None) => Some(g),
+            (None, k) => k,
+        })
     }
 
     /// Follower-side ack.
@@ -772,6 +915,10 @@ impl BarrierCoordinator {
                     };
 
                 let local_id = self.local_node_id().await;
+                // One sequence value per Prepare round: each round is a
+                // (re-)announcement, so it must supersede any earlier
+                // same-epoch announcement (e.g. a prior attempt's Abort).
+                let round_seq = self.next_seq();
                 let mut futures = Vec::new();
                 for &peer in expected {
                     let clients_pool = Arc::clone(&state.clients);
@@ -786,6 +933,7 @@ impl BarrierCoordinator {
                             epoch,
                             checkpoint_id,
                             flags: 0,
+                            seq: round_seq,
                         });
                         if let Some(lid) = local_id {
                             if let Ok(val) = lid.0.to_string().parse() {
@@ -942,14 +1090,22 @@ mod tests {
         use super::*;
         use std::net::SocketAddr;
 
-        async fn wait_observe(coord: &BarrierCoordinator, leader: NodeId) -> BarrierAnnouncement {
+        /// Observation is latest-wins (non-destructive), so wait for the
+        /// expected phase specifically — earlier phases may linger.
+        async fn wait_observe(
+            coord: &BarrierCoordinator,
+            leader: NodeId,
+            phase: Phase,
+        ) -> BarrierAnnouncement {
             for _ in 0..100 {
                 if let Some(ann) = coord.observe(leader).await.unwrap() {
-                    return ann;
+                    if ann.phase == phase {
+                        return ann;
+                    }
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
-            panic!("timed out waiting for announcement from leader {leader:?}");
+            panic!("timed out waiting for {phase:?} announcement from leader {leader:?}");
         }
 
         #[tokio::test]
@@ -970,11 +1126,15 @@ mod tests {
             leader_kv.seed(NodeId(2), BARRIER_ADDR_KEY, bound_addr.to_string());
             follower_kv.seed(NodeId(1), BARRIER_ADDR_KEY, leader_addr.to_string());
 
+            // Sequencing handshake: observation is latest-wins, so the
+            // leader must not announce Commit until the follower has
+            // observed Aligned (otherwise Commit may overwrite it).
+            let (aligned_seen_tx, aligned_seen_rx) = tokio::sync::oneshot::channel::<()>();
+
             let follower_task = tokio::spawn(async move {
-                let ann = wait_observe(&follower_coord, NodeId(1)).await;
+                let ann = wait_observe(&follower_coord, NodeId(1), Phase::Prepare).await;
                 assert_eq!(ann.epoch, 1);
                 assert_eq!(ann.checkpoint_id, 42);
-                assert_eq!(ann.phase, Phase::Prepare);
 
                 follower_coord
                     .ack(&BarrierAck {
@@ -986,8 +1146,12 @@ mod tests {
                     .await
                     .unwrap();
 
-                let commit_ann = wait_observe(&follower_coord, NodeId(1)).await;
-                assert_eq!(commit_ann.phase, Phase::Commit);
+                let aligned_ann = wait_observe(&follower_coord, NodeId(1), Phase::Aligned).await;
+                assert_eq!(aligned_ann.epoch, 1);
+                assert_eq!(aligned_ann.min_watermark_ms, Some(100));
+                aligned_seen_tx.send(()).unwrap();
+
+                let commit_ann = wait_observe(&follower_coord, NodeId(1), Phase::Commit).await;
                 assert_eq!(commit_ann.min_watermark_ms, Some(100));
             });
 
@@ -998,6 +1162,7 @@ mod tests {
                     phase: Phase::Prepare,
                     flags: 0,
                     min_watermark_ms: None,
+                    seq: 0,
                 })
                 .await
                 .unwrap();
@@ -1013,6 +1178,21 @@ mod tests {
                     assert_eq!(acks, vec![NodeId(2)]);
                     assert_eq!(min_follower_watermark_ms, Some(100));
 
+                    // Two-level completion: resume gate first…
+                    leader_coord
+                        .announce(&BarrierAnnouncement {
+                            epoch: 1,
+                            checkpoint_id: 42,
+                            phase: Phase::Aligned,
+                            flags: 0,
+                            min_watermark_ms: min_follower_watermark_ms,
+                            seq: 0,
+                        })
+                        .await
+                        .unwrap();
+                    aligned_seen_rx.await.unwrap();
+
+                    // …then the restorable decision.
                     leader_coord
                         .announce(&BarrierAnnouncement {
                             epoch: 1,
@@ -1020,6 +1200,7 @@ mod tests {
                             phase: Phase::Commit,
                             flags: 0,
                             min_watermark_ms: min_follower_watermark_ms,
+                            seq: 0,
                         })
                         .await
                         .unwrap();
@@ -1029,6 +1210,92 @@ mod tests {
 
             follower_task.await.unwrap();
         }
+    }
+
+    /// Regression: observation is latest-wins, and a retry of an
+    /// aborted epoch reuses the same epoch/checkpoint id. Without the
+    /// announce `seq`, a stale gRPC-delivered `Abort(N)` would mask
+    /// the retry's gossip-delivered `Prepare(N)` forever (follower
+    /// never starts the retry → leader alignment times out → abort →
+    /// livelock).
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn kv_retry_prepare_supersedes_stale_grpc_abort() {
+        let leader_kv = kv(NodeId(1));
+        let follower_kv = kv(NodeId(2));
+        let leader_coord = BarrierCoordinator::new(leader_kv.clone());
+        let follower_coord = BarrierCoordinator::new(follower_kv.clone());
+
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let slot = || Arc::new(parking_lot::RwLock::new(None));
+        let leader_addr = leader_coord.start_server(addr, None, slot()).await.unwrap();
+        let bound_addr = follower_coord
+            .start_server(addr, None, slot())
+            .await
+            .unwrap();
+        leader_kv.seed(NodeId(2), BARRIER_ADDR_KEY, bound_addr.to_string());
+        follower_kv.seed(NodeId(1), BARRIER_ADDR_KEY, leader_addr.to_string());
+
+        // Attempt 1 aborts — delivered over gRPC, lands in the
+        // follower's latest-wins watch (announce stamps seq = 1).
+        leader_coord
+            .announce(&BarrierAnnouncement {
+                epoch: 5,
+                checkpoint_id: 9,
+                phase: Phase::Abort,
+                flags: 0,
+                min_watermark_ms: None,
+                seq: 0,
+            })
+            .await
+            .unwrap();
+        for _ in 0..100 {
+            if let Some(ann) = follower_coord.observe(NodeId(1)).await.unwrap() {
+                if ann.phase == Phase::Abort {
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Attempt 2's early Prepare reaches this follower via
+        // gossip KV only (the prepare RPC comes later, at quorum
+        // time). Its higher seq must win the merge.
+        let retry = serde_json::to_string(&BarrierAnnouncement {
+            epoch: 5,
+            checkpoint_id: 9,
+            phase: Phase::Prepare,
+            flags: 0,
+            min_watermark_ms: None,
+            seq: 2,
+        })
+        .unwrap();
+        follower_kv.seed(NodeId(1), ANNOUNCEMENT_KEY, retry);
+        let got = follower_coord.observe(NodeId(1)).await.unwrap().unwrap();
+        assert_eq!(
+            got.phase,
+            Phase::Prepare,
+            "retry Prepare (higher seq) must supersede the stale gRPC Abort",
+        );
+
+        // Conversely, a *stale* lower-seq KV value (gossip lag)
+        // must not mask the fresher gRPC value.
+        let stale = serde_json::to_string(&BarrierAnnouncement {
+            epoch: 5,
+            checkpoint_id: 9,
+            phase: Phase::Prepare,
+            flags: 0,
+            min_watermark_ms: None,
+            seq: 0,
+        })
+        .unwrap();
+        follower_kv.seed(NodeId(1), ANNOUNCEMENT_KEY, stale);
+        let got = follower_coord.observe(NodeId(1)).await.unwrap().unwrap();
+        assert_eq!(
+            got.phase,
+            Phase::Abort,
+            "lagging gossip must not mask the fresher gRPC announcement",
+        );
     }
 
     #[tokio::test]
@@ -1042,6 +1309,7 @@ mod tests {
                 phase: Phase::Prepare,
                 flags: 0,
                 min_watermark_ms: None,
+                seq: 0,
             })
             .await
             .unwrap();

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -66,15 +66,6 @@ pub struct BarrierAnnouncement {
     /// node is still processing earlier events.
     #[serde(default)]
     pub min_watermark_ms: Option<i64>,
-    /// Leader-stamped monotonic announce sequence, assigned by
-    /// [`BarrierCoordinator::announce`] (caller-set values are
-    /// overwritten). Orders same-epoch announcements under latest-wins
-    /// observation: a retry of an aborted epoch reuses the epoch and
-    /// checkpoint id, so only `seq` distinguishes the stale `Abort`
-    /// from the retry's `Prepare`. Resets on leader change; epoch
-    /// ordering dominates across leaders. `0` = legacy/unset.
-    #[serde(default)]
-    pub seq: u64,
 }
 
 /// Follower ack. `ok = false` forces the leader to abort instead of wait.
@@ -345,7 +336,6 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Prepare,
             flags: req.flags,
             min_watermark_ms: None,
-            seq: req.seq,
         };
 
         if self.incoming_tx.send(ann).await.is_err() {
@@ -388,7 +378,6 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Aligned,
             flags: req.flags,
             min_watermark_ms: req.min_watermark_ms,
-            seq: req.seq,
         };
         if self.incoming_tx.send(ann).await.is_err() {
             return Err(tonic::Status::aborted("Follower coordinator shutdown"));
@@ -420,7 +409,6 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Commit,
             flags: req.flags,
             min_watermark_ms: req.min_watermark_ms,
-            seq: req.seq,
         };
         if self.incoming_tx.send(ann).await.is_err() {
             return Err(tonic::Status::aborted("Follower coordinator shutdown"));
@@ -452,7 +440,6 @@ impl barrier_v1::barrier_sync_server::BarrierSync for GrpcBarrierServer {
             phase: Phase::Abort,
             flags: req.flags,
             min_watermark_ms: None,
-            seq: req.seq,
         };
         if self.incoming_tx.send(ann).await.is_err() {
             return Err(tonic::Status::aborted("Follower coordinator shutdown"));
@@ -516,7 +503,6 @@ async fn send_phase_rpc(
                 checkpoint_id: ann.checkpoint_id,
                 flags: ann.flags,
                 min_watermark_ms: ann.min_watermark_ms,
-                seq: ann.seq,
             });
             stamp_leader_id(&mut req, local_id);
             client
@@ -531,7 +517,6 @@ async fn send_phase_rpc(
                 checkpoint_id: ann.checkpoint_id,
                 flags: ann.flags,
                 min_watermark_ms: ann.min_watermark_ms,
-                seq: ann.seq,
             });
             stamp_leader_id(&mut req, local_id);
             client
@@ -545,7 +530,6 @@ async fn send_phase_rpc(
                 epoch: ann.epoch,
                 checkpoint_id: ann.checkpoint_id,
                 flags: ann.flags,
-                seq: ann.seq,
             });
             stamp_leader_id(&mut req, local_id);
             client
@@ -565,11 +549,6 @@ async fn send_phase_rpc(
 /// Cross-instance barrier coordination.
 pub struct BarrierCoordinator {
     kv: Arc<dyn ClusterKv>,
-    /// Monotonic per-process announce sequence (see
-    /// [`BarrierAnnouncement::seq`]). Stamped on every announce and on
-    /// each `wait_for_quorum` Prepare round so observers can order
-    /// same-epoch announcements across retries.
-    announce_seq: std::sync::atomic::AtomicU64,
     #[cfg(feature = "cluster")]
     grpc: Arc<parking_lot::Mutex<Option<Arc<GrpcState>>>>,
     #[cfg(feature = "cluster")]
@@ -607,20 +586,11 @@ impl BarrierCoordinator {
     pub fn new(kv: Arc<dyn ClusterKv>) -> Self {
         Self {
             kv,
-            announce_seq: std::sync::atomic::AtomicU64::new(0),
             #[cfg(feature = "cluster")]
             grpc: Arc::new(parking_lot::Mutex::new(None)),
             #[cfg(feature = "cluster")]
             leader_election: Arc::new(parking_lot::Mutex::new(None)),
         }
-    }
-
-    /// Next announce sequence value (starts at 1 so `0` stays the
-    /// legacy/unset sentinel).
-    fn next_seq(&self) -> u64 {
-        self.announce_seq
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
-            + 1
     }
 
     /// Configure the leader election state used to validate incoming leader identity.
@@ -744,18 +714,11 @@ impl BarrierCoordinator {
         Ok(local_addr)
     }
 
-    /// Leader-side announce. Stamps [`BarrierAnnouncement::seq`] from
-    /// this coordinator's monotonic counter (any caller-set value is
-    /// overwritten) so observers can order same-epoch announcements
-    /// across abort/retry sequences.
+    /// Leader-side announce.
     ///
     /// # Errors
     /// Returns a string on JSON encode failure.
     pub async fn announce(&self, ann: &BarrierAnnouncement) -> Result<(), String> {
-        let ann = &BarrierAnnouncement {
-            seq: self.next_seq(),
-            ..ann.clone()
-        };
         #[cfg(feature = "cluster")]
         {
             let grpc_opt = self.grpc.lock().clone();
@@ -826,10 +789,10 @@ impl BarrierCoordinator {
     /// (non-destructive; repeated calls return the same value until a
     /// newer one arrives, matching the gossip-KV fallback). Callers
     /// already dedup by epoch/phase. The gRPC-delivered value and the
-    /// gossip-KV value are merged by `(epoch, seq)` — within an epoch
-    /// only the leader's announce sequence distinguishes a retry's
-    /// `Prepare` from the previous attempt's `Abort`; on a full tie the
-    /// gRPC value wins (RPC arrival order is authoritative).
+    /// gossip-KV value are merged by epoch (higher wins — epochs are
+    /// never reused: failed ones are abandoned); within an epoch the
+    /// gRPC value wins, since RPC arrival order is authoritative while
+    /// gossip may lag.
     ///
     /// # Errors
     /// Returns a string on JSON decode failure.
@@ -854,7 +817,7 @@ impl BarrierCoordinator {
 
         Ok(match (grpc_latest, kv_latest) {
             (Some(g), Some(k)) => {
-                if (k.epoch, k.seq) > (g.epoch, g.seq) {
+                if k.epoch > g.epoch {
                     Some(k)
                 } else {
                     Some(g)
@@ -922,10 +885,6 @@ impl BarrierCoordinator {
                     };
 
                 let local_id = self.local_node_id().await;
-                // One sequence value per Prepare round: each round is a
-                // (re-)announcement, so it must supersede any earlier
-                // same-epoch announcement (e.g. a prior attempt's Abort).
-                let round_seq = self.next_seq();
                 let mut futures = Vec::new();
                 for &peer in expected {
                     let clients_pool = Arc::clone(&state.clients);
@@ -940,7 +899,6 @@ impl BarrierCoordinator {
                             epoch,
                             checkpoint_id,
                             flags: 0,
-                            seq: round_seq,
                         });
                         stamp_leader_id(&mut req, local_id);
 
@@ -1165,7 +1123,6 @@ mod tests {
                     phase: Phase::Prepare,
                     flags: 0,
                     min_watermark_ms: None,
-                    seq: 0,
                 })
                 .await
                 .unwrap();
@@ -1189,7 +1146,6 @@ mod tests {
                             phase: Phase::Aligned,
                             flags: 0,
                             min_watermark_ms: min_follower_watermark_ms,
-                            seq: 0,
                         })
                         .await
                         .unwrap();
@@ -1203,7 +1159,6 @@ mod tests {
                             phase: Phase::Commit,
                             flags: 0,
                             min_watermark_ms: min_follower_watermark_ms,
-                            seq: 0,
                         })
                         .await
                         .unwrap();
@@ -1215,15 +1170,15 @@ mod tests {
         }
     }
 
-    /// Regression: observation is latest-wins, and a retry of an
-    /// aborted epoch reuses the same epoch/checkpoint id. Without the
-    /// announce `seq`, a stale gRPC-delivered `Abort(N)` would mask
-    /// the retry's gossip-delivered `Prepare(N)` forever (follower
-    /// never starts the retry → leader alignment times out → abort →
-    /// livelock).
+    /// The gRPC-vs-gossip merge in `observe`: a newer epoch's
+    /// gossip-only announcement (the early `Prepare` is KV-only)
+    /// supersedes an older epoch in the gRPC watch, while lagging
+    /// gossip for the *same* epoch never masks the fresher gRPC value.
+    /// Epochs are never reused — failed ones are abandoned — so epoch
+    /// comparison alone orders the channels.
     #[cfg(feature = "cluster")]
     #[tokio::test]
-    async fn kv_retry_prepare_supersedes_stale_grpc_abort() {
+    async fn observe_merges_grpc_and_gossip_by_epoch() {
         let leader_kv = kv(NodeId(1));
         let follower_kv = kv(NodeId(2));
         let leader_coord = BarrierCoordinator::new(leader_kv.clone());
@@ -1239,8 +1194,8 @@ mod tests {
         leader_kv.seed(NodeId(2), BARRIER_ADDR_KEY, bound_addr.to_string());
         follower_kv.seed(NodeId(1), BARRIER_ADDR_KEY, leader_addr.to_string());
 
-        // Attempt 1 aborts — delivered over gRPC, lands in the
-        // follower's latest-wins watch (announce stamps seq = 1).
+        // Epoch 5 aborts — delivered over gRPC, lands in the
+        // follower's latest-wins watch.
         leader_coord
             .announce(&BarrierAnnouncement {
                 epoch: 5,
@@ -1248,7 +1203,6 @@ mod tests {
                 phase: Phase::Abort,
                 flags: 0,
                 min_watermark_ms: None,
-                seq: 0,
             })
             .await
             .unwrap();
@@ -1261,35 +1215,30 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
 
-        // Attempt 2's early Prepare reaches this follower via
-        // gossip KV only (the prepare RPC comes later, at quorum
-        // time). Its higher seq must win the merge.
-        let retry = serde_json::to_string(&BarrierAnnouncement {
-            epoch: 5,
-            checkpoint_id: 9,
+        // The next epoch's early Prepare reaches this follower via
+        // gossip KV only (its prepare RPC comes later, at quorum time)
+        // and must win the merge over the stale watch value.
+        let next = serde_json::to_string(&BarrierAnnouncement {
+            epoch: 6,
+            checkpoint_id: 10,
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 2,
         })
         .unwrap();
-        follower_kv.seed(NodeId(1), ANNOUNCEMENT_KEY, retry);
+        follower_kv.seed(NodeId(1), ANNOUNCEMENT_KEY, next);
         let got = follower_coord.observe(NodeId(1)).await.unwrap().unwrap();
-        assert_eq!(
-            got.phase,
-            Phase::Prepare,
-            "retry Prepare (higher seq) must supersede the stale gRPC Abort",
-        );
+        assert_eq!(got.epoch, 6);
+        assert_eq!(got.phase, Phase::Prepare);
 
-        // Conversely, a *stale* lower-seq KV value (gossip lag)
-        // must not mask the fresher gRPC value.
+        // Same-epoch lagging gossip must not mask the fresher gRPC
+        // value (RPC arrival order is authoritative within an epoch).
         let stale = serde_json::to_string(&BarrierAnnouncement {
             epoch: 5,
             checkpoint_id: 9,
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .unwrap();
         follower_kv.seed(NodeId(1), ANNOUNCEMENT_KEY, stale);
@@ -1312,7 +1261,6 @@ mod tests {
                 phase: Phase::Prepare,
                 flags: 0,
                 min_watermark_ms: None,
-                seq: 0,
             })
             .await
             .unwrap();

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -546,6 +546,16 @@ async fn send_phase_rpc(
     })
 }
 
+/// Typed prepare-failure classification for the quorum wait:
+/// `Unreachable` counts toward `TimedOut{missing}` (the peer cannot
+/// participate), `Nack` toward `Failed` (a live follower answered
+/// `ok = false`).
+#[cfg(feature = "cluster")]
+enum PeerFailure {
+    Unreachable,
+    Nack(String),
+}
+
 /// Cross-instance barrier coordination.
 pub struct BarrierCoordinator {
     kv: Arc<dyn ClusterKv>,
@@ -807,11 +817,16 @@ impl BarrierCoordinator {
 
         let kv_latest: Option<BarrierAnnouncement> =
             match self.kv.read_from(leader, ANNOUNCEMENT_KEY).await {
-                Some(json) => serde_json::from_str(&json).map(Some).map_err(|e| {
+                Some(json) => match serde_json::from_str(&json) {
+                    Ok(a) => Some(a),
                     // A decode failure on the KV path is fatal only when
                     // there is no gRPC value to fall back on.
-                    e.to_string()
-                })?,
+                    Err(e) if grpc_latest.is_some() => {
+                        tracing::warn!(error = %e, "corrupt gossip announcement; using gRPC value");
+                        None
+                    }
+                    Err(e) => return Err(e.to_string()),
+                },
                 None => None,
             };
 
@@ -859,6 +874,8 @@ impl BarrierCoordinator {
 
     /// Leader-side: wait until quorum or `deadline`.
     #[allow(clippy::too_many_lines)]
+    // `PeerFailure` (module level, below) classifies each peer's
+    // prepare outcome.
     pub async fn wait_for_quorum(
         &self,
         epoch: u64,
@@ -892,7 +909,7 @@ impl BarrierCoordinator {
                     futures.push(async move {
                         let client_opt = get_barrier_client(peer, &clients_pool, &kv).await;
                         let Some(mut client) = client_opt else {
-                            return Err((peer, "Discovery failed".to_string()));
+                            return Err((peer, PeerFailure::Unreachable));
                         };
 
                         let mut req = tonic::Request::new(barrier_v1::PrepareRequest {
@@ -910,25 +927,30 @@ impl BarrierCoordinator {
                                 } else {
                                     Err((
                                         peer,
-                                        ack.error.unwrap_or_else(|| {
+                                        PeerFailure::Nack(ack.error.unwrap_or_else(|| {
                                             "Unknown prepare failure".to_string()
-                                        }),
+                                        })),
                                     ))
                                 }
                             }
-                            Ok(Err(e)) => {
+                            Ok(Err(status)) => {
                                 clients_pool.lock().remove(&peer);
-                                // Transport-level failure (connect refused,
-                                // reset): the peer is unreachable — the same
-                                // epistemic state as a timeout, NOT an
-                                // application-level NACK. Classified as
-                                // missing below so `Failed` keeps meaning
-                                // "a live follower answered ok = false".
-                                Err((peer, format!("unreachable: {e}")))
+                                // Classify by gRPC status code, not message
+                                // text: transport-level codes mean the peer
+                                // cannot participate (same epistemic state
+                                // as a timeout); anything else is a live
+                                // server refusing the call.
+                                match status.code() {
+                                    tonic::Code::Unavailable
+                                    | tonic::Code::DeadlineExceeded
+                                    | tonic::Code::Cancelled
+                                    | tonic::Code::Aborted => Err((peer, PeerFailure::Unreachable)),
+                                    _ => Err((peer, PeerFailure::Nack(status.to_string()))),
+                                }
                             }
                             Err(_) => {
                                 clients_pool.lock().remove(&peer);
-                                Err((peer, "Timeout".to_string()))
+                                Err((peer, PeerFailure::Unreachable))
                             }
                         }
                     });
@@ -952,16 +974,8 @@ impl BarrierCoordinator {
                                 });
                             }
                         }
-                        Err((peer, msg)) => {
-                            if msg.contains("Timeout")
-                                || msg.contains("deadline exceeded")
-                                || msg.starts_with("unreachable:")
-                            {
-                                timed_out.push(peer);
-                            } else {
-                                failures.push((peer, msg));
-                            }
-                        }
+                        Err((peer, PeerFailure::Unreachable)) => timed_out.push(peer),
+                        Err((peer, PeerFailure::Nack(msg))) => failures.push((peer, msg)),
                     }
                 }
 

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -68,14 +68,11 @@ pub struct BarrierAnnouncement {
     pub min_watermark_ms: Option<i64>,
     /// Leader-stamped monotonic announce sequence, assigned by
     /// [`BarrierCoordinator::announce`] (caller-set values are
-    /// overwritten). Observation is latest-wins across two channels
-    /// (gRPC push + gossip KV), and a retry of an aborted epoch reuses
-    /// the same epoch/checkpoint id — within an epoch only this
-    /// sequence distinguishes `Abort(attempt 1)` from the retry's
-    /// `Prepare(attempt 2)`. Resets on leader change/restart; epoch
-    /// ordering dominates across leaders, and the gRPC push physically
-    /// overwriting the watch self-heals same-epoch staleness.
-    /// `0` on legacy payloads via `#[serde(default)]`.
+    /// overwritten). Orders same-epoch announcements under latest-wins
+    /// observation: a retry of an aborted epoch reuses the epoch and
+    /// checkpoint id, so only `seq` distinguishes the stale `Abort`
+    /// from the retry's `Prepare`. Resets on leader change; epoch
+    /// ordering dominates across leaders. `0` = legacy/unset.
     #[serde(default)]
     pub seq: u64,
 }
@@ -935,11 +932,7 @@ impl BarrierCoordinator {
                             flags: 0,
                             seq: round_seq,
                         });
-                        if let Some(lid) = local_id {
-                            if let Ok(val) = lid.0.to_string().parse() {
-                                req.metadata_mut().insert("x-leader-id", val);
-                            }
-                        }
+                        stamp_leader_id(&mut req, local_id);
 
                         match tokio::time::timeout(deadline, client.prepare(req)).await {
                             Ok(Ok(response)) => {

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -918,7 +918,13 @@ impl BarrierCoordinator {
                             }
                             Ok(Err(e)) => {
                                 clients_pool.lock().remove(&peer);
-                                Err((peer, e.to_string()))
+                                // Transport-level failure (connect refused,
+                                // reset): the peer is unreachable — the same
+                                // epistemic state as a timeout, NOT an
+                                // application-level NACK. Classified as
+                                // missing below so `Failed` keeps meaning
+                                // "a live follower answered ok = false".
+                                Err((peer, format!("unreachable: {e}")))
                             }
                             Err(_) => {
                                 clients_pool.lock().remove(&peer);
@@ -947,7 +953,10 @@ impl BarrierCoordinator {
                             }
                         }
                         Err((peer, msg)) => {
-                            if msg.contains("Timeout") || msg.contains("deadline exceeded") {
+                            if msg.contains("Timeout")
+                                || msg.contains("deadline exceeded")
+                                || msg.starts_with("unreachable:")
+                            {
                                 timed_out.push(peer);
                             } else {
                                 failures.push((peer, msg));

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -36,7 +36,7 @@ pub struct ClusterController {
     active: Arc<AtomicBool>,
     /// Peers that recently failed a capture quorum (no ack within the
     /// timeout), keyed by node id. Gossip failure detection can lag a
-    /// hard kill by tens of seconds; this is the leader''s faster local
+    /// hard kill by tens of seconds; this is the leader's faster local
     /// signal, consulted by the checkpoint durability gate to fail
     /// doomed epochs instead of burning their full timeout. Entries
     /// clear when the peer acks again, and expire after

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -34,6 +34,14 @@ pub struct ClusterController {
     draining: Arc<AtomicBool>,
     /// Whether this node has announced itself as Active.
     active: Arc<AtomicBool>,
+    /// Peers that recently failed a capture quorum (no ack within the
+    /// timeout), keyed by node id. Gossip failure detection can lag a
+    /// hard kill by tens of seconds; this is the leader''s faster local
+    /// signal, consulted by the checkpoint durability gate to fail
+    /// doomed epochs instead of burning their full timeout. Entries
+    /// clear when the peer acks again, and expire after
+    /// [`UNRESPONSIVE_TTL`].
+    unresponsive: Arc<parking_lot::Mutex<rustc_hash::FxHashMap<u64, std::time::Instant>>>,
     /// This node's own failure-domain locality (peers carry theirs in
     /// `members_rx`; self is only known by id). Set once at startup.
     self_locality: parking_lot::RwLock<Locality>,
@@ -74,6 +82,7 @@ impl ClusterController {
             cluster_min_watermark: Arc::new(AtomicI64::new(i64::MIN)),
             draining: Arc::new(AtomicBool::new(false)),
             active: Arc::new(AtomicBool::new(true)),
+            unresponsive: Arc::new(parking_lot::Mutex::new(rustc_hash::FxHashMap::default())),
             self_locality: parking_lot::RwLock::new(Locality::default()),
             #[cfg(feature = "cluster")]
             query_handler: Arc::new(parking_lot::RwLock::new(None)),
@@ -184,6 +193,34 @@ impl ClusterController {
             ids.push(self.instance_id);
         }
         ids
+    }
+
+    /// Record peers that failed to ack a capture quorum in time.
+    pub fn note_unresponsive(&self, peers: &[NodeId]) {
+        let now = std::time::Instant::now();
+        let mut map = self.unresponsive.lock();
+        for p in peers {
+            map.insert(p.0, now);
+        }
+    }
+
+    /// Clear peers that acked (they are demonstrably alive).
+    pub fn note_responsive(&self, peers: &[NodeId]) {
+        let mut map = self.unresponsive.lock();
+        for p in peers {
+            map.remove(&p.0);
+        }
+    }
+
+    /// Whether `peer` failed a capture quorum within the TTL window.
+    #[must_use]
+    pub fn is_recently_unresponsive(&self, peer: NodeId) -> bool {
+        /// How long a quorum miss keeps a peer suspect for the gate.
+        const UNRESPONSIVE_TTL: Duration = Duration::from_secs(60);
+        self.unresponsive
+            .lock()
+            .get(&peer.0)
+            .is_some_and(|at| at.elapsed() < UNRESPONSIVE_TTL)
     }
 
     /// Mark this node as draining. Idempotent.

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -341,8 +341,7 @@ impl ClusterController {
     /// matching `pred`, or `timeout` expires (→ `None`). Push-driven
     /// off the gRPC announcement watch when available; gossip-KV-only
     /// deployments (and KV-only announcements) are covered by a
-    /// fallback poll — 250ms with the watch, 25ms without (ADR-003
-    /// Phase 4 replaced the old fixed 50ms decision poll).
+    /// fallback poll — 250ms with the watch, 25ms without.
     #[cfg(feature = "cluster")]
     pub async fn wait_for_barrier<F>(
         &self,

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -292,10 +292,12 @@ impl ClusterController {
 
     /// Follower-side observe; `Ok(None)` if no leader is visible.
     ///
-    /// As a side effect, a `Commit` announcement with a populated
-    /// `min_watermark_ms` updates the shared cluster-min-watermark
-    /// atomic so operators on this instance see the cluster-wide
-    /// minimum without a separate polling path.
+    /// As a side effect, an `Aligned` or `Commit` announcement with a
+    /// populated `min_watermark_ms` updates the shared
+    /// cluster-min-watermark atomic so operators on this instance see
+    /// the cluster-wide minimum without a separate polling path
+    /// (`Aligned` carries it so a resuming pipeline sees fresh
+    /// event-time progress before the upload-gated `Commit`).
     ///
     /// # Errors
     /// Propagates [`BarrierCoordinator::observe`] errors.
@@ -305,7 +307,7 @@ impl ClusterController {
         };
         let observed = self.barrier.observe(leader).await?;
         if let Some(ref ann) = observed {
-            if ann.phase == Phase::Commit {
+            if matches!(ann.phase, Phase::Commit | Phase::Aligned) {
                 if let Some(wm) = ann.min_watermark_ms {
                     // Monotonic publish — never lower the watermark,
                     // even if a stale announcement re-gossips.
@@ -452,6 +454,7 @@ mod tests {
             phase: crate::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .await
         .unwrap();
@@ -496,6 +499,7 @@ mod tests {
             phase: crate::cluster::control::Phase::Commit,
             flags: 0,
             min_watermark_ms: Some(12_345),
+            seq: 0,
         })
         .await
         .unwrap();
@@ -510,6 +514,7 @@ mod tests {
             phase: crate::cluster::control::Phase::Commit,
             flags: 0,
             min_watermark_ms: Some(100), // stale re-gossip
+            seq: 0,
         })
         .await
         .unwrap();
@@ -527,6 +532,7 @@ mod tests {
             phase: crate::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .await
         .unwrap();

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -389,10 +389,14 @@ impl ClusterController {
         F: FnMut(&BarrierAnnouncement) -> bool,
     {
         let mut watch = self.barrier.announcement_watch();
-        let poll = if watch.is_some() {
-            Duration::from_millis(250)
-        } else {
-            Duration::from_millis(25)
+        // Recomputed per iteration: when the watch sender drops
+        // mid-wait, the fallback must tighten to the no-watch cadence.
+        let poll_for = |watch: &Option<_>| {
+            if watch.is_some() {
+                Duration::from_millis(250)
+            } else {
+                Duration::from_millis(25)
+            }
         };
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
@@ -404,6 +408,7 @@ impl ClusterController {
             if tokio::time::Instant::now() >= deadline {
                 return None;
             }
+            let poll = poll_for(&watch);
             let pushed = async {
                 match watch.as_mut() {
                     Some(w) => w.changed().await.is_ok(),

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -505,7 +505,6 @@ mod tests {
             phase: crate::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .await
         .unwrap();
@@ -550,7 +549,6 @@ mod tests {
             phase: crate::cluster::control::Phase::Commit,
             flags: 0,
             min_watermark_ms: Some(12_345),
-            seq: 0,
         })
         .await
         .unwrap();
@@ -565,7 +563,6 @@ mod tests {
             phase: crate::cluster::control::Phase::Commit,
             flags: 0,
             min_watermark_ms: Some(100), // stale re-gossip
-            seq: 0,
         })
         .await
         .unwrap();
@@ -583,7 +580,6 @@ mod tests {
             phase: crate::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .await
         .unwrap();

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -337,6 +337,57 @@ impl ClusterController {
         self.barrier.ack(ack).await
     }
 
+    /// Wait until [`Self::observe_barrier`] yields an announcement
+    /// matching `pred`, or `timeout` expires (→ `None`). Push-driven
+    /// off the gRPC announcement watch when available; gossip-KV-only
+    /// deployments (and KV-only announcements) are covered by a
+    /// fallback poll — 250ms with the watch, 25ms without (ADR-003
+    /// Phase 4 replaced the old fixed 50ms decision poll).
+    #[cfg(feature = "cluster")]
+    pub async fn wait_for_barrier<F>(
+        &self,
+        mut pred: F,
+        timeout: Duration,
+    ) -> Option<BarrierAnnouncement>
+    where
+        F: FnMut(&BarrierAnnouncement) -> bool,
+    {
+        let mut watch = self.barrier.announcement_watch();
+        let poll = if watch.is_some() {
+            Duration::from_millis(250)
+        } else {
+            Duration::from_millis(25)
+        };
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Ok(Some(ann)) = self.observe_barrier().await {
+                if pred(&ann) {
+                    return Some(ann);
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            let pushed = async {
+                match watch.as_mut() {
+                    Some(w) => w.changed().await.is_ok(),
+                    None => std::future::pending().await,
+                }
+            };
+            tokio::select! {
+                ok = pushed => {
+                    if !ok {
+                        // Sender gone (server shutdown) — degrade to
+                        // polling instead of spinning on the error.
+                        watch = None;
+                    }
+                }
+                () = tokio::time::sleep(poll) => {}
+                () = tokio::time::sleep_until(deadline) => return None,
+            }
+        }
+    }
+
     /// Leader-side: poll until quorum or `deadline`.
     pub async fn wait_for_quorum(
         &self,

--- a/crates/laminar-core/src/cluster/discovery/mod.rs
+++ b/crates/laminar-core/src/cluster/discovery/mod.rs
@@ -56,7 +56,14 @@ impl fmt::Display for NodeState {
 
 /// Hardware and deployment metadata for a node.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
 )]
 pub struct NodeMetadata {
     /// Number of CPU cores available.
@@ -88,7 +95,14 @@ impl Default for NodeMetadata {
 
 /// Full information about a discovered node.
 #[derive(
-    Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
 )]
 pub struct NodeInfo {
     /// The node's unique identifier.

--- a/crates/laminar-core/src/cluster/discovery/static_discovery.rs
+++ b/crates/laminar-core/src/cluster/discovery/static_discovery.rs
@@ -441,15 +441,18 @@ fn publish_if_changed(tx: &watch::Sender<Vec<NodeInfo>>, mut peer_list: Vec<Node
     // equality must not depend on it.
     peer_list.sort_by_key(|n| n.id.0);
     tx.send_if_modified(|cur| {
-        // Compare the MEMBERSHIP projection only — `last_heartbeat_ms`
-        // refreshes every tick, so whole-struct equality would still
-        // notify continuously. Consumers of the watch react to who is
-        // in the cluster and in what state, not to heartbeat times.
+        // Compare everything EXCEPT `last_heartbeat_ms` — it refreshes
+        // every tick, so whole-struct equality would still notify
+        // continuously. All other fields (state, addresses, name,
+        // metadata/locality) are real membership changes watchers must
+        // see.
+        fn same_member(a: &NodeInfo, b: &NodeInfo) -> bool {
+            let mut a = a.clone();
+            a.last_heartbeat_ms = b.last_heartbeat_ms;
+            a == *b
+        }
         let same = cur.len() == peer_list.len()
-            && cur
-                .iter()
-                .zip(&peer_list)
-                .all(|(a, b)| a.id == b.id && a.state == b.state && a.rpc_address == b.rpc_address);
+            && cur.iter().zip(&peer_list).all(|(a, b)| same_member(a, b));
         if same {
             false
         } else {

--- a/crates/laminar-core/src/cluster/discovery/static_discovery.rs
+++ b/crates/laminar-core/src/cluster/discovery/static_discovery.rs
@@ -435,7 +435,7 @@ impl StaticDiscovery {
 /// heartbeater publishes each tick — unconditional sends starve any
 /// consumer that debounces on `changed()` waiting for a quiet period
 /// (the rebalance controller never saw 5s of quiet, so vnode rotation
-/// never ran and a dead node''s vnodes were never shed).
+/// never ran and a dead node's vnodes were never shed).
 fn publish_if_changed(tx: &watch::Sender<Vec<NodeInfo>>, mut peer_list: Vec<NodeInfo>) {
     // Stable order: the peer map iterates in arbitrary order, and
     // equality must not depend on it.

--- a/crates/laminar-core/src/cluster/discovery/static_discovery.rs
+++ b/crates/laminar-core/src/cluster/discovery/static_discovery.rs
@@ -128,7 +128,7 @@ impl StaticDiscovery {
     fn broadcast_membership(&self) {
         let peers = self.peers.read();
         let peer_list: Vec<NodeInfo> = peers.values().map(|p| p.info.clone()).collect();
-        let _ = self.membership_tx.send(peer_list);
+        publish_if_changed(&self.membership_tx, peer_list);
     }
 
     /// Send a heartbeat to a single seed address with connect + I/O timeouts.
@@ -288,7 +288,7 @@ impl StaticDiscovery {
                                     peer.info.last_heartbeat_ms = now;
                                     guard.values().map(|p| p.info.clone()).collect::<Vec<_>>()
                                 };
-                                let _ = membership_tx.send(peer_list);
+                                publish_if_changed(&membership_tx, peer_list);
                             }
 
                             if let Ok(resp) = Self::serialize_node_info(&local_info) {
@@ -423,11 +423,40 @@ impl StaticDiscovery {
                         let peers = ctx.peers.read();
                         peers.values().map(|p| p.info.clone()).collect()
                     };
-                    let _ = ctx.membership_tx.send(peer_list);
+                    publish_if_changed(&ctx.membership_tx, peer_list);
                 }
             }
         }
     }
+}
+
+/// Update the membership watch only when the list actually changed.
+/// `watch::Sender::send` notifies receivers on EVERY call, and the
+/// heartbeater publishes each tick — unconditional sends starve any
+/// consumer that debounces on `changed()` waiting for a quiet period
+/// (the rebalance controller never saw 5s of quiet, so vnode rotation
+/// never ran and a dead node''s vnodes were never shed).
+fn publish_if_changed(tx: &watch::Sender<Vec<NodeInfo>>, mut peer_list: Vec<NodeInfo>) {
+    // Stable order: the peer map iterates in arbitrary order, and
+    // equality must not depend on it.
+    peer_list.sort_by_key(|n| n.id.0);
+    tx.send_if_modified(|cur| {
+        // Compare the MEMBERSHIP projection only — `last_heartbeat_ms`
+        // refreshes every tick, so whole-struct equality would still
+        // notify continuously. Consumers of the watch react to who is
+        // in the cluster and in what state, not to heartbeat times.
+        let same = cur.len() == peer_list.len()
+            && cur
+                .iter()
+                .zip(&peer_list)
+                .all(|(a, b)| a.id == b.id && a.state == b.state && a.rpc_address == b.rpc_address);
+        if same {
+            false
+        } else {
+            *cur = peer_list;
+            true
+        }
+    });
 }
 
 /// Shared context for the heartbeater background task.

--- a/crates/laminar-core/src/state/config.rs
+++ b/crates/laminar-core/src/state/config.rs
@@ -35,6 +35,21 @@ pub enum DiscoveryMode {
     Dynamic,
 }
 
+/// Cloud credential/config overrides for the state object store.
+/// `Debug` redacts values — they can hold secrets
+/// (`aws_secret_access_key`, ...).
+#[derive(Clone, PartialEq, Eq, Default, Deserialize)]
+#[serde(transparent)]
+pub struct StorageOptions(pub rustc_hash::FxHashMap<String, String>);
+
+impl std::fmt::Debug for StorageOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entries(self.0.keys().map(|k| (k, "[REDACTED]")))
+            .finish()
+    }
+}
+
 /// Tagged-union config that selects the runtime [`StateBackend`].
 ///
 /// See module docs for the five deployment shapes.
@@ -72,7 +87,7 @@ pub enum StateBackendConfig {
         /// Anything absent falls back to the provider's standard env
         /// vars (`AWS_ACCESS_KEY_ID`, ...).
         #[serde(default)]
-        storage: rustc_hash::FxHashMap<String, String>,
+        storage: StorageOptions,
         /// This node's identity. Written into epoch manifests and used
         /// by the assignment-version fence to reject stale writes.
         instance_id: String,
@@ -143,7 +158,7 @@ impl StateBackendConfig {
     pub fn object_store(url: impl Into<String>, instance_id: impl Into<String>) -> Self {
         Self::ObjectStore {
             url: url.into(),
-            storage: rustc_hash::FxHashMap::default(),
+            storage: StorageOptions::default(),
             instance_id: instance_id.into(),
             vnode_capacity: DEFAULT_VNODE_CAPACITY,
             vnodes: None,
@@ -193,15 +208,7 @@ impl StateBackendConfig {
                 vnode_capacity,
                 ..
             } => {
-                // Collected into the builder's std-HashMap parameter by
-                // inference (cold path, runs once at startup).
-                let store = crate::checkpoint::object_store_builder::build_object_store(
-                    url,
-                    &storage
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                )?;
+                let store = cloud_store(url, storage)?;
                 Ok(Arc::new(ObjectStoreBackend::new(
                     store,
                     instance_id,
@@ -240,15 +247,7 @@ impl StateBackendConfig {
                     .map_err(|e| StateBackendBuildError::Io(e.to_string()))?;
                 Ok(Some(Arc::new(fs)))
             }
-            Self::ObjectStore { url, storage, .. } => Ok(Some(
-                crate::checkpoint::object_store_builder::build_object_store(
-                    url,
-                    &storage
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                )?,
-            )),
+            Self::ObjectStore { url, storage, .. } => Ok(Some(cloud_store(url, storage)?)),
         }
     }
 
@@ -268,6 +267,24 @@ impl StateBackendConfig {
             | Self::ObjectStore { vnode_capacity, .. } => *vnode_capacity,
         }
     }
+}
+
+/// Cloud-store construction shared by [`StateBackendConfig::build`] and
+/// [`StateBackendConfig::build_object_store`]: translates the
+/// `StorageOptions` map into the builder's std-HashMap parameter
+/// (cold path, runs once at startup).
+fn cloud_store(
+    url: &str,
+    storage: &StorageOptions,
+) -> Result<Arc<dyn ::object_store::ObjectStore>, StateBackendBuildError> {
+    Ok(crate::checkpoint::object_store_builder::build_object_store(
+        url,
+        &storage
+            .0
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    )?)
 }
 
 #[cfg(test)]
@@ -412,11 +429,20 @@ seed_peers = ["10.0.0.1:7946", "10.0.0.2:7946"]
     #[cfg(not(feature = "aws"))]
     #[tokio::test]
     async fn build_object_store_s3_requires_aws_feature() {
+        use crate::checkpoint::object_store_builder::ObjectStoreBuilderError;
+
         let c = StateBackendConfig::object_store("s3://bucket/path", "node-0");
-        match c.build().await {
-            Err(e) => assert!(e.to_string().contains("aws"), "got: {e}"),
+        let err = match c.build().await {
             Ok(_) => panic!("s3 must not build without the aws feature"),
-        }
+            Err(e) => e,
+        };
+        assert!(
+            matches!(
+                err,
+                StateBackendBuildError::Store(ObjectStoreBuilderError::MissingFeature { .. })
+            ),
+            "got: {err}",
+        );
     }
 
     /// With the `aws` feature, an `s3://` URL + explicit `storage`

--- a/crates/laminar-core/src/state/config.rs
+++ b/crates/laminar-core/src/state/config.rs
@@ -67,6 +67,12 @@ pub enum StateBackendConfig {
         /// Object store URL: `s3://bucket/prefix`, `gs://bucket/prefix`,
         /// etc.
         url: String,
+        /// Cloud credentials/config overrides (e.g. `endpoint`,
+        /// `aws_access_key_id`), same keys as `[checkpoint.storage]`.
+        /// Anything absent falls back to the provider's standard env
+        /// vars (`AWS_ACCESS_KEY_ID`, ...).
+        #[serde(default)]
+        storage: rustc_hash::FxHashMap<String, String>,
         /// This node's identity. Written into epoch manifests and used
         /// by the assignment-version fence to reject stale writes.
         instance_id: String,
@@ -101,10 +107,10 @@ impl Default for StateBackendConfig {
 /// Failure modes for [`StateBackendConfig::build`].
 #[derive(Debug, thiserror::Error)]
 pub enum StateBackendBuildError {
-    /// The selected backend exists in config but its runtime impl has
-    /// not been wired up yet.
-    #[error("state backend '{0}' is not yet implemented")]
-    NotImplemented(&'static str),
+    /// Object store construction failed (bad URL, missing feature
+    /// flag for the scheme, missing credentials, ...).
+    #[error("state backend object store: {0}")]
+    Store(#[from] crate::checkpoint::object_store_builder::ObjectStoreBuilderError),
 
     /// Backend construction failed at the I/O layer.
     #[error("state backend construction failed: {0}")]
@@ -131,10 +137,13 @@ impl StateBackendConfig {
     }
 
     /// Builder: distributed-embedded over an object store, static mode.
+    /// Credentials resolve from the provider's standard env vars; use
+    /// the `storage` config field for explicit overrides.
     #[must_use]
     pub fn object_store(url: impl Into<String>, instance_id: impl Into<String>) -> Self {
         Self::ObjectStore {
             url: url.into(),
+            storage: rustc_hash::FxHashMap::default(),
             instance_id: instance_id.into(),
             vnode_capacity: DEFAULT_VNODE_CAPACITY,
             vnodes: None,
@@ -152,9 +161,10 @@ impl StateBackendConfig {
     /// still `.await` for forward-compatibility.
     ///
     /// # Errors
-    /// - [`StateBackendBuildError::NotImplemented`] for remote
-    ///   `object_store` schemes not yet wired (`s3://`, `gs://`, `az://`).
-    /// - [`StateBackendBuildError::Io`] on filesystem/network setup.
+    /// - [`StateBackendBuildError::Store`] for a bad URL, a scheme
+    ///   whose feature flag (`aws`/`gcs`/`azure`) is not compiled in,
+    ///   or cloud-client construction failure.
+    /// - [`StateBackendBuildError::Io`] on filesystem setup.
     #[allow(clippy::unused_async)]
     pub async fn build(&self) -> Result<Arc<dyn StateBackend>, StateBackendBuildError> {
         match self {
@@ -178,11 +188,20 @@ impl StateBackendConfig {
             }
             Self::ObjectStore {
                 url,
+                storage,
                 instance_id,
                 vnode_capacity,
                 ..
             } => {
-                let store = build_object_store(url)?;
+                // Collected into the builder's std-HashMap parameter by
+                // inference (cold path, runs once at startup).
+                let store = crate::checkpoint::object_store_builder::build_object_store(
+                    url,
+                    &storage
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                )?;
                 Ok(Arc::new(ObjectStoreBackend::new(
                     store,
                     instance_id,
@@ -221,7 +240,15 @@ impl StateBackendConfig {
                     .map_err(|e| StateBackendBuildError::Io(e.to_string()))?;
                 Ok(Some(Arc::new(fs)))
             }
-            Self::ObjectStore { url, .. } => Ok(Some(build_object_store(url)?)),
+            Self::ObjectStore { url, storage, .. } => Ok(Some(
+                crate::checkpoint::object_store_builder::build_object_store(
+                    url,
+                    &storage
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                )?,
+            )),
         }
     }
 
@@ -240,26 +267,6 @@ impl StateBackendConfig {
             | Self::Local { vnode_capacity, .. }
             | Self::ObjectStore { vnode_capacity, .. } => *vnode_capacity,
         }
-    }
-}
-
-/// Dispatch a URL to the matching `object_store` implementation.
-///
-/// Supported: `file://<path>`.
-/// Returns `NotImplemented` for `s3://`, `gs://`, `az://` — these will
-/// be added in a later iteration once the workspace pulls in
-/// `url::Url` and the corresponding `object_store` features.
-fn build_object_store(
-    url: &str,
-) -> Result<Arc<dyn ::object_store::ObjectStore>, StateBackendBuildError> {
-    if let Some(path) = url.strip_prefix("file://") {
-        let path = path.trim_start_matches('/');
-        std::fs::create_dir_all(path).map_err(|e| StateBackendBuildError::Io(e.to_string()))?;
-        let fs = ::object_store::local::LocalFileSystem::new_with_prefix(path)
-            .map_err(|e| StateBackendBuildError::Io(e.to_string()))?;
-        Ok(Arc::new(fs))
-    } else {
-        Err(StateBackendBuildError::NotImplemented("object_store"))
     }
 }
 
@@ -400,13 +407,38 @@ seed_peers = ["10.0.0.1:7946", "10.0.0.2:7946"]
         assert_eq!(&got[..], b"z");
     }
 
+    /// Without the `aws` feature an `s3://` URL must fail with the
+    /// missing-feature error, not silently fall back to local.
+    #[cfg(not(feature = "aws"))]
     #[tokio::test]
-    async fn build_object_store_s3_returns_not_implemented() {
+    async fn build_object_store_s3_requires_aws_feature() {
         let c = StateBackendConfig::object_store("s3://bucket/path", "node-0");
-        assert!(matches!(
-            c.build().await,
-            Err(StateBackendBuildError::NotImplemented("object_store"))
-        ));
+        match c.build().await {
+            Err(e) => assert!(e.to_string().contains("aws"), "got: {e}"),
+            Ok(_) => panic!("s3 must not build without the aws feature"),
+        }
+    }
+
+    /// With the `aws` feature, an `s3://` URL + explicit `storage`
+    /// credentials builds a client (construction is offline — no
+    /// network until first use).
+    #[cfg(feature = "aws")]
+    #[tokio::test]
+    async fn build_object_store_s3_builds_with_storage_options() {
+        let toml = r#"
+backend = "object_store"
+url = "s3://bucket/laminar"
+instance_id = "node-0"
+
+[storage]
+endpoint = "http://127.0.0.1:9000"
+aws_access_key_id = "k"
+aws_secret_access_key = "s"
+region = "us-east-1"
+allow_http = "true"
+"#;
+        let c: StateBackendConfig = toml::from_str(toml).unwrap();
+        c.build().await.expect("s3 client must build offline");
     }
 
     #[test]

--- a/crates/laminar-core/src/streaming/checkpoint.rs
+++ b/crates/laminar-core/src/streaming/checkpoint.rs
@@ -14,6 +14,13 @@ pub struct StreamCheckpointConfig {
     /// Barrier-alignment timeout in milliseconds at fan-in operators.
     /// `None` = default (`30_000`).
     pub alignment_timeout_ms: Option<u64>,
+    /// Max epochs admitted between capture and restorable (the upload
+    /// backlog). `None` = default (4). Exactly-once pipelines are
+    /// capped at 1 regardless.
+    pub max_in_flight_epochs: Option<u64>,
+    /// Cap on captured-state bytes held by in-flight epochs; admission
+    /// pauses at the cap. `None` = default (512 MiB).
+    pub max_staged_bytes: Option<u64>,
 }
 
 /// Errors from checkpoint operations.

--- a/crates/laminar-core/tests/cluster_integration.rs
+++ b/crates/laminar-core/tests/cluster_integration.rs
@@ -103,6 +103,7 @@ async fn barrier_announce_then_follower_observes_and_acks() {
         phase: laminar_core::cluster::control::Phase::Prepare,
         flags: 0,
         min_watermark_ms: None,
+        seq: 0,
     };
 
     // Step 1: leader announces.
@@ -553,6 +554,7 @@ async fn quorum_times_out_when_follower_silent() {
             phase: laminar_core::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .await
         .unwrap();

--- a/crates/laminar-core/tests/cluster_integration.rs
+++ b/crates/laminar-core/tests/cluster_integration.rs
@@ -103,7 +103,6 @@ async fn barrier_announce_then_follower_observes_and_acks() {
         phase: laminar_core::cluster::control::Phase::Prepare,
         flags: 0,
         min_watermark_ms: None,
-        seq: 0,
     };
 
     // Step 1: leader announces.
@@ -554,7 +553,6 @@ async fn quorum_times_out_when_follower_silent() {
             phase: laminar_core::cluster::control::Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .await
         .unwrap();

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -63,6 +63,12 @@ pub struct CheckpointConfig {
     pub max_checkpoint_bytes: Option<usize>,
     /// Quorum wait timeout for checkpoint coordination.
     pub quorum_timeout: Duration,
+    /// Max wait for every participating vnode's partial to land before
+    /// the epoch is declared restorable. Followers ack at *capture* and
+    /// upload asynchronously (ADR-003 two-level completion), so the
+    /// leader's durability gate polls for partial presence instead of
+    /// checking once. Expiry aborts the epoch.
+    pub restorable_gate_timeout: Duration,
 }
 
 impl Default for CheckpointConfig {
@@ -79,6 +85,7 @@ impl Default for CheckpointConfig {
             state_inline_threshold: 1_048_576,
             max_checkpoint_bytes: None,
             quorum_timeout: Duration::from_secs(3),
+            restorable_gate_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -654,6 +661,60 @@ impl CheckpointCoordinator {
         futures::future::try_join_all(writes).await.map(|_| ())
     }
 
+    /// Poll the state backend's durability gate until every vnode in
+    /// `gate_vnode_set` has its partial for `epoch` persisted (sealing
+    /// the epoch's `_COMMIT` marker), or `restorable_gate_timeout`
+    /// expires. No-op without a backend or with an empty gate set.
+    ///
+    /// Polling (vs the old single check) is what lets followers ack at
+    /// capture and upload asynchronously: each node writes its vnode
+    /// partials *after* sink pre-commit + manifest save, so full
+    /// presence here also proves every node completed its durable
+    /// prepare. A follower whose prepare fails after acking surfaces as
+    /// a gate timeout → abort.
+    ///
+    /// Transient backend errors are retried until the deadline; a
+    /// split-brain commit marker aborts immediately.
+    async fn await_restorable_gate(&self, epoch: u64) -> Result<(), String> {
+        use laminar_core::state::StateBackendError;
+
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+        let Some(ref backend) = self.state_backend else {
+            return Ok(());
+        };
+        if self.gate_vnode_set.is_empty() {
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + self.config.restorable_gate_timeout;
+        let mut last_state = String::from("not all vnodes persisted");
+        loop {
+            match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
+                Ok(true) => return Ok(()),
+                // Keep the default/previous message; a lingering
+                // transient-error string is more informative than
+                // resetting it.
+                Ok(false) => {}
+                Err(e @ StateBackendError::SplitBrainCommit { .. }) => {
+                    return Err(format!("state durability gate: {e}"));
+                }
+                Err(e) => {
+                    // Transient I/O — keep polling until the deadline.
+                    debug!(epoch, error = %e, "durability gate poll error; retrying");
+                    last_state = e.to_string();
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "state durability gate timed out after {:?}: {last_state}",
+                    self.config.restorable_gate_timeout
+                ));
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
     /// On startup, reconcile any Pending sinks in the last manifest
     /// against the durable commit marker. Marker present → drive
     /// local commit (idempotent); marker absent → rollback. Runs on
@@ -793,6 +854,7 @@ impl CheckpointCoordinator {
             phase,
             flags: 0,
             min_watermark_ms,
+            seq: 0,
         };
         if let Err(e) = cc.announce_barrier(&ann).await {
             warn!(
@@ -1158,9 +1220,18 @@ impl CheckpointCoordinator {
         self.checkpoint_inner(request).await
     }
 
-    /// Follower half of a cluster checkpoint: pre-commit + save +
-    /// markers + ack, then wait for the leader's commit/abort.
+    /// Follower half of a cluster checkpoint: ack the capture, run the
+    /// durable prepare (pre-commit + manifest + partial uploads), then
+    /// wait for the leader's commit/abort.
     /// `Ok(true)` = committed, `Ok(false)` = aborted/timed out.
+    ///
+    /// The ack is sent *before* the durable prepare (ADR-003 two-level
+    /// completion): it means "aligned + captured" — the caller has
+    /// already aligned the shuffle and captured state into `request`.
+    /// The leader announces `Aligned` on the full ack quorum (releasing
+    /// every pipeline), and verifies prepare completion through the
+    /// restorable gate (this node writes its vnode partials last, so
+    /// partial presence implies the whole prepare finished).
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1185,26 +1256,45 @@ impl CheckpointCoordinator {
         self.epoch = epoch;
         self.next_checkpoint_id = checkpoint_id.saturating_add(1);
 
-        // Phase 1: local prepare.
-        let prepare_result = self.follower_prepare(request, epoch, checkpoint_id).await;
-        let prepare_err = prepare_result.as_ref().err().map(ToString::to_string);
+        // Capture ack — state is already consistently captured by the
+        // caller; the leader needs nothing more to release pipelines.
         cc.ack_barrier(&BarrierAck {
             epoch,
-            ok: prepare_err.is_none(),
-            error: prepare_err.clone(),
-            // Leader folds this into the cluster-wide min before
-            // announcing Commit. `None` is non-blocking.
+            ok: true,
+            error: None,
+            // Leader folds this into the cluster-wide min announced on
+            // Aligned/Commit. `None` is non-blocking.
             local_watermark_ms: self.local_watermark_ms,
         })
         .await
         .ok(); // best effort; leader's quorum wait tolerates missed acks
-        if let Err(e) = prepare_result {
+
+        // Durable prepare (runs after the ack, off the critical path
+        // when the caller drives this from a background task).
+        if let Err(e) = self.follower_prepare(request, epoch, checkpoint_id).await {
+            // Best-effort fast failure signal: overwrites the capture
+            // ack in the gossip-KV slot so a still-polling leader fails
+            // the quorum instead of waiting; in gRPC mode the leader
+            // learns through its restorable-gate timeout.
+            cc.ack_barrier(&BarrierAck {
+                epoch,
+                ok: false,
+                error: Some(e.to_string()),
+                local_watermark_ms: self.local_watermark_ms,
+            })
+            .await
+            .ok();
             self.rollback_sinks(epoch).await.ok();
             self.phase = CheckpointPhase::Idle;
             return Err(e);
         }
 
-        // Phase 2: wait for the leader's decision.
+        // Phase 2: wait for the leader's decision. `Aligned` is not a
+        // decision — only Commit/Abort (or epoch advancement) end the
+        // wait. Observation is latest-wins, so a newer epoch's
+        // announcement can supersede this epoch's Commit: the leader
+        // only advances epochs after a successful commit, so verify via
+        // the durable marker and drive the commit.
         let deadline = Instant::now() + decision_timeout;
         loop {
             match cc.observe_barrier().await.ok().flatten() {
@@ -1216,6 +1306,23 @@ impl CheckpointCoordinator {
                     self.checkpoints_failed += 1;
                     self.phase = CheckpointPhase::Idle;
                     return Ok(false);
+                }
+                Some(a) if a.epoch > epoch => {
+                    let committed = match self.decision_store.as_ref() {
+                        Some(ds) => ds.is_committed(epoch).await.unwrap_or(false),
+                        None => false,
+                    };
+                    if committed {
+                        info!(
+                            epoch,
+                            checkpoint_id,
+                            observed_epoch = a.epoch,
+                            "newer epoch observed with commit marker present — driving commit",
+                        );
+                        return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
+                    }
+                    // No marker yet — keep waiting for the decision or
+                    // the timeout's marker re-check below.
                 }
                 _ => {}
             }
@@ -1379,6 +1486,52 @@ impl CheckpointCoordinator {
         let source_offsets = source_offset_overrides;
         let table_offsets = extra_table_offsets;
 
+        // Cluster 2PC, level 1 of two-level completion (ADR-003): collect
+        // capture acks from every live follower, then announce `Aligned` —
+        // the full-membership pipeline-resume gate. Followers ack as soon
+        // as they have aligned the shuffle and captured state locally;
+        // their durable prepare (sink pre-commit + manifest + partial
+        // uploads) runs after the ack, and its completion is verified by
+        // the restorable gate below (each node writes its vnode partials
+        // *last*, so full partial presence implies every prepare finished).
+        // Running this before the leader's own uploads keeps the
+        // cluster-wide stall at alignment + capture.
+        #[cfg(feature = "cluster")]
+        {
+            if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await {
+                self.phase = CheckpointPhase::Idle;
+                self.checkpoints_failed += 1;
+                let duration = start.elapsed();
+                self.emit_checkpoint_metrics(false, epoch, duration);
+                // Idempotent: this epoch's sinks have not pre-committed yet,
+                // but rollback also closes any transaction opened by
+                // `begin_epoch_for_sinks` after the previous checkpoint.
+                if let Err(rollback_err) = self.rollback_sinks(epoch).await {
+                    error!(
+                        checkpoint_id,
+                        epoch,
+                        error = %rollback_err,
+                        "[LDB-6032] sink rollback failed after quorum miss",
+                    );
+                }
+                self.pending_vnode_states.clear();
+                return Ok(CheckpointResult {
+                    success: false,
+                    checkpoint_id,
+                    epoch,
+                    duration,
+                    error: Some(quorum_failure),
+                });
+            }
+            self.announce_if_leader(
+                epoch,
+                checkpoint_id,
+                laminar_core::cluster::control::Phase::Aligned,
+                self.cluster_min_watermark,
+            )
+            .await;
+        }
+
         self.phase = CheckpointPhase::PreCommitting;
         if let Err(e) = self.pre_commit_sinks(epoch).await {
             self.phase = CheckpointPhase::Idle;
@@ -1531,119 +1684,50 @@ impl CheckpointCoordinator {
             });
         }
 
-        // Cluster 2PC phase 1: announce PREPARE and wait for followers
-        // to snapshot + ack.
-        #[cfg(feature = "cluster")]
-        {
-            if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await {
-                self.phase = CheckpointPhase::Idle;
-                self.checkpoints_failed += 1;
-                let duration = start.elapsed();
-                self.emit_checkpoint_metrics(false, epoch, duration);
-                if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                    error!(
-                        checkpoint_id,
-                        epoch,
-                        error = %rollback_err,
-                        "[LDB-6032] sink rollback failed after quorum miss",
-                    );
-                }
-                self.pending_vnode_states.clear();
-                return Ok(CheckpointResult {
-                    success: false,
+        // Durability gate (level 2, "restorable"): confirm every
+        // participating vnode has its partial persisted before sinks
+        // commit. `gate_vnode_set` is the FULL registry in cluster mode —
+        // the leader verifies markers from every follower's
+        // shared-storage writes, not just its own. Single-instance
+        // defaults to `vnode_set` (the two match). Followers upload
+        // asynchronously after their capture ack, so this polls until
+        // `restorable_gate_timeout` rather than checking once.
+        if let Err(gate_err) = self.await_restorable_gate(epoch).await {
+            warn!(
+                checkpoint_id,
+                epoch,
+                vnodes = self.gate_vnode_set.len(),
+                error = %gate_err,
+                "[LDB-6020] state durability gate failed — rolling back sinks",
+            );
+            #[cfg(feature = "cluster")]
+            self.announce_if_leader(
+                epoch,
+                checkpoint_id,
+                laminar_core::cluster::control::Phase::Abort,
+                None,
+            )
+            .await;
+            self.checkpoints_failed += 1;
+            self.phase = CheckpointPhase::Idle;
+            let duration = start.elapsed();
+            self.emit_checkpoint_metrics(false, epoch, duration);
+            if let Err(rollback_err) = self.rollback_sinks(epoch).await {
+                error!(
                     checkpoint_id,
                     epoch,
-                    duration,
-                    error: Some(quorum_failure),
-                });
+                    error = %rollback_err,
+                    "[LDB-6021] sink rollback failed after durability gate miss",
+                );
             }
-        }
-
-        // Durability gate: confirm every participating vnode has its
-        // partial persisted before sinks commit. `gate_vnode_set` is the
-        // FULL registry in cluster mode — the leader verifies markers
-        // from every follower's shared-storage writes, not just its own.
-        // Single-instance defaults to `vnode_set` (the two match).
-        if let Some(ref backend) = self.state_backend {
-            if !self.gate_vnode_set.is_empty() {
-                match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        warn!(
-                            checkpoint_id,
-                            epoch,
-                            vnodes = self.gate_vnode_set.len(),
-                            "[LDB-6020] state durability gate returned false — \
-                             rolling back sinks",
-                        );
-                        #[cfg(feature = "cluster")]
-                        self.announce_if_leader(
-                            epoch,
-                            checkpoint_id,
-                            laminar_core::cluster::control::Phase::Abort,
-                            None,
-                        )
-                        .await;
-                        self.checkpoints_failed += 1;
-                        self.phase = CheckpointPhase::Idle;
-                        let duration = start.elapsed();
-                        self.emit_checkpoint_metrics(false, epoch, duration);
-                        if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                            error!(
-                                checkpoint_id,
-                                epoch,
-                                error = %rollback_err,
-                                "[LDB-6021] sink rollback failed after durability gate miss",
-                            );
-                        }
-                        self.pending_vnode_states.clear();
-                        return Ok(CheckpointResult {
-                            success: false,
-                            checkpoint_id,
-                            epoch,
-                            duration,
-                            error: Some("state durability gate: not all vnodes persisted".into()),
-                        });
-                    }
-                    Err(e) => {
-                        warn!(
-                            checkpoint_id,
-                            epoch,
-                            error = %e,
-                            "[LDB-6022] state backend error during durability gate — \
-                             treating as gate miss, rolling back sinks",
-                        );
-                        #[cfg(feature = "cluster")]
-                        self.announce_if_leader(
-                            epoch,
-                            checkpoint_id,
-                            laminar_core::cluster::control::Phase::Abort,
-                            None,
-                        )
-                        .await;
-                        self.checkpoints_failed += 1;
-                        self.phase = CheckpointPhase::Idle;
-                        let duration = start.elapsed();
-                        self.emit_checkpoint_metrics(false, epoch, duration);
-                        if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                            error!(
-                                checkpoint_id,
-                                epoch,
-                                error = %rollback_err,
-                                "[LDB-6023] sink rollback failed after durability gate error",
-                            );
-                        }
-                        self.pending_vnode_states.clear();
-                        return Ok(CheckpointResult {
-                            success: false,
-                            checkpoint_id,
-                            epoch,
-                            duration,
-                            error: Some(format!("state durability gate: {e}")),
-                        });
-                    }
-                }
-            }
+            self.pending_vnode_states.clear();
+            return Ok(CheckpointResult {
+                success: false,
+                checkpoint_id,
+                epoch,
+                duration,
+                error: Some(gate_err),
+            });
         }
 
         // Record the commit marker before issuing sink commits — this
@@ -2058,6 +2142,18 @@ mod tests {
         CheckpointCoordinator::new(CheckpointConfig::default(), store)
             .await
             .unwrap()
+    }
+
+    /// Coordinator whose restorable gate gives up quickly — for tests
+    /// that exercise a gate *miss* (the default 30s poll would stall
+    /// the suite).
+    async fn make_coordinator_with_fast_gate(dir: &std::path::Path) -> CheckpointCoordinator {
+        let store = Box::new(FileSystemCheckpointStore::new(dir, 3));
+        let config = CheckpointConfig {
+            restorable_gate_timeout: Duration::from_millis(250),
+            ..CheckpointConfig::default()
+        };
+        CheckpointCoordinator::new(config, store).await.unwrap()
     }
 
     #[tokio::test]
@@ -2672,6 +2768,7 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .unwrap();
         let commit_json = serde_json::to_string(&BarrierAnnouncement {
@@ -2680,6 +2777,7 @@ mod tests {
             phase: Phase::Commit,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .unwrap();
         // Overwrite the prepare with commit — observe_barrier reads the
@@ -2694,6 +2792,7 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
         let committed = coord
             .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(2))
@@ -2747,6 +2846,7 @@ mod tests {
             phase: Phase::Abort,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         })
         .unwrap();
         kv.seed(leader_id, ANNOUNCEMENT_KEY, abort_json);
@@ -2757,12 +2857,157 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
         let committed = coord
             .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(2))
             .await
             .unwrap();
         assert!(!committed, "follower should roll back on leader's Abort");
+    }
+
+    /// KV that records every announcement written, preserving order —
+    /// the single-slot `InMemoryKv` only keeps the latest.
+    #[cfg(feature = "cluster")]
+    struct RecordingKv {
+        inner: laminar_core::cluster::control::InMemoryKv,
+        announcements: Arc<parking_lot::Mutex<Vec<String>>>,
+    }
+
+    #[cfg(feature = "cluster")]
+    #[async_trait::async_trait]
+    impl laminar_core::cluster::control::ClusterKv for RecordingKv {
+        async fn write(&self, key: &str, value: String) {
+            if key == laminar_core::cluster::control::ANNOUNCEMENT_KEY {
+                self.announcements.lock().push(value.clone());
+            }
+            self.inner.write(key, value).await;
+        }
+        async fn read_from(
+            &self,
+            who: laminar_core::cluster::discovery::NodeId,
+            key: &str,
+        ) -> Option<String> {
+            self.inner.read_from(who, key).await
+        }
+        async fn scan(&self, key: &str) -> Vec<(laminar_core::cluster::discovery::NodeId, String)> {
+            self.inner.scan(key).await
+        }
+        async fn scan_prefix(
+            &self,
+            prefix: &str,
+        ) -> Vec<(laminar_core::cluster::discovery::NodeId, String, String)> {
+            self.inner.scan_prefix(prefix).await
+        }
+    }
+
+    /// ADR-003 two-level completion: the leader must announce `Aligned`
+    /// (the pipeline resume gate) after the capture quorum and *before*
+    /// the durable tail's `Commit`.
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn leader_announces_aligned_between_prepare_and_commit() {
+        use laminar_core::cluster::control::{
+            BarrierAnnouncement, ClusterController, ClusterKv, InMemoryKv, Phase,
+        };
+        use laminar_core::cluster::discovery::NodeId;
+        use tokio::sync::watch;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut coord = make_coordinator(dir.path()).await;
+
+        let self_id = NodeId(1);
+        let announcements = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let kv: Arc<dyn ClusterKv> = Arc::new(RecordingKv {
+            inner: InMemoryKv::new(self_id),
+            announcements: Arc::clone(&announcements),
+        });
+        let (_tx, rx) = watch::channel(Vec::new());
+        let controller = Arc::new(ClusterController::new(self_id, kv, None, rx));
+        coord.set_cluster_controller(controller);
+
+        let result = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        let phases: Vec<Phase> = announcements
+            .lock()
+            .iter()
+            .map(|json| {
+                serde_json::from_str::<BarrierAnnouncement>(json)
+                    .unwrap()
+                    .phase
+            })
+            .collect();
+        assert_eq!(
+            phases,
+            vec![Phase::Prepare, Phase::Aligned, Phase::Commit],
+            "two-level completion must announce Aligned between Prepare and Commit",
+        );
+    }
+
+    /// ADR-003: the follower acks at capture (before its durable
+    /// prepare). If the prepare then fails, a best-effort `ok = false`
+    /// ack overwrites the capture ack so a still-polling leader can
+    /// fail the quorum fast instead of waiting for its gate timeout.
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn follower_prepare_failure_overwrites_capture_ack() {
+        use laminar_core::cluster::control::{
+            BarrierAck, BarrierAnnouncement, ClusterController, ClusterKv, InMemoryKv, Phase,
+            ACK_KEY,
+        };
+        use laminar_core::cluster::discovery::{NodeId, NodeInfo, NodeMetadata, NodeState};
+        use laminar_core::state::InProcessBackend;
+        use tokio::sync::watch;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut coord = make_coordinator(dir.path()).await;
+
+        let leader_id = NodeId(1);
+        let follower_id = NodeId(7);
+        let kv = Arc::new(InMemoryKv::new(follower_id));
+        let kv_trait: Arc<dyn ClusterKv> = kv.clone();
+        let leader_info = NodeInfo {
+            id: leader_id,
+            name: "leader".into(),
+            rpc_address: String::new(),
+            raft_address: String::new(),
+            state: NodeState::Active,
+            metadata: NodeMetadata::default(),
+            last_heartbeat_ms: 0,
+        };
+        let (_tx, rx) = watch::channel(vec![leader_info]);
+        let controller = Arc::new(ClusterController::new(follower_id, kv_trait, None, rx));
+        coord.set_cluster_controller(controller);
+        // Backend sized for 2 vnodes but the follower claims vnode 99 —
+        // `write_vnode_partials` (the last prepare step) fails.
+        coord.set_state_backend(Arc::new(InProcessBackend::new(2)));
+        coord.set_vnode_set(vec![99]);
+
+        let ann = BarrierAnnouncement {
+            epoch: 1,
+            checkpoint_id: 1,
+            phase: Phase::Prepare,
+            flags: 0,
+            min_watermark_ms: None,
+            seq: 0,
+        };
+        let result = coord
+            .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(1))
+            .await;
+        assert!(result.is_err(), "prepare failure must surface as an error");
+
+        let ack_raw = kv.read_from(follower_id, ACK_KEY).await.unwrap();
+        let ack: BarrierAck = serde_json::from_str(&ack_raw).unwrap();
+        assert_eq!(ack.epoch, 1);
+        assert!(!ack.ok, "the failure ack must overwrite the capture ack");
+        assert!(
+            ack.error.unwrap().contains("vnode partial write failed"),
+            "failure ack should carry the prepare error",
+        );
     }
 
     #[cfg(feature = "cluster")]
@@ -2881,7 +3126,7 @@ mod tests {
         // gate must fail even though the leader wrote its own.
         use laminar_core::state::InProcessBackend;
         let dir = tempfile::tempdir().unwrap();
-        let mut coord = make_coordinator(dir.path()).await;
+        let mut coord = make_coordinator_with_fast_gate(dir.path()).await;
         let backend = Arc::new(InProcessBackend::new(4));
         coord.set_state_backend(backend.clone());
         coord.set_vnode_set(vec![0, 1]); // leader's owned subset
@@ -2899,6 +3144,51 @@ mod tests {
         assert!(
             err.contains("not all vnodes persisted"),
             "expected full-registry gate miss, got: {err}",
+        );
+    }
+
+    /// ADR-003: followers ack at capture and upload partials
+    /// asynchronously, so the leader's restorable gate must *wait* for
+    /// late partials rather than failing on the first check.
+    #[tokio::test]
+    async fn restorable_gate_waits_for_async_follower_uploads() {
+        use bytes::Bytes;
+        use laminar_core::state::InProcessBackend;
+        let dir = tempfile::tempdir().unwrap();
+        let mut coord = make_coordinator(dir.path()).await;
+        let backend = Arc::new(InProcessBackend::new(4));
+        // Leader's own partials are present; the "follower's" vnodes
+        // {2, 3} land only after a delay, simulating its background
+        // upload completing while the leader polls.
+        backend
+            .write_partial(0, 1, 0, Bytes::from_static(b"leader"))
+            .await
+            .unwrap();
+        backend
+            .write_partial(1, 1, 0, Bytes::from_static(b"leader"))
+            .await
+            .unwrap();
+        let late = Arc::clone(&backend);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            for v in [2u32, 3] {
+                late.write_partial(v, 1, 0, Bytes::from_static(b"follower"))
+                    .await
+                    .unwrap();
+            }
+        });
+        coord.set_state_backend(backend);
+        coord.set_vnode_set(vec![0, 1]);
+        coord.set_gate_vnode_set(vec![0, 1, 2, 3]);
+
+        let start = std::time::Instant::now();
+        coord
+            .await_restorable_gate(1)
+            .await
+            .expect("gate must seal once the late partials land");
+        assert!(
+            start.elapsed() >= Duration::from_millis(250),
+            "gate returned before the late partials could have landed",
         );
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -186,6 +186,14 @@ impl EpochAllocator {
     }
 }
 
+/// Capture-quorum participant id. Aliased so non-cluster builds (where
+/// `laminar_core::cluster` is compiled out and participant sets are
+/// always empty) still type-check the shared plumbing.
+#[cfg(feature = "cluster")]
+pub(crate) type QuorumPeer = laminar_core::cluster::discovery::NodeId;
+#[cfg(not(feature = "cluster"))]
+pub(crate) type QuorumPeer = u64;
+
 /// Whether `checkpoint_inner` still needs to run the cluster capture
 /// quorum, or a pipelined tail already ran it before taking the
 /// coordinator mutex.
@@ -202,7 +210,7 @@ pub(crate) enum QuorumStage {
         /// Merged cluster-min watermark from the capture acks.
         min_watermark_ms: Option<i64>,
         /// Followers that acked the capture quorum.
-        participants: Vec<laminar_core::cluster::discovery::NodeId>,
+        participants: Vec<QuorumPeer>,
     },
 }
 
@@ -850,7 +858,7 @@ impl CheckpointCoordinator {
     async fn await_restorable_gate(
         &self,
         epoch: u64,
-        participants: &[laminar_core::cluster::discovery::NodeId],
+        participants: &[QuorumPeer],
     ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
@@ -1204,7 +1212,7 @@ impl CheckpointCoordinator {
     #[cfg(feature = "cluster")]
     fn unhealthy_participant(
         members: &[laminar_core::cluster::discovery::NodeInfo],
-        participants: &[laminar_core::cluster::discovery::NodeId],
+        participants: &[QuorumPeer],
     ) -> Option<String> {
         use laminar_core::cluster::discovery::NodeState;
         for &id in participants {
@@ -1950,7 +1958,7 @@ impl CheckpointCoordinator {
         // behind an earlier epoch's uploads) and pass `Done` here.
         #[cfg(feature = "cluster")]
         #[allow(unused_assignments)] // both match arms assign; init keeps non-cluster shape
-        let mut quorum_participants: Vec<laminar_core::cluster::discovery::NodeId> = Vec::new();
+        let mut quorum_participants: Vec<QuorumPeer> = Vec::new();
         #[cfg(feature = "cluster")]
         match quorum {
             QuorumStage::RunInline => {
@@ -2095,7 +2103,7 @@ impl CheckpointCoordinator {
         // asynchronously after their capture ack, so this polls until
         // `restorable_gate_timeout` rather than checking once.
         #[cfg(not(feature = "cluster"))]
-        let quorum_participants: Vec<laminar_core::cluster::discovery::NodeId> = Vec::new();
+        let quorum_participants: Vec<QuorumPeer> = Vec::new();
         if let Err(gate_err) = self
             .await_restorable_gate(epoch, &quorum_participants)
             .await

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -94,7 +94,10 @@ impl Default for CheckpointConfig {
             state_inline_threshold: 1_048_576,
             max_checkpoint_bytes: None,
             quorum_timeout: Duration::from_secs(3),
-            restorable_gate_timeout: Duration::from_secs(30),
+            // Last-resort bound only: membership/unresponsive/rotation
+            // fail-fasts catch dead participants in seconds. Long values
+            // serialize recovery (pipelined doomed epochs each burn it).
+            restorable_gate_timeout: Duration::from_secs(10),
             max_in_flight_epochs: 4,
             max_staged_bytes: 512 * 1024 * 1024,
         }

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1424,7 +1424,12 @@ impl CheckpointCoordinator {
             let handle = sink.handle.clone();
             let name = sink.name.clone();
             async move {
-                let result = handle.rollback_epoch(epoch).await;
+                // Live abandon, not a hard rollback: a healthy sink
+                // keeps its pending transactional output for the next
+                // epoch's commit — sources don't rewind on a live
+                // abort, so discarding it would lose the rows.
+                // Restart-time rollback (recovery manager) stays hard.
+                let result = handle.abandon_epoch(epoch).await;
                 (name, result)
             }
         });
@@ -1691,6 +1696,10 @@ impl CheckpointCoordinator {
             }
             self.rollback_sinks(epoch).await.ok();
             self.phase = CheckpointPhase::Idle;
+            // The rollback aborted the sinks' open transaction; open
+            // the next epoch's so post-failure writes stay
+            // transactional (mirrors the leader's `fail_epoch`).
+            self.begin_next_epoch_bounded().await;
             return Err(e);
         }
         Ok(())
@@ -1786,14 +1795,22 @@ impl CheckpointCoordinator {
         checkpoint_id: u64,
         committed: bool,
     ) -> bool {
-        if committed {
+        let clean = if committed {
             self.drive_follower_commit(epoch, checkpoint_id).await
         } else {
             self.rollback_sinks(epoch).await.ok();
             self.checkpoints_failed += 1;
             self.phase = CheckpointPhase::Idle;
             false
-        }
+        };
+        // Commit and rollback both close the sinks' open transaction;
+        // open the next epoch's so subsequent writes are transactional.
+        // The leader does this inside `checkpoint_inner`/`fail_epoch`;
+        // without the follower mirror, the first commit left
+        // exactly-once sinks transaction-less and every later write
+        // failed (found by the kill -9 exactly-once soak).
+        self.begin_next_epoch_bounded().await;
+        clean
     }
 
     /// Durable commit-marker store handle, for the lock-free decision
@@ -4065,8 +4082,13 @@ mod tests {
         }
     }
 
+    /// A pre-commit failure abandons the epoch but must NOT hard-roll
+    /// the connector back: sources do not rewind on a live abort, so
+    /// discarding a healthy sink's pending transactional output would
+    /// lose those rows forever (measured as gaps by the exactly-once
+    /// soak). The pending output rides into the next epoch's commit.
     #[tokio::test]
-    async fn test_pre_commit_failure_triggers_rollback() {
+    async fn pre_commit_failure_abandons_without_connector_rollback() {
         use arrow::datatypes::{DataType, Field, Schema};
 
         let dir = tempfile::tempdir().unwrap();
@@ -4111,12 +4133,15 @@ mod tests {
         );
         assert_eq!(
             rollback_count.load(std::sync::atomic::Ordering::Relaxed),
-            1,
-            "rollback_epoch should have been called once"
+            0,
+            "a healthy sink must keep its pending output on a live \
+             abandon — connector rollback would lose unreplayable rows"
         );
     }
 
-    /// `pre_commit` fails; `rollback_epoch` hangs forever.
+    /// Writes fail (poisoning the epoch); `rollback_epoch` hangs
+    /// forever. The poisoned epoch is what makes the live abandon take
+    /// the forced connector-rollback path that can hang.
     struct StuckRollbackSink {
         schema: arrow::datatypes::SchemaRef,
     }
@@ -4137,7 +4162,9 @@ mod tests {
             laminar_connectors::connector::WriteResult,
             laminar_connectors::error::ConnectorError,
         > {
-            Ok(laminar_connectors::connector::WriteResult::new(0, 0))
+            Err(laminar_connectors::error::ConnectorError::WriteError(
+                "synthetic write failure".into(),
+            ))
         }
 
         async fn pre_commit(
@@ -4202,11 +4229,23 @@ mod tests {
             write_timeout: Duration::from_secs(5),
             event_tx,
         });
-        coord.register_sink("stuck-sink", handle, true);
+        coord.register_sink("stuck-sink", handle.clone(), true);
         coord.begin_initial_epoch().await.unwrap();
 
-        // pre_commit fails → rollback_sinks fires → hangs → 100ms
-        // rollback_timeout fires → coordinator returns.
+        // Poison the epoch with a failing write — only a poisoned sink
+        // takes the forced connector-rollback path that can hang.
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let batch = arrow::array::RecordBatch::try_new(
+            schema,
+            vec![Arc::new(arrow::array::Int32Array::from(vec![1]))],
+        )
+        .unwrap();
+        handle.write_batch(batch).await.unwrap();
+        handle.sync().await.unwrap();
+
+        // Poisoned pre_commit fails → rollback_sinks fires → connector
+        // rollback hangs → 100ms rollback_timeout fires → coordinator
+        // returns instead of wedging.
         let result = coord
             .checkpoint(CheckpointRequest::default())
             .await

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -143,6 +143,12 @@ impl EpochAllocator {
     }
 
     /// Claim the next `(epoch, checkpoint_id)` pair.
+    ///
+    /// The two counters advance independently (not as one atomic unit):
+    /// every allocation site runs on the pipeline task or under the
+    /// coordinator mutex, so concurrent `allocate` calls cannot occur
+    /// today. A new call site off those paths would need this upgraded
+    /// to a single CAS over a packed pair.
     pub(crate) fn allocate(&self) -> (u64, u64) {
         use std::sync::atomic::Ordering;
         (
@@ -3524,6 +3530,208 @@ mod tests {
         .unwrap();
         assert_eq!(p4.base_epoch, None);
         assert!(!p4.operators.is_empty());
+    }
+
+    /// `InProcessBackend` wrapper with a per-write delay (forces epoch
+    /// overlap) and injected failures keyed by `(epoch, vnode)`.
+    struct FaultBackend {
+        inner: laminar_core::state::InProcessBackend,
+        fail: parking_lot::Mutex<std::collections::HashSet<(u64, u32)>>,
+        write_delay: Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl StateBackend for FaultBackend {
+        async fn write_partial(
+            &self,
+            vnode: u32,
+            epoch: u64,
+            assignment_version: u64,
+            bytes: bytes::Bytes,
+        ) -> Result<(), laminar_core::state::StateBackendError> {
+            tokio::time::sleep(self.write_delay).await;
+            if self.fail.lock().contains(&(epoch, vnode)) {
+                return Err(laminar_core::state::StateBackendError::Io(
+                    "injected write failure".into(),
+                ));
+            }
+            self.inner
+                .write_partial(vnode, epoch, assignment_version, bytes)
+                .await
+        }
+
+        async fn read_partial(
+            &self,
+            vnode: u32,
+            epoch: u64,
+        ) -> Result<Option<bytes::Bytes>, laminar_core::state::StateBackendError> {
+            self.inner.read_partial(vnode, epoch).await
+        }
+
+        async fn epoch_complete(
+            &self,
+            epoch: u64,
+            vnodes: &[u32],
+        ) -> Result<bool, laminar_core::state::StateBackendError> {
+            self.inner.epoch_complete(epoch, vnodes).await
+        }
+
+        async fn prune_before(
+            &self,
+            before: u64,
+        ) -> Result<(), laminar_core::state::StateBackendError> {
+            self.inner.prune_before(before).await
+        }
+
+        async fn latest_committed_epoch(
+            &self,
+        ) -> Result<Option<u64>, laminar_core::state::StateBackendError> {
+            self.inner.latest_committed_epoch().await
+        }
+
+        fn set_authoritative_version(&self, version: u64) {
+            self.inner.set_authoritative_version(version);
+        }
+
+        fn authoritative_version(&self) -> u64 {
+            self.inner.authoritative_version()
+        }
+    }
+
+    /// Fault injection at pipeline depth > 1 (ADR-003 Phase 2). Four
+    /// epochs are admitted (ids allocated, tails spawned) while the
+    /// first is still uploading; the third epoch's upload partially
+    /// fails — one vnode's write lands, the other's is injected to
+    /// fail. Must hold:
+    /// - tails complete in admission order (FIFO coordinator mutex);
+    /// - the failed epoch is abandoned without disturbing successors;
+    /// - the recovery point is the last successful epoch;
+    /// - the partial that *landed* for the failed epoch never becomes
+    ///   a reference base (a successor with identical state must
+    ///   re-upload full, or reference an older *successful* epoch).
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // four-epoch fault sequence reads better unsplit
+    async fn overlapping_epoch_failure_is_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Box::new(FileSystemCheckpointStore::new(dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(CheckpointConfig::default(), store)
+            .await
+            .unwrap();
+        let backend = Arc::new(FaultBackend {
+            inner: laminar_core::state::InProcessBackend::new(2),
+            fail: parking_lot::Mutex::new(std::collections::HashSet::new()),
+            write_delay: Duration::from_millis(100),
+        });
+        coord.set_state_backend(Arc::clone(&backend) as Arc<dyn StateBackend>);
+        coord.set_vnode_set(vec![0, 1]);
+
+        let allocator = coord.epoch_allocator();
+        let coordinator = Arc::new(tokio::sync::Mutex::new(Some(coord)));
+        let (done_tx, mut done_rx) = tokio::sync::mpsc::unbounded_channel::<CheckpointResult>();
+
+        // Admit an epoch exactly as the pipeline callback does: claim
+        // ids lock-free, spawn the tail; the FIFO mutex serializes the
+        // durable work.
+        let admit = |tag: &'static [u8]| {
+            let (epoch, checkpoint_id) = allocator.allocate();
+            let coordinator = Arc::clone(&coordinator);
+            let done = done_tx.clone();
+            let states = std::collections::HashMap::from([
+                (
+                    0u32,
+                    std::collections::HashMap::from([(
+                        "agg".to_string(),
+                        bytes::Bytes::from_static(tag),
+                    )]),
+                ),
+                (
+                    1u32,
+                    std::collections::HashMap::from([(
+                        "agg".to_string(),
+                        bytes::Bytes::from_static(tag),
+                    )]),
+                ),
+            ]);
+            tokio::spawn(async move {
+                let mut guard = coordinator.lock().await;
+                let coord = guard.as_mut().unwrap();
+                coord.set_pending_vnode_states(states);
+                let result = coord
+                    .checkpoint_preallocated(
+                        CheckpointRequest::default(),
+                        epoch,
+                        checkpoint_id,
+                        QuorumStage::RunInline,
+                    )
+                    .await
+                    .unwrap();
+                done.send(result).unwrap();
+            });
+            epoch
+        };
+
+        // All four admitted while epoch A's tail is still uploading
+        // (each write sleeps 100ms; admissions are microseconds apart,
+        // paced just enough that lock-queue order is admission order).
+        let a = admit(b"v1");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let b = admit(b"v1"); // unchanged → reference to A
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let (c_epoch, _) = allocator.peek();
+        backend.fail.lock().insert((c_epoch, 1)); // vnode 0 lands, vnode 1 fails
+        let c = admit(b"v2"); // changed → full attempt, partially fails
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let d = admit(b"v2"); // same state as the failed epoch
+
+        let mut results = Vec::new();
+        for _ in 0..4 {
+            results.push(done_rx.recv().await.unwrap());
+        }
+
+        assert_eq!(
+            results.iter().map(|r| r.epoch).collect::<Vec<_>>(),
+            vec![a, b, c, d],
+            "tails must complete in admission order",
+        );
+        assert_eq!(
+            results.iter().map(|r| r.success).collect::<Vec<_>>(),
+            vec![true, true, false, true],
+            "the failed epoch must not disturb its successors",
+        );
+        assert!(results[2]
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("vnode partial write failed")));
+
+        // Recovery point: the failed epoch was never sealed.
+        assert_eq!(
+            backend.latest_committed_epoch().await.unwrap(),
+            Some(d),
+            "the last successful epoch is the recovery point",
+        );
+
+        // B was unchanged from A → reference. D matches the FAILED
+        // epoch's state, and C's vnode-0 write landed before the
+        // injected failure — D must not reference it (bases are
+        // recorded only after every write in an epoch lands).
+        let p_b = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, b).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(p_b.base_epoch, Some(a));
+        for vnode in [0u32, 1] {
+            let p_d = crate::vnode_partial::VnodePartial::decode(
+                &backend.read_partial(vnode, d).await.unwrap().unwrap(),
+            )
+            .unwrap();
+            assert_eq!(
+                p_d.base_epoch, None,
+                "vnode {vnode}: a successor of a failed epoch must re-upload full, \
+                 never reference the failed epoch's stray partial",
+            );
+            assert_eq!(p_d.operators[0].1, b"v2");
+        }
+        assert_eq!(c, d - 1, "abandoned epoch's id is burned, not reused");
     }
 
     #[test]

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1607,9 +1607,10 @@ impl CheckpointCoordinator {
                         );
                         return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
                     }
-                    // No marker yet — keep waiting (the predicate keeps
-                    // matching the newer epoch, so pace the re-check).
-                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    // No marker yet — keep waiting. Each pass through
+                    // this (rare) state costs an object-store HEAD, so
+                    // pace the re-check well below the decision timeout.
+                    tokio::time::sleep(Duration::from_millis(500)).await;
                 }
                 None => {
                     // Deadline: one last durable-marker check.

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -862,17 +862,11 @@ impl CheckpointCoordinator {
     ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
-        // Each `epoch_complete` call LISTs the epoch prefix on the
-        // object store, so back off after the first second: fast for
-        // the common local/in-process case, cheap on S3 for a slow
-        // follower upload (≤10 + ~60 LISTs over the 30s default).
         // Each poll LISTs the epoch prefix on the object store, so back
         // off exponentially: fast for the common local/in-process case,
         // ~1 LIST/s steady-state per slow epoch on S3 (gates also
         // serialize on the coordinator mutex, so at most one loop polls
-        // at a time regardless of pipelining depth). Replacing the poll
-        // with follower upload-completion acks is the protocol-level
-        // follow-up tracked in the plan.
+        // at a time regardless of pipelining depth).
         const INITIAL_POLL: Duration = Duration::from_millis(100);
         const MAX_POLL: Duration = Duration::from_secs(1);
 
@@ -1324,7 +1318,7 @@ impl CheckpointCoordinator {
             }
             Ok(QuorumOutcome::TimedOut { missing, .. }) => {
                 // Gossip failure detection can lag a hard kill by tens
-                // of seconds; record the leader''s own faster signal so
+                // of seconds; record the leader's own faster signal so
                 // the durability gates of already-captured epochs fail
                 // fast instead of each burning their full timeout.
                 cc.note_unresponsive(&missing);

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -727,6 +727,77 @@ impl CheckpointCoordinator {
         }
     }
 
+    /// Common abandon path for a failed checkpoint attempt: announce
+    /// `Abort` so prepared followers release immediately, roll the
+    /// epoch's sink transactions back, and begin the next epoch's
+    /// transactions so writes arriving after the failure are not
+    /// orphaned in a rolled-back transaction. Ids were allocated at the
+    /// start of [`checkpoint_inner`](Self::checkpoint_inner), so the
+    /// failed epoch is abandoned, never retried.
+    async fn fail_epoch(
+        &mut self,
+        checkpoint_id: u64,
+        epoch: u64,
+        started: Instant,
+        error: String,
+    ) -> CheckpointResult {
+        #[cfg(feature = "cluster")]
+        self.announce_if_leader(
+            epoch,
+            checkpoint_id,
+            laminar_core::cluster::control::Phase::Abort,
+            None,
+        )
+        .await;
+        self.checkpoints_failed += 1;
+        self.phase = CheckpointPhase::Idle;
+        let duration = started.elapsed();
+        self.emit_checkpoint_metrics(false, epoch, duration);
+        if let Err(e) = self.rollback_sinks(epoch).await {
+            error!(
+                checkpoint_id, epoch, error = %e,
+                "[LDB-6004] sink rollback failed after checkpoint failure",
+            );
+        }
+        self.begin_next_epoch_bounded().await;
+        self.pending_vnode_states.clear();
+        CheckpointResult {
+            success: false,
+            checkpoint_id,
+            epoch,
+            duration,
+            error: Some(error),
+        }
+    }
+
+    /// Begin the (already-allocated) next epoch's sink transactions
+    /// after a failed or partially-committed checkpoint, bounded by
+    /// `rollback_timeout` — the sink that just failed may be wedged,
+    /// and an unbounded `begin_epoch` await would hang the coordinator
+    /// on it.
+    async fn begin_next_epoch_bounded(&self) {
+        let next_epoch = self.epoch;
+        match tokio::time::timeout(
+            self.config.rollback_timeout,
+            self.begin_epoch_for_sinks(next_epoch),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => error!(
+                next_epoch, error = %e,
+                "[LDB-6015] failed to begin next epoch after abandoning a \
+                 failed one — writes will be non-transactional",
+            ),
+            Err(_) => error!(
+                next_epoch,
+                timeout_secs = self.config.rollback_timeout.as_secs(),
+                "[LDB-6015] begin next epoch timed out after a failed \
+                 checkpoint — writes will be non-transactional",
+            ),
+        }
+    }
+
     /// On startup, reconcile any Pending sinks in the last manifest
     /// against the durable commit marker. Marker present → drive
     /// local commit (idempotent); marker absent → rollback. Runs on
@@ -1139,13 +1210,14 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Collects the last committed epoch from each sink.
-    fn collect_sink_epochs(&self) -> HashMap<String, u64> {
+    /// Per-sink epoch map for the manifest: every exactly-once sink is
+    /// committing `epoch` (passed in — `self.epoch` already points at
+    /// the next epoch once a checkpoint is underway).
+    fn collect_sink_epochs(&self, epoch: u64) -> HashMap<String, u64> {
         let mut epochs = HashMap::with_capacity(self.sinks.len());
         for sink in &self.sinks {
-            // The epoch being committed is the current one
             if sink.exactly_once {
-                epochs.insert(sink.name.clone(), self.epoch);
+                epochs.insert(sink.name.clone(), epoch);
             }
         }
         epochs
@@ -1435,7 +1507,7 @@ impl CheckpointCoordinator {
         let mut manifest = CheckpointManifest::new(checkpoint_id, epoch);
         manifest.source_offsets = source_offset_overrides;
         manifest.table_offsets = extra_table_offsets;
-        manifest.sink_epochs = self.collect_sink_epochs();
+        manifest.sink_epochs = self.collect_sink_epochs(epoch);
         manifest.sink_commit_statuses = self.initial_sink_commit_statuses();
         manifest.watermark = watermark;
         manifest.source_watermarks = source_watermarks;
@@ -1489,6 +1561,14 @@ impl CheckpointCoordinator {
         let start = Instant::now();
         let checkpoint_id = self.next_checkpoint_id;
         let epoch = self.epoch;
+        // Allocate ids up front (Flink-style): a failed attempt is
+        // abandoned — never retried under the same ids — so a future
+        // epoch's identity never depends on this one's outcome. That
+        // independence is what allows epochs to overlap (ADR-003
+        // Phase 2); it also removes the same-epoch-retry ambiguity the
+        // announcement `seq` otherwise has to disambiguate.
+        self.next_checkpoint_id += 1;
+        self.epoch += 1;
 
         info!(checkpoint_id, epoch, "starting checkpoint");
 
@@ -1508,29 +1588,10 @@ impl CheckpointCoordinator {
         #[cfg(feature = "cluster")]
         {
             if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await {
-                self.phase = CheckpointPhase::Idle;
-                self.checkpoints_failed += 1;
-                let duration = start.elapsed();
-                self.emit_checkpoint_metrics(false, epoch, duration);
-                // Idempotent: this epoch's sinks have not pre-committed yet,
-                // but rollback also closes any transaction opened by
-                // `begin_epoch_for_sinks` after the previous checkpoint.
-                if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                    error!(
-                        checkpoint_id,
-                        epoch,
-                        error = %rollback_err,
-                        "[LDB-6032] sink rollback failed after quorum miss",
-                    );
-                }
-                self.pending_vnode_states.clear();
-                return Ok(CheckpointResult {
-                    success: false,
-                    checkpoint_id,
-                    epoch,
-                    duration,
-                    error: Some(quorum_failure),
-                });
+                error!(checkpoint_id, epoch, error = %quorum_failure, "[LDB-6032] quorum miss");
+                return Ok(self
+                    .fail_epoch(checkpoint_id, epoch, start, quorum_failure)
+                    .await);
             }
             self.announce_if_leader(
                 epoch,
@@ -1543,36 +1604,21 @@ impl CheckpointCoordinator {
 
         self.phase = CheckpointPhase::PreCommitting;
         if let Err(e) = self.pre_commit_sinks(epoch).await {
-            self.phase = CheckpointPhase::Idle;
-            self.checkpoints_failed += 1;
-            // Roll back unconditionally — `rollback_epoch` is idempotent.
-            // Without this, a poisoned epoch leaves Kafka transactions
-            // open until the broker-side transaction.timeout.ms fires.
-            if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                error!(
+            error!(checkpoint_id, epoch, error = %e, "pre-commit failed");
+            return Ok(self
+                .fail_epoch(
                     checkpoint_id,
                     epoch,
-                    error = %rollback_err,
-                    "[LDB-6004] sink rollback failed after pre-commit failure"
-                );
-            }
-            let duration = start.elapsed();
-            self.emit_checkpoint_metrics(false, epoch, duration);
-            error!(checkpoint_id, epoch, error = %e, "pre-commit failed");
-            self.pending_vnode_states.clear();
-            return Ok(CheckpointResult {
-                success: false,
-                checkpoint_id,
-                epoch,
-                duration,
-                error: Some(format!("pre-commit failed: {e}")),
-            });
+                    start,
+                    format!("pre-commit failed: {e}"),
+                )
+                .await);
         }
 
         let mut manifest = CheckpointManifest::new(checkpoint_id, epoch);
         manifest.source_offsets = source_offsets;
         manifest.table_offsets = table_offsets;
-        manifest.sink_epochs = self.collect_sink_epochs();
+        manifest.sink_epochs = self.collect_sink_epochs(epoch);
         // Mark all exactly-once sinks as Pending before commit phase.
         manifest.sink_commit_statuses = self.initial_sink_commit_statuses();
         manifest.watermark = watermark;
@@ -1607,23 +1653,15 @@ impl CheckpointCoordinator {
 
         if let Some(cap) = self.config.max_checkpoint_bytes {
             if sidecar_bytes > cap {
-                self.phase = CheckpointPhase::Idle;
-                self.checkpoints_failed += 1;
-                let duration = start.elapsed();
-                self.emit_checkpoint_metrics(false, epoch, duration);
                 let msg = format!(
                     "[LDB-6014] checkpoint size {sidecar_bytes} bytes exceeds \
                      cap {cap} bytes — checkpoint rejected"
                 );
                 error!(checkpoint_id, epoch, sidecar_bytes, cap, "{msg}");
-                self.pending_vnode_states.clear();
-                return Ok(CheckpointResult {
-                    success: false,
-                    checkpoint_id,
-                    epoch,
-                    duration,
-                    error: Some(msg),
-                });
+                // `fail_epoch` also rolls the pre-committed sinks back —
+                // previously this path returned without a rollback,
+                // leaving the epoch's transactions open.
+                return Ok(self.fail_epoch(checkpoint_id, epoch, start, msg).await);
             }
             let warn_threshold = cap * 4 / 5; // 80%
             if sidecar_bytes > warn_threshold {
@@ -1642,55 +1680,30 @@ impl CheckpointCoordinator {
         // free mutable reference for the post-commit sink-status update.
         let mut manifest = Arc::new(manifest);
         if let Err(e) = self.save_manifest(Arc::clone(&manifest), state_data).await {
-            self.phase = CheckpointPhase::Idle;
-            self.checkpoints_failed += 1;
-            let duration = start.elapsed();
-            self.emit_checkpoint_metrics(false, epoch, duration);
-            if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                error!(
+            error!(checkpoint_id, epoch, error = %e, "[LDB-6008] manifest persist failed");
+            return Ok(self
+                .fail_epoch(
                     checkpoint_id,
                     epoch,
-                    error = %rollback_err,
-                    "[LDB-6004] sink rollback failed after manifest persist failure — \
-                     sinks may be in an inconsistent state"
-                );
-            }
-            error!(checkpoint_id, epoch, error = %e, "[LDB-6008] manifest persist failed");
-            self.pending_vnode_states.clear();
-            return Ok(CheckpointResult {
-                success: false,
-                checkpoint_id,
-                epoch,
-                duration,
-                error: Some(format!("manifest persist failed: {e}")),
-            });
+                    start,
+                    format!("manifest persist failed: {e}"),
+                )
+                .await);
         }
 
         // Publish each owned vnode's partial (operator-state slice + commit
         // marker in one blob) so the durability gate below has something to
         // check and a future owner can rehydrate the vnode's state.
         if let Err(e) = self.write_vnode_partials(epoch, checkpoint_id).await {
-            self.phase = CheckpointPhase::Idle;
-            self.checkpoints_failed += 1;
-            let duration = start.elapsed();
-            self.emit_checkpoint_metrics(false, epoch, duration);
-            if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                error!(
+            error!(checkpoint_id, epoch, error = %e, "[LDB-6025] vnode partial write failed");
+            return Ok(self
+                .fail_epoch(
                     checkpoint_id,
                     epoch,
-                    error = %rollback_err,
-                    "[LDB-6025] sink rollback failed after marker write failure",
-                );
-            }
-            error!(checkpoint_id, epoch, error = %e, "vnode partial write failed");
-            self.pending_vnode_states.clear();
-            return Ok(CheckpointResult {
-                success: false,
-                checkpoint_id,
-                epoch,
-                duration,
-                error: Some(format!("vnode partial write failed: {e}")),
-            });
+                    start,
+                    format!("vnode partial write failed: {e}"),
+                )
+                .await);
         }
 
         // Durability gate (level 2, "restorable"): confirm every
@@ -1709,34 +1722,7 @@ impl CheckpointCoordinator {
                 error = %gate_err,
                 "[LDB-6020] state durability gate failed — rolling back sinks",
             );
-            #[cfg(feature = "cluster")]
-            self.announce_if_leader(
-                epoch,
-                checkpoint_id,
-                laminar_core::cluster::control::Phase::Abort,
-                None,
-            )
-            .await;
-            self.checkpoints_failed += 1;
-            self.phase = CheckpointPhase::Idle;
-            let duration = start.elapsed();
-            self.emit_checkpoint_metrics(false, epoch, duration);
-            if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                error!(
-                    checkpoint_id,
-                    epoch,
-                    error = %rollback_err,
-                    "[LDB-6021] sink rollback failed after durability gate miss",
-                );
-            }
-            self.pending_vnode_states.clear();
-            return Ok(CheckpointResult {
-                success: false,
-                checkpoint_id,
-                epoch,
-                duration,
-                error: Some(gate_err),
-            });
+            return Ok(self.fail_epoch(checkpoint_id, epoch, start, gate_err).await);
         }
 
         // Record the commit marker before issuing sink commits — this
@@ -1758,37 +1744,13 @@ impl CheckpointCoordinator {
         if is_decision_leader {
             if let Some(ds) = self.decision_store.as_ref() {
                 if let Err(e) = ds.record_committed(epoch).await {
-                    let reason = e.to_string();
                     error!(
-                        checkpoint_id, epoch, error = %reason,
+                        checkpoint_id, epoch, error = %e,
                         "[LDB-6038] cannot record commit marker — aborting epoch",
                     );
-                    #[cfg(feature = "cluster")]
-                    self.announce_if_leader(
-                        epoch,
-                        checkpoint_id,
-                        laminar_core::cluster::control::Phase::Abort,
-                        None,
-                    )
-                    .await;
-                    self.checkpoints_failed += 1;
-                    self.phase = CheckpointPhase::Idle;
-                    let duration = start.elapsed();
-                    self.emit_checkpoint_metrics(false, epoch, duration);
-                    if let Err(rollback_err) = self.rollback_sinks(epoch).await {
-                        error!(
-                            checkpoint_id, epoch, error = %rollback_err,
-                            "[LDB-6039] sink rollback failed after commit marker failure",
-                        );
-                    }
-                    self.pending_vnode_states.clear();
-                    return Ok(CheckpointResult {
-                        success: false,
-                        checkpoint_id,
-                        epoch,
-                        duration,
-                        error: Some(format!("commit marker: {reason}")),
-                    });
+                    return Ok(self
+                        .fail_epoch(checkpoint_id, epoch, start, format!("commit marker: {e}"))
+                        .await);
                 }
             }
         }
@@ -1827,14 +1789,22 @@ impl CheckpointCoordinator {
         }
 
         if has_failures {
+            // The commit decision is already durable (marker + Commit
+            // announcement), so the epoch is NOT rolled back: the failed
+            // sinks' statuses are recorded in the manifest and re-driven
+            // by `reconcile_prepared_on_init` on restart. Begin the next
+            // epoch so subsequent writes stay transactional.
             self.checkpoints_failed += 1;
             error!(
                 checkpoint_id,
-                epoch, "sink commit partially failed — epoch NOT advanced, will retry"
+                epoch,
+                "sink commit partially failed after the commit decision — \
+                 statuses recorded for recovery-time re-drive"
             );
             self.phase = CheckpointPhase::Idle;
             let duration = start.elapsed();
             self.emit_checkpoint_metrics(false, epoch, duration);
+            self.begin_next_epoch_bounded().await;
             self.pending_vnode_states.clear();
             return Ok(CheckpointResult {
                 success: false,
@@ -1846,8 +1816,6 @@ impl CheckpointCoordinator {
         }
 
         self.phase = CheckpointPhase::Idle;
-        self.next_checkpoint_id += 1;
-        self.epoch += 1;
         self.checkpoints_completed += 1;
         self.total_bytes_written += checkpoint_bytes;
         let duration = start.elapsed();
@@ -3252,6 +3220,43 @@ mod tests {
         );
         let err = result.error.expect("failure produces an error message");
         assert!(err.contains("vnode partial write failed"), "got: {err}");
+    }
+
+    /// Ids are allocated at the start of an attempt: a failed epoch is
+    /// abandoned (Flink-style), never retried under the same ids.
+    #[tokio::test]
+    async fn failed_epoch_is_abandoned_not_retried() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CheckpointConfig {
+            max_checkpoint_bytes: Some(16),
+            ..CheckpointConfig::default()
+        };
+        let store = Box::new(FileSystemCheckpointStore::new(dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(config, store).await.unwrap();
+
+        // Oversized state → size-cap rejection.
+        let mut ops = HashMap::new();
+        ops.insert("big".to_string(), bytes::Bytes::from(vec![0u8; 2_000_000]));
+        let failed = coord
+            .checkpoint(CheckpointRequest {
+                operator_states: ops,
+                ..CheckpointRequest::default()
+            })
+            .await
+            .unwrap();
+        assert!(!failed.success);
+
+        let ok = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(ok.success);
+        assert_eq!(
+            ok.epoch,
+            failed.epoch + 1,
+            "the failed epoch must be abandoned, not reused",
+        );
+        assert_eq!(ok.checkpoint_id, failed.checkpoint_id + 1);
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -439,6 +439,10 @@ impl CheckpointCoordinator {
         if self.gate_vnode_set.is_empty() {
             self.gate_vnode_set.clone_from(&vnodes);
         }
+        // Drop reference bases for vnodes shed in a rebalance — they
+        // hold refcounts on serialized state this node no longer owns
+        // (and the new owner builds its own bases from a full upload).
+        self.last_vnode_uploads.retain(|v, _| vnodes.contains(v));
         self.vnode_set = vnodes;
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -309,6 +309,13 @@ pub struct CheckpointCoordinator {
     /// Vnodes the leader's durability gate checks. In cluster mode the
     /// full registry; single-instance mirrors `vnode_set`.
     gate_vnode_set: Vec<u32>,
+    /// First epoch admitted at-or-after the latest vnode rotation. An
+    /// in-flight epoch BELOW this captured under the previous
+    /// assignment: vnodes that changed hands mid-epoch were captured by
+    /// nobody, so its durability gate can never seal — fail it fast
+    /// instead of burning the gate timeout (with pipelining, several
+    /// such epochs would burn serially).
+    rotation_epoch_floor: u64,
     /// Per-vnode operator-state slices for the in-flight checkpoint,
     /// `vnode → (operator_name → bytes)`. Set fresh before each checkpoint
     /// by the pipeline callback from `OperatorGraph::snapshot_state_by_vnode`;
@@ -390,6 +397,7 @@ impl CheckpointCoordinator {
             cluster_min_watermark: None,
             vnode_set: Vec::new(),
             gate_vnode_set: Vec::new(),
+            rotation_epoch_floor: 0,
             pending_vnode_states: std::collections::HashMap::new(),
             last_vnode_uploads: std::collections::HashMap::new(),
             #[cfg(feature = "cluster")]
@@ -460,6 +468,7 @@ impl CheckpointCoordinator {
         if self.gate_vnode_set.is_empty() {
             self.gate_vnode_set.clone_from(&vnodes);
         }
+        self.rotation_epoch_floor = self.allocator.peek().0;
         // Drop reference bases for vnodes shed in a rebalance — they
         // hold refcounts on serialized state this node no longer owns
         // (and the new owner builds its own bases from a full upload).
@@ -867,6 +876,13 @@ impl CheckpointCoordinator {
         let mut interval = INITIAL_POLL;
         let mut last_state = String::from("not all vnodes persisted");
         loop {
+            if epoch < self.rotation_epoch_floor {
+                return Err(format!(
+                    "vnode assignment rotated after epoch {epoch} captured \
+                     (rotation floor {}); epoch cannot seal",
+                    self.rotation_epoch_floor
+                ));
+            }
             match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
                 Ok(true) => return Ok(()),
                 // Keep the default/previous message; a lingering

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1559,25 +1559,37 @@ impl CheckpointCoordinator {
             return Err(e);
         }
 
-        // Phase 2: wait for the leader's decision. `Aligned` is not a
-        // decision — only Commit/Abort (or epoch advancement) end the
-        // wait. Observation is latest-wins, so a newer epoch's
-        // announcement can supersede this epoch's Commit: the leader
-        // only advances epochs after a successful commit, so verify via
-        // the durable marker and drive the commit.
+        // Phase 2: wait for the leader's decision — push-driven off the
+        // announcement watch. `Aligned` is not a decision; only
+        // Commit/Abort (or epoch advancement) end the wait. Observation
+        // is latest-wins, so a newer epoch's announcement can supersede
+        // this epoch's Commit: the leader only advances epochs after a
+        // successful commit, so verify via the durable marker.
         let deadline = Instant::now() + decision_timeout;
         loop {
-            match cc.observe_barrier().await.ok().flatten() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let decision = cc
+                .wait_for_barrier(
+                    |a| {
+                        a.epoch > epoch
+                            || (a.epoch == epoch && matches!(a.phase, Phase::Commit | Phase::Abort))
+                    },
+                    remaining,
+                )
+                .await;
+            match decision {
                 Some(a) if a.epoch == epoch && a.phase == Phase::Commit => {
                     return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
                 }
-                Some(a) if a.epoch == epoch && a.phase == Phase::Abort => {
+                Some(a) if a.epoch == epoch => {
+                    // Abort.
                     self.rollback_sinks(epoch).await.ok();
                     self.checkpoints_failed += 1;
                     self.phase = CheckpointPhase::Idle;
                     return Ok(false);
                 }
-                Some(a) if a.epoch > epoch => {
+                Some(a) => {
+                    // Newer epoch supersedes the decision announcement.
                     let committed = match self.decision_store.as_ref() {
                         Some(ds) => ds.is_committed(epoch).await.unwrap_or(false),
                         None => false,
@@ -1591,40 +1603,40 @@ impl CheckpointCoordinator {
                         );
                         return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
                     }
-                    // No marker yet — keep waiting for the decision or
-                    // the timeout's marker re-check below.
+                    // No marker yet — keep waiting (the predicate keeps
+                    // matching the newer epoch, so pace the re-check).
+                    tokio::time::sleep(Duration::from_millis(50)).await;
                 }
-                _ => {}
-            }
-            if Instant::now() >= deadline {
-                let committed = match self.decision_store.as_ref() {
-                    Some(ds) => ds.is_committed(epoch).await.unwrap_or_else(|e| {
+                None => {
+                    // Deadline: one last durable-marker check.
+                    let committed = match self.decision_store.as_ref() {
+                        Some(ds) => ds.is_committed(epoch).await.unwrap_or_else(|e| {
+                            warn!(
+                                epoch, checkpoint_id, error = %e,
+                                "[LDB-6045] decision store read failed — defaulting to Abort",
+                            );
+                            false
+                        }),
+                        None => false,
+                    };
+                    if committed {
                         warn!(
-                            epoch, checkpoint_id, error = %e,
-                            "[LDB-6045] decision store read failed — defaulting to Abort",
+                            epoch,
+                            checkpoint_id,
+                            "[LDB-6046] follower timeout but marker present — driving commit",
                         );
-                        false
-                    }),
-                    None => false,
-                };
-                if committed {
+                        return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
+                    }
                     warn!(
                         epoch,
-                        checkpoint_id,
-                        "[LDB-6046] follower timeout but marker present — driving commit",
+                        checkpoint_id, "[LDB-6034] follower decision timeout; rolling back",
                     );
-                    return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
+                    self.rollback_sinks(epoch).await.ok();
+                    self.checkpoints_failed += 1;
+                    self.phase = CheckpointPhase::Idle;
+                    return Ok(false);
                 }
-                warn!(
-                    epoch,
-                    checkpoint_id, "[LDB-6034] follower decision timeout; rolling back",
-                );
-                self.rollback_sinks(epoch).await.ok();
-                self.checkpoints_failed += 1;
-                self.phase = CheckpointPhase::Idle;
-                return Ok(false);
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1424,10 +1424,8 @@ impl CheckpointCoordinator {
             let handle = sink.handle.clone();
             let name = sink.name.clone();
             async move {
-                // Live abandon, not a hard rollback: a healthy sink
-                // keeps its pending transactional output for the next
-                // epoch's commit — sources don't rewind on a live
-                // abort, so discarding it would lose the rows.
+                // Live abandon, not a hard rollback — a healthy sink
+                // keeps its pending output (see `SinkCommand::RollbackEpoch`).
                 // Restart-time rollback (recovery manager) stays hard.
                 let result = handle.abandon_epoch(epoch).await;
                 (name, result)
@@ -1804,11 +1802,8 @@ impl CheckpointCoordinator {
             false
         };
         // Commit and rollback both close the sinks' open transaction;
-        // open the next epoch's so subsequent writes are transactional.
-        // The leader does this inside `checkpoint_inner`/`fail_epoch`;
-        // without the follower mirror, the first commit left
-        // exactly-once sinks transaction-less and every later write
-        // failed (found by the kill -9 exactly-once soak).
+        // open the next epoch's so subsequent writes are transactional
+        // (the leader's mirror lives in `checkpoint_inner`/`fail_epoch`).
         self.begin_next_epoch_bounded().await;
         clean
     }
@@ -4083,10 +4078,8 @@ mod tests {
     }
 
     /// A pre-commit failure abandons the epoch but must NOT hard-roll
-    /// the connector back: sources do not rewind on a live abort, so
-    /// discarding a healthy sink's pending transactional output would
-    /// lose those rows forever (measured as gaps by the exactly-once
-    /// soak). The pending output rides into the next epoch's commit.
+    /// a healthy connector back (see `SinkCommand::RollbackEpoch`):
+    /// the pending output rides into the next epoch's commit.
     #[tokio::test]
     async fn pre_commit_failure_abandons_without_connector_rollback() {
         use arrow::datatypes::{DataType, Field, Schema};
@@ -4134,8 +4127,7 @@ mod tests {
         assert_eq!(
             rollback_count.load(std::sync::atomic::Ordering::Relaxed),
             0,
-            "a healthy sink must keep its pending output on a live \
-             abandon — connector rollback would lose unreplayable rows"
+            "a healthy sink must keep its pending output on a live abandon"
         );
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -678,7 +678,13 @@ impl CheckpointCoordinator {
     async fn await_restorable_gate(&self, epoch: u64) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
-        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+        // Each `epoch_complete` call LISTs the epoch prefix on the
+        // object store, so back off after the first second: fast for
+        // the common local/in-process case, cheap on S3 for a slow
+        // follower upload (≤10 + ~60 LISTs over the 30s default).
+        const FAST_POLL: Duration = Duration::from_millis(100);
+        const SLOW_POLL: Duration = Duration::from_millis(500);
+        const FAST_WINDOW: Duration = Duration::from_secs(1);
 
         let Some(ref backend) = self.state_backend else {
             return Ok(());
@@ -687,7 +693,8 @@ impl CheckpointCoordinator {
             return Ok(());
         }
 
-        let deadline = Instant::now() + self.config.restorable_gate_timeout;
+        let start = Instant::now();
+        let deadline = start + self.config.restorable_gate_timeout;
         let mut last_state = String::from("not all vnodes persisted");
         loop {
             match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
@@ -711,7 +718,12 @@ impl CheckpointCoordinator {
                     self.config.restorable_gate_timeout
                 ));
             }
-            tokio::time::sleep(POLL_INTERVAL).await;
+            let interval = if start.elapsed() < FAST_WINDOW {
+                FAST_POLL
+            } else {
+                SLOW_POLL
+            };
+            tokio::time::sleep(interval).await;
         }
     }
 
@@ -1486,16 +1498,13 @@ impl CheckpointCoordinator {
         let source_offsets = source_offset_overrides;
         let table_offsets = extra_table_offsets;
 
-        // Cluster 2PC, level 1 of two-level completion (ADR-003): collect
-        // capture acks from every live follower, then announce `Aligned` —
-        // the full-membership pipeline-resume gate. Followers ack as soon
-        // as they have aligned the shuffle and captured state locally;
-        // their durable prepare (sink pre-commit + manifest + partial
-        // uploads) runs after the ack, and its completion is verified by
-        // the restorable gate below (each node writes its vnode partials
-        // *last*, so full partial presence implies every prepare finished).
-        // Running this before the leader's own uploads keeps the
-        // cluster-wide stall at alignment + capture.
+        // Cluster 2PC, level 1 of two-level completion: collect capture
+        // acks from every live follower, then announce `Aligned` — the
+        // full-membership pipeline-resume gate. Followers' durable
+        // prepare runs after their ack; its completion is verified by
+        // the restorable gate below (each node writes its vnode
+        // partials *last*, so full presence implies every prepare
+        // finished).
         #[cfg(feature = "cluster")]
         {
             if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await {

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -866,7 +866,9 @@ impl CheckpointCoordinator {
         // off exponentially: fast for the common local/in-process case,
         // ~1 LIST/s steady-state per slow epoch on S3 (gates also
         // serialize on the coordinator mutex, so at most one loop polls
-        // at a time regardless of pipelining depth).
+        // at a time regardless of pipelining depth). Push-driven
+        // follower upload-completion acks are the protocol-level
+        // replacement for this poll (tracked in the plan).
         const INITIAL_POLL: Duration = Duration::from_millis(100);
         const MAX_POLL: Duration = Duration::from_secs(1);
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -169,15 +169,10 @@ impl EpochAllocator {
         )
     }
 
-    /// Monotonic advance — the only way the allocator moves after
-    /// construction; an epoch number can never be re-allocated. That
-    /// matters because an aborted epoch leaves artifacts behind (a
-    /// Pending manifest, uploaded partials): construction seeds from
-    /// the highest *loadable* manifest even if Pending, and recovery
-    /// (which restores from the highest *committed* one, possibly
-    /// older) must not pull ids back down onto those stale artifacts.
-    /// Also keeps a depth>1 follower tail finishing out of order from
-    /// walking past a successor's ids.
+    /// Monotonic advance — ids never walk backwards. An aborted epoch
+    /// leaves artifacts behind (Pending manifest, uploaded partials);
+    /// recovery restoring an OLDER committed epoch must not pull ids
+    /// back down onto them and re-allocate the aborted epoch.
     fn advance_to(&self, epoch: u64, next_checkpoint_id: u64) {
         use std::sync::atomic::Ordering;
         self.epoch.fetch_max(epoch, Ordering::AcqRel);
@@ -745,12 +740,11 @@ impl CheckpointCoordinator {
     /// which still seals the durability gate (presence is all the gate checks).
     ///
     /// A vnode whose slices are byte-identical to its last full upload
-    /// writes a tiny *reference* partial instead of re-uploading the
-    /// state — upload cost becomes proportional to
-    /// changed vnodes. References are forced back to full before their
-    /// base ages out of the `max_retained` prune window, and bases are
-    /// recorded only after every write lands so a partially-failed
-    /// epoch re-uploads full next time.
+    /// writes a tiny *reference* partial instead — upload cost scales
+    /// with changed vnodes. References are forced back to full before
+    /// their base leaves the `max_retained` prune window; bases record
+    /// only after every write lands, so a partially-failed epoch
+    /// re-uploads full.
     ///
     /// Fires every vnode write concurrently via `try_join_all`: the serial
     /// version was O(`vnode_count` × per-write latency) — trivial CPU but each
@@ -846,14 +840,9 @@ impl CheckpointCoordinator {
     /// the epoch's `_COMMIT` marker), or `restorable_gate_timeout`
     /// expires. No-op without a backend or with an empty gate set.
     ///
-    /// Polling (vs the old single check) is what lets followers ack at
-    /// capture and upload asynchronously: each node writes its vnode
-    /// partials *after* sink pre-commit + manifest save, so full
-    /// presence here also proves every node completed its durable
-    /// prepare. A follower whose prepare fails after acking surfaces as
-    /// a gate timeout → abort.
-    ///
-    /// Transient backend errors are retried until the deadline; a
+    /// Each node writes its partials *after* sink pre-commit + manifest
+    /// save, so full presence proves every node finished its durable
+    /// prepare. Transient backend errors retry until the deadline; a
     /// split-brain commit marker aborts immediately.
     async fn await_restorable_gate(
         &self,
@@ -1583,12 +1572,10 @@ impl CheckpointCoordinator {
     /// wait for the leader's commit/abort.
     /// `Ok(true)` = committed, `Ok(false)` = aborted/timed out.
     ///
-    /// The ack is sent *before* the durable prepare: it means "aligned + captured" — the caller has
-    /// already aligned the shuffle and captured state into `request`.
-    /// The leader announces `Aligned` on the full ack quorum (releasing
-    /// every pipeline), and verifies prepare completion through the
-    /// restorable gate (this node writes its vnode partials last, so
-    /// partial presence implies the whole prepare finished).
+    /// The ack precedes the durable prepare — it means "aligned +
+    /// captured". The leader verifies prepare completion through the
+    /// restorable gate instead (partials are written last, so their
+    /// presence implies the whole prepare finished).
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1661,10 +1648,8 @@ impl CheckpointCoordinator {
 
     /// Stage 1 of the follower tail: durable prepare (sink pre-commit +
     /// manifest + partial uploads), after the capture ack. On failure,
-    /// sends a best-effort `ok = false` ack (overwrites the capture ack
-    /// in the gossip-KV slot so a still-polling leader fails the quorum
-    /// fast; in gRPC mode the leader learns via its restorable-gate
-    /// timeout) and rolls the epoch back.
+    /// a best-effort `ok = false` ack overwrites the capture ack and
+    /// the epoch rolls back.
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1706,13 +1691,11 @@ impl CheckpointCoordinator {
     }
 
     /// Stage 2 of the follower tail: wait for the leader's decision —
-    /// push-driven off the announcement watch, and deliberately
-    /// `&self`-free so the wait does not hold the coordinator mutex.
-    /// `Aligned` is not a decision; only Commit/Abort (or epoch
-    /// advancement) end the wait. Observation is latest-wins, so a
-    /// newer epoch's announcement can supersede this epoch's Commit:
-    /// the leader only advances epochs after a successful commit, so
-    /// the durable marker is the tie-breaker. Returns the verdict.
+    /// `&self`-free so the wait never holds the coordinator mutex.
+    /// Only Commit/Abort (or epoch advancement) end the wait; a newer
+    /// epoch's announcement can supersede this epoch's Commit under
+    /// latest-wins observation, so the durable marker is the
+    /// tie-breaker. Returns the verdict.
     #[cfg(feature = "cluster")]
     pub(crate) async fn await_follower_decision(
         cc: &laminar_core::cluster::control::ClusterController,
@@ -1955,15 +1938,11 @@ impl CheckpointCoordinator {
         let source_offsets = source_offset_overrides;
         let table_offsets = extra_table_offsets;
 
-        // Cluster 2PC, level 1 of two-level completion: collect capture
-        // acks from every live follower, then announce `Aligned` — the
-        // full-membership pipeline-resume gate. Followers' durable
-        // prepare runs after their ack; its completion is verified by
-        // the restorable gate below (each node writes its vnode
-        // partials *last*, so full presence implies every prepare
-        // finished). Pipelined barrier tails run this stage *before*
-        // taking the coordinator mutex (so Aligned is never queued
-        // behind an earlier epoch's uploads) and pass `Done` here.
+        // Two-level completion, level 1: collect capture acks from
+        // every live follower, then announce `Aligned` (the pipeline
+        // resume gate); the restorable gate below verifies their
+        // durable prepares. Pipelined barrier tails run this stage
+        // pre-mutex and pass `Done` here.
         #[cfg(feature = "cluster")]
         #[allow(unused_assignments)] // both match arms assign; init keeps non-cluster shape
         let mut quorum_participants: Vec<QuorumPeer> = Vec::new();
@@ -4084,12 +4063,15 @@ mod tests {
             laminar_connectors::connector::SinkConnectorCapabilities::new(Duration::from_secs(5))
                 .with_exactly_once()
                 .with_two_phase_commit()
+                .with_preserves_pending_on_abandon()
         }
     }
 
     /// A pre-commit failure abandons the epoch but must NOT hard-roll
-    /// a healthy connector back (see `SinkCommand::RollbackEpoch`):
-    /// the pending output rides into the next epoch's commit.
+    /// back a connector that preserves pending output (see
+    /// `SinkCommand::RollbackEpoch`): the pending rows ride into the
+    /// next epoch's commit. Connectors without the capability ARE
+    /// rolled back.
     #[tokio::test]
     async fn pre_commit_failure_abandons_without_connector_rollback() {
         use arrow::datatypes::{DataType, Field, Schema};

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -297,6 +297,13 @@ pub struct CheckpointCoordinator {
     #[allow(clippy::disallowed_types)] // matches the graph snapshot shape
     pending_vnode_states:
         std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+    /// Per-vnode `(epoch, slices)` of the last *full* partial uploaded —
+    /// the bases for unchanged-vnode reference partials (ADR-003
+    /// Phase 3). Bytes are refcounted, so this holds one serialized
+    /// snapshot's worth of memory, not a deep copy per epoch.
+    #[allow(clippy::disallowed_types)]
+    last_vnode_uploads:
+        std::collections::HashMap<u32, (u64, std::collections::HashMap<String, bytes::Bytes>)>,
     /// `Some` in cluster mode, `None` in single-instance / embedded.
     #[cfg(feature = "cluster")]
     cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
@@ -363,6 +370,7 @@ impl CheckpointCoordinator {
             vnode_set: Vec::new(),
             gate_vnode_set: Vec::new(),
             pending_vnode_states: std::collections::HashMap::new(),
+            last_vnode_uploads: std::collections::HashMap::new(),
             #[cfg(feature = "cluster")]
             cluster_controller: None,
             cached_sorted_sink_names: None,
@@ -688,14 +696,25 @@ impl CheckpointCoordinator {
     /// The payload is a [`VnodePartial`](crate::vnode_partial::VnodePartial)
     /// carrying the operator-state slices staged via
     /// [`set_pending_vnode_states`](Self::set_pending_vnode_states) for that
-    /// vnode — real, rehydratable state rather than the old `ckpt:{id}`
-    /// marker. A vnode with no staged state writes an empty `VnodePartial`,
+    /// vnode. A vnode with no staged state writes an empty `VnodePartial`,
     /// which still seals the durability gate (presence is all the gate checks).
+    ///
+    /// A vnode whose slices are byte-identical to its last full upload
+    /// writes a tiny *reference* partial instead of re-uploading the
+    /// state (ADR-003 Phase 3) — upload cost becomes proportional to
+    /// changed vnodes. References are forced back to full before their
+    /// base ages out of the `max_retained` prune window, and bases are
+    /// recorded only after every write lands so a partially-failed
+    /// epoch re-uploads full next time.
     ///
     /// Fires every vnode write concurrently via `try_join_all`: the serial
     /// version was O(`vnode_count` × per-write latency) — trivial CPU but each
     /// a scheduling hop (and tens-to-hundreds of ms on a remote object store).
-    async fn write_vnode_partials(&self, epoch: u64, checkpoint_id: u64) -> Result<(), DbError> {
+    async fn write_vnode_partials(
+        &mut self,
+        epoch: u64,
+        checkpoint_id: u64,
+    ) -> Result<(), DbError> {
         let Some(ref backend) = self.state_backend else {
             return Ok(());
         };
@@ -706,27 +725,50 @@ impl CheckpointCoordinator {
         // means the host hasn't wired a version (single-instance path) and
         // the fence is a no-op.
         let caller_version = self.assignment_version;
-        let writes = self
-            .vnode_set
-            .iter()
-            .map(|&v| {
-                let backend = Arc::clone(backend);
-                let operators = self
-                    .pending_vnode_states
+        let max_ref_age = (self.config.max_retained as u64).max(1);
+
+        // Phase 1 (sync): classify each vnode as reference or full and
+        // encode its payload.
+        let mut full_uploads: Vec<(u32, std::collections::HashMap<String, bytes::Bytes>)> =
+            Vec::new();
+        let mut emptied: Vec<u32> = Vec::new();
+        let mut reference_count: u64 = 0;
+        let mut encoded: Vec<(u32, bytes::Bytes)> = Vec::with_capacity(self.vnode_set.len());
+        for &v in &self.vnode_set {
+            let ops = self.pending_vnode_states.get(&v);
+            let base = ops.filter(|ops| !ops.is_empty()).and_then(|ops| {
+                self.last_vnode_uploads
                     .get(&v)
-                    .map(|ops| ops.iter().map(|(n, b)| (n.clone(), b.to_vec())).collect())
-                    .unwrap_or_default();
-                let partial = crate::vnode_partial::VnodePartial {
+                    .filter(|(base, last)| epoch.saturating_sub(*base) < max_ref_age && last == ops)
+                    .map(|(base, _)| *base)
+            });
+            let partial = if let Some(base_epoch) = base {
+                reference_count += 1;
+                crate::vnode_partial::VnodePartial {
                     checkpoint_id,
-                    operators,
-                };
-                partial
-                    .encode()
-                    .map(|bytes| (v, backend, bytes::Bytes::from(bytes)))
-            })
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .map(|(v, backend, payload)| async move {
+                    operators: Vec::new(),
+                    base_epoch: Some(base_epoch),
+                }
+            } else {
+                match ops {
+                    Some(ops) if !ops.is_empty() => full_uploads.push((v, ops.clone())),
+                    _ => emptied.push(v),
+                }
+                crate::vnode_partial::VnodePartial {
+                    checkpoint_id,
+                    operators: ops
+                        .map(|ops| ops.iter().map(|(n, b)| (n.clone(), b.to_vec())).collect())
+                        .unwrap_or_default(),
+                    base_epoch: None,
+                }
+            };
+            encoded.push((v, bytes::Bytes::from(partial.encode()?)));
+        }
+
+        // Phase 2 (async): upload concurrently.
+        let writes = encoded.into_iter().map(|(v, payload)| {
+            let backend = Arc::clone(backend);
+            async move {
                 backend
                     .write_partial(v, epoch, caller_version, payload)
                     .await
@@ -735,8 +777,23 @@ impl CheckpointCoordinator {
                             "[LDB-6024] vnode partial write failed (vnode={v}, epoch={epoch}): {e}"
                         ))
                     })
-            });
-        futures::future::try_join_all(writes).await.map(|_| ())
+            }
+        });
+        futures::future::try_join_all(writes).await?;
+
+        // Phase 3 (sync): record the new bases / clear emptied vnodes.
+        for (v, ops) in full_uploads {
+            self.last_vnode_uploads.insert(v, (epoch, ops));
+        }
+        for v in emptied {
+            self.last_vnode_uploads.remove(&v);
+        }
+        if reference_count > 0 {
+            if let Some(ref m) = self.prom {
+                m.checkpoint_unchanged_vnodes.inc_by(reference_count);
+            }
+        }
+        Ok(())
     }
 
     /// Poll the state backend's durability gate until every vnode in
@@ -3357,6 +3414,99 @@ mod tests {
         );
         let err = result.error.expect("failure produces an error message");
         assert!(err.contains("vnode partial write failed"), "got: {err}");
+    }
+
+    /// ADR-003 Phase 3: a vnode whose slices didn't change uploads a
+    /// reference to its last full partial instead of the state bytes,
+    /// and is forced back to full before the base ages out of the
+    /// prune retention window.
+    #[tokio::test]
+    async fn unchanged_vnode_state_becomes_reference_partial() {
+        use laminar_core::state::InProcessBackend;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = CheckpointConfig {
+            max_retained: 2, // reference age cap = 2 epochs
+            ..CheckpointConfig::default()
+        };
+        let store = Box::new(FileSystemCheckpointStore::new(dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(config, store).await.unwrap();
+        let backend = Arc::new(InProcessBackend::new(2));
+        coord.set_state_backend(Arc::clone(&backend) as Arc<dyn StateBackend>);
+        coord.set_vnode_set(vec![0]);
+
+        let slices = || {
+            let mut ops = std::collections::HashMap::new();
+            ops.insert("agg".to_string(), bytes::Bytes::from_static(b"state-v1"));
+            std::collections::HashMap::from([(0u32, ops)])
+        };
+
+        // Epoch 1: full upload.
+        coord.set_pending_vnode_states(slices());
+        let r1 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r1.success);
+        let p1 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r1.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(p1.base_epoch, None, "first upload must be full");
+        assert!(!p1.operators.is_empty());
+
+        // Epoch 2: identical slices → reference to epoch 1.
+        coord.set_pending_vnode_states(slices());
+        let r2 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r2.success);
+        let p2 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r2.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            p2.base_epoch,
+            Some(r1.epoch),
+            "unchanged slice must reference its base"
+        );
+        assert!(p2.operators.is_empty());
+
+        // Epoch 3: still identical, but the base would hit the age cap —
+        // forced back to a full upload (new base).
+        coord.set_pending_vnode_states(slices());
+        let r3 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r3.success);
+        let p3 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r3.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            p3.base_epoch, None,
+            "reference age cap must force a full re-upload",
+        );
+
+        // Changed slices always upload full.
+        let mut changed = std::collections::HashMap::new();
+        let mut ops = std::collections::HashMap::new();
+        ops.insert("agg".to_string(), bytes::Bytes::from_static(b"state-v2"));
+        changed.insert(0u32, ops);
+        coord.set_pending_vnode_states(changed);
+        let r4 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r4.success);
+        let p4 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r4.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(p4.base_epoch, None);
+        assert!(!p4.operators.is_empty());
     }
 
     #[test]

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1478,6 +1478,7 @@ impl CheckpointCoordinator {
     /// Abandon a pre-allocated epoch whose pre-mutex stage (alignment
     /// or capture quorum) failed: announce `Abort`, roll back, and
     /// begin the next epoch's sink transactions.
+    #[cfg(feature = "cluster")]
     pub(crate) async fn abandon_epoch(
         &mut self,
         checkpoint_id: u64,

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -166,12 +166,22 @@ impl EpochAllocator {
         )
     }
 
-    /// Rebase after recovery, or on a follower mirroring the leader's ids.
+    /// Rebase after recovery (authoritative — may move backwards).
     fn reset(&self, epoch: u64, next_checkpoint_id: u64) {
         use std::sync::atomic::Ordering;
         self.epoch.store(epoch, Ordering::Release);
         self.next_checkpoint_id
             .store(next_checkpoint_id, Ordering::Release);
+    }
+
+    /// Monotonic advance, for followers mirroring the leader's ids: a
+    /// depth>1 tail finishing out of order must never walk the
+    /// allocator backwards past a successor's ids.
+    fn advance_to(&self, epoch: u64, next_checkpoint_id: u64) {
+        use std::sync::atomic::Ordering;
+        self.epoch.fetch_max(epoch, Ordering::AcqRel);
+        self.next_checkpoint_id
+            .fetch_max(next_checkpoint_id, Ordering::AcqRel);
     }
 }
 
@@ -827,9 +837,15 @@ impl CheckpointCoordinator {
         // object store, so back off after the first second: fast for
         // the common local/in-process case, cheap on S3 for a slow
         // follower upload (≤10 + ~60 LISTs over the 30s default).
-        const FAST_POLL: Duration = Duration::from_millis(100);
-        const SLOW_POLL: Duration = Duration::from_millis(500);
-        const FAST_WINDOW: Duration = Duration::from_secs(1);
+        // Each poll LISTs the epoch prefix on the object store, so back
+        // off exponentially: fast for the common local/in-process case,
+        // ~1 LIST/s steady-state per slow epoch on S3 (gates also
+        // serialize on the coordinator mutex, so at most one loop polls
+        // at a time regardless of pipelining depth). Replacing the poll
+        // with follower upload-completion acks is the protocol-level
+        // follow-up tracked in the plan.
+        const INITIAL_POLL: Duration = Duration::from_millis(100);
+        const MAX_POLL: Duration = Duration::from_secs(1);
 
         let Some(ref backend) = self.state_backend else {
             return Ok(());
@@ -838,8 +854,8 @@ impl CheckpointCoordinator {
             return Ok(());
         }
 
-        let start = Instant::now();
-        let deadline = start + self.config.restorable_gate_timeout;
+        let deadline = Instant::now() + self.config.restorable_gate_timeout;
+        let mut interval = INITIAL_POLL;
         let mut last_state = String::from("not all vnodes persisted");
         loop {
             match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
@@ -863,12 +879,8 @@ impl CheckpointCoordinator {
                     self.config.restorable_gate_timeout
                 ));
             }
-            let interval = if start.elapsed() < FAST_WINDOW {
-                FAST_POLL
-            } else {
-                SLOW_POLL
-            };
             tokio::time::sleep(interval).await;
+            interval = (interval * 2).min(MAX_POLL);
         }
     }
 
@@ -1082,7 +1094,6 @@ impl CheckpointCoordinator {
             phase,
             flags: 0,
             min_watermark_ms,
-            seq: 0,
         };
         if let Err(e) = cc.announce_barrier(&ann).await {
             warn!(
@@ -1152,7 +1163,6 @@ impl CheckpointCoordinator {
                 phase: Phase::Prepare,
                 flags: 0,
                 min_watermark_ms: None,
-                seq: 0,
             })
             .await
         {
@@ -1199,6 +1209,11 @@ impl CheckpointCoordinator {
                     }
                 }
                 if members_rx.changed().await.is_err() {
+                    // Membership watch closed (host shutting down): this
+                    // arm can no longer fail fast, so park it and let the
+                    // sibling `select!` arm — the deadline-bounded quorum
+                    // wait — decide the outcome. Not a leak: the select
+                    // always completes via that arm.
                     futures::future::pending::<()>().await;
                 }
             }
@@ -1523,9 +1538,11 @@ impl CheckpointCoordinator {
     }
 
     /// [`follower_checkpoint`](Self::follower_checkpoint) minus the
-    /// capture ack, for pipelined tails that ack *before* queuing on
-    /// the coordinator mutex (an earlier epoch's durable tail may hold
-    /// it for the duration of its uploads).
+    /// capture ack: prepare, await the decision, then commit/rollback.
+    /// Pipelined tails call the three stages separately so the
+    /// decision wait does not hold the coordinator mutex (the next
+    /// epoch's uploads would queue behind it for up to
+    /// `decision_timeout`).
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1536,45 +1553,98 @@ impl CheckpointCoordinator {
         ann: laminar_core::cluster::control::BarrierAnnouncement,
         decision_timeout: Duration,
     ) -> Result<bool, DbError> {
-        use laminar_core::cluster::control::{BarrierAck, Phase};
-
         let Some(cc) = self.cluster_controller.clone() else {
             return Err(DbError::Checkpoint(
                 "[LDB-6033] follower_checkpoint called without cluster controller".into(),
             ));
         };
+        let (epoch, checkpoint_id) = (ann.epoch, ann.checkpoint_id);
+        self.follower_prepare_acked(request, epoch, checkpoint_id)
+            .await?;
+        let committed = Self::await_follower_decision(
+            &cc,
+            self.decision_store.as_deref(),
+            epoch,
+            checkpoint_id,
+            decision_timeout,
+        )
+        .await;
+        Ok(self.follower_finish(epoch, checkpoint_id, committed).await)
+    }
 
-        let epoch = ann.epoch;
-        let checkpoint_id = ann.checkpoint_id;
-        // Align with the leader so a later leader-mode call resumes correctly.
-        self.allocator.reset(epoch, checkpoint_id.saturating_add(1));
+    /// Stage 1 of the follower tail: durable prepare (sink pre-commit +
+    /// manifest + partial uploads), after the capture ack. On failure,
+    /// sends a best-effort `ok = false` ack (overwrites the capture ack
+    /// in the gossip-KV slot so a still-polling leader fails the quorum
+    /// fast; in gRPC mode the leader learns via its restorable-gate
+    /// timeout) and rolls the epoch back.
+    ///
+    /// # Errors
+    /// Propagates sink pre-commit, manifest save, or marker-write failures.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn follower_prepare_acked(
+        &mut self,
+        request: CheckpointRequest,
+        epoch: u64,
+        checkpoint_id: u64,
+    ) -> Result<(), DbError> {
+        use laminar_core::cluster::control::BarrierAck;
 
-        // Durable prepare (runs after the ack, off the critical path
-        // when the caller drives this from a background task).
+        // Track the leader's ids so a later leader-mode call resumes
+        // correctly. Monotonic: a depth>1 tail finishing late must not
+        // walk the allocator backwards past a successor's ids.
+        self.allocator
+            .advance_to(epoch, checkpoint_id.saturating_add(1));
+
         if let Err(e) = self.follower_prepare(request, epoch, checkpoint_id).await {
-            // Best-effort fast failure signal: overwrites the capture
-            // ack in the gossip-KV slot so a still-polling leader fails
-            // the quorum instead of waiting; in gRPC mode the leader
-            // learns through its restorable-gate timeout.
-            cc.ack_barrier(&BarrierAck {
-                epoch,
-                ok: false,
-                error: Some(e.to_string()),
-                local_watermark_ms: self.local_watermark_ms,
-            })
-            .await
-            .ok();
+            if let Some(cc) = self.cluster_controller.clone() {
+                cc.ack_barrier(&BarrierAck {
+                    epoch,
+                    ok: false,
+                    error: Some(e.to_string()),
+                    local_watermark_ms: self.local_watermark_ms,
+                })
+                .await
+                .ok();
+            }
             self.rollback_sinks(epoch).await.ok();
             self.phase = CheckpointPhase::Idle;
             return Err(e);
         }
+        Ok(())
+    }
 
-        // Phase 2: wait for the leader's decision — push-driven off the
-        // announcement watch. `Aligned` is not a decision; only
-        // Commit/Abort (or epoch advancement) end the wait. Observation
-        // is latest-wins, so a newer epoch's announcement can supersede
-        // this epoch's Commit: the leader only advances epochs after a
-        // successful commit, so verify via the durable marker.
+    /// Stage 2 of the follower tail: wait for the leader's decision —
+    /// push-driven off the announcement watch, and deliberately
+    /// `&self`-free so the wait does not hold the coordinator mutex.
+    /// `Aligned` is not a decision; only Commit/Abort (or epoch
+    /// advancement) end the wait. Observation is latest-wins, so a
+    /// newer epoch's announcement can supersede this epoch's Commit:
+    /// the leader only advances epochs after a successful commit, so
+    /// the durable marker is the tie-breaker. Returns the verdict.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn await_follower_decision(
+        cc: &laminar_core::cluster::control::ClusterController,
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
+        epoch: u64,
+        checkpoint_id: u64,
+        decision_timeout: Duration,
+    ) -> bool {
+        use laminar_core::cluster::control::Phase;
+
+        let is_marked = || async {
+            match decision_store {
+                Some(ds) => ds.is_committed(epoch).await.unwrap_or_else(|e| {
+                    warn!(
+                        epoch, checkpoint_id, error = %e,
+                        "[LDB-6045] decision store read failed — defaulting to Abort",
+                    );
+                    false
+                }),
+                None => false,
+            }
+        };
+
         let deadline = Instant::now() + decision_timeout;
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -1588,30 +1658,17 @@ impl CheckpointCoordinator {
                 )
                 .await;
             match decision {
-                Some(a) if a.epoch == epoch && a.phase == Phase::Commit => {
-                    return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
-                }
-                Some(a) if a.epoch == epoch => {
-                    // Abort.
-                    self.rollback_sinks(epoch).await.ok();
-                    self.checkpoints_failed += 1;
-                    self.phase = CheckpointPhase::Idle;
-                    return Ok(false);
-                }
+                Some(a) if a.epoch == epoch => return a.phase == Phase::Commit,
                 Some(a) => {
                     // Newer epoch supersedes the decision announcement.
-                    let committed = match self.decision_store.as_ref() {
-                        Some(ds) => ds.is_committed(epoch).await.unwrap_or(false),
-                        None => false,
-                    };
-                    if committed {
+                    if is_marked().await {
                         info!(
                             epoch,
                             checkpoint_id,
                             observed_epoch = a.epoch,
-                            "newer epoch observed with commit marker present — driving commit",
+                            "newer epoch observed with commit marker present — committing",
                         );
-                        return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
+                        return true;
                     }
                     // No marker yet — keep waiting. Each pass through
                     // this (rare) state costs an object-store HEAD, so
@@ -1620,35 +1677,50 @@ impl CheckpointCoordinator {
                 }
                 None => {
                     // Deadline: one last durable-marker check.
-                    let committed = match self.decision_store.as_ref() {
-                        Some(ds) => ds.is_committed(epoch).await.unwrap_or_else(|e| {
-                            warn!(
-                                epoch, checkpoint_id, error = %e,
-                                "[LDB-6045] decision store read failed — defaulting to Abort",
-                            );
-                            false
-                        }),
-                        None => false,
-                    };
-                    if committed {
+                    if is_marked().await {
                         warn!(
                             epoch,
                             checkpoint_id,
-                            "[LDB-6046] follower timeout but marker present — driving commit",
+                            "[LDB-6046] follower timeout but marker present — committing",
                         );
-                        return Ok(self.drive_follower_commit(epoch, checkpoint_id).await);
+                        return true;
                     }
                     warn!(
                         epoch,
                         checkpoint_id, "[LDB-6034] follower decision timeout; rolling back",
                     );
-                    self.rollback_sinks(epoch).await.ok();
-                    self.checkpoints_failed += 1;
-                    self.phase = CheckpointPhase::Idle;
-                    return Ok(false);
+                    return false;
                 }
             }
         }
+    }
+
+    /// Stage 3 of the follower tail: act on the decision. Returns
+    /// `true` on a clean commit.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn follower_finish(
+        &mut self,
+        epoch: u64,
+        checkpoint_id: u64,
+        committed: bool,
+    ) -> bool {
+        if committed {
+            self.drive_follower_commit(epoch, checkpoint_id).await
+        } else {
+            self.rollback_sinks(epoch).await.ok();
+            self.checkpoints_failed += 1;
+            self.phase = CheckpointPhase::Idle;
+            false
+        }
+    }
+
+    /// Durable commit-marker store handle, for the lock-free decision
+    /// wait in pipelined follower tails.
+    #[cfg(feature = "cluster")]
+    pub(crate) fn decision_store_handle(
+        &self,
+    ) -> Option<Arc<laminar_core::checkpoint_decision::CheckpointDecisionStore>> {
+        self.decision_store.clone()
     }
 
     /// Commit this follower's sinks for `epoch` and update its
@@ -1685,7 +1757,7 @@ impl CheckpointCoordinator {
         }
         self.checkpoints_completed += 1;
         let (_, next_id) = self.allocator.peek();
-        self.allocator.reset(epoch.saturating_add(1), next_id);
+        self.allocator.advance_to(epoch.saturating_add(1), next_id);
         self.phase = CheckpointPhase::Idle;
         true
     }
@@ -2962,7 +3034,6 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .unwrap();
         let commit_json = serde_json::to_string(&BarrierAnnouncement {
@@ -2971,7 +3042,6 @@ mod tests {
             phase: Phase::Commit,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .unwrap();
         // Overwrite the prepare with commit — observe_barrier reads the
@@ -2986,7 +3056,6 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let committed = coord
             .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(2))
@@ -3040,7 +3109,6 @@ mod tests {
             phase: Phase::Abort,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .unwrap();
         kv.seed(leader_id, ANNOUNCEMENT_KEY, abort_json);
@@ -3051,7 +3119,6 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let committed = coord
             .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(2))
@@ -3187,7 +3254,6 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let result = coord
             .follower_checkpoint(CheckpointRequest::default(), ann, Duration::from_secs(1))

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -65,12 +65,12 @@ pub struct CheckpointConfig {
     pub quorum_timeout: Duration,
     /// Max wait for every participating vnode's partial to land before
     /// the epoch is declared restorable. Followers ack at *capture* and
-    /// upload asynchronously (ADR-003 two-level completion), so the
+    /// upload asynchronously after acking, so the
     /// leader's durability gate polls for partial presence instead of
     /// checking once. Expiry aborts the epoch.
     pub restorable_gate_timeout: Duration,
     /// Maximum epochs admitted between `Aligned` and restorable — the
-    /// upload backlog (ADR-003 Phase 2). Exactly-once pipelines are
+    /// upload backlog. Exactly-once pipelines are
     /// capped at 1: a single-open-transaction sink (e.g. a Kafka
     /// transactional producer) cannot overlap epochs.
     pub max_in_flight_epochs: u64,
@@ -122,7 +122,7 @@ pub struct CheckpointRequest {
     pub source_offset_overrides: HashMap<String, ConnectorCheckpoint>,
 }
 
-/// Lock-free epoch/checkpoint-id allocator (ADR-003 Phase 2).
+/// Lock-free epoch/checkpoint-id allocator.
 ///
 /// Ids are handed out at barrier admission — possibly while an earlier
 /// epoch's durable tail still holds the coordinator mutex — so they
@@ -314,8 +314,8 @@ pub struct CheckpointCoordinator {
     pending_vnode_states:
         std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
     /// Per-vnode `(epoch, slices)` of the last *full* partial uploaded —
-    /// the bases for unchanged-vnode reference partials (ADR-003
-    /// Phase 3). Bytes are refcounted, so this holds one serialized
+    /// the bases for unchanged-vnode reference partials. Bytes are
+    /// refcounted, so this holds one serialized
     /// snapshot's worth of memory, not a deep copy per epoch.
     #[allow(clippy::disallowed_types)]
     last_vnode_uploads:
@@ -721,7 +721,7 @@ impl CheckpointCoordinator {
     ///
     /// A vnode whose slices are byte-identical to its last full upload
     /// writes a tiny *reference* partial instead of re-uploading the
-    /// state (ADR-003 Phase 3) — upload cost becomes proportional to
+    /// state — upload cost becomes proportional to
     /// changed vnodes. References are forced back to full before their
     /// base ages out of the `max_retained` prune window, and bases are
     /// recorded only after every write lands so a partially-failed
@@ -747,7 +747,7 @@ impl CheckpointCoordinator {
         let caller_version = self.assignment_version;
         let max_ref_age = (self.config.max_retained as u64).max(1);
 
-        // Phase 1 (sync): classify each vnode as reference or full and
+        // Step 1 (sync): classify each vnode as reference or full and
         // encode its payload.
         let mut full_uploads: Vec<(u32, std::collections::HashMap<String, bytes::Bytes>)> =
             Vec::new();
@@ -785,7 +785,7 @@ impl CheckpointCoordinator {
             encoded.push((v, bytes::Bytes::from(partial.encode()?)));
         }
 
-        // Phase 2 (async): upload concurrently.
+        // Step 2 (async): upload concurrently.
         let writes = encoded.into_iter().map(|(v, payload)| {
             let backend = Arc::clone(backend);
             async move {
@@ -801,7 +801,7 @@ impl CheckpointCoordinator {
         });
         futures::future::try_join_all(writes).await?;
 
-        // Phase 3 (sync): record the new bases / clear emptied vnodes.
+        // Step 3 (sync): record the new bases / clear emptied vnodes.
         for (v, ops) in full_uploads {
             self.last_vnode_uploads.insert(v, (epoch, ops));
         }
@@ -1495,8 +1495,7 @@ impl CheckpointCoordinator {
     /// wait for the leader's commit/abort.
     /// `Ok(true)` = committed, `Ok(false)` = aborted/timed out.
     ///
-    /// The ack is sent *before* the durable prepare (ADR-003 two-level
-    /// completion): it means "aligned + captured" — the caller has
+    /// The ack is sent *before* the durable prepare: it means "aligned + captured" — the caller has
     /// already aligned the shuffle and captured state into `request`.
     /// The leader announces `Aligned` on the full ack quorum (releasing
     /// every pipeline), and verifies prepare completion through the
@@ -1845,12 +1844,10 @@ impl CheckpointCoordinator {
         let start = Instant::now();
         // Ids are allocated up front (Flink-style): a failed attempt is
         // abandoned — never retried under the same ids — so a future
-        // epoch's identity never depends on this one's outcome. That
-        // independence is what allows epochs to overlap (ADR-003
-        // Phase 2); it also removes the same-epoch-retry ambiguity the
-        // announcement `seq` otherwise has to disambiguate. Pipelined
-        // barrier paths allocate at admission and pass the ids in;
-        // forced/timer paths allocate here.
+        // epoch's identity never depends on this one's outcome, which
+        // is what allows epochs to overlap. Pipelined barrier paths
+        // allocate at admission and pass the ids in; forced/timer
+        // paths allocate here.
         let (epoch, checkpoint_id) = ids.unwrap_or_else(|| self.allocator.allocate());
 
         info!(checkpoint_id, epoch, "starting checkpoint");
@@ -3162,7 +3159,7 @@ mod tests {
         }
     }
 
-    /// ADR-003 two-level completion: the leader must announce `Aligned`
+    /// Two-level completion: the leader must announce `Aligned`
     /// (the pipeline resume gate) after the capture quorum and *before*
     /// the durable tail's `Commit`.
     #[cfg(feature = "cluster")]
@@ -3209,7 +3206,7 @@ mod tests {
         );
     }
 
-    /// ADR-003: the follower acks at capture (before its durable
+    /// The follower acks at capture (before its durable
     /// prepare). If the prepare then fails, a best-effort `ok = false`
     /// ack overwrites the capture ack so a still-polling leader can
     /// fail the quorum fast instead of waiting for its gate timeout.
@@ -3407,7 +3404,7 @@ mod tests {
         );
     }
 
-    /// ADR-003: followers ack at capture and upload partials
+    /// Followers ack at capture and upload partials
     /// asynchronously, so the leader's restorable gate must *wait* for
     /// late partials rather than failing on the first check.
     #[tokio::test]
@@ -3505,7 +3502,7 @@ mod tests {
         assert!(err.contains("vnode partial write failed"), "got: {err}");
     }
 
-    /// ADR-003 Phase 3: a vnode whose slices didn't change uploads a
+    /// A vnode whose slices didn't change uploads a
     /// reference to its last full partial instead of the state bytes,
     /// and is forced back to full before the base ages out of the
     /// prune retention window.
@@ -3664,7 +3661,7 @@ mod tests {
         }
     }
 
-    /// Fault injection at pipeline depth > 1 (ADR-003 Phase 2). Four
+    /// Fault injection at pipeline depth > 1. Four
     /// epochs are admitted (ids allocated, tails spawned) while the
     /// first is still uploading; the third epoch's upload partially
     /// fails — one vnode's write lands, the other's is injected to

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -186,14 +186,21 @@ impl EpochAllocator {
 /// Whether `checkpoint_inner` still needs to run the cluster capture
 /// quorum, or a pipelined tail already ran it before taking the
 /// coordinator mutex.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) enum QuorumStage {
     /// Run the quorum + `Aligned` announce inline (forced/timer paths).
     RunInline,
     /// Already reached before the coordinator lock; carries the merged
-    /// cluster-min watermark for the `Commit` announcement.
+    /// cluster-min watermark for the `Commit` announcement plus the
+    /// capture-time follower set, so the durability gate can fail fast
+    /// if one of them dies instead of burning its full timeout.
     #[cfg_attr(not(feature = "cluster"), allow(dead_code))]
-    Done(Option<i64>),
+    Done {
+        /// Merged cluster-min watermark from the capture acks.
+        min_watermark_ms: Option<i64>,
+        /// Followers that acked the capture quorum.
+        participants: Vec<laminar_core::cluster::discovery::NodeId>,
+    },
 }
 
 /// Phase of the checkpoint lifecycle.
@@ -828,7 +835,11 @@ impl CheckpointCoordinator {
     ///
     /// Transient backend errors are retried until the deadline; a
     /// split-brain commit marker aborts immediately.
-    async fn await_restorable_gate(&self, epoch: u64) -> Result<(), String> {
+    async fn await_restorable_gate(
+        &self,
+        epoch: u64,
+        participants: &[laminar_core::cluster::discovery::NodeId],
+    ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
         // Each `epoch_complete` call LISTs the epoch prefix on the
@@ -871,6 +882,29 @@ impl CheckpointCoordinator {
                     last_state = e.to_string();
                 }
             }
+            // Fail fast when a capture participant dies: its uploads
+            // will never arrive, so waiting out the timeout only
+            // stalls the pipeline — and with pipelining, queued doomed
+            // epochs would each burn the full timeout serially.
+            #[cfg(feature = "cluster")]
+            if let Some(cc) = self.cluster_controller.as_ref() {
+                if let Some(reason) =
+                    Self::unhealthy_participant(&cc.members_watch().borrow(), participants)
+                {
+                    return Err(format!("durability gate fail-fast: {reason}"));
+                }
+                if let Some(p) = participants
+                    .iter()
+                    .find(|p| cc.is_recently_unresponsive(**p))
+                {
+                    return Err(format!(
+                        "durability gate fail-fast: follower {} missed a capture quorum",
+                        p.0
+                    ));
+                }
+            }
+            #[cfg(not(feature = "cluster"))]
+            let _ = participants;
             if Instant::now() >= deadline {
                 return Err(format!(
                     "state durability gate timed out after {:?}: {last_state}",
@@ -1104,17 +1138,24 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Announce PREPARE and block for follower acks. Returns `None` on
-    /// quorum or no-op (not leader); `Some(msg)` with the failure
-    /// (after announcing `Abort`). When quorum is reached, writes the
+    /// Announce PREPARE and block for follower acks. On quorum (or
+    /// no-op — not leader / no controller) returns the capture-time
+    /// follower set for the durability gate fail-fast and writes the
     /// cluster-wide minimum watermark into `self.cluster_min_watermark`
-    /// so the subsequent `Commit` announcement can fan it out.
+    /// so the subsequent `Commit` announcement can fan it out. On
+    /// failure, announces `Abort` and returns the failure message.
     #[cfg(feature = "cluster")]
-    async fn await_prepare_quorum(&mut self, epoch: u64, checkpoint_id: u64) -> Option<String> {
+    async fn await_prepare_quorum(
+        &mut self,
+        epoch: u64,
+        checkpoint_id: u64,
+    ) -> Result<Vec<laminar_core::cluster::discovery::NodeId>, String> {
         use laminar_core::cluster::control::Phase;
-        let cc = Arc::clone(self.cluster_controller.as_ref()?);
+        let Some(cc) = self.cluster_controller.clone() else {
+            return Ok(Vec::new());
+        };
         if !cc.is_leader() {
-            return None;
+            return Ok(Vec::new());
         }
         match Self::run_prepare_quorum(
             &cc,
@@ -1125,16 +1166,48 @@ impl CheckpointCoordinator {
         )
         .await
         {
-            Ok(merged) => {
+            Ok((merged, participants)) => {
                 self.cluster_min_watermark = merged;
-                None
+                Ok(participants)
             }
             Err(msg) => {
                 self.announce_if_leader(epoch, checkpoint_id, Phase::Abort, None)
                     .await;
-                Some(msg)
+                Err(msg)
             }
         }
+    }
+
+    /// Shared health predicate for the capture quorum and the
+    /// durability gate: a participant that is suspected, draining,
+    /// left, or vanished can no longer contribute to this epoch, so
+    /// waiting out the full timeout only stalls the pipeline.
+    #[cfg(feature = "cluster")]
+    fn unhealthy_participant(
+        members: &[laminar_core::cluster::discovery::NodeInfo],
+        participants: &[laminar_core::cluster::discovery::NodeId],
+    ) -> Option<String> {
+        use laminar_core::cluster::discovery::NodeState;
+        for &id in participants {
+            match members.iter().find(|m| m.id.0 == id.0) {
+                Some(node)
+                    if matches!(
+                        node.state,
+                        NodeState::Suspected | NodeState::Left | NodeState::Draining
+                    ) =>
+                {
+                    return Some(format!(
+                        "Follower {} transitioned to unhealthy state {:?}",
+                        id.0, node.state
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    return Some(format!("Follower {} missing from cluster membership", id.0));
+                }
+            }
+        }
+        None
     }
 
     /// The capture-quorum stage, callable without the coordinator mutex
@@ -1151,7 +1224,7 @@ impl CheckpointCoordinator {
         epoch: u64,
         checkpoint_id: u64,
         local_watermark_ms: Option<i64>,
-    ) -> Result<Option<i64>, String> {
+    ) -> Result<(Option<i64>, Vec<laminar_core::cluster::discovery::NodeId>), String> {
         use laminar_core::cluster::control::{BarrierAnnouncement, Phase, QuorumOutcome};
 
         if let Err(e) = cc
@@ -1175,36 +1248,17 @@ impl CheckpointCoordinator {
             if let Some(wm) = local_watermark_ms {
                 cc.publish_cluster_min_watermark(wm);
             }
-            return Ok(local_watermark_ms);
+            return Ok((local_watermark_ms, Vec::new()));
         }
 
         let mut members_rx = cc.members_watch();
 
         let quorum_fut = cc.wait_for_quorum(epoch, &followers, quorum_timeout);
         let membership_fut = async {
-            use laminar_core::cluster::discovery::NodeState;
             loop {
+                if let Some(reason) = Self::unhealthy_participant(&members_rx.borrow(), &followers)
                 {
-                    let members = members_rx.borrow();
-                    for &follower_id in &followers {
-                        let follower_node = members.iter().find(|m| m.id.0 == follower_id.0);
-                        if let Some(node) = follower_node {
-                            if matches!(
-                                node.state,
-                                NodeState::Suspected | NodeState::Left | NodeState::Draining
-                            ) {
-                                return format!(
-                                    "Follower {} transitioned to unhealthy state {:?}",
-                                    follower_id.0, node.state
-                                );
-                            }
-                        } else {
-                            return format!(
-                                "Follower {} missing from cluster membership",
-                                follower_id.0
-                            );
-                        }
-                    }
+                    return reason;
                 }
                 if members_rx.changed().await.is_err() {
                     // Membership watch closed (host shutting down): this
@@ -1225,8 +1279,10 @@ impl CheckpointCoordinator {
         match outcome {
             Ok(QuorumOutcome::Reached {
                 min_follower_watermark_ms,
-                ..
+                ref acks,
             }) => {
+                // Demonstrably alive — clear any quorum-miss suspicion.
+                cc.note_responsive(acks);
                 // Fold follower min with the leader's own watermark.
                 let merged = match (local_watermark_ms, min_follower_watermark_ms) {
                     (Some(a), Some(b)) => Some(a.min(b)),
@@ -1237,12 +1293,19 @@ impl CheckpointCoordinator {
                 if let Some(wm) = merged {
                     cc.publish_cluster_min_watermark(wm);
                 }
-                Ok(merged)
+                Ok((merged, followers))
             }
-            Ok(QuorumOutcome::TimedOut { missing, .. }) => Err(format!(
-                "quorum timeout: {} follower(s) did not ack",
-                missing.len()
-            )),
+            Ok(QuorumOutcome::TimedOut { missing, .. }) => {
+                // Gossip failure detection can lag a hard kill by tens
+                // of seconds; record the leader''s own faster signal so
+                // the durability gates of already-captured epochs fail
+                // fast instead of each burning their full timeout.
+                cc.note_unresponsive(&missing);
+                Err(format!(
+                    "quorum timeout: {} follower(s) did not ack",
+                    missing.len()
+                ))
+            }
             Ok(QuorumOutcome::Failed { failures }) => {
                 let first = failures.first().map_or("unknown", |(_, msg)| msg.as_str());
                 Err(format!(
@@ -1867,14 +1930,19 @@ impl CheckpointCoordinator {
         // taking the coordinator mutex (so Aligned is never queued
         // behind an earlier epoch's uploads) and pass `Done` here.
         #[cfg(feature = "cluster")]
+        #[allow(unused_assignments)] // both match arms assign; init keeps non-cluster shape
+        let mut quorum_participants: Vec<laminar_core::cluster::discovery::NodeId> = Vec::new();
+        #[cfg(feature = "cluster")]
         match quorum {
             QuorumStage::RunInline => {
-                if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await
-                {
-                    error!(checkpoint_id, epoch, error = %quorum_failure, "[LDB-6032] quorum miss");
-                    return Ok(self
-                        .fail_epoch(checkpoint_id, epoch, start, quorum_failure)
-                        .await);
+                match self.await_prepare_quorum(epoch, checkpoint_id).await {
+                    Ok(p) => quorum_participants = p,
+                    Err(quorum_failure) => {
+                        error!(checkpoint_id, epoch, error = %quorum_failure, "[LDB-6032] quorum miss");
+                        return Ok(self
+                            .fail_epoch(checkpoint_id, epoch, start, quorum_failure)
+                            .await);
+                    }
                 }
                 self.announce_if_leader(
                     epoch,
@@ -1884,8 +1952,12 @@ impl CheckpointCoordinator {
                 )
                 .await;
             }
-            QuorumStage::Done(min_watermark_ms) => {
+            QuorumStage::Done {
+                min_watermark_ms,
+                participants,
+            } => {
                 self.cluster_min_watermark = min_watermark_ms;
+                quorum_participants = participants;
             }
         }
         #[cfg(not(feature = "cluster"))]
@@ -2003,7 +2075,12 @@ impl CheckpointCoordinator {
         // defaults to `vnode_set` (the two match). Followers upload
         // asynchronously after their capture ack, so this polls until
         // `restorable_gate_timeout` rather than checking once.
-        if let Err(gate_err) = self.await_restorable_gate(epoch).await {
+        #[cfg(not(feature = "cluster"))]
+        let quorum_participants: Vec<laminar_core::cluster::discovery::NodeId> = Vec::new();
+        if let Err(gate_err) = self
+            .await_restorable_gate(epoch, &quorum_participants)
+            .await
+        {
             warn!(
                 checkpoint_id,
                 epoch,
@@ -3440,7 +3517,7 @@ mod tests {
 
         let start = std::time::Instant::now();
         coord
-            .await_restorable_gate(1)
+            .await_restorable_gate(1, &[])
             .await
             .expect("gate must seal once the late partials land");
         assert!(

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -69,6 +69,15 @@ pub struct CheckpointConfig {
     /// leader's durability gate polls for partial presence instead of
     /// checking once. Expiry aborts the epoch.
     pub restorable_gate_timeout: Duration,
+    /// Maximum epochs admitted between `Aligned` and restorable — the
+    /// upload backlog (ADR-003 Phase 2). Exactly-once pipelines are
+    /// capped at 1: a single-open-transaction sink (e.g. a Kafka
+    /// transactional producer) cannot overlap epochs.
+    pub max_in_flight_epochs: u64,
+    /// Cap on captured-state bytes held in memory by in-flight epochs
+    /// awaiting upload. At the cap, barrier admission pauses — cadence
+    /// degrades to upload speed instead of exhausting memory.
+    pub max_staged_bytes: u64,
 }
 
 impl Default for CheckpointConfig {
@@ -86,6 +95,8 @@ impl Default for CheckpointConfig {
             max_checkpoint_bytes: None,
             quorum_timeout: Duration::from_secs(3),
             restorable_gate_timeout: Duration::from_secs(30),
+            max_in_flight_epochs: 4,
+            max_staged_bytes: 512 * 1024 * 1024,
         }
     }
 }
@@ -109,6 +120,66 @@ pub struct CheckpointRequest {
     pub pipeline_hash: Option<u64>,
     /// Source offset overrides for recovery.
     pub source_offset_overrides: HashMap<String, ConnectorCheckpoint>,
+}
+
+/// Lock-free epoch/checkpoint-id allocator (ADR-003 Phase 2).
+///
+/// Ids are handed out at barrier admission — possibly while an earlier
+/// epoch's durable tail still holds the coordinator mutex — so they
+/// live outside the coordinator's exclusive state. Failed epochs are
+/// abandoned, never re-allocated.
+#[derive(Debug)]
+pub(crate) struct EpochAllocator {
+    epoch: std::sync::atomic::AtomicU64,
+    next_checkpoint_id: std::sync::atomic::AtomicU64,
+}
+
+impl EpochAllocator {
+    fn new(epoch: u64, next_checkpoint_id: u64) -> Self {
+        Self {
+            epoch: std::sync::atomic::AtomicU64::new(epoch),
+            next_checkpoint_id: std::sync::atomic::AtomicU64::new(next_checkpoint_id),
+        }
+    }
+
+    /// Claim the next `(epoch, checkpoint_id)` pair.
+    pub(crate) fn allocate(&self) -> (u64, u64) {
+        use std::sync::atomic::Ordering;
+        (
+            self.epoch.fetch_add(1, Ordering::AcqRel),
+            self.next_checkpoint_id.fetch_add(1, Ordering::AcqRel),
+        )
+    }
+
+    /// The pair the next [`allocate`](Self::allocate) would return.
+    pub(crate) fn peek(&self) -> (u64, u64) {
+        use std::sync::atomic::Ordering;
+        (
+            self.epoch.load(Ordering::Acquire),
+            self.next_checkpoint_id.load(Ordering::Acquire),
+        )
+    }
+
+    /// Rebase after recovery, or on a follower mirroring the leader's ids.
+    fn reset(&self, epoch: u64, next_checkpoint_id: u64) {
+        use std::sync::atomic::Ordering;
+        self.epoch.store(epoch, Ordering::Release);
+        self.next_checkpoint_id
+            .store(next_checkpoint_id, Ordering::Release);
+    }
+}
+
+/// Whether `checkpoint_inner` still needs to run the cluster capture
+/// quorum, or a pipelined tail already ran it before taking the
+/// coordinator mutex.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum QuorumStage {
+    /// Run the quorum + `Aligned` announce inline (forced/timer paths).
+    RunInline,
+    /// Already reached before the coordinator lock; carries the merged
+    /// cluster-min watermark for the `Commit` announcement.
+    #[cfg_attr(not(feature = "cluster"), allow(dead_code))]
+    Done(Option<i64>),
 }
 
 /// Phase of the checkpoint lifecycle.
@@ -185,8 +256,9 @@ pub struct CheckpointCoordinator {
     config: CheckpointConfig,
     store: Arc<dyn CheckpointStore>,
     sinks: Vec<RegisteredSink>,
-    next_checkpoint_id: u64,
-    epoch: u64,
+    /// Shared with the pipeline callback, which allocates ids at
+    /// barrier admission without taking the coordinator mutex.
+    allocator: Arc<EpochAllocator>,
     phase: CheckpointPhase,
     checkpoints_completed: u64,
     checkpoints_failed: u64,
@@ -274,8 +346,7 @@ impl CheckpointCoordinator {
             config,
             store,
             sinks: Vec::new(),
-            next_checkpoint_id: next_id,
-            epoch,
+            allocator: Arc::new(EpochAllocator::new(epoch, next_id)),
             phase: CheckpointPhase::Idle,
             checkpoints_completed: 0,
             checkpoints_failed: 0,
@@ -397,7 +468,13 @@ impl CheckpointCoordinator {
     ///
     /// Returns the first error from any sink that fails to begin the epoch.
     pub async fn begin_initial_epoch(&self) -> Result<(), DbError> {
-        self.begin_epoch_for_sinks(self.epoch).await
+        self.begin_epoch_for_sinks(self.allocator.peek().0).await
+    }
+
+    /// Shared id allocator, cloned by the pipeline callback so barrier
+    /// admission can claim ids without the coordinator mutex.
+    pub(crate) fn epoch_allocator(&self) -> Arc<EpochAllocator> {
+        Arc::clone(&self.allocator)
     }
 
     /// Begins an epoch on all exactly-once sinks. If any sink fails,
@@ -461,7 +538,8 @@ impl CheckpointCoordinator {
         &mut self,
         request: CheckpointRequest,
     ) -> Result<CheckpointResult, DbError> {
-        self.checkpoint_inner(request).await
+        self.checkpoint_inner(request, None, QuorumStage::RunInline)
+            .await
     }
 
     /// Pre-commits all exactly-once sinks (phase 1) with a timeout.
@@ -776,7 +854,7 @@ impl CheckpointCoordinator {
     /// and an unbounded `begin_epoch` await would hang the coordinator
     /// on it.
     async fn begin_next_epoch_bounded(&self) {
-        let next_epoch = self.epoch;
+        let next_epoch = self.allocator.peek().0;
         match tokio::time::timeout(
             self.config.rollback_timeout,
             self.begin_epoch_for_sinks(next_epoch),
@@ -950,75 +1028,81 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Leader-only: announce `Prepare` *early* — before operator capture — so
-    /// peers can start cross-node shuffle barrier alignment. Returns the
-    /// checkpoint id every node aligns on (the same one `checkpoint_inner` will
-    /// use, since `next_checkpoint_id` is stable until commit), or `None` if not
-    /// the leader. `await_prepare_quorum` later re-announces the identical
-    /// `Prepare` idempotently, and followers dedup by epoch.
-    #[cfg(feature = "cluster")]
-    pub async fn announce_prepare(&self) -> Option<u64> {
-        use laminar_core::cluster::control::Phase;
-        let cc = self.cluster_controller.as_ref()?;
-        if !cc.is_leader() {
-            return None;
-        }
-        let checkpoint_id = self.next_checkpoint_id;
-        self.announce_if_leader(self.epoch, checkpoint_id, Phase::Prepare, None)
-            .await;
-        Some(checkpoint_id)
-    }
-
-    /// Leader-only: announce `Abort` for an early-announced checkpoint whose
-    /// shuffle alignment failed, so followers already prepared on the `Prepare`
-    /// don't block until their decision timeout.
-    #[cfg(feature = "cluster")]
-    pub async fn announce_abort(&self, checkpoint_id: u64) {
-        use laminar_core::cluster::control::Phase;
-        self.announce_if_leader(self.epoch, checkpoint_id, Phase::Abort, None)
-            .await;
-    }
-
-    /// Live cluster node ids (the controller's view), for the caller to derive
-    /// the shuffle barrier-alignment peer set. Empty without a controller.
-    #[cfg(feature = "cluster")]
-    #[must_use]
-    pub fn live_node_ids(&self) -> Vec<u64> {
-        self.cluster_controller
-            .as_ref()
-            .map(|cc| cc.live_instances().iter().map(|n| n.0).collect())
-            .unwrap_or_default()
-    }
-
     /// Announce PREPARE and block for follower acks. Returns `None` on
-    /// quorum or no-op (not leader); `Some(msg)` with the failure.
-    /// When quorum is reached, the `Ok` path writes the cluster-wide
-    /// minimum watermark (leader's local + min of follower acks) into
-    /// `self.cluster_min_watermark` so the subsequent `Commit`
-    /// announcement can fan it out.
+    /// quorum or no-op (not leader); `Some(msg)` with the failure
+    /// (after announcing `Abort`). When quorum is reached, writes the
+    /// cluster-wide minimum watermark into `self.cluster_min_watermark`
+    /// so the subsequent `Commit` announcement can fan it out.
     #[cfg(feature = "cluster")]
     async fn await_prepare_quorum(&mut self, epoch: u64, checkpoint_id: u64) -> Option<String> {
-        use laminar_core::cluster::control::{Phase, QuorumOutcome};
-        let cc = self.cluster_controller.as_ref()?;
+        use laminar_core::cluster::control::Phase;
+        let cc = Arc::clone(self.cluster_controller.as_ref()?);
         if !cc.is_leader() {
             return None;
         }
-        self.announce_if_leader(epoch, checkpoint_id, Phase::Prepare, None)
-            .await;
+        match Self::run_prepare_quorum(
+            &cc,
+            self.config.quorum_timeout,
+            epoch,
+            checkpoint_id,
+            self.local_watermark_ms,
+        )
+        .await
+        {
+            Ok(merged) => {
+                self.cluster_min_watermark = merged;
+                None
+            }
+            Err(msg) => {
+                self.announce_if_leader(epoch, checkpoint_id, Phase::Abort, None)
+                    .await;
+                Some(msg)
+            }
+        }
+    }
+
+    /// The capture-quorum stage, callable without the coordinator mutex
+    /// so pipelined barrier tails can reach `Aligned` while an earlier
+    /// epoch's durable tail still holds it. Announces `Prepare`, waits
+    /// for every live follower's capture ack (failing fast on unhealthy
+    /// membership), and returns the merged cluster-min watermark. The
+    /// caller announces `Aligned` on success / `Abort` on failure and
+    /// publishes the watermark via the announcement.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn run_prepare_quorum(
+        cc: &laminar_core::cluster::control::ClusterController,
+        quorum_timeout: Duration,
+        epoch: u64,
+        checkpoint_id: u64,
+        local_watermark_ms: Option<i64>,
+    ) -> Result<Option<i64>, String> {
+        use laminar_core::cluster::control::{BarrierAnnouncement, Phase, QuorumOutcome};
+
+        if let Err(e) = cc
+            .announce_barrier(&BarrierAnnouncement {
+                epoch,
+                checkpoint_id,
+                phase: Phase::Prepare,
+                flags: 0,
+                min_watermark_ms: None,
+                seq: 0,
+            })
+            .await
+        {
+            warn!(epoch, checkpoint_id, error = %e, "[LDB-6031] prepare announcement failed");
+        }
 
         let mut followers = cc.live_instances();
         followers.retain(|id| *id != cc.instance_id());
         if followers.is_empty() {
             // Leader-only cluster — cluster-wide min is just the
             // leader's local watermark (if any).
-            self.cluster_min_watermark = self.local_watermark_ms;
-            if let Some(wm) = self.local_watermark_ms {
+            if let Some(wm) = local_watermark_ms {
                 cc.publish_cluster_min_watermark(wm);
             }
-            return None;
+            return Ok(local_watermark_ms);
         }
 
-        let quorum_timeout = self.config.quorum_timeout;
         let mut members_rx = cc.members_watch();
 
         let quorum_fut = cc.wait_for_quorum(epoch, &followers, quorum_timeout);
@@ -1064,40 +1148,29 @@ impl CheckpointCoordinator {
                 ..
             }) => {
                 // Fold follower min with the leader's own watermark.
-                let merged = match (self.local_watermark_ms, min_follower_watermark_ms) {
+                let merged = match (local_watermark_ms, min_follower_watermark_ms) {
                     (Some(a), Some(b)) => Some(a.min(b)),
                     (Some(a), None) => Some(a),
                     (None, Some(b)) => Some(b),
                     (None, None) => None,
                 };
-                self.cluster_min_watermark = merged;
                 if let Some(wm) = merged {
                     cc.publish_cluster_min_watermark(wm);
                 }
-                None
+                Ok(merged)
             }
-            Ok(QuorumOutcome::TimedOut { missing, .. }) => {
-                self.announce_if_leader(epoch, checkpoint_id, Phase::Abort, None)
-                    .await;
-                Some(format!(
-                    "quorum timeout: {} follower(s) did not ack",
-                    missing.len()
-                ))
-            }
+            Ok(QuorumOutcome::TimedOut { missing, .. }) => Err(format!(
+                "quorum timeout: {} follower(s) did not ack",
+                missing.len()
+            )),
             Ok(QuorumOutcome::Failed { failures }) => {
-                self.announce_if_leader(epoch, checkpoint_id, Phase::Abort, None)
-                    .await;
                 let first = failures.first().map_or("unknown", |(_, msg)| msg.as_str());
-                Some(format!(
+                Err(format!(
                     "follower snapshot failed on {} peer(s): {first}",
                     failures.len()
                 ))
             }
-            Err(err_msg) => {
-                self.announce_if_leader(epoch, checkpoint_id, Phase::Abort, None)
-                    .await;
-                Some(format!("fail-fast: {err_msg}"))
-            }
+            Err(err_msg) => Err(format!("fail-fast: {err_msg}")),
         }
     }
 
@@ -1244,16 +1317,16 @@ impl CheckpointCoordinator {
         self.phase
     }
 
-    /// Returns the current epoch.
+    /// Returns the next epoch to be allocated.
     #[must_use]
     pub fn epoch(&self) -> u64 {
-        self.epoch
+        self.allocator.peek().0
     }
 
-    /// Returns the next checkpoint ID.
+    /// Returns the next checkpoint ID to be allocated.
     #[must_use]
     pub fn next_checkpoint_id(&self) -> u64 {
-        self.next_checkpoint_id
+        self.allocator.peek().1
     }
 
     /// Returns the checkpoint config.
@@ -1276,7 +1349,7 @@ impl CheckpointCoordinator {
             duration_p99_ms: p99 / 1_000,
             total_bytes_written: self.total_bytes_written,
             current_phase: self.phase,
-            current_epoch: self.epoch,
+            current_epoch: self.allocator.peek().0,
         }
     }
 
@@ -1301,7 +1374,38 @@ impl CheckpointCoordinator {
         &mut self,
         request: CheckpointRequest,
     ) -> Result<CheckpointResult, DbError> {
-        self.checkpoint_inner(request).await
+        self.checkpoint_inner(request, None, QuorumStage::RunInline)
+            .await
+    }
+
+    /// Pipelined-barrier entry point: ids were allocated at admission
+    /// and the capture quorum already ran before the coordinator mutex
+    /// was taken (see `QuorumStage::Done`).
+    ///
+    /// # Errors
+    /// Returns `DbError::Checkpoint` if any phase fails.
+    pub(crate) async fn checkpoint_preallocated(
+        &mut self,
+        request: CheckpointRequest,
+        epoch: u64,
+        checkpoint_id: u64,
+        quorum: QuorumStage,
+    ) -> Result<CheckpointResult, DbError> {
+        self.checkpoint_inner(request, Some((epoch, checkpoint_id)), quorum)
+            .await
+    }
+
+    /// Abandon a pre-allocated epoch whose pre-mutex stage (alignment
+    /// or capture quorum) failed: announce `Abort`, roll back, and
+    /// begin the next epoch's sink transactions.
+    pub(crate) async fn abandon_epoch(
+        &mut self,
+        checkpoint_id: u64,
+        epoch: u64,
+        error: String,
+    ) -> CheckpointResult {
+        self.fail_epoch(checkpoint_id, epoch, Instant::now(), error)
+            .await
     }
 
     /// Follower half of a cluster checkpoint: ack the capture, run the
@@ -1326,6 +1430,45 @@ impl CheckpointCoordinator {
         ann: laminar_core::cluster::control::BarrierAnnouncement,
         decision_timeout: Duration,
     ) -> Result<bool, DbError> {
+        use laminar_core::cluster::control::BarrierAck;
+
+        let Some(cc) = self.cluster_controller.clone() else {
+            return Err(DbError::Checkpoint(
+                "[LDB-6033] follower_checkpoint called without cluster controller".into(),
+            ));
+        };
+
+        // Capture ack — state is already consistently captured by the
+        // caller; the leader needs nothing more to release pipelines.
+        cc.ack_barrier(&BarrierAck {
+            epoch: ann.epoch,
+            ok: true,
+            error: None,
+            // Leader folds this into the cluster-wide min announced on
+            // Aligned/Commit. `None` is non-blocking.
+            local_watermark_ms: self.local_watermark_ms,
+        })
+        .await
+        .ok(); // best effort; leader's quorum wait tolerates missed acks
+
+        self.follower_checkpoint_acked(request, ann, decision_timeout)
+            .await
+    }
+
+    /// [`follower_checkpoint`](Self::follower_checkpoint) minus the
+    /// capture ack, for pipelined tails that ack *before* queuing on
+    /// the coordinator mutex (an earlier epoch's durable tail may hold
+    /// it for the duration of its uploads).
+    ///
+    /// # Errors
+    /// Propagates sink pre-commit, manifest save, or marker-write failures.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn follower_checkpoint_acked(
+        &mut self,
+        request: CheckpointRequest,
+        ann: laminar_core::cluster::control::BarrierAnnouncement,
+        decision_timeout: Duration,
+    ) -> Result<bool, DbError> {
         use laminar_core::cluster::control::{BarrierAck, Phase};
 
         let Some(cc) = self.cluster_controller.clone() else {
@@ -1337,21 +1480,7 @@ impl CheckpointCoordinator {
         let epoch = ann.epoch;
         let checkpoint_id = ann.checkpoint_id;
         // Align with the leader so a later leader-mode call resumes correctly.
-        self.epoch = epoch;
-        self.next_checkpoint_id = checkpoint_id.saturating_add(1);
-
-        // Capture ack — state is already consistently captured by the
-        // caller; the leader needs nothing more to release pipelines.
-        cc.ack_barrier(&BarrierAck {
-            epoch,
-            ok: true,
-            error: None,
-            // Leader folds this into the cluster-wide min announced on
-            // Aligned/Commit. `None` is non-blocking.
-            local_watermark_ms: self.local_watermark_ms,
-        })
-        .await
-        .ok(); // best effort; leader's quorum wait tolerates missed acks
+        self.allocator.reset(epoch, checkpoint_id.saturating_add(1));
 
         // Durable prepare (runs after the ack, off the critical path
         // when the caller drives this from a background task).
@@ -1475,7 +1604,8 @@ impl CheckpointCoordinator {
             );
         }
         self.checkpoints_completed += 1;
-        self.epoch = epoch.saturating_add(1);
+        let (_, next_id) = self.allocator.peek();
+        self.allocator.reset(epoch.saturating_add(1), next_id);
         self.phase = CheckpointPhase::Idle;
         true
     }
@@ -1548,6 +1678,8 @@ impl CheckpointCoordinator {
     async fn checkpoint_inner(
         &mut self,
         request: CheckpointRequest,
+        ids: Option<(u64, u64)>,
+        quorum: QuorumStage,
     ) -> Result<CheckpointResult, DbError> {
         let CheckpointRequest {
             operator_states,
@@ -1559,16 +1691,15 @@ impl CheckpointCoordinator {
             source_offset_overrides,
         } = request;
         let start = Instant::now();
-        let checkpoint_id = self.next_checkpoint_id;
-        let epoch = self.epoch;
-        // Allocate ids up front (Flink-style): a failed attempt is
+        // Ids are allocated up front (Flink-style): a failed attempt is
         // abandoned — never retried under the same ids — so a future
         // epoch's identity never depends on this one's outcome. That
         // independence is what allows epochs to overlap (ADR-003
         // Phase 2); it also removes the same-epoch-retry ambiguity the
-        // announcement `seq` otherwise has to disambiguate.
-        self.next_checkpoint_id += 1;
-        self.epoch += 1;
+        // announcement `seq` otherwise has to disambiguate. Pipelined
+        // barrier paths allocate at admission and pass the ids in;
+        // forced/timer paths allocate here.
+        let (epoch, checkpoint_id) = ids.unwrap_or_else(|| self.allocator.allocate());
 
         info!(checkpoint_id, epoch, "starting checkpoint");
 
@@ -1584,23 +1715,33 @@ impl CheckpointCoordinator {
         // prepare runs after their ack; its completion is verified by
         // the restorable gate below (each node writes its vnode
         // partials *last*, so full presence implies every prepare
-        // finished).
+        // finished). Pipelined barrier tails run this stage *before*
+        // taking the coordinator mutex (so Aligned is never queued
+        // behind an earlier epoch's uploads) and pass `Done` here.
         #[cfg(feature = "cluster")]
-        {
-            if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await {
-                error!(checkpoint_id, epoch, error = %quorum_failure, "[LDB-6032] quorum miss");
-                return Ok(self
-                    .fail_epoch(checkpoint_id, epoch, start, quorum_failure)
-                    .await);
+        match quorum {
+            QuorumStage::RunInline => {
+                if let Some(quorum_failure) = self.await_prepare_quorum(epoch, checkpoint_id).await
+                {
+                    error!(checkpoint_id, epoch, error = %quorum_failure, "[LDB-6032] quorum miss");
+                    return Ok(self
+                        .fail_epoch(checkpoint_id, epoch, start, quorum_failure)
+                        .await);
+                }
+                self.announce_if_leader(
+                    epoch,
+                    checkpoint_id,
+                    laminar_core::cluster::control::Phase::Aligned,
+                    self.cluster_min_watermark,
+                )
+                .await;
             }
-            self.announce_if_leader(
-                epoch,
-                checkpoint_id,
-                laminar_core::cluster::control::Phase::Aligned,
-                self.cluster_min_watermark,
-            )
-            .await;
+            QuorumStage::Done(min_watermark_ms) => {
+                self.cluster_min_watermark = min_watermark_ms;
+            }
         }
+        #[cfg(not(feature = "cluster"))]
+        let _ = quorum;
 
         self.phase = CheckpointPhase::PreCommitting;
         if let Err(e) = self.pre_commit_sinks(epoch).await {
@@ -1855,7 +1996,7 @@ impl CheckpointCoordinator {
             }
         }
 
-        let next_epoch = self.epoch;
+        let next_epoch = self.allocator.peek().0;
         let begin_epoch_error = match self.begin_epoch_for_sinks(next_epoch).await {
             Ok(()) => None,
             Err(e) => {
@@ -1913,13 +2054,10 @@ impl CheckpointCoordinator {
 
         if let Some(ref recovered) = result {
             // Advance epoch past the recovered one
-            self.epoch = recovered.epoch() + 1;
-            self.next_checkpoint_id = recovered.manifest.checkpoint_id + 1;
-            info!(
-                epoch = self.epoch,
-                checkpoint_id = self.next_checkpoint_id,
-                "coordinator epoch set after recovery"
-            );
+            self.allocator
+                .reset(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
+            let (epoch, checkpoint_id) = self.allocator.peek();
+            info!(epoch, checkpoint_id, "coordinator epoch set after recovery");
         }
 
         Ok(result)
@@ -1938,8 +2076,7 @@ impl CheckpointCoordinator {
 impl std::fmt::Debug for CheckpointCoordinator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CheckpointCoordinator")
-            .field("epoch", &self.epoch)
-            .field("next_checkpoint_id", &self.next_checkpoint_id)
+            .field("allocator", &self.allocator)
             .field("phase", &self.phase)
             .field("sinks", &self.sinks.len())
             .field("completed", &self.checkpoints_completed)
@@ -3220,6 +3357,17 @@ mod tests {
         );
         let err = result.error.expect("failure produces an error message");
         assert!(err.contains("vnode partial write failed"), "got: {err}");
+    }
+
+    #[test]
+    fn epoch_allocator_allocates_monotonic_pairs() {
+        let a = EpochAllocator::new(5, 9);
+        assert_eq!(a.peek(), (5, 9));
+        assert_eq!(a.allocate(), (5, 9));
+        assert_eq!(a.allocate(), (6, 10));
+        assert_eq!(a.peek(), (7, 11));
+        a.reset(20, 30);
+        assert_eq!(a.allocate(), (20, 30));
     }
 
     /// Ids are allocated at the start of an attempt: a failed epoch is

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -166,17 +166,15 @@ impl EpochAllocator {
         )
     }
 
-    /// Rebase after recovery (authoritative — may move backwards).
-    fn reset(&self, epoch: u64, next_checkpoint_id: u64) {
-        use std::sync::atomic::Ordering;
-        self.epoch.store(epoch, Ordering::Release);
-        self.next_checkpoint_id
-            .store(next_checkpoint_id, Ordering::Release);
-    }
-
-    /// Monotonic advance, for followers mirroring the leader's ids: a
-    /// depth>1 tail finishing out of order must never walk the
-    /// allocator backwards past a successor's ids.
+    /// Monotonic advance — the only way the allocator moves after
+    /// construction; an epoch number can never be re-allocated. That
+    /// matters because an aborted epoch leaves artifacts behind (a
+    /// Pending manifest, uploaded partials): construction seeds from
+    /// the highest *loadable* manifest even if Pending, and recovery
+    /// (which restores from the highest *committed* one, possibly
+    /// older) must not pull ids back down onto those stale artifacts.
+    /// Also keeps a depth>1 follower tail finishing out of order from
+    /// walking past a successor's ids.
     fn advance_to(&self, epoch: u64, next_checkpoint_id: u64) {
         use std::sync::atomic::Ordering;
         self.epoch.fetch_max(epoch, Ordering::AcqRel);
@@ -2202,9 +2200,10 @@ impl CheckpointCoordinator {
         let result = mgr.recover(&[], &self.sinks, &[]).await?;
 
         if let Some(ref recovered) = result {
-            // Advance epoch past the recovered one
+            // Monotonic: the recovered (committed) epoch may be older
+            // than a Pending manifest this node seeded its ids from.
             self.allocator
-                .reset(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
+                .advance_to(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
             let (epoch, checkpoint_id) = self.allocator.peek();
             info!(epoch, checkpoint_id, "coordinator epoch set after recovery");
         }
@@ -3797,6 +3796,46 @@ mod tests {
         assert_eq!(c, d - 1, "abandoned epoch's id is burned, not reused");
     }
 
+    /// A follower persists its manifest before learning the leader
+    /// aborted, so an aborted epoch's Pending manifest can be the
+    /// highest on disk at restart. Construction seeds ids from it
+    /// (high is safe); recovery then restores from the older committed
+    /// epoch and must NOT walk the ids back down — that would
+    /// re-allocate the aborted epoch over its stale artifacts.
+    #[tokio::test]
+    async fn recovery_never_walks_ids_back_onto_aborted_epochs() {
+        use laminar_core::storage::checkpoint_manifest::SinkCommitStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSystemCheckpointStore::new(dir.path(), 5);
+        // Committed epoch 3.
+        let mut committed = CheckpointManifest::new(3, 3);
+        committed
+            .sink_commit_statuses
+            .insert("out".into(), SinkCommitStatus::Committed);
+        store.save(&committed).await.unwrap();
+        // Aborted epoch 5: persisted by a follower before the leader's
+        // Abort, never committed.
+        let mut aborted = CheckpointManifest::new(5, 5);
+        aborted
+            .sink_commit_statuses
+            .insert("out".into(), SinkCommitStatus::Pending);
+        store.save(&aborted).await.unwrap();
+
+        let mut coord = CheckpointCoordinator::new(CheckpointConfig::default(), Box::new(store))
+            .await
+            .unwrap();
+        assert_eq!(coord.epoch(), 6, "seeds from the highest loadable manifest");
+
+        let recovered = coord.recover().await.unwrap().expect("recovers");
+        assert_eq!(recovered.epoch(), 3, "restores from the committed epoch");
+        assert_eq!(
+            coord.epoch(),
+            6,
+            "ids must stay above the aborted epoch, never re-allocating it",
+        );
+    }
+
     #[test]
     fn epoch_allocator_allocates_monotonic_pairs() {
         let a = EpochAllocator::new(5, 9);
@@ -3804,8 +3843,11 @@ mod tests {
         assert_eq!(a.allocate(), (5, 9));
         assert_eq!(a.allocate(), (6, 10));
         assert_eq!(a.peek(), (7, 11));
-        a.reset(20, 30);
+        a.advance_to(20, 30);
         assert_eq!(a.allocate(), (20, 30));
+        // Monotonic: never walks backwards.
+        a.advance_to(5, 5);
+        assert_eq!(a.peek(), (21, 31));
     }
 
     /// Ids are allocated at the start of an attempt: a failed epoch is

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -2112,10 +2112,18 @@ impl CheckpointCoordinator {
         // `restorable_gate_timeout` rather than checking once.
         #[cfg(not(feature = "cluster"))]
         let quorum_participants: Vec<QuorumPeer> = Vec::new();
-        if let Err(gate_err) = self
+        let gate_start = Instant::now();
+        let gate_result = self
             .await_restorable_gate(epoch, &quorum_participants)
-            .await
-        {
+            .await;
+        // Observed on failure too — a burned gate timeout is the signal
+        // that decides when the push-driven completion-ack follow-up is
+        // worth building.
+        if let Some(ref m) = self.prom {
+            m.checkpoint_restorable_gate_wait
+                .observe(gate_start.elapsed().as_secs_f64());
+        }
+        if let Err(gate_err) = gate_result {
             warn!(
                 checkpoint_id,
                 epoch,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -22,7 +22,6 @@ use crate::handle::{
     UntypedSourceHandle,
 };
 use crate::pipeline::ControlMsg;
-use crate::pipeline_lifecycle::url_to_checkpoint_prefix;
 use crate::sql_utils;
 
 /// Cloneable async sender for the live-DDL control channel.
@@ -2253,16 +2252,16 @@ impl LaminarDB {
         );
 
         if let Some(ref url) = self.config.object_store_url {
+            // The builder roots the store at the URL's path prefix.
             let obj_store = laminar_core::storage::object_store_builder::build_object_store(
                 url,
                 &self.config.object_store_options,
             )
             .ok()?;
-            let prefix = url_to_checkpoint_prefix(url);
             Some(Box::new(
                 laminar_core::storage::checkpoint_store::ObjectStoreCheckpointStore::new(
                     obj_store,
-                    prefix,
+                    String::new(),
                     max_retained,
                 )
                 .with_vnode_count(vnode_count),

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -865,6 +865,9 @@ impl LaminarDB {
     /// Register built-in connectors based on enabled features.
     #[allow(unused_variables)]
     fn register_builtin_connectors(registry: &laminar_connectors::registry::ConnectorRegistry) {
+        // Infra-free synthetic source; always available (used by demos
+        // and the cluster soak harness).
+        laminar_connectors::generator::register_generator_source(registry);
         #[cfg(feature = "kafka")]
         {
             laminar_connectors::kafka::register_kafka_source(registry);

--- a/crates/laminar-db/src/db/tests.rs
+++ b/crates/laminar-db/src/db/tests.rs
@@ -721,7 +721,8 @@ async fn test_connector_registry_accessor() {
     // With feature flags enabled, built-in connectors are auto-registered.
     // Without any features, registry should be empty.
     #[allow(unused_mut)]
-    let mut expected_sources = 0;
+    // The generator source is unconditional (no feature gate).
+    let mut expected_sources = 1;
     #[allow(unused_mut)]
     let mut expected_sinks = 0;
 

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -81,6 +81,9 @@ pub struct EngineMetrics {
     /// a checkpoint (shuffle alignment + state capture + the Aligned
     /// resume gate), excluding the background durable tail (ADR-003).
     pub checkpoint_pipeline_stall_duration: Histogram,
+    /// Vnode partials written as references to an unchanged base
+    /// instead of re-uploading state (ADR-003 Phase 3).
+    pub checkpoint_unchanged_vnodes: IntCounter,
     /// Sink pre-commit round-trip (2PC phase 1).
     pub sink_precommit_duration: Histogram,
     /// Sink commit round-trip (2PC phase 2).
@@ -282,6 +285,11 @@ impl EngineMetrics {
                     "Pipeline stall per checkpoint barrier (align + capture + resume gate)",
                 )
                 .buckets(prometheus::exponential_buckets(0.001, 2.0, 16).unwrap()),
+            )
+            .unwrap()),
+            checkpoint_unchanged_vnodes: reg!(IntCounter::new(
+                "checkpoint_unchanged_vnodes_total",
+                "Vnode partials written as unchanged-base references"
             )
             .unwrap()),
             // pre_commit_timeout=30s. 0.005 * 2^13 = 40.96s.

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -77,6 +77,10 @@ pub struct EngineMetrics {
     pub cycle_duration: Histogram,
     /// Checkpoint cycle duration.
     pub checkpoint_duration: Histogram,
+    /// Pipeline stall per barrier: time the pipeline task is blocked by
+    /// a checkpoint (shuffle alignment + state capture + the Aligned
+    /// resume gate), excluding the background durable tail (ADR-003).
+    pub checkpoint_pipeline_stall_duration: Histogram,
     /// Sink pre-commit round-trip (2PC phase 1).
     pub sink_precommit_duration: Histogram,
     /// Sink commit round-trip (2PC phase 2).
@@ -268,6 +272,16 @@ impl EngineMetrics {
             checkpoint_duration: reg!(Histogram::with_opts(
                 HistogramOpts::new("checkpoint_duration_seconds", "Checkpoint cycle duration")
                     .buckets(prometheus::exponential_buckets(0.01, 2.0, 15).unwrap()),
+            )
+            .unwrap()),
+            // Stall target is sub-second; the resume gate is bounded at
+            // 30s. 0.001 * 2^15 = 32.77s.
+            checkpoint_pipeline_stall_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new(
+                    "checkpoint_pipeline_stall_duration_seconds",
+                    "Pipeline stall per checkpoint barrier (align + capture + resume gate)",
+                )
+                .buckets(prometheus::exponential_buckets(0.001, 2.0, 16).unwrap()),
             )
             .unwrap()),
             // pre_commit_timeout=30s. 0.005 * 2^13 = 40.96s.

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -81,6 +81,12 @@ pub struct EngineMetrics {
     /// a checkpoint (shuffle alignment + state capture + the Aligned
     /// resume gate), excluding the background durable tail.
     pub checkpoint_pipeline_stall_duration: Histogram,
+    /// Time the leader's restorable gate spends polling for vnode
+    /// partials (failed gates that burn the timeout are observed too).
+    /// When this dominates restorable latency at production cadence,
+    /// the push-driven upload-completion-ack follow-up is worth
+    /// building.
+    pub checkpoint_restorable_gate_wait: Histogram,
     /// Vnode partials written as references to an unchanged base
     /// instead of re-uploading state.
     pub checkpoint_unchanged_vnodes: IntCounter,
@@ -285,6 +291,15 @@ impl EngineMetrics {
                     "Pipeline stall per checkpoint barrier (align + capture + resume gate)",
                 )
                 .buckets(prometheus::exponential_buckets(0.001, 2.0, 16).unwrap()),
+            )
+            .unwrap()),
+            // Gate timeout default 10s. 0.001 * 2^14 = 16.38s.
+            checkpoint_restorable_gate_wait: reg!(Histogram::with_opts(
+                HistogramOpts::new(
+                    "checkpoint_restorable_gate_wait_seconds",
+                    "Restorable-gate poll wait per epoch (vnode-partial presence)",
+                )
+                .buckets(prometheus::exponential_buckets(0.001, 2.0, 15).unwrap()),
             )
             .unwrap()),
             checkpoint_unchanged_vnodes: reg!(IntCounter::new(

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -79,10 +79,10 @@ pub struct EngineMetrics {
     pub checkpoint_duration: Histogram,
     /// Pipeline stall per barrier: time the pipeline task is blocked by
     /// a checkpoint (shuffle alignment + state capture + the Aligned
-    /// resume gate), excluding the background durable tail (ADR-003).
+    /// resume gate), excluding the background durable tail.
     pub checkpoint_pipeline_stall_duration: Histogram,
     /// Vnode partials written as references to an unchanged base
-    /// instead of re-uploading state (ADR-003 Phase 3).
+    /// instead of re-uploading state.
     pub checkpoint_unchanged_vnodes: IntCounter,
     /// Sink pre-commit round-trip (2PC phase 1).
     pub sink_precommit_duration: Histogram,

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -62,6 +62,7 @@ mod filter_compile;
 mod handle;
 mod interval_join;
 mod key_column;
+mod log_throttle;
 mod metrics;
 mod metrics_api;
 mod mv_store;

--- a/crates/laminar-db/src/log_throttle.rs
+++ b/crates/laminar-db/src/log_throttle.rs
@@ -1,0 +1,53 @@
+//! Rate gate for hot-path warnings.
+
+use std::time::{Duration, Instant};
+
+/// Allows an event through at most once per `interval`. Monotonic
+/// (`Instant`-based), so an NTP step backwards can't suppress warnings
+/// indefinitely the way the old `SystemTime` throttles could.
+///
+/// Usable as a `static`:
+///
+/// ```ignore
+/// static THROTTLE: LogThrottle = LogThrottle::every(Duration::from_secs(10));
+/// if THROTTLE.allow() {
+///     tracing::warn!("...");
+/// }
+/// ```
+pub(crate) struct LogThrottle {
+    last: parking_lot::Mutex<Option<Instant>>,
+    interval: Duration,
+}
+
+impl LogThrottle {
+    pub(crate) const fn every(interval: Duration) -> Self {
+        Self {
+            last: parking_lot::Mutex::new(None),
+            interval,
+        }
+    }
+
+    /// `true` if the caller should emit its event now.
+    pub(crate) fn allow(&self) -> bool {
+        let mut last = self.last.lock();
+        match *last {
+            Some(at) if at.elapsed() < self.interval => false,
+            _ => {
+                *last = Some(Instant::now());
+                true
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_event_passes_then_throttles() {
+        let t = LogThrottle::every(Duration::from_secs(60));
+        assert!(t.allow());
+        assert!(!t.allow());
+    }
+}

--- a/crates/laminar-db/src/log_throttle.rs
+++ b/crates/laminar-db/src/log_throttle.rs
@@ -45,9 +45,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_event_passes_then_throttles() {
-        let t = LogThrottle::every(Duration::from_secs(60));
+    fn first_event_passes_then_throttles_then_reopens() {
+        let t = LogThrottle::every(Duration::from_millis(10));
         assert!(t.allow());
         assert!(!t.allow());
+        std::thread::sleep(Duration::from_millis(15));
+        assert!(t.allow(), "an elapsed interval must reopen the gate");
     }
 }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -2063,6 +2063,22 @@ impl OperatorGraph {
                                     "checkpoint {checkpoint_id} was aborted by leader"
                                 )));
                             }
+                            // Observation is latest-wins, so this checkpoint''s
+                            // Abort can be superseded before we ever see it. A
+                            // NEWER announcement is just as conclusive: ids are
+                            // never reused (failed epochs are abandoned), and
+                            // the leader only moves on once this checkpoint is
+                            // aligned cluster-wide or dead — either way the
+                            // peer barriers we are waiting for will never
+                            // arrive. Without this release, a rejoining node
+                            // livelocks one epoch behind the cluster, timing
+                            // out every alignment.
+                            if ann.checkpoint_id > checkpoint_id {
+                                return Err(DbError::Pipeline(format!(
+                                    "checkpoint {checkpoint_id} superseded by {} — alignment abandoned",
+                                    ann.checkpoint_id
+                                )));
+                            }
                         }
                     }
                 }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -2063,7 +2063,7 @@ impl OperatorGraph {
                                     "checkpoint {checkpoint_id} was aborted by leader"
                                 )));
                             }
-                            // Observation is latest-wins, so this checkpoint''s
+                            // Observation is latest-wins, so this checkpoint's
                             // Abort can be superseded before we ever see it. A
                             // NEWER announcement is just as conclusive: ids are
                             // never reused (failed epochs are abandoned), and

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -1939,7 +1939,7 @@ impl OperatorGraph {
         use laminar_core::cluster::control::Phase;
         use laminar_core::shuffle::{BarrierTracker, ShuffleMessage};
 
-        const ALIGN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        const ALIGN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
         let Some(cfg) = self.cluster_shuffle.clone() else {
             return Ok(());

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -116,9 +116,13 @@ pub trait PipelineCallback: Send + 'static {
     ) -> Option<u64>;
 
     /// Called when all sources have aligned on a barrier.
+    /// `checkpoint_id` identifies the barrier round the offsets were
+    /// captured under — implementations must not attribute them to a
+    /// different (e.g. newer, post-abandonment) announcement.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
+        checkpoint_id: u64,
     ) -> BarrierOutcome;
 
     /// Record cycle metrics.

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -19,7 +19,7 @@
 //!                            Sinks
 //! ```
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -125,9 +125,18 @@ pub struct StreamingCoordinator {
     control_rx: ControlMsgRx,
     checkpoint_complete_rx:
         Option<crossfire::AsyncRx<crossfire::mpsc::Array<CheckpointCompletion>>>,
-    /// True while a background checkpoint persists; gates `maybe_checkpoint` to
-    /// one in-flight checkpoint at a time. Shared with the callback.
-    checkpoint_in_flight: Arc<AtomicBool>,
+    /// Epochs between admission and restorable (durable tails still
+    /// running). Shared with the callback; gated against
+    /// `max_in_flight_epochs` (ADR-003 Phase 2).
+    checkpoint_in_flight: Arc<AtomicU64>,
+    /// Barrier admission cap on `checkpoint_in_flight`. Exactly-once
+    /// pipelines are wired with 1.
+    max_in_flight_epochs: u64,
+    /// Captured-state bytes held by in-flight epochs (shared with the
+    /// callback).
+    staged_bytes: Arc<AtomicU64>,
+    /// Barrier admission cap on `staged_bytes`.
+    max_staged_bytes: u64,
 }
 
 /// Tracks in-flight checkpoint barrier alignment.
@@ -440,14 +449,27 @@ impl StreamingCoordinator {
             committed_offsets,
             control_rx,
             checkpoint_complete_rx: None,
-            checkpoint_in_flight: Arc::new(AtomicBool::new(false)),
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
         })
     }
 
-    /// Share the callback's in-flight checkpoint flag so the coordinator holds
-    /// off a new checkpoint while a background persist is still running.
-    pub(crate) fn with_checkpoint_in_flight(mut self, flag: Arc<AtomicBool>) -> Self {
-        self.checkpoint_in_flight = flag;
+    /// Share the callback's admission state so the coordinator admits a
+    /// new barrier only while in-flight epochs and staged bytes are
+    /// under their caps (ADR-003 Phase 2).
+    pub(crate) fn with_checkpoint_admission(
+        mut self,
+        in_flight: Arc<AtomicU64>,
+        max_in_flight_epochs: u64,
+        staged_bytes: Arc<AtomicU64>,
+        max_staged_bytes: u64,
+    ) -> Self {
+        self.checkpoint_in_flight = in_flight;
+        self.max_in_flight_epochs = max_in_flight_epochs.max(1);
+        self.staged_bytes = staged_bytes;
+        self.max_staged_bytes = max_staged_bytes;
         self
     }
 
@@ -913,7 +935,10 @@ impl StreamingCoordinator {
             // offsets, ack tokens) advances only with the durable manifest.
             let fan_out = checkpoints.clone();
             let checkpoint_id = self.pending_barrier.checkpoint_id;
-            match callback.checkpoint_with_barrier(checkpoints).await {
+            match callback
+                .checkpoint_with_barrier(checkpoints, checkpoint_id)
+                .await
+            {
                 BarrierOutcome::Committed(epoch) => {
                     self.broadcast_epoch_committed(epoch, &fan_out);
                     // Wire barrier = durable epoch.
@@ -947,8 +972,18 @@ impl StreamingCoordinator {
         if self.pending_barrier.active {
             return; // Already tracking a barrier.
         }
-        if self.checkpoint_in_flight.load(Ordering::Acquire) {
-            return; // A background checkpoint persist is still running.
+        if self.checkpoint_in_flight.load(Ordering::Acquire) >= self.max_in_flight_epochs {
+            return; // The in-flight epoch backlog is at its cap.
+        }
+        if self.staged_bytes.load(Ordering::Acquire) >= self.max_staged_bytes {
+            // Cadence degrades to upload speed rather than buffering
+            // unbounded captured state.
+            tracing::warn!(
+                staged_bytes = self.staged_bytes.load(Ordering::Acquire),
+                cap = self.max_staged_bytes,
+                "checkpoint admission paused: staged-state cap reached"
+            );
+            return;
         }
 
         // Always give the callback a chance to run cluster-follower
@@ -1086,6 +1121,7 @@ mod tests {
         async fn checkpoint_with_barrier(
             &mut self,
             _source_checkpoints: FxHashMap<String, SourceCheckpoint>,
+            _checkpoint_id: u64,
         ) -> BarrierOutcome {
             BarrierOutcome::Committed(1)
         }
@@ -1136,7 +1172,10 @@ mod tests {
             pending_offsets: vec![None],
             control_rx,
             checkpoint_complete_rx: None,
-            checkpoint_in_flight: Arc::new(AtomicBool::new(false)),
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
         };
 
         let callback = MockCallback::new();
@@ -1208,7 +1247,10 @@ mod tests {
             pending_offsets: vec![None],
             control_rx,
             checkpoint_complete_rx: None,
-            checkpoint_in_flight: Arc::new(AtomicBool::new(false)),
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
         };
 
         let force_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -1282,7 +1324,10 @@ mod tests {
             pending_offsets: vec![None, None],
             control_rx: control_rx2,
             checkpoint_complete_rx: None,
-            checkpoint_in_flight: Arc::new(AtomicBool::new(false)),
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
         };
 
         let mut callback = MockCallback::new();
@@ -1486,8 +1531,9 @@ mod tests {
         async fn checkpoint_with_barrier(
             &mut self,
             cp: FxHashMap<String, SourceCheckpoint>,
+            checkpoint_id: u64,
         ) -> BarrierOutcome {
-            self.inner.checkpoint_with_barrier(cp).await
+            self.inner.checkpoint_with_barrier(cp, checkpoint_id).await
         }
         fn record_cycle(&self, e: u64, b: u64, ns: u64) {
             self.inner.record_cycle(e, b, ns);
@@ -1547,7 +1593,10 @@ mod tests {
             pending_offsets: vec![None],
             control_rx,
             checkpoint_complete_rx: None,
-            checkpoint_in_flight: Arc::new(AtomicBool::new(false)),
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
         };
 
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -178,20 +178,15 @@ const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 /// staged-state cap — this check runs every coordinator tick, so an
 /// unthrottled warn would spam under a sustained upload backlog.
 fn warn_staged_cap_throttled(staged_bytes: u64, cap: u64) {
-    use std::sync::atomic::AtomicI64;
-    static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
-    if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
-        return;
+    static THROTTLE: crate::log_throttle::LogThrottle =
+        crate::log_throttle::LogThrottle::every(Duration::from_secs(10));
+    if THROTTLE.allow() {
+        tracing::warn!(
+            staged_bytes,
+            cap,
+            "checkpoint admission paused: staged-state cap reached"
+        );
     }
-    LAST_WARN_MS.store(now_ms, Ordering::Relaxed);
-    tracing::warn!(
-        staged_bytes,
-        cap,
-        "checkpoint admission paused: staged-state cap reached"
-    );
 }
 
 /// What woke a source task's select loop.

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -174,6 +174,26 @@ impl PendingBarrier {
 /// Fallback timeout for idle wake.
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// Throttled (~once/10s) WARN while barrier admission is paused at the
+/// staged-state cap — this check runs every coordinator tick, so an
+/// unthrottled warn would spam under a sustained upload backlog.
+fn warn_staged_cap_throttled(staged_bytes: u64, cap: u64) {
+    use std::sync::atomic::AtomicI64;
+    static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
+    if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
+        return;
+    }
+    LAST_WARN_MS.store(now_ms, Ordering::Relaxed);
+    tracing::warn!(
+        staged_bytes,
+        cap,
+        "checkpoint admission paused: staged-state cap reached"
+    );
+}
+
 /// What woke a source task's select loop.
 enum SourceWake {
     Shutdown,
@@ -978,10 +998,9 @@ impl StreamingCoordinator {
         if self.staged_bytes.load(Ordering::Acquire) >= self.max_staged_bytes {
             // Cadence degrades to upload speed rather than buffering
             // unbounded captured state.
-            tracing::warn!(
-                staged_bytes = self.staged_bytes.load(Ordering::Acquire),
-                cap = self.max_staged_bytes,
-                "checkpoint admission paused: staged-state cap reached"
+            warn_staged_cap_throttled(
+                self.staged_bytes.load(Ordering::Acquire),
+                self.max_staged_bytes,
             );
             return;
         }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -127,7 +127,7 @@ pub struct StreamingCoordinator {
         Option<crossfire::AsyncRx<crossfire::mpsc::Array<CheckpointCompletion>>>,
     /// Epochs between admission and restorable (durable tails still
     /// running). Shared with the callback; gated against
-    /// `max_in_flight_epochs` (ADR-003 Phase 2).
+    /// `max_in_flight_epochs`.
     checkpoint_in_flight: Arc<AtomicU64>,
     /// Barrier admission cap on `checkpoint_in_flight`. Exactly-once
     /// pipelines are wired with 1.
@@ -473,7 +473,7 @@ impl StreamingCoordinator {
 
     /// Share the callback's admission state so the coordinator admits a
     /// new barrier only while in-flight epochs and staged bytes are
-    /// under their caps (ADR-003 Phase 2).
+    /// under their caps.
     pub(crate) fn with_checkpoint_admission(
         mut self,
         in_flight: Arc<AtomicU64>,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -97,6 +97,66 @@ impl Drop for CheckpointInFlightGuard {
     }
 }
 
+/// Follower durable-tail bookkeeping shared between the pipeline task
+/// and the spawned tail task (ADR-003 two-level completion). Epochs
+/// start at 1, so `0` encodes "none".
+#[cfg(feature = "cluster")]
+#[derive(Debug, Default)]
+pub(crate) struct FollowerTailState {
+    /// Epoch whose durable tail (prepare + decision wait + 2PC commit)
+    /// is currently running in a background task.
+    in_flight_epoch: std::sync::atomic::AtomicU64,
+    /// Highest epoch this follower has successfully committed; dedups
+    /// the leader's idempotent `Prepare` re-announcements. Advanced
+    /// only on commit so a failed-then-retried epoch is reprocessed,
+    /// not deduped.
+    committed_epoch: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(feature = "cluster")]
+impl FollowerTailState {
+    fn in_flight(&self) -> Option<u64> {
+        match self
+            .in_flight_epoch
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            0 => None,
+            e => Some(e),
+        }
+    }
+
+    fn committed(&self) -> Option<u64> {
+        match self
+            .committed_epoch
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            0 => None,
+            e => Some(e),
+        }
+    }
+
+    fn begin(&self, epoch: u64) {
+        self.in_flight_epoch
+            .store(epoch, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Record the tail's outcome. The in-flight slot is cleared only if
+    /// it still belongs to `epoch` so a late-finishing stale tail can't
+    /// clobber a newer epoch's bookkeeping.
+    fn finish(&self, epoch: u64, committed: bool) {
+        if committed {
+            self.committed_epoch
+                .fetch_max(epoch, std::sync::atomic::Ordering::AcqRel);
+        }
+        let _ = self.in_flight_epoch.compare_exchange(
+            epoch,
+            0,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        );
+    }
+}
+
 pub(crate) struct ConnectorPipelineCallback {
     pub(crate) graph: crate::operator_graph::OperatorGraph,
     pub(crate) stream_sources: Vec<(String, streaming::Source<crate::catalog::ArrowRecord>)>,
@@ -152,12 +212,13 @@ pub(crate) struct ConnectorPipelineCallback {
     /// non-leaders.
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
-    /// Highest epoch this non-leader has successfully committed; dedups the
-    /// leader's idempotent `Prepare` re-announcements. Advanced only on commit
-    /// (see [`Self::follower_should_skip`]). In-flight deferred epochs are
-    /// tracked by [`Self::pending_follower_checkpoint`].
+    /// Shared follower durable-tail bookkeeping: the epoch whose tail is
+    /// in flight and the highest committed epoch (dedup, advanced only
+    /// on commit — see [`Self::follower_should_skip`]). Epochs awaiting
+    /// local source barriers are tracked separately by
+    /// [`Self::pending_follower_checkpoint`].
     #[cfg(feature = "cluster")]
-    pub(crate) last_follower_epoch: Option<u64>,
+    pub(crate) follower_tail: Arc<FollowerTailState>,
     /// Local source barrier injectors to trigger follower-side checkpoints.
     #[cfg(feature = "cluster")]
     pub(crate) barrier_injectors: Vec<(
@@ -322,7 +383,7 @@ impl ConnectorPipelineCallback {
         self.sync_sinks_and_drain_events().await;
 
         #[cfg(feature = "cluster")]
-        self.align_shuffle_for_leader().await?;
+        let _ = self.align_shuffle_for_leader().await?;
 
         let operator_states = self
             .capture_and_serialize_operator_state()
@@ -377,17 +438,142 @@ impl ConnectorPipelineCallback {
     }
 
     /// Skip a follower `Prepare` for `ann_epoch` only if it is already
-    /// committed (`last_committed`) or already in flight as a deferred
-    /// checkpoint (`in_flight`). A failed checkpoint does not advance
+    /// committed (`last_committed`), already awaiting local source
+    /// barriers (`pending`), or its durable tail is already running
+    /// (`tail_in_flight`). A failed checkpoint does not advance
     /// `last_committed`, and the leader retries the same epoch (it advances
     /// only on success), so the retry must be reprocessed, not deduped.
     #[cfg(feature = "cluster")]
     fn follower_should_skip(
         last_committed: Option<u64>,
-        in_flight: Option<u64>,
+        pending: Option<u64>,
+        tail_in_flight: Option<u64>,
         ann_epoch: u64,
     ) -> bool {
-        last_committed.is_some_and(|e| e >= ann_epoch) || in_flight.is_some_and(|e| e >= ann_epoch)
+        last_committed.is_some_and(|e| e >= ann_epoch)
+            || pending.is_some_and(|e| e >= ann_epoch)
+            || tail_in_flight.is_some_and(|e| e >= ann_epoch)
+    }
+
+    /// Hand the follower's durable tail — sink pre-commit, manifest
+    /// save, vnode-partial uploads, the leader-decision wait, and the
+    /// 2PC commit/rollback — to a background task so the pipeline can
+    /// resume on `Aligned` instead of stalling until `Commit`
+    /// (ADR-003 two-level completion). `follower_checkpoint` acks the
+    /// capture as its first action, which is what releases the leader's
+    /// quorum wait. On commit, completion flows through
+    /// `checkpoint_complete_tx` so the streaming coordinator fans
+    /// `EpochCommitted` out to sources and publishes the wire barrier —
+    /// the same path the leader's background persist uses.
+    #[cfg(feature = "cluster")]
+    fn spawn_follower_tail(
+        &mut self,
+        request: crate::checkpoint_coordinator::CheckpointRequest,
+        ann: laminar_core::cluster::control::BarrierAnnouncement,
+        fan_out: FxHashMap<String, SourceCheckpoint>,
+    ) {
+        let epoch = ann.epoch;
+        let vnode_states = self.capture_vnode_states();
+        let wm = self
+            .pipeline_watermark
+            .load(std::sync::atomic::Ordering::Acquire);
+        self.follower_tail.begin(epoch);
+
+        let coordinator = Arc::clone(&self.coordinator);
+        let tail = Arc::clone(&self.follower_tail);
+        let complete_tx = self.checkpoint_complete_tx.clone();
+        tokio::spawn(async move {
+            let committed = {
+                let mut guard = coordinator.lock().await;
+                match guard.as_mut() {
+                    Some(coord) => {
+                        coord.set_pending_vnode_states(vnode_states);
+                        coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
+                        match coord
+                            .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
+                            .await
+                        {
+                            Ok(true) => {
+                                tracing::info!(epoch, "follower checkpoint committed");
+                                true
+                            }
+                            Ok(false) => {
+                                tracing::warn!(
+                                    epoch,
+                                    "follower checkpoint aborted (leader signalled Abort)"
+                                );
+                                false
+                            }
+                            Err(e) => {
+                                tracing::warn!(epoch, error = %e, "follower checkpoint errored");
+                                false
+                            }
+                        }
+                    }
+                    None => false,
+                }
+            };
+            // Record only on commit so a failed-then-retried epoch is
+            // reprocessed, not deduped.
+            tail.finish(epoch, committed);
+            if committed {
+                let _ = complete_tx.send((epoch, fan_out)).await;
+            }
+        });
+    }
+
+    /// Block the pipeline until the leader announces `Aligned` for
+    /// `epoch` — the re-keyed shuffle-alignment resume gate (ADR-003).
+    /// `Aligned` is announced only after the *full-membership* capture
+    /// quorum, preserving the invariant the no-post-barrier-buffering
+    /// shuffle drain relies on: no peer ships epoch-N+1 rows while
+    /// another node is still folding pre-barrier rows into its epoch-N
+    /// snapshot. `Commit`, `Abort`, or any newer epoch's announcement
+    /// also releases the gate (observation is latest-wins, so a quick
+    /// successor can overwrite `Aligned`).
+    ///
+    /// No-op without a cross-node shuffle — there are no in-flight
+    /// peer rows to protect. Bounded: on timeout the pipeline resumes
+    /// anyway (the epoch aborts independently via the leader's gate).
+    ///
+    /// Associated fn (no `&self`) so callers' futures stay `Send`
+    /// without requiring `ConnectorPipelineCallback: Sync`.
+    #[cfg(feature = "cluster")]
+    async fn wait_for_aligned_resume(
+        has_cluster_shuffle: bool,
+        controller: &laminar_core::cluster::control::ClusterController,
+        epoch: u64,
+    ) {
+        use laminar_core::cluster::control::Phase;
+
+        const RESUME_GATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        const POLL: std::time::Duration = std::time::Duration::from_millis(10);
+
+        if !has_cluster_shuffle {
+            return;
+        }
+        let start = std::time::Instant::now();
+        loop {
+            match controller.observe_barrier().await.ok().flatten() {
+                Some(a) if a.epoch > epoch => return,
+                Some(a)
+                    if a.epoch == epoch
+                        && matches!(a.phase, Phase::Aligned | Phase::Commit | Phase::Abort) =>
+                {
+                    return;
+                }
+                _ => {}
+            }
+            if start.elapsed() >= RESUME_GATE_TIMEOUT {
+                tracing::warn!(
+                    epoch,
+                    "aligned resume gate timed out — resuming pipeline \
+                     (epoch will abort via the leader's restorable gate)"
+                );
+                return;
+            }
+            tokio::time::sleep(POLL).await;
+        }
     }
 
     #[cfg(feature = "cluster")]
@@ -403,8 +589,13 @@ impl ConnectorPipelineCallback {
             Ok(Some(a)) if a.phase == Phase::Prepare => a,
             _ => return None,
         };
-        let in_flight = self.pending_follower_checkpoint.as_ref().map(|p| p.epoch);
-        if Self::follower_should_skip(self.last_follower_epoch, in_flight, ann.epoch) {
+        let pending = self.pending_follower_checkpoint.as_ref().map(|p| p.epoch);
+        if Self::follower_should_skip(
+            self.follower_tail.committed(),
+            pending,
+            self.follower_tail.in_flight(),
+            ann.epoch,
+        ) {
             return None;
         }
 
@@ -474,38 +665,19 @@ impl ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        let vnode_states = self.capture_vnode_states();
-        let mut guard = self.coordinator.lock().await;
-        let coord = (*guard).as_mut()?;
-        coord.set_pending_vnode_states(vnode_states);
-        // Stamp this instance's current pipeline watermark into the
-        // coordinator so the next `BarrierAck` carries it. i64::MIN
-        // means unset; don't propagate — leader treats us as non-blocking.
-        let wm = self
-            .pipeline_watermark
-            .load(std::sync::atomic::Ordering::Acquire);
-        coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
-        let follower_epoch = ann.epoch;
-        match coord
-            .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
-            .await
-        {
-            Ok(true) => {
-                tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
-                self.last_checkpoint = std::time::Instant::now();
-                // Record only on commit so a failed-then-retried epoch is not deduped.
-                self.last_follower_epoch = Some(follower_epoch);
-                Some(follower_epoch)
-            }
-            Ok(false) => {
-                tracing::warn!("follower checkpoint aborted (leader signalled Abort)");
-                None
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "follower checkpoint errored");
-                None
-            }
-        }
+        // Durable tail off the pipeline task; resume once every node has
+        // captured (Aligned). Completion is reported asynchronously via
+        // `checkpoint_complete_tx`, so there is no epoch to return here.
+        let stall_start = std::time::Instant::now();
+        let epoch = ann.epoch;
+        let has_shuffle = self.graph.cluster_shuffle_config().is_some();
+        self.spawn_follower_tail(request, ann, source_offsets);
+        Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        self.prom
+            .checkpoint_pipeline_stall_duration
+            .observe(stall_start.elapsed().as_secs_f64());
+        self.last_checkpoint = std::time::Instant::now();
+        None
     }
 
     #[cfg(feature = "cluster")]
@@ -517,7 +689,9 @@ impl ConnectorPipelineCallback {
         use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use crate::pipeline::BarrierOutcome;
 
-        let Some(ref controller) = self.cluster_controller else {
+        // Owned clone: `controller` outlives the `&mut self` calls below
+        // (state capture, tail spawn) without borrowing `self`.
+        let Some(controller) = self.cluster_controller.clone() else {
             return BarrierOutcome::Failed;
         };
 
@@ -530,7 +704,7 @@ impl ConnectorPipelineCallback {
                 .load(std::sync::atomic::Ordering::Acquire);
             if let Err(e) = self
                 .graph
-                .align_shuffle_barriers(ann.checkpoint_id, wm, &live, Some(controller))
+                .align_shuffle_barriers(ann.checkpoint_id, wm, &live, Some(&*controller))
                 .await
             {
                 tracing::warn!(error = %e, "follower shuffle alignment failed — skipping");
@@ -575,41 +749,22 @@ impl ConnectorPipelineCallback {
             source_offset_overrides: source_overrides,
         };
 
-        let vnode_states = self.capture_vnode_states();
-        let mut guard = self.coordinator.lock().await;
-        let Some(ref mut coord) = *guard else {
-            return BarrierOutcome::Failed;
-        };
-
-        coord.set_pending_vnode_states(vnode_states);
-        let wm = self
-            .pipeline_watermark
-            .load(std::sync::atomic::Ordering::Acquire);
-        coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
-        let follower_epoch = ann.epoch;
-
-        match coord
-            .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
-            .await
-        {
-            Ok(true) => {
-                tracing::info!(epoch = follower_epoch, "follower checkpoint committed");
-                self.last_checkpoint = std::time::Instant::now();
-                // Record only on commit; the caller already took
-                // `pending_follower_checkpoint`, so a failed deferred checkpoint
-                // leaves no dedup state and the leader's retry is reprocessed.
-                self.last_follower_epoch = Some(follower_epoch);
-                BarrierOutcome::Committed(follower_epoch)
-            }
-            Ok(false) => {
-                tracing::warn!("follower checkpoint aborted (leader signalled Abort)");
-                BarrierOutcome::Failed
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "follower checkpoint errored");
-                BarrierOutcome::Failed
-            }
-        }
+        // Durable tail (pre-commit + manifest + uploads + decision wait
+        // + 2PC) off the pipeline task; resume processing once every
+        // node has captured (Aligned) instead of stalling until Commit.
+        // Commit completion flows through `checkpoint_complete_tx`
+        // (EpochCommitted fan-out + wire barrier), so the outcome here
+        // is Async, not Committed.
+        let stall_start = std::time::Instant::now();
+        let epoch = ann.epoch;
+        let has_shuffle = self.graph.cluster_shuffle_config().is_some();
+        self.spawn_follower_tail(request, ann, source_checkpoints);
+        Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        self.prom
+            .checkpoint_pipeline_stall_duration
+            .observe(stall_start.elapsed().as_secs_f64());
+        self.last_checkpoint = std::time::Instant::now();
+        BarrierOutcome::Async
     }
 
     /// Leader-side cross-node shuffle barrier alignment, run *before* capture so
@@ -617,17 +772,26 @@ impl ConnectorPipelineCallback {
     /// leader announces `Prepare` early here (so followers begin aligning), then
     /// aligns. No-op when not the leader or there is no cross-node shuffle. On
     /// alignment failure it signals `Abort` so prepared followers don't block.
+    ///
+    /// Returns the epoch announced (read under the same coordinator lock,
+    /// before the background tail can hold it) so the caller can gate its
+    /// resume on the matching `Aligned` announcement; `None` when this
+    /// node isn't the cluster leader.
     #[cfg(feature = "cluster")]
-    async fn align_shuffle_for_leader(&mut self) -> Result<(), DbError> {
-        let (checkpoint_id, live) = {
+    async fn align_shuffle_for_leader(&mut self) -> Result<Option<u64>, DbError> {
+        let (checkpoint_id, epoch, live) = {
             let mut guard = self.coordinator.lock().await;
             match guard.as_mut() {
-                Some(coord) => (coord.announce_prepare().await, coord.live_node_ids()),
-                None => (None, Vec::new()),
+                Some(coord) => (
+                    coord.announce_prepare().await,
+                    coord.epoch(),
+                    coord.live_node_ids(),
+                ),
+                None => (None, 0, Vec::new()),
             }
         };
         let Some(checkpoint_id) = checkpoint_id else {
-            return Ok(());
+            return Ok(None);
         };
         let wm = self
             .pipeline_watermark
@@ -642,7 +806,7 @@ impl ConnectorPipelineCallback {
             }
             return Err(e);
         }
-        Ok(())
+        Ok(Some(epoch))
     }
 
     async fn capture_and_serialize_operator_state(
@@ -1394,6 +1558,10 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             return BarrierOutcome::Skipped(SkipReason::PreservingReplayWindowAfterSinkTimeout);
         }
 
+        // Everything from here until the Aligned resume gate releases is
+        // pipeline stall — the ADR-003 Phase-1 metric.
+        let stall_start = std::time::Instant::now();
+
         // Capture table source offsets.
         let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
         for (name, source, _) in &self.table_sources {
@@ -1405,11 +1573,15 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
         // Drain + align the cross-node shuffle before capture so peers'
         // pre-barrier rows enter the snapshot (announces Prepare early).
+        // The returned epoch keys this barrier's Aligned resume gate.
         #[cfg(feature = "cluster")]
-        if let Err(e) = self.align_shuffle_for_leader().await {
-            tracing::warn!(error = %e, "shuffle barrier alignment failed");
-            return BarrierOutcome::Failed;
-        }
+        let leader_epoch = match self.align_shuffle_for_leader().await {
+            Ok(epoch) => epoch,
+            Err(e) => {
+                tracing::warn!(error = %e, "shuffle barrier alignment failed");
+                return BarrierOutcome::Failed;
+            }
+        };
 
         // Capture stream executor aggregate state — now consistent because
         // all pre-barrier data has been executed. Serialize on blocking thread.
@@ -1481,6 +1653,21 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
         });
+
+        // Leader resume gate (ADR-003): hold the pipeline until the tail
+        // above announces `Aligned` (full-membership capture quorum) —
+        // resuming earlier could ship epoch-N+1 shuffle rows to a peer
+        // still folding pre-barrier rows into its epoch-N snapshot.
+        // Abort (quorum miss) also releases; the gate is bounded.
+        #[cfg(feature = "cluster")]
+        if let (Some(epoch), Some(cc)) = (leader_epoch, self.cluster_controller.clone()) {
+            let has_shuffle = self.graph.cluster_shuffle_config().is_some();
+            Self::wait_for_aligned_resume(has_shuffle, &cc, epoch).await;
+        }
+        self.prom
+            .checkpoint_pipeline_stall_duration
+            .observe(stall_start.elapsed().as_secs_f64());
+
         self.last_checkpoint = std::time::Instant::now();
         BarrierOutcome::Async
     }
@@ -1909,22 +2096,40 @@ mod tests {
         assert!(ConnectorPipelineCallback::follower_should_skip(
             Some(5),
             None,
+            None,
             5
         ));
         assert!(ConnectorPipelineCallback::follower_should_skip(
             Some(5),
             None,
+            None,
             3
         ));
     }
 
-    /// A deferred epoch awaiting local barriers (tracked via the in-flight
+    /// A deferred epoch awaiting local barriers (tracked via the pending
     /// arg) is deduped so its injectors aren't re-triggered each cycle.
     #[cfg(feature = "cluster")]
     #[test]
     fn follower_skips_in_flight_deferred_epoch() {
         assert!(ConnectorPipelineCallback::follower_should_skip(
             Some(4),
+            Some(5),
+            None,
+            5
+        ));
+    }
+
+    /// An epoch whose durable tail (prepare + decision wait) is running
+    /// in the background is deduped — the pipeline has already resumed,
+    /// so the same Prepare announcement stays visible (latest-wins
+    /// observation) and must not re-trigger capture.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_skips_epoch_with_tail_in_flight() {
+        assert!(ConnectorPipelineCallback::follower_should_skip(
+            Some(4),
+            None,
             Some(5),
             5
         ));
@@ -1940,11 +2145,12 @@ mod tests {
         assert!(!ConnectorPipelineCallback::follower_should_skip(
             Some(4),
             None,
+            None,
             5
         ));
         // Same on a fresh follower whose first epoch failed.
         assert!(!ConnectorPipelineCallback::follower_should_skip(
-            None, None, 5
+            None, None, None, 5
         ));
     }
 
@@ -1955,12 +2161,152 @@ mod tests {
         assert!(!ConnectorPipelineCallback::follower_should_skip(
             Some(5),
             None,
+            None,
             6
         ));
         assert!(!ConnectorPipelineCallback::follower_should_skip(
             Some(5),
             Some(5),
+            Some(5),
             6
         ));
+    }
+
+    /// Build a follower-side controller whose `current_leader()` is a
+    /// seeded peer, for resume-gate tests.
+    #[cfg(feature = "cluster")]
+    fn gate_controller() -> (
+        Arc<laminar_core::cluster::control::InMemoryKv>,
+        laminar_core::cluster::control::ClusterController,
+        laminar_core::cluster::discovery::NodeId,
+    ) {
+        use laminar_core::cluster::control::{ClusterController, ClusterKv, InMemoryKv};
+        use laminar_core::cluster::discovery::{NodeId, NodeInfo, NodeMetadata, NodeState};
+
+        let leader_id = NodeId(1);
+        let follower_id = NodeId(7);
+        let kv = Arc::new(InMemoryKv::new(follower_id));
+        let kv_trait: Arc<dyn ClusterKv> = kv.clone();
+        let leader_info = NodeInfo {
+            id: leader_id,
+            name: "leader".into(),
+            rpc_address: String::new(),
+            raft_address: String::new(),
+            state: NodeState::Active,
+            metadata: NodeMetadata::default(),
+            last_heartbeat_ms: 0,
+        };
+        let (tx, rx) = tokio::sync::watch::channel(vec![leader_info]);
+        // Keep the membership sender alive for the controller's lifetime.
+        std::mem::forget(tx);
+        (
+            kv,
+            ClusterController::new(follower_id, kv_trait, None, rx),
+            leader_id,
+        )
+    }
+
+    /// The resume gate releases on the leader's `Aligned` announcement.
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn aligned_resume_gate_releases_on_aligned() {
+        use laminar_core::cluster::control::{BarrierAnnouncement, Phase, ANNOUNCEMENT_KEY};
+
+        let (kv, controller, leader_id) = gate_controller();
+        let aligned = serde_json::to_string(&BarrierAnnouncement {
+            epoch: 3,
+            checkpoint_id: 3,
+            phase: Phase::Aligned,
+            flags: 0,
+            min_watermark_ms: Some(42),
+            seq: 0,
+        })
+        .unwrap();
+        kv.seed(leader_id, ANNOUNCEMENT_KEY, aligned);
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            ConnectorPipelineCallback::wait_for_aligned_resume(true, &controller, 3),
+        )
+        .await
+        .expect("gate must release on Aligned");
+        // The Aligned announcement also publishes the cluster-min
+        // watermark, so a resuming pipeline sees fresh event-time
+        // progress before the upload-gated Commit.
+        assert_eq!(controller.cluster_min_watermark(), Some(42));
+    }
+
+    /// A newer epoch's announcement supersedes the awaited one
+    /// (latest-wins observation can overwrite Aligned/Commit).
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn aligned_resume_gate_releases_on_newer_epoch() {
+        use laminar_core::cluster::control::{BarrierAnnouncement, Phase, ANNOUNCEMENT_KEY};
+
+        let (kv, controller, leader_id) = gate_controller();
+        let newer = serde_json::to_string(&BarrierAnnouncement {
+            epoch: 4,
+            checkpoint_id: 4,
+            phase: Phase::Prepare,
+            flags: 0,
+            min_watermark_ms: None,
+            seq: 0,
+        })
+        .unwrap();
+        kv.seed(leader_id, ANNOUNCEMENT_KEY, newer);
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            ConnectorPipelineCallback::wait_for_aligned_resume(true, &controller, 3),
+        )
+        .await
+        .expect("gate must release when a newer epoch is announced");
+    }
+
+    /// Without a cross-node shuffle there is no in-flight-row invariant
+    /// to protect — the gate is a no-op even with no announcement.
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn aligned_resume_gate_skips_without_shuffle() {
+        let (_kv, controller, _leader_id) = gate_controller();
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            ConnectorPipelineCallback::wait_for_aligned_resume(false, &controller, 3),
+        )
+        .await
+        .expect("gate must be a no-op without a cluster shuffle");
+    }
+
+    /// Tail bookkeeping: `finish` clears only its own epoch's in-flight
+    /// slot and advances `committed` only on commit.
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn follower_tail_state_lifecycle() {
+        let tail = FollowerTailState::default();
+        assert_eq!(tail.in_flight(), None);
+        assert_eq!(tail.committed(), None);
+
+        tail.begin(5);
+        assert_eq!(tail.in_flight(), Some(5));
+
+        // Aborted tail: in-flight cleared, committed not advanced.
+        tail.finish(5, false);
+        assert_eq!(tail.in_flight(), None);
+        assert_eq!(tail.committed(), None);
+
+        // Committed tail.
+        tail.begin(5);
+        tail.finish(5, true);
+        assert_eq!(tail.in_flight(), None);
+        assert_eq!(tail.committed(), Some(5));
+
+        // A stale tail finishing late must not clobber a newer epoch's
+        // in-flight slot, and committed stays monotonic.
+        tail.begin(7);
+        tail.finish(5, true);
+        assert_eq!(tail.in_flight(), Some(7), "stale finish must not clear");
+        assert_eq!(tail.committed(), Some(5));
+        tail.finish(7, true);
+        assert_eq!(tail.committed(), Some(7));
     }
 }

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -631,12 +631,22 @@ impl ConnectorPipelineCallback {
             .load(std::sync::atomic::Ordering::Acquire);
         self.follower_tail.begin(epoch);
 
+        // Charge the in-flight slot + staged bytes on followers too —
+        // without it, follower memory between capture and upload is
+        // unaccounted and unbounded by the admission caps.
+        let in_flight = EpochInFlightGuard::claim(
+            &self.checkpoint_in_flight,
+            &self.staged_bytes,
+            staged_request_bytes(&request, &vnode_states),
+        );
         let coordinator = Arc::clone(&self.coordinator);
         let tail = Arc::clone(&self.follower_tail);
         let complete_tx = self.checkpoint_complete_tx.clone();
         let cc = self.cluster_controller.clone();
         async move {
             use crate::checkpoint_coordinator::CheckpointCoordinator;
+
+            let _in_flight = in_flight; // released on drop, even on panic
 
             let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
             if let Some(ref cc) = cc {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -378,8 +378,6 @@ impl ConnectorPipelineCallback {
     async fn force_capture_and_checkpoint(
         &mut self,
     ) -> Result<crate::checkpoint_coordinator::CheckpointResult, DbError> {
-        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
-
         self.sync_sinks_and_drain_events().await;
 
         #[cfg(feature = "cluster")]
@@ -389,32 +387,7 @@ impl ConnectorPipelineCallback {
             .capture_and_serialize_operator_state()
             .await
             .map_err(DbError::Checkpoint)?;
-
-        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
-        for (name, source, _) in &self.table_sources {
-            extra_tables.insert(
-                name.clone(),
-                source_to_connector_checkpoint(&source.checkpoint()),
-            );
-        }
-
-        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
-        for (name, wm_state) in &self.watermark_states {
-            let wm = wm_state.generator.current_watermark();
-            if wm > i64::MIN {
-                per_source_watermarks.insert(name.clone(), wm);
-            }
-        }
-
-        let request = crate::checkpoint_coordinator::CheckpointRequest {
-            operator_states,
-            watermark: None,
-            table_store_checkpoint_path: None,
-            extra_table_offsets: extra_tables,
-            source_watermarks: per_source_watermarks,
-            pipeline_hash: self.pipeline_hash,
-            source_offset_overrides: HashMap::new(),
-        };
+        let request = self.build_checkpoint_request(operator_states, &FxHashMap::default());
 
         let vnode_states = self.capture_vnode_states();
         let mut guard = self.coordinator.lock().await;
@@ -582,7 +555,6 @@ impl ConnectorPipelineCallback {
         controller: Arc<laminar_core::cluster::control::ClusterController>,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64> {
-        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use laminar_core::cluster::control::Phase;
 
         let ann = match controller.observe_barrier().await {
@@ -637,33 +609,8 @@ impl ConnectorPipelineCallback {
             }
         }
 
-        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
-        for (name, source, _) in &self.table_sources {
-            extra_tables.insert(
-                name.clone(),
-                source_to_connector_checkpoint(&source.checkpoint()),
-            );
-        }
-        let source_overrides: HashMap<String, _> = source_offsets
-            .iter()
-            .map(|(name, cp)| (name.clone(), source_to_connector_checkpoint(cp)))
-            .collect();
-        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
-        for (name, wm_state) in &self.watermark_states {
-            let wm = wm_state.generator.current_watermark();
-            if wm > i64::MIN {
-                per_source_watermarks.insert(name.clone(), wm);
-            }
-        }
-        let request = crate::checkpoint_coordinator::CheckpointRequest {
-            operator_states: std::collections::HashMap::new(),
-            watermark: None,
-            table_store_checkpoint_path: None,
-            extra_table_offsets: extra_tables,
-            source_watermarks: per_source_watermarks,
-            pipeline_hash: self.pipeline_hash,
-            source_offset_overrides: source_overrides,
-        };
+        let request =
+            self.build_checkpoint_request(std::collections::HashMap::new(), &source_offsets);
 
         // Durable tail off the pipeline task; resume once every node has
         // captured (Aligned). Completion is reported asynchronously via
@@ -686,7 +633,6 @@ impl ConnectorPipelineCallback {
         ann: laminar_core::cluster::control::BarrierAnnouncement,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
     ) -> crate::pipeline::BarrierOutcome {
-        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use crate::pipeline::BarrierOutcome;
 
         // Owned clone: `controller` outlives the `&mut self` calls below
@@ -719,35 +665,7 @@ impl ConnectorPipelineCallback {
                 return BarrierOutcome::Failed;
             }
         };
-
-        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
-        for (name, source, _) in &self.table_sources {
-            extra_tables.insert(
-                name.clone(),
-                source_to_connector_checkpoint(&source.checkpoint()),
-            );
-        }
-        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
-        for (name, wm_state) in &self.watermark_states {
-            let wm = wm_state.generator.current_watermark();
-            if wm > i64::MIN {
-                per_source_watermarks.insert(name.clone(), wm);
-            }
-        }
-        let mut source_overrides = HashMap::with_capacity(source_checkpoints.len());
-        for (name, cp) in &source_checkpoints {
-            source_overrides.insert(name.clone(), source_to_connector_checkpoint(cp));
-        }
-
-        let request = crate::checkpoint_coordinator::CheckpointRequest {
-            operator_states,
-            watermark: None,
-            table_store_checkpoint_path: None,
-            extra_table_offsets: extra_tables,
-            source_watermarks: per_source_watermarks,
-            pipeline_hash: self.pipeline_hash,
-            source_offset_overrides: source_overrides,
-        };
+        let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
         // Durable tail (pre-commit + manifest + uploads + decision wait
         // + 2PC) off the pipeline task; resume processing once every
@@ -807,6 +725,48 @@ impl ConnectorPipelineCallback {
             return Err(e);
         }
         Ok(Some(epoch))
+    }
+
+    /// Assemble a [`CheckpointRequest`](crate::checkpoint_coordinator::CheckpointRequest)
+    /// from the given operator states and barrier-captured source
+    /// offsets, folding in table-source offsets and per-source
+    /// watermarks. Shared by every checkpoint entry point (leader
+    /// barrier, follower, timer, forced).
+    fn build_checkpoint_request(
+        &self,
+        operator_states: std::collections::HashMap<String, bytes::Bytes>,
+        source_checkpoints: &FxHashMap<String, SourceCheckpoint>,
+    ) -> crate::checkpoint_coordinator::CheckpointRequest {
+        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
+
+        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
+        for (name, source, _) in &self.table_sources {
+            extra_tables.insert(
+                name.clone(),
+                source_to_connector_checkpoint(&source.checkpoint()),
+            );
+        }
+        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
+        for (name, wm_state) in &self.watermark_states {
+            let wm = wm_state.generator.current_watermark();
+            if wm > i64::MIN {
+                per_source_watermarks.insert(name.clone(), wm);
+            }
+        }
+        let source_offset_overrides = source_checkpoints
+            .iter()
+            .map(|(name, cp)| (name.clone(), source_to_connector_checkpoint(cp)))
+            .collect();
+
+        crate::checkpoint_coordinator::CheckpointRequest {
+            operator_states,
+            watermark: None,
+            table_store_checkpoint_path: None,
+            extra_table_offsets: extra_tables,
+            source_watermarks: per_source_watermarks,
+            pipeline_hash: self.pipeline_hash,
+            source_offset_overrides,
+        }
     }
 
     async fn capture_and_serialize_operator_state(
@@ -1344,8 +1304,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64> {
-        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
-
         // Drain any pending `db.checkpoint()` requests first. Each
         // request gets a capture of operator state (the same path the
         // periodic barrier-aligned checkpoint uses), committed through
@@ -1421,21 +1379,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        // Capture table source offsets.
-        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
-        for (name, source, _) in &self.table_sources {
-            extra_tables.insert(
-                name.clone(),
-                source_to_connector_checkpoint(&source.checkpoint()),
-            );
-        }
-
-        // Convert source offsets from connector format to manifest format.
-        let source_overrides: HashMap<String, _> = source_offsets
-            .iter()
-            .map(|(name, cp)| (name.clone(), source_to_connector_checkpoint(cp)))
-            .collect();
-
         // Capture stream executor aggregate state and serialize on blocking thread.
         // Abort the checkpoint if serialization fails — persisting source
         // offsets without matching operator state would cause data loss on
@@ -1447,25 +1390,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 return None;
             }
         };
-
-        // Collect per-source watermarks from the watermark tracker.
-        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
-        for (name, wm_state) in &self.watermark_states {
-            let wm = wm_state.generator.current_watermark();
-            if wm > i64::MIN {
-                per_source_watermarks.insert(name.clone(), wm);
-            }
-        }
-
-        let request = crate::checkpoint_coordinator::CheckpointRequest {
-            operator_states,
-            watermark: None,
-            table_store_checkpoint_path: None,
-            extra_table_offsets: extra_tables,
-            source_watermarks: per_source_watermarks,
-            pipeline_hash: self.pipeline_hash,
-            source_offset_overrides: source_overrides,
-        };
+        let request = self.build_checkpoint_request(operator_states, &source_offsets);
 
         let vnode_states = self.capture_vnode_states();
         let mut committed = None;
@@ -1529,7 +1454,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
     ) -> crate::pipeline::BarrierOutcome {
-        use crate::checkpoint_coordinator::source_to_connector_checkpoint;
         use crate::pipeline::{BarrierOutcome, SkipReason};
 
         #[cfg(feature = "cluster")]
@@ -1559,17 +1483,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         }
 
         // Everything from here until the Aligned resume gate releases is
-        // pipeline stall — the ADR-003 Phase-1 metric.
+        // pipeline stall — the metric Phase 1 of ADR-003 targets.
         let stall_start = std::time::Instant::now();
-
-        // Capture table source offsets.
-        let mut extra_tables = HashMap::with_capacity(self.table_sources.len());
-        for (name, source, _) in &self.table_sources {
-            extra_tables.insert(
-                name.clone(),
-                source_to_connector_checkpoint(&source.checkpoint()),
-            );
-        }
 
         // Drain + align the cross-node shuffle before capture so peers'
         // pre-barrier rows enter the snapshot (announces Prepare early).
@@ -1595,34 +1510,11 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         };
 
-        // Collect per-source watermarks.
-        let mut per_source_watermarks = HashMap::with_capacity(self.watermark_states.len());
-        for (name, wm_state) in &self.watermark_states {
-            let wm = wm_state.generator.current_watermark();
-            if wm > i64::MIN {
-                per_source_watermarks.insert(name.clone(), wm);
-            }
-        }
-
-        // Barrier-captured source offsets go into source_offset_overrides
-        // so they land in manifest.source_offsets (not table_offsets).
-        // These positions are consistent with the operator state at the
-        // barrier point and must not be re-queried from the live connectors.
-        let mut source_overrides = HashMap::with_capacity(source_checkpoints.len());
-        for (name, cp) in &source_checkpoints {
-            source_overrides.insert(name.clone(), source_to_connector_checkpoint(cp));
-        }
-
+        // The barrier-captured source offsets are consistent with the
+        // operator state at the barrier point and must not be re-queried
+        // from the live connectors.
         let vnode_states = self.capture_vnode_states();
-        let request = crate::checkpoint_coordinator::CheckpointRequest {
-            operator_states,
-            watermark: None,
-            table_store_checkpoint_path: None,
-            extra_table_offsets: extra_tables,
-            source_watermarks: per_source_watermarks,
-            pipeline_hash: self.pipeline_hash,
-            source_offset_overrides: source_overrides,
-        };
+        let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
         // Persist in the background; in-flight flag bounds to one checkpoint at a time.
         self.checkpoint_in_flight
@@ -2173,12 +2065,14 @@ mod tests {
     }
 
     /// Build a follower-side controller whose `current_leader()` is a
-    /// seeded peer, for resume-gate tests.
+    /// seeded peer, for resume-gate tests. The caller holds the
+    /// returned membership sender alive for the test's duration.
     #[cfg(feature = "cluster")]
     fn gate_controller() -> (
         Arc<laminar_core::cluster::control::InMemoryKv>,
         laminar_core::cluster::control::ClusterController,
         laminar_core::cluster::discovery::NodeId,
+        tokio::sync::watch::Sender<Vec<laminar_core::cluster::discovery::NodeInfo>>,
     ) {
         use laminar_core::cluster::control::{ClusterController, ClusterKv, InMemoryKv};
         use laminar_core::cluster::discovery::{NodeId, NodeInfo, NodeMetadata, NodeState};
@@ -2197,12 +2091,11 @@ mod tests {
             last_heartbeat_ms: 0,
         };
         let (tx, rx) = tokio::sync::watch::channel(vec![leader_info]);
-        // Keep the membership sender alive for the controller's lifetime.
-        std::mem::forget(tx);
         (
             kv,
             ClusterController::new(follower_id, kv_trait, None, rx),
             leader_id,
+            tx,
         )
     }
 
@@ -2212,7 +2105,7 @@ mod tests {
     async fn aligned_resume_gate_releases_on_aligned() {
         use laminar_core::cluster::control::{BarrierAnnouncement, Phase, ANNOUNCEMENT_KEY};
 
-        let (kv, controller, leader_id) = gate_controller();
+        let (kv, controller, leader_id, _members_tx) = gate_controller();
         let aligned = serde_json::to_string(&BarrierAnnouncement {
             epoch: 3,
             checkpoint_id: 3,
@@ -2243,7 +2136,7 @@ mod tests {
     async fn aligned_resume_gate_releases_on_newer_epoch() {
         use laminar_core::cluster::control::{BarrierAnnouncement, Phase, ANNOUNCEMENT_KEY};
 
-        let (kv, controller, leader_id) = gate_controller();
+        let (kv, controller, leader_id, _members_tx) = gate_controller();
         let newer = serde_json::to_string(&BarrierAnnouncement {
             epoch: 4,
             checkpoint_id: 4,
@@ -2268,7 +2161,7 @@ mod tests {
     #[cfg(feature = "cluster")]
     #[tokio::test]
     async fn aligned_resume_gate_skips_without_shuffle() {
-        let (_kv, controller, _leader_id) = gate_controller();
+        let (_kv, controller, _leader_id, _members_tx) = gate_controller();
         tokio::time::timeout(
             Duration::from_millis(100),
             ConnectorPipelineCallback::wait_for_aligned_resume(false, &controller, 3),

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -158,7 +158,7 @@ fn staged_request_bytes(
 }
 
 /// Follower durable-tail bookkeeping shared between the pipeline task
-/// and the spawned tail task (ADR-003 two-level completion). Epochs
+/// and the spawned tail task. Epochs
 /// start at 1, so `0` encodes "none".
 #[cfg(feature = "cluster")]
 #[derive(Debug, Default)]
@@ -602,8 +602,8 @@ impl ConnectorPipelineCallback {
     /// Hand the follower's durable tail — sink pre-commit, manifest
     /// save, vnode-partial uploads, the leader-decision wait, and the
     /// 2PC commit/rollback — to a background task so the pipeline can
-    /// resume on `Aligned` instead of stalling until `Commit`
-    /// (ADR-003 two-level completion). The capture ack is sent before
+    /// resume on `Aligned` instead of stalling until `Commit`.
+    /// The capture ack is sent before
     /// queuing on the coordinator mutex — an earlier epoch's tail may
     /// hold it for the duration of its uploads, and the leader's quorum
     /// must not wait on those. On commit, completion flows through
@@ -707,7 +707,7 @@ impl ConnectorPipelineCallback {
     }
 
     /// Block the pipeline until the leader announces `Aligned` for
-    /// `epoch` — the re-keyed shuffle-alignment resume gate (ADR-003).
+    /// `epoch` — the re-keyed shuffle-alignment resume gate.
     /// `Aligned` is announced only after the *full-membership* capture
     /// quorum, preserving the invariant the no-post-barrier-buffering
     /// shuffle drain relies on: no peer ships epoch-N+1 rows while
@@ -1721,7 +1721,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         }
 
         // Everything from here until the Aligned resume gate releases is
-        // pipeline stall — the metric Phase 1 of ADR-003 targets.
+        // pipeline stall — what checkpoint_pipeline_stall_duration measures.
         let stall_start = std::time::Instant::now();
 
         // Drain + align the cross-node shuffle before capture so peers'
@@ -1784,7 +1784,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             quorum_timeout: self.quorum_timeout,
         }));
 
-        // Leader resume gate (ADR-003): hold the pipeline until the tail
+        // Leader resume gate: hold the pipeline until the tail
         // above announces `Aligned` (full-membership capture quorum) —
         // resuming earlier could ship epoch-N+1 shuffle rows to a peer
         // still folding pre-barrier rows into its epoch-N snapshot.

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -122,6 +122,28 @@ impl Drop for EpochInFlightGuard {
     }
 }
 
+/// Everything the leader's spawned durable tail needs
+/// (see [`ConnectorPipelineCallback::run_leader_tail`]).
+struct LeaderTail {
+    in_flight: EpochInFlightGuard,
+    coordinator:
+        Arc<tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>>,
+    complete_tx: crossfire::MAsyncTx<
+        crossfire::mpsc::Array<(u64, rustc_hash::FxHashMap<String, SourceCheckpoint>)>,
+    >,
+    request: crate::checkpoint_coordinator::CheckpointRequest,
+    #[allow(clippy::disallowed_types)]
+    vnode_states: std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+    fan_out: FxHashMap<String, SourceCheckpoint>,
+    local_watermark_ms: Option<i64>,
+    /// `Some` when this node admitted the barrier as cluster leader.
+    leader_ids: Option<(u64, u64)>,
+    #[cfg(feature = "cluster")]
+    controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
+    #[cfg(feature = "cluster")]
+    quorum_timeout: Duration,
+}
+
 /// Captured-state bytes a pending [`CheckpointRequest`]
 /// (plus per-vnode slices) holds in memory while its epoch is between
 /// capture and upload — the unit the `max_staged_bytes` admission cap
@@ -500,6 +522,91 @@ impl ConnectorPipelineCallback {
         last_committed.is_some_and(|e| e >= ann_epoch)
             || pending.is_some_and(|e| e >= ann_epoch)
             || tail_in_flight.is_some_and(|e| e >= ann_epoch)
+    }
+
+    /// The leader's durable tail, spawned per admitted barrier
+    /// (`run_leader_tail`). Stage 1 (cluster): capture quorum +
+    /// `Aligned` announce, run *before* the coordinator mutex so the
+    /// resume gate never queues behind an earlier epoch's uploads.
+    /// Stage 2: the durable remainder under the FIFO mutex, which keeps
+    /// epochs restorable in order. Commit completion flows back through
+    /// `complete_tx` (`EpochCommitted` fan-out + wire barrier).
+    async fn run_leader_tail(tail: LeaderTail) {
+        use crate::checkpoint_coordinator::QuorumStage;
+
+        let _in_flight = tail.in_flight; // released on drop, even on panic
+
+        #[allow(unused_mut)]
+        let mut quorum = QuorumStage::RunInline;
+        #[cfg(feature = "cluster")]
+        if let (Some(cc), Some((epoch, checkpoint_id))) =
+            (tail.controller.as_ref(), tail.leader_ids)
+        {
+            use crate::checkpoint_coordinator::CheckpointCoordinator;
+            use laminar_core::cluster::control::{BarrierAnnouncement, Phase};
+            match CheckpointCoordinator::run_prepare_quorum(
+                cc,
+                tail.quorum_timeout,
+                epoch,
+                checkpoint_id,
+                tail.local_watermark_ms,
+            )
+            .await
+            {
+                Ok(min_watermark_ms) => {
+                    if let Err(e) = cc
+                        .announce_barrier(&BarrierAnnouncement {
+                            epoch,
+                            checkpoint_id,
+                            phase: Phase::Aligned,
+                            flags: 0,
+                            min_watermark_ms,
+                            seq: 0,
+                        })
+                        .await
+                    {
+                        tracing::warn!(
+                            epoch, error = %e,
+                            "[LDB-6031] aligned announcement failed; peers resume on Commit"
+                        );
+                    }
+                    quorum = QuorumStage::Done(min_watermark_ms);
+                }
+                Err(msg) => {
+                    tracing::error!(checkpoint_id, epoch, error = %msg, "[LDB-6032] quorum miss");
+                    let mut guard = tail.coordinator.lock().await;
+                    if let Some(ref mut coord) = *guard {
+                        coord.abandon_epoch(checkpoint_id, epoch, msg).await;
+                    }
+                    return;
+                }
+            }
+        }
+
+        let mut guard = tail.coordinator.lock().await;
+        if let Some(ref mut coord) = *guard {
+            coord.set_pending_vnode_states(tail.vnode_states);
+            coord.set_local_watermark_ms(tail.local_watermark_ms);
+            let result = match tail.leader_ids {
+                Some((epoch, checkpoint_id)) => {
+                    coord
+                        .checkpoint_preallocated(tail.request, epoch, checkpoint_id, quorum)
+                        .await
+                }
+                None => coord.checkpoint_with_offsets(tail.request).await,
+            };
+            match result {
+                Ok(result) if result.success => {
+                    let _ = tail.complete_tx.send((result.epoch, tail.fan_out)).await;
+                }
+                Ok(result) => tracing::warn!(
+                    epoch = result.epoch,
+                    error = ?result.error,
+                    "Barrier-aligned checkpoint failed"
+                ),
+                Err(e) => tracing::warn!(error = %e, "Barrier-aligned checkpoint error"),
+            }
+        }
     }
 
     /// Hand the follower's durable tail — sink pre-commit, manifest
@@ -1647,91 +1754,23 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             &self.staged_bytes,
             staged_request_bytes(&request, &vnode_states),
         );
-        let coordinator_clone = Arc::clone(&self.coordinator);
-        let tx = self.checkpoint_complete_tx.clone();
-        let fan_out = source_checkpoints.clone();
         let wm = self
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
-        #[cfg(feature = "cluster")]
-        let cc_for_tail = self.cluster_controller.clone();
-        #[cfg(feature = "cluster")]
-        let quorum_timeout = self.quorum_timeout;
-        tokio::spawn(async move {
-            use crate::checkpoint_coordinator::{CheckpointCoordinator, QuorumStage};
-
-            let _in_flight = in_flight; // released on drop, even on panic
-            let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
-
-            #[allow(unused_mut)]
-            let mut quorum = QuorumStage::RunInline;
+        tokio::spawn(Self::run_leader_tail(LeaderTail {
+            in_flight,
+            coordinator: Arc::clone(&self.coordinator),
+            complete_tx: self.checkpoint_complete_tx.clone(),
+            request,
+            vnode_states,
+            fan_out: source_checkpoints.clone(),
+            local_watermark_ms: if wm == i64::MIN { None } else { Some(wm) },
+            leader_ids,
             #[cfg(feature = "cluster")]
-            if let (Some(cc), Some((epoch, checkpoint_id))) = (cc_for_tail.as_ref(), leader_ids) {
-                use laminar_core::cluster::control::{BarrierAnnouncement, Phase};
-                match CheckpointCoordinator::run_prepare_quorum(
-                    cc,
-                    quorum_timeout,
-                    epoch,
-                    checkpoint_id,
-                    wm_opt,
-                )
-                .await
-                {
-                    Ok(min_watermark_ms) => {
-                        if let Err(e) = cc
-                            .announce_barrier(&BarrierAnnouncement {
-                                epoch,
-                                checkpoint_id,
-                                phase: Phase::Aligned,
-                                flags: 0,
-                                min_watermark_ms,
-                                seq: 0,
-                            })
-                            .await
-                        {
-                            tracing::warn!(
-                                epoch, error = %e,
-                                "[LDB-6031] aligned announcement failed; peers resume on Commit"
-                            );
-                        }
-                        quorum = QuorumStage::Done(min_watermark_ms);
-                    }
-                    Err(msg) => {
-                        tracing::error!(checkpoint_id, epoch, error = %msg, "[LDB-6032] quorum miss");
-                        let mut guard = coordinator_clone.lock().await;
-                        if let Some(ref mut coord) = *guard {
-                            coord.abandon_epoch(checkpoint_id, epoch, msg).await;
-                        }
-                        return;
-                    }
-                }
-            }
-
-            let mut guard = coordinator_clone.lock().await;
-            if let Some(ref mut coord) = *guard {
-                coord.set_pending_vnode_states(vnode_states);
-                coord.set_local_watermark_ms(wm_opt);
-                let result = match leader_ids {
-                    Some((epoch, checkpoint_id)) => {
-                        coord
-                            .checkpoint_preallocated(request, epoch, checkpoint_id, quorum)
-                            .await
-                    }
-                    None => coord.checkpoint_with_offsets(request).await,
-                };
-                match result {
-                    Ok(result) if result.success => {
-                        let _ = tx.send((result.epoch, fan_out)).await;
-                    }
-                    Ok(result) => tracing::warn!(
-                        epoch = result.epoch,
-                        error = ?result.error,
-                        "Barrier-aligned checkpoint failed"
-                    ),
-                    Err(e) => tracing::warn!(error = %e, "Barrier-aligned checkpoint error"),
-                }
-            }
-        });
+            controller: self.cluster_controller.clone(),
+            #[cfg(feature = "cluster")]
+            quorum_timeout: self.quorum_timeout,
+        }));
 
         // Leader resume gate (ADR-003): hold the pipeline until the tail
         // above announces `Aligned` (full-membership capture quorum) —

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -42,15 +42,11 @@ enum SinkFilterDispatch {
 /// 3. The compute thread is dedicated — blocking is acceptable
 // Throttled (~once/10s) WARN so silent watermark drops are diagnosable.
 fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize) {
-    use std::sync::atomic::{AtomicI64, Ordering};
-    static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
-    if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
+    static THROTTLE: crate::log_throttle::LogThrottle =
+        crate::log_throttle::LogThrottle::every(Duration::from_secs(10));
+    if !THROTTLE.allow() {
         return;
     }
-    LAST_WARN_MS.store(now_ms, Ordering::Relaxed);
     tracing::warn!(
         source,
         time_column = column,
@@ -75,16 +71,11 @@ const SUB_ROUTE_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// with `cause` so a full queue isn't confused with a slow peer.
 #[cfg(feature = "cluster")]
 fn warn_subscription_route_drop(cause: &str) {
-    use std::sync::atomic::{AtomicI64, Ordering};
-    static LAST_WARN_MS: AtomicI64 = AtomicI64::new(0);
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
-    if now_ms - LAST_WARN_MS.load(Ordering::Relaxed) < 10_000 {
-        return;
+    static THROTTLE: crate::log_throttle::LogThrottle =
+        crate::log_throttle::LogThrottle::every(Duration::from_secs(10));
+    if THROTTLE.allow() {
+        tracing::warn!(cause, "dropping remote subscription batch");
     }
-    LAST_WARN_MS.store(now_ms, Ordering::Relaxed);
-    tracing::warn!(cause, "dropping remote subscription batch");
 }
 
 /// Releases an in-flight epoch's admission slot and staged-bytes
@@ -561,7 +552,6 @@ impl ConnectorPipelineCallback {
                             phase: Phase::Aligned,
                             flags: 0,
                             min_watermark_ms,
-                            seq: 0,
                         })
                         .await
                     {
@@ -624,10 +614,10 @@ impl ConnectorPipelineCallback {
     fn spawn_follower_tail(
         &mut self,
         request: crate::checkpoint_coordinator::CheckpointRequest,
-        ann: laminar_core::cluster::control::BarrierAnnouncement,
+        epoch: u64,
+        checkpoint_id: u64,
         fan_out: FxHashMap<String, SourceCheckpoint>,
     ) {
-        let epoch = ann.epoch;
         let vnode_states = self.capture_vnode_states();
         let wm = self
             .pipeline_watermark
@@ -639,6 +629,8 @@ impl ConnectorPipelineCallback {
         let complete_tx = self.checkpoint_complete_tx.clone();
         let cc = self.cluster_controller.clone();
         tokio::spawn(async move {
+            use crate::checkpoint_coordinator::CheckpointCoordinator;
+
             let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
             if let Some(ref cc) = cc {
                 cc.ack_barrier(&laminar_core::cluster::control::BarrierAck {
@@ -650,40 +642,61 @@ impl ConnectorPipelineCallback {
                 .await
                 .ok();
             }
-            let committed = {
+
+            // Stage 1: durable prepare under the FIFO mutex.
+            let decision_store = {
                 let mut guard = coordinator.lock().await;
                 match guard.as_mut() {
                     Some(coord) => {
                         coord.set_pending_vnode_states(vnode_states);
                         coord.set_local_watermark_ms(wm_opt);
                         match coord
-                            .follower_checkpoint_acked(
-                                request,
-                                ann,
-                                std::time::Duration::from_secs(30),
-                            )
+                            .follower_prepare_acked(request, epoch, checkpoint_id)
                             .await
                         {
-                            Ok(true) => {
-                                tracing::info!(epoch, "follower checkpoint committed");
-                                true
-                            }
-                            Ok(false) => {
-                                tracing::warn!(
-                                    epoch,
-                                    "follower checkpoint aborted (leader signalled Abort)"
-                                );
-                                false
-                            }
+                            Ok(()) => Some(coord.decision_store_handle()),
                             Err(e) => {
-                                tracing::warn!(epoch, error = %e, "follower checkpoint errored");
-                                false
+                                tracing::warn!(epoch, error = %e, "follower prepare errored");
+                                None
                             }
                         }
                     }
-                    None => false,
+                    None => None,
                 }
             };
+
+            // Stage 2: await the leader's decision WITHOUT the mutex —
+            // the next epoch's prepare/uploads must not queue behind a
+            // wait that can last the full decision timeout.
+            let committed = match (decision_store, cc.as_ref()) {
+                (Some(decision_store), Some(cc)) => {
+                    let verdict = CheckpointCoordinator::await_follower_decision(
+                        cc,
+                        decision_store.as_deref(),
+                        epoch,
+                        checkpoint_id,
+                        std::time::Duration::from_secs(30),
+                    )
+                    .await;
+                    // Stage 3: act on the verdict under the mutex.
+                    let mut guard = coordinator.lock().await;
+                    match guard.as_mut() {
+                        Some(coord) => {
+                            let committed =
+                                coord.follower_finish(epoch, checkpoint_id, verdict).await;
+                            if committed {
+                                tracing::info!(epoch, "follower checkpoint committed");
+                            } else {
+                                tracing::warn!(epoch, "follower checkpoint aborted");
+                            }
+                            committed
+                        }
+                        None => false,
+                    }
+                }
+                _ => false,
+            };
+
             // Record only on commit so a failed-then-retried epoch is
             // reprocessed, not deduped.
             tail.finish(epoch, committed);
@@ -810,7 +823,7 @@ impl ConnectorPipelineCallback {
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
-        self.spawn_follower_tail(request, ann, source_offsets);
+        self.spawn_follower_tail(request, ann.epoch, ann.checkpoint_id, source_offsets);
         Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
         self.prom
             .checkpoint_pipeline_stall_duration
@@ -868,7 +881,7 @@ impl ConnectorPipelineCallback {
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
-        self.spawn_follower_tail(request, ann, source_checkpoints);
+        self.spawn_follower_tail(request, ann.epoch, ann.checkpoint_id, source_checkpoints);
         Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
         self.prom
             .checkpoint_pipeline_stall_duration
@@ -907,7 +920,6 @@ impl ConnectorPipelineCallback {
                 phase: Phase::Prepare,
                 flags: 0,
                 min_watermark_ms: None,
-                seq: 0,
             })
             .await
         {
@@ -2338,7 +2350,6 @@ mod tests {
             phase: Phase::Aligned,
             flags: 0,
             min_watermark_ms: Some(42),
-            seq: 0,
         })
         .unwrap();
         kv.seed(leader_id, ANNOUNCEMENT_KEY, aligned);
@@ -2369,7 +2380,6 @@ mod tests {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         })
         .unwrap();
         kv.seed(leader_id, ANNOUNCEMENT_KEY, newer);

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -614,10 +614,8 @@ impl ConnectorPipelineCallback {
     /// pre-commit, manifest save, vnode-partial uploads, the
     /// leader-decision wait, and the 2PC commit/rollback. Spawned to a
     /// background task so the pipeline can resume on `Aligned`, or
-    /// awaited inline for exactly-once pipelines (a single
-    /// transactional producer must not receive post-barrier rows while
-    /// the epoch's transaction is still open — resuming early would
-    /// commit them with epoch N and duplicate them on replay).
+    /// awaited inline for exactly-once pipelines (see
+    /// [`Self::exactly_once_sinks`]).
     /// The capture ack is sent before
     /// queuing on the coordinator mutex — an earlier epoch's tail may
     /// hold it for the duration of its uploads, and the leader's quorum
@@ -835,10 +833,7 @@ impl ConnectorPipelineCallback {
         // Durable tail off the pipeline task; resume once every node has
         // captured (Aligned). Completion is reported asynchronously via
         // `checkpoint_complete_tx`, so there is no epoch to return here.
-        // Exactly-once: the tail runs INLINE — the single transactional
-        // producer must not receive post-barrier rows while the epoch's
-        // transaction is open (resuming on Aligned would commit them
-        // with this epoch and duplicate them on replay).
+        // Exactly-once runs the tail inline (see `exactly_once_sinks`).
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
@@ -1815,10 +1810,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             quorum_timeout: self.quorum_timeout,
         };
         if self.exactly_once_sinks {
-            // Inline: the single transactional producer must not see
-            // post-barrier rows while the epoch's transaction is open —
-            // an early resume would commit them with this epoch and
-            // duplicate them on replay. (Producer pooling lifts this.)
+            // Inline — no early resume (see `exactly_once_sinks`).
             Self::run_leader_tail(tail).await;
         } else {
             tokio::spawn(Self::run_leader_tail(tail));

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -325,6 +325,14 @@ pub(crate) struct ConnectorPipelineCallback {
     /// Copied from `CheckpointConfig` for the pre-mutex quorum stage.
     #[cfg(feature = "cluster")]
     pub(crate) quorum_timeout: Duration,
+    /// True when any registered sink is exactly-once. Durable tails
+    /// then run INLINE (pipeline blocked until the commit decision):
+    /// a single transactional producer must not receive post-barrier
+    /// rows while the epoch's transaction is open — an early resume
+    /// would commit them with epoch N and duplicate them on replay.
+    /// Producer pooling (one transaction per in-flight epoch) is the
+    /// follow-up that lifts this.
+    pub(crate) exactly_once_sinks: bool,
 }
 
 impl ConnectorPipelineCallback {
@@ -602,10 +610,14 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Hand the follower's durable tail — sink pre-commit, manifest
-    /// save, vnode-partial uploads, the leader-decision wait, and the
-    /// 2PC commit/rollback — to a background task so the pipeline can
-    /// resume on `Aligned` instead of stalling until `Commit`.
+    /// Build the follower's durable tail — capture ack, sink
+    /// pre-commit, manifest save, vnode-partial uploads, the
+    /// leader-decision wait, and the 2PC commit/rollback. Spawned to a
+    /// background task so the pipeline can resume on `Aligned`, or
+    /// awaited inline for exactly-once pipelines (a single
+    /// transactional producer must not receive post-barrier rows while
+    /// the epoch's transaction is still open — resuming early would
+    /// commit them with epoch N and duplicate them on replay).
     /// The capture ack is sent before
     /// queuing on the coordinator mutex — an earlier epoch's tail may
     /// hold it for the duration of its uploads, and the leader's quorum
@@ -614,13 +626,13 @@ impl ConnectorPipelineCallback {
     /// `EpochCommitted` out to sources and publishes the wire barrier —
     /// the same path the leader's background persist uses.
     #[cfg(feature = "cluster")]
-    fn spawn_follower_tail(
+    fn follower_tail_future(
         &mut self,
         request: crate::checkpoint_coordinator::CheckpointRequest,
         epoch: u64,
         checkpoint_id: u64,
         fan_out: FxHashMap<String, SourceCheckpoint>,
-    ) {
+    ) -> impl std::future::Future<Output = ()> + Send + 'static {
         let vnode_states = self.capture_vnode_states();
         let wm = self
             .pipeline_watermark
@@ -631,7 +643,7 @@ impl ConnectorPipelineCallback {
         let tail = Arc::clone(&self.follower_tail);
         let complete_tx = self.checkpoint_complete_tx.clone();
         let cc = self.cluster_controller.clone();
-        tokio::spawn(async move {
+        async move {
             use crate::checkpoint_coordinator::CheckpointCoordinator;
 
             let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
@@ -706,7 +718,7 @@ impl ConnectorPipelineCallback {
             if committed {
                 let _ = complete_tx.send((epoch, fan_out)).await;
             }
-        });
+        }
     }
 
     /// Block the pipeline until the leader announces `Aligned` for
@@ -823,11 +835,20 @@ impl ConnectorPipelineCallback {
         // Durable tail off the pipeline task; resume once every node has
         // captured (Aligned). Completion is reported asynchronously via
         // `checkpoint_complete_tx`, so there is no epoch to return here.
+        // Exactly-once: the tail runs INLINE — the single transactional
+        // producer must not receive post-barrier rows while the epoch's
+        // transaction is open (resuming on Aligned would commit them
+        // with this epoch and duplicate them on replay).
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
-        self.spawn_follower_tail(request, ann.epoch, ann.checkpoint_id, source_offsets);
-        Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        let tail = self.follower_tail_future(request, ann.epoch, ann.checkpoint_id, source_offsets);
+        if self.exactly_once_sinks {
+            tail.await;
+        } else {
+            tokio::spawn(tail);
+            Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        }
         self.prom
             .checkpoint_pipeline_stall_duration
             .observe(stall_start.elapsed().as_secs_f64());
@@ -880,12 +901,19 @@ impl ConnectorPipelineCallback {
         // node has captured (Aligned) instead of stalling until Commit.
         // Commit completion flows through `checkpoint_complete_tx`
         // (EpochCommitted fan-out + wire barrier), so the outcome here
-        // is Async, not Committed.
+        // is Async, not Committed. Exactly-once runs the tail inline
+        // (see `run_follower_checkpoint_deferred`).
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
-        self.spawn_follower_tail(request, ann.epoch, ann.checkpoint_id, source_checkpoints);
-        Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        let tail =
+            self.follower_tail_future(request, ann.epoch, ann.checkpoint_id, source_checkpoints);
+        if self.exactly_once_sinks {
+            tail.await;
+        } else {
+            tokio::spawn(tail);
+            Self::wait_for_aligned_resume(has_shuffle, &controller, epoch).await;
+        }
         self.prom
             .checkpoint_pipeline_stall_duration
             .observe(stall_start.elapsed().as_secs_f64());
@@ -1772,7 +1800,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let wm = self
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
-        tokio::spawn(Self::run_leader_tail(LeaderTail {
+        let tail = LeaderTail {
             in_flight,
             coordinator: Arc::clone(&self.coordinator),
             complete_tx: self.checkpoint_complete_tx.clone(),
@@ -1785,17 +1813,27 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             controller: self.cluster_controller.clone(),
             #[cfg(feature = "cluster")]
             quorum_timeout: self.quorum_timeout,
-        }));
+        };
+        if self.exactly_once_sinks {
+            // Inline: the single transactional producer must not see
+            // post-barrier rows while the epoch's transaction is open —
+            // an early resume would commit them with this epoch and
+            // duplicate them on replay. (Producer pooling lifts this.)
+            Self::run_leader_tail(tail).await;
+        } else {
+            tokio::spawn(Self::run_leader_tail(tail));
 
-        // Leader resume gate: hold the pipeline until the tail
-        // above announces `Aligned` (full-membership capture quorum) —
-        // resuming earlier could ship epoch-N+1 shuffle rows to a peer
-        // still folding pre-barrier rows into its epoch-N snapshot.
-        // Abort (quorum miss) also releases; the gate is bounded.
-        #[cfg(feature = "cluster")]
-        if let (Some((epoch, _)), Some(cc)) = (leader_ids, self.cluster_controller.clone()) {
-            let has_shuffle = self.graph.cluster_shuffle_config().is_some();
-            Self::wait_for_aligned_resume(has_shuffle, &cc, epoch).await;
+            // Leader resume gate: hold the pipeline until the tail
+            // above announces `Aligned` (full-membership capture
+            // quorum) — resuming earlier could ship epoch-N+1 shuffle
+            // rows to a peer still folding pre-barrier rows into its
+            // epoch-N snapshot. Abort (quorum miss) also releases; the
+            // gate is bounded.
+            #[cfg(feature = "cluster")]
+            if let (Some((epoch, _)), Some(cc)) = (leader_ids, self.cluster_controller.clone()) {
+                let has_shuffle = self.graph.cluster_shuffle_config().is_some();
+                Self::wait_for_aligned_resume(has_shuffle, &cc, epoch).await;
+            }
         }
         self.prom
             .checkpoint_pipeline_stall_duration

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -87,14 +87,61 @@ fn warn_subscription_route_drop(cause: &str) {
     tracing::warn!(cause, "dropping remote subscription batch");
 }
 
-/// Clears the in-flight checkpoint flag on drop, so a panicking persist task
-/// can't leave it stuck and permanently disable checkpointing.
-struct CheckpointInFlightGuard(Arc<std::sync::atomic::AtomicBool>);
+/// Releases an in-flight epoch's admission slot and staged-bytes
+/// budget on drop, so a panicking tail can't leave them leaked and
+/// permanently stall checkpoint admission.
+struct EpochInFlightGuard {
+    in_flight: Arc<std::sync::atomic::AtomicU64>,
+    staged_bytes: Arc<std::sync::atomic::AtomicU64>,
+    bytes: u64,
+}
 
-impl Drop for CheckpointInFlightGuard {
-    fn drop(&mut self) {
-        self.0.store(false, std::sync::atomic::Ordering::Release);
+impl EpochInFlightGuard {
+    /// Claim one admission slot and `bytes` of the staged budget.
+    fn claim(
+        in_flight: &Arc<std::sync::atomic::AtomicU64>,
+        staged_bytes: &Arc<std::sync::atomic::AtomicU64>,
+        bytes: u64,
+    ) -> Self {
+        in_flight.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        staged_bytes.fetch_add(bytes, std::sync::atomic::Ordering::AcqRel);
+        Self {
+            in_flight: Arc::clone(in_flight),
+            staged_bytes: Arc::clone(staged_bytes),
+            bytes,
+        }
     }
+}
+
+impl Drop for EpochInFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight
+            .fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+        self.staged_bytes
+            .fetch_sub(self.bytes, std::sync::atomic::Ordering::AcqRel);
+    }
+}
+
+/// Captured-state bytes a pending [`CheckpointRequest`]
+/// (plus per-vnode slices) holds in memory while its epoch is between
+/// capture and upload — the unit the `max_staged_bytes` admission cap
+/// counts.
+#[allow(clippy::disallowed_types)]
+fn staged_request_bytes(
+    request: &crate::checkpoint_coordinator::CheckpointRequest,
+    vnode_states: &std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+) -> u64 {
+    let ops: usize = request
+        .operator_states
+        .values()
+        .map(bytes::Bytes::len)
+        .sum();
+    let vnodes: usize = vnode_states
+        .values()
+        .flat_map(|m| m.values())
+        .map(bytes::Bytes::len)
+        .sum();
+    (ops + vnodes) as u64
 }
 
 /// Follower durable-tail bookkeeping shared between the pipeline task
@@ -251,9 +298,20 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) checkpoint_complete_tx: crossfire::MAsyncTx<
         crossfire::mpsc::Array<(u64, rustc_hash::FxHashMap<String, SourceCheckpoint>)>,
     >,
-    /// Set while a background checkpoint persists; the coordinator reads it to
-    /// bound concurrent checkpoints to one.
-    pub(crate) checkpoint_in_flight: Arc<std::sync::atomic::AtomicBool>,
+    /// Count of epochs between admission and restorable (tails still
+    /// running). The streaming coordinator compares it against
+    /// `max_in_flight_epochs` to admit the next barrier.
+    pub(crate) checkpoint_in_flight: Arc<std::sync::atomic::AtomicU64>,
+    /// Captured-state bytes held by in-flight epochs; admission pauses
+    /// at `max_staged_bytes`.
+    pub(crate) staged_bytes: Arc<std::sync::atomic::AtomicU64>,
+    /// Shared id allocator (cloned from the coordinator) so barrier
+    /// admission claims ids without the coordinator mutex, which an
+    /// earlier epoch's durable tail may hold.
+    pub(crate) epoch_allocator: Option<Arc<crate::checkpoint_coordinator::EpochAllocator>>,
+    /// Copied from `CheckpointConfig` for the pre-mutex quorum stage.
+    #[cfg(feature = "cluster")]
+    pub(crate) quorum_timeout: Duration,
 }
 
 impl ConnectorPipelineCallback {
@@ -380,8 +438,13 @@ impl ConnectorPipelineCallback {
     ) -> Result<crate::checkpoint_coordinator::CheckpointResult, DbError> {
         self.sync_sinks_and_drain_events().await;
 
+        // Ids allocated at alignment must be threaded through to the
+        // checkpoint, otherwise the inner allocation would burn a second
+        // pair and checkpoint a different epoch than was announced.
         #[cfg(feature = "cluster")]
-        let _ = self.align_shuffle_for_leader().await?;
+        let leader_ids = self.align_shuffle_for_leader().await?;
+        #[cfg(not(feature = "cluster"))]
+        let leader_ids: Option<(u64, u64)> = None;
 
         let operator_states = self
             .capture_and_serialize_operator_state()
@@ -403,7 +466,19 @@ impl ConnectorPipelineCallback {
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
         coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
-        let result = coord.checkpoint_with_offsets(request).await?;
+        let result = match leader_ids {
+            Some((epoch, checkpoint_id)) => {
+                coord
+                    .checkpoint_preallocated(
+                        request,
+                        epoch,
+                        checkpoint_id,
+                        crate::checkpoint_coordinator::QuorumStage::RunInline,
+                    )
+                    .await?
+            }
+            None => coord.checkpoint_with_offsets(request).await?,
+        };
         if result.success {
             self.last_checkpoint = std::time::Instant::now();
         }
@@ -413,9 +488,8 @@ impl ConnectorPipelineCallback {
     /// Skip a follower `Prepare` for `ann_epoch` only if it is already
     /// committed (`last_committed`), already awaiting local source
     /// barriers (`pending`), or its durable tail is already running
-    /// (`tail_in_flight`). A failed checkpoint does not advance
-    /// `last_committed`, and the leader retries the same epoch (it advances
-    /// only on success), so the retry must be reprocessed, not deduped.
+    /// (`tail_in_flight`). Comparisons are monotonic — leaders abandon
+    /// failed epochs, so gaps in the announced sequence are normal.
     #[cfg(feature = "cluster")]
     fn follower_should_skip(
         last_committed: Option<u64>,
@@ -432,9 +506,10 @@ impl ConnectorPipelineCallback {
     /// save, vnode-partial uploads, the leader-decision wait, and the
     /// 2PC commit/rollback — to a background task so the pipeline can
     /// resume on `Aligned` instead of stalling until `Commit`
-    /// (ADR-003 two-level completion). `follower_checkpoint` acks the
-    /// capture as its first action, which is what releases the leader's
-    /// quorum wait. On commit, completion flows through
+    /// (ADR-003 two-level completion). The capture ack is sent before
+    /// queuing on the coordinator mutex — an earlier epoch's tail may
+    /// hold it for the duration of its uploads, and the leader's quorum
+    /// must not wait on those. On commit, completion flows through
     /// `checkpoint_complete_tx` so the streaming coordinator fans
     /// `EpochCommitted` out to sources and publishes the wire barrier —
     /// the same path the leader's background persist uses.
@@ -455,15 +530,31 @@ impl ConnectorPipelineCallback {
         let coordinator = Arc::clone(&self.coordinator);
         let tail = Arc::clone(&self.follower_tail);
         let complete_tx = self.checkpoint_complete_tx.clone();
+        let cc = self.cluster_controller.clone();
         tokio::spawn(async move {
+            let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
+            if let Some(ref cc) = cc {
+                cc.ack_barrier(&laminar_core::cluster::control::BarrierAck {
+                    epoch,
+                    ok: true,
+                    error: None,
+                    local_watermark_ms: wm_opt,
+                })
+                .await
+                .ok();
+            }
             let committed = {
                 let mut guard = coordinator.lock().await;
                 match guard.as_mut() {
                     Some(coord) => {
                         coord.set_pending_vnode_states(vnode_states);
-                        coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
+                        coord.set_local_watermark_ms(wm_opt);
                         match coord
-                            .follower_checkpoint(request, ann, std::time::Duration::from_secs(30))
+                            .follower_checkpoint_acked(
+                                request,
+                                ann,
+                                std::time::Duration::from_secs(30),
+                            )
                             .await
                         {
                             Ok(true) => {
@@ -685,46 +776,60 @@ impl ConnectorPipelineCallback {
         BarrierOutcome::Async
     }
 
-    /// Leader-side cross-node shuffle barrier alignment, run *before* capture so
-    /// the snapshot includes peers' pre-checkpoint rows. Prepare-triggered: the
-    /// leader announces `Prepare` early here (so followers begin aligning), then
-    /// aligns. No-op when not the leader or there is no cross-node shuffle. On
-    /// alignment failure it signals `Abort` so prepared followers don't block.
-    ///
-    /// Returns the epoch announced (read under the same coordinator lock,
-    /// before the background tail can hold it) so the caller can gate its
-    /// resume on the matching `Aligned` announcement; `None` when this
-    /// node isn't the cluster leader.
+    /// Leader-side barrier admission: allocate this barrier's ids
+    /// (lock-free — an earlier epoch's durable tail may hold the
+    /// coordinator mutex), announce `Prepare` so followers begin
+    /// aligning, then drain + align the cross-node shuffle so the
+    /// snapshot includes peers' pre-barrier rows. Returns the allocated
+    /// `(epoch, checkpoint_id)`; `None` when this node isn't the
+    /// cluster leader or no coordinator is wired. On alignment failure
+    /// the allocated epoch is abandoned (Abort + rollback + next epoch
+    /// begun).
     #[cfg(feature = "cluster")]
-    async fn align_shuffle_for_leader(&mut self) -> Result<Option<u64>, DbError> {
-        let (checkpoint_id, epoch, live) = {
-            let mut guard = self.coordinator.lock().await;
-            match guard.as_mut() {
-                Some(coord) => (
-                    coord.announce_prepare().await,
-                    coord.epoch(),
-                    coord.live_node_ids(),
-                ),
-                None => (None, 0, Vec::new()),
-            }
-        };
-        let Some(checkpoint_id) = checkpoint_id else {
+    async fn align_shuffle_for_leader(&mut self) -> Result<Option<(u64, u64)>, DbError> {
+        use laminar_core::cluster::control::{BarrierAnnouncement, Phase};
+
+        let (Some(cc), Some(allocator)) = (
+            self.cluster_controller.clone(),
+            self.epoch_allocator.clone(),
+        ) else {
             return Ok(None);
         };
+        if !cc.is_leader() {
+            return Ok(None);
+        }
+        let (epoch, checkpoint_id) = allocator.allocate();
+        if let Err(e) = cc
+            .announce_barrier(&BarrierAnnouncement {
+                epoch,
+                checkpoint_id,
+                phase: Phase::Prepare,
+                flags: 0,
+                min_watermark_ms: None,
+                seq: 0,
+            })
+            .await
+        {
+            tracing::warn!(epoch, checkpoint_id, error = %e, "prepare announcement failed");
+        }
+
+        let live: Vec<u64> = cc.live_instances().iter().map(|n| n.0).collect();
         let wm = self
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
         if let Err(e) = self
             .graph
-            .align_shuffle_barriers(checkpoint_id, wm, &live, self.cluster_controller.as_deref())
+            .align_shuffle_barriers(checkpoint_id, wm, &live, Some(&*cc))
             .await
         {
-            if let Some(coord) = self.coordinator.lock().await.as_ref() {
-                coord.announce_abort(checkpoint_id).await;
+            if let Some(coord) = self.coordinator.lock().await.as_mut() {
+                coord
+                    .abandon_epoch(checkpoint_id, epoch, format!("shuffle alignment: {e}"))
+                    .await;
             }
             return Err(e);
         }
-        Ok(Some(epoch))
+        Ok(Some((epoch, checkpoint_id)))
     }
 
     /// Assemble a [`CheckpointRequest`](crate::checkpoint_coordinator::CheckpointRequest)
@@ -1417,14 +1522,17 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
         } else {
-            // Persist in the background; in-flight flag bounds to one checkpoint at a time.
-            self.checkpoint_in_flight
-                .store(true, std::sync::atomic::Ordering::Release);
+            // Persist in the background; the in-flight slot + staged
+            // bytes are released by the guard when the tail finishes.
+            let in_flight = EpochInFlightGuard::claim(
+                &self.checkpoint_in_flight,
+                &self.staged_bytes,
+                staged_request_bytes(&request, &vnode_states),
+            );
             let coordinator_clone = Arc::clone(&self.coordinator);
             let tx = self.checkpoint_complete_tx.clone();
-            let in_flight = CheckpointInFlightGuard(Arc::clone(&self.checkpoint_in_flight));
             tokio::spawn(async move {
-                let _in_flight = in_flight; // cleared on drop, even on panic
+                let _in_flight = in_flight; // released on drop, even on panic
                 let mut guard = coordinator_clone.lock().await;
                 if let Some(ref mut coord) = *guard {
                     coord.set_pending_vnode_states(vnode_states);
@@ -1453,13 +1561,30 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
+        checkpoint_id: u64,
     ) -> crate::pipeline::BarrierOutcome {
         use crate::pipeline::{BarrierOutcome, SkipReason};
 
+        #[cfg(not(feature = "cluster"))]
+        let _ = checkpoint_id;
         #[cfg(feature = "cluster")]
         if let Some(cc) = self.cluster_controller.clone() {
             if !cc.is_leader() {
                 if let Some(ann) = self.pending_follower_checkpoint.take() {
+                    // Leaders abandon failed epochs, so a slow barrier
+                    // round can complete after its announcement was
+                    // superseded — the captured offsets must never be
+                    // attributed to the newer epoch's announcement.
+                    if ann.checkpoint_id != checkpoint_id {
+                        tracing::warn!(
+                            round_checkpoint_id = checkpoint_id,
+                            pending_checkpoint_id = ann.checkpoint_id,
+                            "stale follower barrier round — its epoch was abandoned; \
+                             re-queueing the newer announcement"
+                        );
+                        self.pending_follower_checkpoint = Some(ann);
+                        return BarrierOutcome::Failed;
+                    }
                     return self
                         .run_follower_checkpoint_deferred(ann, source_checkpoints)
                         .await;
@@ -1488,15 +1613,17 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
         // Drain + align the cross-node shuffle before capture so peers'
         // pre-barrier rows enter the snapshot (announces Prepare early).
-        // The returned epoch keys this barrier's Aligned resume gate.
+        // The returned ids key this barrier's tail and resume gate.
         #[cfg(feature = "cluster")]
-        let leader_epoch = match self.align_shuffle_for_leader().await {
-            Ok(epoch) => epoch,
+        let leader_ids = match self.align_shuffle_for_leader().await {
+            Ok(ids) => ids,
             Err(e) => {
                 tracing::warn!(error = %e, "shuffle barrier alignment failed");
                 return BarrierOutcome::Failed;
             }
         };
+        #[cfg(not(feature = "cluster"))]
+        let leader_ids: Option<(u64, u64)> = None;
 
         // Capture stream executor aggregate state — now consistent because
         // all pre-barrier data has been executed. Serialize on blocking thread.
@@ -1516,23 +1643,89 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let vnode_states = self.capture_vnode_states();
         let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
-        // Persist in the background; in-flight flag bounds to one checkpoint at a time.
-        self.checkpoint_in_flight
-            .store(true, std::sync::atomic::Ordering::Release);
+        // Durable tail in the background, two stages: the capture
+        // quorum + `Aligned` run *before* the coordinator mutex (an
+        // earlier epoch's tail may hold it for its uploads — Aligned
+        // must never queue behind those), then the durable remainder
+        // under the FIFO mutex, which keeps epochs restorable in order.
+        let in_flight = EpochInFlightGuard::claim(
+            &self.checkpoint_in_flight,
+            &self.staged_bytes,
+            staged_request_bytes(&request, &vnode_states),
+        );
         let coordinator_clone = Arc::clone(&self.coordinator);
         let tx = self.checkpoint_complete_tx.clone();
-        let in_flight = CheckpointInFlightGuard(Arc::clone(&self.checkpoint_in_flight));
         let fan_out = source_checkpoints.clone();
         let wm = self
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
+        #[cfg(feature = "cluster")]
+        let cc_for_tail = self.cluster_controller.clone();
+        #[cfg(feature = "cluster")]
+        let quorum_timeout = self.quorum_timeout;
         tokio::spawn(async move {
-            let _in_flight = in_flight; // cleared on drop, even on panic
+            use crate::checkpoint_coordinator::{CheckpointCoordinator, QuorumStage};
+
+            let _in_flight = in_flight; // released on drop, even on panic
+            let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
+
+            #[allow(unused_mut)]
+            let mut quorum = QuorumStage::RunInline;
+            #[cfg(feature = "cluster")]
+            if let (Some(cc), Some((epoch, checkpoint_id))) = (cc_for_tail.as_ref(), leader_ids) {
+                use laminar_core::cluster::control::{BarrierAnnouncement, Phase};
+                match CheckpointCoordinator::run_prepare_quorum(
+                    cc,
+                    quorum_timeout,
+                    epoch,
+                    checkpoint_id,
+                    wm_opt,
+                )
+                .await
+                {
+                    Ok(min_watermark_ms) => {
+                        if let Err(e) = cc
+                            .announce_barrier(&BarrierAnnouncement {
+                                epoch,
+                                checkpoint_id,
+                                phase: Phase::Aligned,
+                                flags: 0,
+                                min_watermark_ms,
+                                seq: 0,
+                            })
+                            .await
+                        {
+                            tracing::warn!(
+                                epoch, error = %e,
+                                "[LDB-6031] aligned announcement failed; peers resume on Commit"
+                            );
+                        }
+                        quorum = QuorumStage::Done(min_watermark_ms);
+                    }
+                    Err(msg) => {
+                        tracing::error!(checkpoint_id, epoch, error = %msg, "[LDB-6032] quorum miss");
+                        let mut guard = coordinator_clone.lock().await;
+                        if let Some(ref mut coord) = *guard {
+                            coord.abandon_epoch(checkpoint_id, epoch, msg).await;
+                        }
+                        return;
+                    }
+                }
+            }
+
             let mut guard = coordinator_clone.lock().await;
             if let Some(ref mut coord) = *guard {
                 coord.set_pending_vnode_states(vnode_states);
-                coord.set_local_watermark_ms(if wm == i64::MIN { None } else { Some(wm) });
-                match coord.checkpoint_with_offsets(request).await {
+                coord.set_local_watermark_ms(wm_opt);
+                let result = match leader_ids {
+                    Some((epoch, checkpoint_id)) => {
+                        coord
+                            .checkpoint_preallocated(request, epoch, checkpoint_id, quorum)
+                            .await
+                    }
+                    None => coord.checkpoint_with_offsets(request).await,
+                };
+                match result {
                     Ok(result) if result.success => {
                         let _ = tx.send((result.epoch, fan_out)).await;
                     }
@@ -1552,7 +1745,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         // still folding pre-barrier rows into its epoch-N snapshot.
         // Abort (quorum miss) also releases; the gate is bounded.
         #[cfg(feature = "cluster")]
-        if let (Some(epoch), Some(cc)) = (leader_epoch, self.cluster_controller.clone()) {
+        if let (Some((epoch, _)), Some(cc)) = (leader_ids, self.cluster_controller.clone()) {
             let has_shuffle = self.graph.cluster_shuffle_config().is_some();
             Self::wait_for_aligned_resume(has_shuffle, &cc, epoch).await;
         }
@@ -1783,9 +1976,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn next_checkpoint_id(&self) -> Option<u64> {
-        let guard = self.coordinator.try_lock().ok()?;
-        let coord = guard.as_ref()?;
-        Some(coord.next_checkpoint_id())
+        // Lock-free: an in-flight epoch's tail may hold the coordinator
+        // mutex for the duration of its uploads.
+        self.epoch_allocator.as_ref().map(|a| a.peek().1)
     }
 
     fn set_barrier_injectors(

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -2222,87 +2222,29 @@ mod tests {
         );
     }
 
-    /// A committed (or older) epoch re-announced by the leader is deduped.
+    /// `follower_should_skip(committed, pending, tail_in_flight, announced)`:
+    /// skip when ANY of the three trackers already covers the announced
+    /// epoch. Committed advances only on commit, so a failed epoch's
+    /// retry (committed still behind) is reprocessed, not deduped — the
+    /// old code recorded the epoch before commit and wedged.
     #[cfg(feature = "cluster")]
     #[test]
-    fn follower_skips_already_committed_or_older_epoch() {
-        assert!(ConnectorPipelineCallback::follower_should_skip(
-            Some(5),
-            None,
-            None,
-            5
-        ));
-        assert!(ConnectorPipelineCallback::follower_should_skip(
-            Some(5),
-            None,
-            None,
-            3
-        ));
-    }
-
-    /// A deferred epoch awaiting local barriers (tracked via the pending
-    /// arg) is deduped so its injectors aren't re-triggered each cycle.
-    #[cfg(feature = "cluster")]
-    #[test]
-    fn follower_skips_in_flight_deferred_epoch() {
-        assert!(ConnectorPipelineCallback::follower_should_skip(
-            Some(4),
-            Some(5),
-            None,
-            5
-        ));
-    }
-
-    /// An epoch whose durable tail (prepare + decision wait) is running
-    /// in the background is deduped — the pipeline has already resumed,
-    /// so the same Prepare announcement stays visible (latest-wins
-    /// observation) and must not re-trigger capture.
-    #[cfg(feature = "cluster")]
-    #[test]
-    fn follower_skips_epoch_with_tail_in_flight() {
-        assert!(ConnectorPipelineCallback::follower_should_skip(
-            Some(4),
-            None,
-            Some(5),
-            5
-        ));
-    }
-
-    /// Regression: a failed checkpoint doesn't advance the committed epoch, and
-    /// the leader retries the same epoch, so the retry must be reprocessed —
-    /// not deduped. The old code recorded the epoch before commit and wedged.
-    #[cfg(feature = "cluster")]
-    #[test]
-    fn follower_reprocesses_retry_of_failed_epoch() {
-        // Epoch 5 failed: committed is still 4, nothing in flight, leader retries 5.
-        assert!(!ConnectorPipelineCallback::follower_should_skip(
-            Some(4),
-            None,
-            None,
-            5
-        ));
-        // Same on a fresh follower whose first epoch failed.
-        assert!(!ConnectorPipelineCallback::follower_should_skip(
-            None, None, None, 5
-        ));
-    }
-
-    /// A higher epoch is always processed.
-    #[cfg(feature = "cluster")]
-    #[test]
-    fn follower_processes_newer_epoch() {
-        assert!(!ConnectorPipelineCallback::follower_should_skip(
-            Some(5),
-            None,
-            None,
-            6
-        ));
-        assert!(!ConnectorPipelineCallback::follower_should_skip(
-            Some(5),
-            Some(5),
-            Some(5),
-            6
-        ));
+    fn follower_should_skip_dedup_matrix() {
+        let skip = ConnectorPipelineCallback::follower_should_skip;
+        // Already committed (or older re-announcement).
+        assert!(skip(Some(5), None, None, 5));
+        assert!(skip(Some(5), None, None, 3));
+        // Deferred, awaiting local barriers.
+        assert!(skip(Some(4), Some(5), None, 5));
+        // Durable tail running in the background (pipeline resumed; the
+        // Prepare stays visible under latest-wins observation).
+        assert!(skip(Some(4), None, Some(5), 5));
+        // Failed-epoch retry: committed didn't advance — reprocess.
+        assert!(!skip(Some(4), None, None, 5));
+        assert!(!skip(None, None, None, 5));
+        // A higher epoch is always processed.
+        assert!(!skip(Some(5), None, None, 6));
+        assert!(!skip(Some(5), Some(5), Some(5), 6));
     }
 
     /// Build a follower-side controller whose `current_leader()` is a

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -544,7 +544,7 @@ impl ConnectorPipelineCallback {
             )
             .await
             {
-                Ok(min_watermark_ms) => {
+                Ok((min_watermark_ms, participants)) => {
                     if let Err(e) = cc
                         .announce_barrier(&BarrierAnnouncement {
                             epoch,
@@ -560,7 +560,10 @@ impl ConnectorPipelineCallback {
                             "[LDB-6031] aligned announcement failed; peers resume on Commit"
                         );
                     }
-                    quorum = QuorumStage::Done(min_watermark_ms);
+                    quorum = QuorumStage::Done {
+                        min_watermark_ms,
+                        participants,
+                    };
                 }
                 Err(msg) => {
                     tracing::error!(checkpoint_id, epoch, error = %msg, "[LDB-6032] quorum miss");

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -325,13 +325,12 @@ pub(crate) struct ConnectorPipelineCallback {
     /// Copied from `CheckpointConfig` for the pre-mutex quorum stage.
     #[cfg(feature = "cluster")]
     pub(crate) quorum_timeout: Duration,
-    /// True when any registered sink is exactly-once. Durable tails
-    /// then run INLINE (pipeline blocked until the commit decision):
-    /// a single transactional producer must not receive post-barrier
+    /// True when any registered sink is exactly-once: durable tails
+    /// then run INLINE (pipeline blocked until the commit decision).
+    /// A single transactional producer must not receive post-barrier
     /// rows while the epoch's transaction is open — an early resume
     /// would commit them with epoch N and duplicate them on replay.
-    /// Producer pooling (one transaction per in-flight epoch) is the
-    /// follow-up that lifts this.
+    /// Producer pooling is the follow-up that lifts this.
     pub(crate) exactly_once_sinks: bool,
 }
 
@@ -610,19 +609,14 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Build the follower's durable tail — capture ack, sink
-    /// pre-commit, manifest save, vnode-partial uploads, the
-    /// leader-decision wait, and the 2PC commit/rollback. Spawned to a
-    /// background task so the pipeline can resume on `Aligned`, or
-    /// awaited inline for exactly-once pipelines (see
-    /// [`Self::exactly_once_sinks`]).
-    /// The capture ack is sent before
-    /// queuing on the coordinator mutex — an earlier epoch's tail may
-    /// hold it for the duration of its uploads, and the leader's quorum
-    /// must not wait on those. On commit, completion flows through
-    /// `checkpoint_complete_tx` so the streaming coordinator fans
-    /// `EpochCommitted` out to sources and publishes the wire barrier —
-    /// the same path the leader's background persist uses.
+    /// Build the follower's durable tail — capture ack, durable
+    /// prepare, decision wait, 2PC commit/rollback. Spawned so the
+    /// pipeline resumes on `Aligned`, or awaited inline for
+    /// exactly-once (see [`Self::exactly_once_sinks`]). The capture
+    /// ack is sent before queuing on the coordinator mutex so the
+    /// leader's quorum never waits on an earlier epoch's uploads.
+    /// Commit completion flows through `checkpoint_complete_tx` — the
+    /// same path the leader's background persist uses.
     #[cfg(feature = "cluster")]
     fn follower_tail_future(
         &mut self,
@@ -720,21 +714,14 @@ impl ConnectorPipelineCallback {
     }
 
     /// Block the pipeline until the leader announces `Aligned` for
-    /// `epoch` — the re-keyed shuffle-alignment resume gate.
-    /// `Aligned` is announced only after the *full-membership* capture
-    /// quorum, preserving the invariant the no-post-barrier-buffering
-    /// shuffle drain relies on: no peer ships epoch-N+1 rows while
-    /// another node is still folding pre-barrier rows into its epoch-N
-    /// snapshot. `Commit`, `Abort`, or any newer epoch's announcement
-    /// also releases the gate (observation is latest-wins, so a quick
-    /// successor can overwrite `Aligned`).
+    /// `epoch` (full-membership capture quorum): no peer may ship
+    /// epoch-N+1 shuffle rows while another node is still folding
+    /// pre-barrier rows into its epoch-N snapshot. `Commit`, `Abort`,
+    /// or any newer epoch's announcement also releases the gate.
     ///
-    /// No-op without a cross-node shuffle — there are no in-flight
-    /// peer rows to protect. Bounded: on timeout the pipeline resumes
-    /// anyway (the epoch aborts independently via the leader's gate).
-    ///
-    /// Associated fn (no `&self`) so callers' futures stay `Send`
-    /// without requiring `ConnectorPipelineCallback: Sync`.
+    /// No-op without a cross-node shuffle; bounded — on timeout the
+    /// pipeline resumes and the epoch aborts via the leader's gate.
+    /// Associated fn (no `&self`) so callers' futures stay `Send`.
     #[cfg(feature = "cluster")]
     async fn wait_for_aligned_resume(
         has_cluster_shuffle: bool,
@@ -1782,11 +1769,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let vnode_states = self.capture_vnode_states();
         let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
-        // Durable tail in the background, two stages: the capture
-        // quorum + `Aligned` run *before* the coordinator mutex (an
-        // earlier epoch's tail may hold it for its uploads — Aligned
-        // must never queue behind those), then the durable remainder
-        // under the FIFO mutex, which keeps epochs restorable in order.
+        // Two-stage tail: capture quorum + `Aligned` run pre-mutex
+        // (never queued behind an earlier epoch's uploads); the durable
+        // remainder serializes on the FIFO mutex.
         let in_flight = EpochInFlightGuard::claim(
             &self.checkpoint_in_flight,
             &self.staged_bytes,

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -611,32 +611,26 @@ impl ConnectorPipelineCallback {
         use laminar_core::cluster::control::Phase;
 
         const RESUME_GATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-        const POLL: std::time::Duration = std::time::Duration::from_millis(10);
 
         if !has_cluster_shuffle {
             return;
         }
-        let start = std::time::Instant::now();
-        loop {
-            match controller.observe_barrier().await.ok().flatten() {
-                Some(a) if a.epoch > epoch => return,
-                Some(a)
-                    if a.epoch == epoch
-                        && matches!(a.phase, Phase::Aligned | Phase::Commit | Phase::Abort) =>
-                {
-                    return;
-                }
-                _ => {}
-            }
-            if start.elapsed() >= RESUME_GATE_TIMEOUT {
-                tracing::warn!(
-                    epoch,
-                    "aligned resume gate timed out — resuming pipeline \
-                     (epoch will abort via the leader's restorable gate)"
-                );
-                return;
-            }
-            tokio::time::sleep(POLL).await;
+        let released = controller
+            .wait_for_barrier(
+                |a| {
+                    a.epoch > epoch
+                        || (a.epoch == epoch
+                            && matches!(a.phase, Phase::Aligned | Phase::Commit | Phase::Abort))
+                },
+                RESUME_GATE_TIMEOUT,
+            )
+            .await;
+        if released.is_none() {
+            tracing::warn!(
+                epoch,
+                "aligned resume gate timed out — resuming pipeline \
+                 (epoch will abort via the leader's restorable gate)"
+            );
         }
     }
 

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -678,7 +678,7 @@ impl ConnectorPipelineCallback {
                         decision_store.as_deref(),
                         epoch,
                         checkpoint_id,
-                        std::time::Duration::from_secs(30),
+                        std::time::Duration::from_secs(10),
                     )
                     .await;
                     // Stage 3: act on the verdict under the mutex.
@@ -733,7 +733,7 @@ impl ConnectorPipelineCallback {
     ) {
         use laminar_core::cluster::control::Phase;
 
-        const RESUME_GATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        const RESUME_GATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
         if !has_cluster_shuffle {
             return;

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1646,7 +1646,7 @@ impl LaminarDB {
             #[cfg(feature = "cluster")]
             cluster_controller: self.cluster_controller.lock().clone(),
             #[cfg(feature = "cluster")]
-            last_follower_epoch: None,
+            follower_tail: Arc::default(),
             #[cfg(feature = "cluster")]
             barrier_injectors: Vec::new(),
             #[cfg(feature = "cluster")]

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -279,10 +279,17 @@ impl LaminarDB {
                 (Box::new(cs), obj)
             };
 
+            let defaults = CkpConfig::default();
             let config = CkpConfig {
                 interval: cp_config.interval_ms.map(std::time::Duration::from_millis),
                 max_retained,
-                ..CkpConfig::default()
+                max_in_flight_epochs: cp_config
+                    .max_in_flight_epochs
+                    .unwrap_or(defaults.max_in_flight_epochs),
+                max_staged_bytes: cp_config
+                    .max_staged_bytes
+                    .unwrap_or(defaults.max_staged_bytes),
+                ..defaults
             };
             let mut coord = CheckpointCoordinator::new(config, store).await?;
             if let Some(ref prom) = *self.engine_metrics.lock() {

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1603,7 +1603,7 @@ impl LaminarDB {
         )>(16);
         // Shared admission state: the callback claims a slot (and staged
         // bytes) per in-flight epoch; the streaming coordinator gates new
-        // barriers on the caps (ADR-003 Phase 2). Exactly-once pipelines
+        // barriers on the caps. Exactly-once pipelines
         // are capped at depth 1 — a single-open-transaction sink cannot
         // overlap epochs.
         let checkpoint_in_flight = Arc::new(std::sync::atomic::AtomicU64::new(0));

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1617,7 +1617,8 @@ impl LaminarDB {
                         Some(coord.epoch_allocator()),
                         cfg.quorum_timeout,
                         depth,
-                        cfg.max_staged_bytes,
+                        // 0 would pause admission permanently.
+                        cfg.max_staged_bytes.max(1),
                     )
                 }
                 None => (None, std::time::Duration::from_secs(3), 1, u64::MAX),

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1588,9 +1588,16 @@ impl LaminarDB {
         )>(16);
         // Shared admission state: the callback claims a slot (and staged
         // bytes) per in-flight epoch; the streaming coordinator gates new
-        // barriers on the caps. Exactly-once pipelines
-        // are capped at depth 1 — a single-open-transaction sink cannot
-        // overlap epochs.
+        // barriers on the caps. A single-open-transaction sink cannot
+        // overlap epochs, so depth is capped at 1 whenever ANY registered
+        // sink is exactly-once — not just when the pipeline-level
+        // guarantee says so. (DDL/server-configured sinks declare
+        // exactly-once via connector capabilities without ever setting
+        // the pipeline-level guarantee; keying off the pipeline config
+        // alone would pipeline epochs over an open Kafka transaction.)
+        let has_exactly_once_sink = sinks
+            .iter()
+            .any(|(_, handle, _, _, _)| handle.exactly_once());
         let checkpoint_in_flight = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let staged_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let (epoch_allocator, ckpt_quorum_timeout, max_in_flight_epochs, max_staged_bytes) = {
@@ -1598,8 +1605,9 @@ impl LaminarDB {
             match guard.as_ref() {
                 Some(coord) => {
                     let cfg = coord.config();
-                    let depth = if pipeline_config.delivery_guarantee
-                        == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
+                    let depth = if has_exactly_once_sink
+                        || pipeline_config.delivery_guarantee
+                            == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
                     {
                         1
                     } else {
@@ -1678,6 +1686,7 @@ impl LaminarDB {
             epoch_allocator,
             #[cfg(feature = "cluster")]
             quorum_timeout: ckpt_quorum_timeout,
+            exactly_once_sinks: has_exactly_once_sink,
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1601,8 +1601,37 @@ impl LaminarDB {
             u64,
             rustc_hash::FxHashMap<String, laminar_connectors::checkpoint::SourceCheckpoint>,
         )>(16);
-        // Shared in-flight flag: callback sets it per persist, coordinator gates on it.
-        let checkpoint_in_flight = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        // Shared admission state: the callback claims a slot (and staged
+        // bytes) per in-flight epoch; the streaming coordinator gates new
+        // barriers on the caps (ADR-003 Phase 2). Exactly-once pipelines
+        // are capped at depth 1 — a single-open-transaction sink cannot
+        // overlap epochs.
+        let checkpoint_in_flight = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let staged_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (epoch_allocator, ckpt_quorum_timeout, max_in_flight_epochs, max_staged_bytes) = {
+            let guard = coordinator.lock().await;
+            match guard.as_ref() {
+                Some(coord) => {
+                    let cfg = coord.config();
+                    let depth = if pipeline_config.delivery_guarantee
+                        == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
+                    {
+                        1
+                    } else {
+                        cfg.max_in_flight_epochs.max(1)
+                    };
+                    (
+                        Some(coord.epoch_allocator()),
+                        cfg.quorum_timeout,
+                        depth,
+                        cfg.max_staged_bytes,
+                    )
+                }
+                None => (None, std::time::Duration::from_secs(3), 1, u64::MAX),
+            }
+        };
+        #[cfg(not(feature = "cluster"))]
+        let _ = ckpt_quorum_timeout;
 
         let static_stream_names: rustc_hash::FxHashSet<Arc<str>> = stream_sources
             .iter()
@@ -1660,6 +1689,10 @@ impl LaminarDB {
             static_stream_names,
             checkpoint_complete_tx,
             checkpoint_in_flight: Arc::clone(&checkpoint_in_flight),
+            staged_bytes: Arc::clone(&staged_bytes),
+            epoch_allocator,
+            #[cfg(feature = "cluster")]
+            quorum_timeout: ckpt_quorum_timeout,
         };
 
         // Start the streaming coordinator on a dedicated compute thread.
@@ -1680,7 +1713,12 @@ impl LaminarDB {
             )
             .await?
             .with_checkpoint_complete_rx(checkpoint_complete_rx)
-            .with_checkpoint_in_flight(checkpoint_in_flight);
+            .with_checkpoint_admission(
+                checkpoint_in_flight,
+                max_in_flight_epochs,
+                staged_bytes,
+                max_staged_bytes,
+            );
 
             let (done_tx, done_rx) = crossfire::oneshot::oneshot::<()>();
             let (startup_tx, startup_rx) = crossfire::oneshot::oneshot::<Result<(), String>>();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -103,30 +103,6 @@ async fn resolve_stream_output_schemas(
     result.map(|()| out)
 }
 
-pub(crate) fn url_to_checkpoint_prefix(url: &str) -> String {
-    // Strip scheme
-    let after_scheme = url.find("://").map_or(url, |i| &url[i + 3..]);
-
-    // For file:// URLs, the prefix is empty (LocalFileSystem already has the root)
-    if url.starts_with("file://") {
-        return String::new();
-    }
-
-    // For cloud URLs like s3://bucket/prefix → extract everything after bucket
-    if let Some(slash_pos) = after_scheme.find('/') {
-        let prefix = &after_scheme[slash_pos + 1..];
-        if prefix.is_empty() {
-            String::new()
-        } else if prefix.ends_with('/') {
-            prefix.to_string()
-        } else {
-            format!("{prefix}/")
-        }
-    } else {
-        String::new()
-    }
-}
-
 impl LaminarDB {
     /// Shut down the database gracefully.
     pub fn close(&self) {
@@ -250,15 +226,17 @@ impl LaminarDB {
                 Box<dyn laminar_core::storage::CheckpointStore>,
                 Arc<dyn object_store::ObjectStore>,
             ) = if let Some(ref url) = self.config.object_store_url {
+                // The builder roots the store at the URL's path prefix,
+                // so the checkpoint store (and the decision store
+                // sharing `obj`) need no extra key prefix.
                 let obj = laminar_core::storage::object_store_builder::build_object_store(
                     url,
                     &self.config.object_store_options,
                 )
                 .map_err(|e| DbError::Config(format!("object store: {e}")))?;
-                let prefix = url_to_checkpoint_prefix(url);
                 let cs = laminar_core::storage::checkpoint_store::ObjectStoreCheckpointStore::new(
                     Arc::clone(&obj),
-                    prefix,
+                    String::new(),
                     max_retained,
                 )
                 .with_vnode_count(vnode_count);

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -189,7 +189,6 @@ pub fn spawn_rebalance_controller(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut members = controller.members_watch();
-        info!("rebalance controller watching membership");
         loop {
             tokio::select! {
                 biased;
@@ -201,7 +200,7 @@ pub fn spawn_rebalance_controller(
                     }
                 }
             }
-            info!("membership change observed; debouncing");
+            debug!("membership change observed; debouncing");
 
             // Debounce: absorb further churn before acting.
             loop {
@@ -224,7 +223,7 @@ pub fn spawn_rebalance_controller(
             // leave the cluster on a stale assignment.
             loop {
                 if !controller.is_leader() {
-                    info!("membership changed; not the leader — skipping rotation check");
+                    debug!("membership changed; not the leader — skipping rotation check");
                     break;
                 }
                 // Use assignable (Active, non-draining) instances so
@@ -239,9 +238,7 @@ pub fn spawn_rebalance_controller(
                         break;
                     }
                     Ok(None) => {
-                        info!(
-                            "membership changed but live set matches current snapshot; no rotation"
-                        );
+                        debug!("live set matches current snapshot; no rotation");
                         break;
                     }
                     Err(e) => {
@@ -322,29 +319,22 @@ async fn try_rebalance(
 
     // Drain in-flight shuffle rows into durable state at the old
     // fence version before rotating. When the rotation sheds a DEAD
-    // node this drain can never succeed — the durability gate needs
-    // captures from a node that will never provide them — and
-    // requiring it would deadlock rotation against the gate (rotation
-    // is the only thing that restores commit availability). In that
-    // case proceed without the drain: the dead node''s in-flight rows
-    // are unrecoverable regardless, and the survivors rehydrate its
-    // vnodes from the last committed epoch — the same at-least-once
-    // duplication window every ungraceful failover already has.
+    // node, skip the drain entirely: its durability gate needs captures
+    // from a node that will never provide them, so it can only burn its
+    // full timeout and abort — deadlocking rotation against the gate
+    // when rotation is the only thing that restores commit
+    // availability. The dead node's in-flight rows are unrecoverable
+    // regardless; survivors rehydrate its vnodes from the last
+    // committed epoch — the same at-least-once duplication window every
+    // ungraceful failover already has.
     let shedding_dead = {
         let owners = current.to_vnode_vec(registry.vnode_count());
         owners.iter().any(|o| !live.contains(o))
     };
     if shedding_dead {
-        // Don''t even attempt the drain: its durability gate needs
-        // captures from the dead node, so it can only burn its full
-        // timeout and abort — delaying the rotation that restores
-        // commit availability. The dead node''s in-flight rows are
-        // unrecoverable regardless; survivors rehydrate its vnodes
-        // from the last committed epoch — the same at-least-once
-        // duplication window every ungraceful failover already has.
         warn!(
             "rotation sheds a dead node — skipping the pre-rotation drain \
-             checkpoint (it cannot seal without the dead node''s captures)"
+             checkpoint (it cannot seal without the dead node's captures)"
         );
     } else {
         let ckpt = tokio::time::timeout(config.checkpoint_timeout, db.checkpoint())

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -327,9 +327,22 @@ async fn try_rebalance(
     // regardless; survivors rehydrate its vnodes from the last
     // committed epoch — the same at-least-once duplication window every
     // ungraceful failover already has.
+    //
+    // "Dead" must be judged from MEMBERSHIP, not the assignable set:
+    // a Draining node is excluded from assignment but is alive and can
+    // checkpoint — its graceful handoff depends on this drain sealing
+    // its in-flight rows before the rotation takes its vnodes.
     let shedding_dead = {
+        use laminar_core::cluster::discovery::NodeState;
         let owners = current.to_vnode_vec(registry.vnode_count());
-        owners.iter().any(|o| !live.contains(o))
+        let members = controller.members_watch().borrow().clone();
+        owners.iter().filter(|o| !live.contains(o)).any(|&o| {
+            let dead_in_membership = match members.iter().find(|m| m.id.0 == o.0) {
+                Some(node) => matches!(node.state, NodeState::Suspected | NodeState::Left),
+                None => true,
+            };
+            dead_in_membership || controller.is_recently_unresponsive(o)
+        })
     };
     if shedding_dead {
         warn!(

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -40,8 +40,12 @@ impl Default for RebalanceConfig {
         Self {
             watcher_poll: Duration::from_secs(2),
             rebalance_debounce: Duration::from_secs(5),
-            checkpoint_timeout: Duration::from_secs(60),
-            retry_delay: Duration::from_secs(10),
+            // A healthy pre-rotation drain commits in well under a
+            // second; a long budget only delays recovery when a node
+            // dies mid-drain (the drain then cannot succeed and the
+            // rotation is what restores commit availability).
+            checkpoint_timeout: Duration::from_secs(15),
+            retry_delay: Duration::from_secs(2),
             placement_isolation_tier: 0,
         }
     }
@@ -185,14 +189,19 @@ pub fn spawn_rebalance_controller(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut members = controller.members_watch();
+        info!("rebalance controller watching membership");
         loop {
             tokio::select! {
                 biased;
                 () = shutdown.notified() => return,
                 res = members.changed() => {
-                    if res.is_err() { return; }
+                    if res.is_err() {
+                        warn!("membership watch sender dropped; rebalance controller exiting");
+                        return;
+                    }
                 }
             }
+            info!("membership change observed; debouncing");
 
             // Debounce: absorb further churn before acting.
             loop {
@@ -215,6 +224,7 @@ pub fn spawn_rebalance_controller(
             // leave the cluster on a stale assignment.
             loop {
                 if !controller.is_leader() {
+                    info!("membership changed; not the leader — skipping rotation check");
                     break;
                 }
                 // Use assignable (Active, non-draining) instances so
@@ -229,7 +239,9 @@ pub fn spawn_rebalance_controller(
                         break;
                     }
                     Ok(None) => {
-                        debug!("live set matches current snapshot; no rotation");
+                        info!(
+                            "membership changed but live set matches current snapshot; no rotation"
+                        );
                         break;
                     }
                     Err(e) => {
@@ -309,20 +321,46 @@ async fn try_rebalance(
     }
 
     // Drain in-flight shuffle rows into durable state at the old
-    // fence version before rotating.
-    let ckpt = tokio::time::timeout(config.checkpoint_timeout, db.checkpoint())
-        .await
-        .map_err(|_| {
-            format!(
-                "pre-rotation checkpoint did not complete within {}s",
-                config.checkpoint_timeout.as_secs()
-            )
-        })?
-        .map_err(|e| e.to_string())?;
-    if !ckpt.success {
-        return Err(ckpt
-            .error
-            .unwrap_or_else(|| "checkpoint returned success=false".into()));
+    // fence version before rotating. When the rotation sheds a DEAD
+    // node this drain can never succeed — the durability gate needs
+    // captures from a node that will never provide them — and
+    // requiring it would deadlock rotation against the gate (rotation
+    // is the only thing that restores commit availability). In that
+    // case proceed without the drain: the dead node''s in-flight rows
+    // are unrecoverable regardless, and the survivors rehydrate its
+    // vnodes from the last committed epoch — the same at-least-once
+    // duplication window every ungraceful failover already has.
+    let shedding_dead = {
+        let owners = current.to_vnode_vec(registry.vnode_count());
+        owners.iter().any(|o| !live.contains(o))
+    };
+    if shedding_dead {
+        // Don''t even attempt the drain: its durability gate needs
+        // captures from the dead node, so it can only burn its full
+        // timeout and abort — delaying the rotation that restores
+        // commit availability. The dead node''s in-flight rows are
+        // unrecoverable regardless; survivors rehydrate its vnodes
+        // from the last committed epoch — the same at-least-once
+        // duplication window every ungraceful failover already has.
+        warn!(
+            "rotation sheds a dead node — skipping the pre-rotation drain \
+             checkpoint (it cannot seal without the dead node''s captures)"
+        );
+    } else {
+        let ckpt = tokio::time::timeout(config.checkpoint_timeout, db.checkpoint())
+            .await
+            .map_err(|_| {
+                format!(
+                    "pre-rotation checkpoint did not complete within {}s",
+                    config.checkpoint_timeout.as_secs()
+                )
+            })?
+            .map_err(|e| e.to_string())?;
+        if !ckpt.success {
+            return Err(ckpt
+                .error
+                .unwrap_or_else(|| "checkpoint returned success=false".into()));
+        }
     }
 
     let proposal = current.next(new_vnodes);

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -184,7 +184,7 @@ impl<'a> VnodeRehydrator<'a> {
             match self.backend.read_partial(vnode, epoch).await {
                 Ok(Some(bytes)) => {
                     // An unchanged-vnode partial is a reference to the
-                    // epoch of its last full upload (ADR-003 Phase 3) —
+                    // epoch of its last full upload —
                     // follow the single hop to the real state. A blob
                     // that doesn't decode is handed through unchanged
                     // (the apply path skips undecodable partials).
@@ -1292,7 +1292,7 @@ mod rehydration_tests {
         assert_eq!(report.restored.get(&0).map(|b| &b[..]), Some(&b"new"[..]));
     }
 
-    /// ADR-003 Phase 3: a reference partial resolves (one hop) to the
+    /// A reference partial resolves (one hop) to the
     /// full partial it points at.
     #[tokio::test]
     async fn rehydrate_resolves_reference_partials() {

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -183,6 +183,39 @@ impl<'a> VnodeRehydrator<'a> {
         for &vnode in vnodes {
             match self.backend.read_partial(vnode, epoch).await {
                 Ok(Some(bytes)) => {
+                    // An unchanged-vnode partial is a reference to the
+                    // epoch of its last full upload (ADR-003 Phase 3) —
+                    // follow the single hop to the real state. A blob
+                    // that doesn't decode is handed through unchanged
+                    // (the apply path skips undecodable partials).
+                    let bytes = match crate::vnode_partial::VnodePartial::decode(&bytes) {
+                        Ok(p) => match p.base_epoch {
+                            Some(base) => match self.backend.read_partial(vnode, base).await {
+                                Ok(Some(base_bytes)) => base_bytes,
+                                Ok(None) => {
+                                    warn!(
+                                        vnode,
+                                        epoch,
+                                        base,
+                                        "[LDB-6052] reference partial's base is missing — \
+                                         vnode starts fresh"
+                                    );
+                                    report.missing.push(vnode);
+                                    continue;
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        vnode, epoch, base, error = %e,
+                                        "[LDB-6051] rehydrate: base read failed — vnode starts fresh"
+                                    );
+                                    report.errors.insert(vnode, e.to_string());
+                                    continue;
+                                }
+                            },
+                            None => bytes,
+                        },
+                        Err(_) => bytes,
+                    };
                     debug!(
                         vnode,
                         epoch,
@@ -1257,6 +1290,47 @@ mod rehydration_tests {
 
         assert_eq!(report.epoch, Some(9), "must read the highest sealed epoch");
         assert_eq!(report.restored.get(&0).map(|b| &b[..]), Some(&b"new"[..]));
+    }
+
+    /// ADR-003 Phase 3: a reference partial resolves (one hop) to the
+    /// full partial it points at.
+    #[tokio::test]
+    async fn rehydrate_resolves_reference_partials() {
+        let backend = InProcessBackend::new(4);
+
+        let full = crate::vnode_partial::VnodePartial {
+            checkpoint_id: 1,
+            operators: vec![("agg".into(), vec![1, 2, 3])],
+            base_epoch: None,
+        };
+        backend
+            .write_partial(0, 5, 0, Bytes::from(full.encode().unwrap()))
+            .await
+            .unwrap();
+        assert!(backend.epoch_complete(5, &[0]).await.unwrap());
+
+        let reference = crate::vnode_partial::VnodePartial {
+            checkpoint_id: 2,
+            operators: Vec::new(),
+            base_epoch: Some(5),
+        };
+        backend
+            .write_partial(0, 6, 0, Bytes::from(reference.encode().unwrap()))
+            .await
+            .unwrap();
+        assert!(backend.epoch_complete(6, &[0]).await.unwrap());
+
+        let report = VnodeRehydrator::new(&backend).rehydrate(&[0]).await;
+        assert_eq!(report.epoch, Some(6));
+        let restored = crate::vnode_partial::VnodePartial::decode(
+            report.restored.get(&0).expect("vnode restored"),
+        )
+        .unwrap();
+        assert_eq!(
+            restored.base_epoch, None,
+            "the resolved partial must be the full base, not the reference",
+        );
+        assert_eq!(restored.operators[0].1, vec![1, 2, 3]);
     }
 
     #[tokio::test]

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -88,9 +88,15 @@ pub(crate) enum SinkCommand {
         epoch: u64,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// Abort a failed epoch.
+    /// Abort a failed epoch. `force = true` (restart/recovery) always
+    /// rolls the connector back; `force = false` (live coordination
+    /// failure) keeps a healthy sink's pending transactional output —
+    /// sources do not rewind on a live abort, so an aborted
+    /// transaction's rows would be lost forever. The next successful
+    /// epoch's commit covers them.
     RollbackEpoch {
         epoch: u64,
+        force: bool,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
     /// No-op barrier: acks once every prior command has been processed.
@@ -257,14 +263,36 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("commit"))?
     }
 
-    /// Abort a failed epoch.
+    /// Roll the connector back unconditionally (restart/recovery, or
+    /// cleanup of a partially-begun epoch).
     pub async fn rollback_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
-            .send(SinkCommand::RollbackEpoch { epoch, ack: ack_tx })
+            .send(SinkCommand::RollbackEpoch {
+                epoch,
+                force: true,
+                ack: ack_tx,
+            })
             .await
             .map_err(|_| self.closed_err())?;
         ack_rx.await.map_err(|_| self.ack_dropped_err("rollback"))?
+    }
+
+    /// Live coordination failure: abandon the epoch but keep a healthy
+    /// sink's pending transactional output for the next epoch's commit
+    /// (see [`SinkCommand::RollbackEpoch`]). Rolls back for real only
+    /// if the sink itself failed (poisoned epoch).
+    pub async fn abandon_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
+        let (ack_tx, ack_rx) = oneshot::oneshot();
+        self.tx
+            .send(SinkCommand::RollbackEpoch {
+                epoch,
+                force: false,
+                ack: ack_tx,
+            })
+            .await
+            .map_err(|_| self.closed_err())?;
+        ack_rx.await.map_err(|_| self.ack_dropped_err("abandon"))?
     }
 
     /// Signals the sink task to close and waits for it to finish (30s timeout).
@@ -402,8 +430,21 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                         };
                         ack.send(result);
                     }
-                    SinkCommand::RollbackEpoch { epoch, ack } => {
-                        let result = inner.sink.rollback_epoch(epoch).await;
+                    SinkCommand::RollbackEpoch { epoch, force, ack } => {
+                        let result = if force || epoch_poisoned.load(Ordering::Acquire) {
+                            inner.sink.rollback_epoch(epoch).await
+                        } else {
+                            // Healthy sink, live coordination failure:
+                            // keep the pending output (see the command's
+                            // docs — the exactly-once soak measured the
+                            // gaps an unconditional abort produced).
+                            tracing::debug!(
+                                sink = %inner.name, epoch,
+                                "coordination rollback — keeping pending sink \
+                                 output for the next epoch's commit"
+                            );
+                            Ok(())
+                        };
                         if let Err(ref e) = result {
                             tracing::warn!(
                                 sink = %inner.name, epoch, error = %e,

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -624,6 +624,129 @@ mod tests {
         assert_eq!(writes.load(Ordering::Relaxed), 2);
     }
 
+    /// Records `rollback_epoch` calls; `preserves` controls the
+    /// abandon capability, `fail_writes` poisons the epoch.
+    struct RollbackProbeSink {
+        rollbacks: Arc<AtomicU64>,
+        preserves: bool,
+        fail_writes: bool,
+        schema: arrow::datatypes::SchemaRef,
+    }
+
+    impl RollbackProbeSink {
+        fn new(preserves: bool, fail_writes: bool) -> (Self, Arc<AtomicU64>) {
+            let rollbacks = Arc::new(AtomicU64::new(0));
+            let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+            (
+                Self {
+                    rollbacks: Arc::clone(&rollbacks),
+                    preserves,
+                    fail_writes,
+                    schema,
+                },
+                rollbacks,
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SinkConnector for RollbackProbeSink {
+        async fn open(
+            &mut self,
+            _config: &laminar_connectors::config::ConnectorConfig,
+        ) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+
+        async fn write_batch(
+            &mut self,
+            _batch: &RecordBatch,
+        ) -> Result<WriteResult, ConnectorError> {
+            if self.fail_writes {
+                Err(ConnectorError::WriteError("synthetic".into()))
+            } else {
+                Ok(WriteResult {
+                    records_written: 1,
+                    bytes_written: 0,
+                })
+            }
+        }
+
+        async fn rollback_epoch(&mut self, _epoch: u64) -> Result<(), ConnectorError> {
+            self.rollbacks.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+
+        fn schema(&self) -> arrow::datatypes::SchemaRef {
+            Arc::clone(&self.schema)
+        }
+
+        fn capabilities(&self) -> laminar_connectors::connector::SinkConnectorCapabilities {
+            let caps = laminar_connectors::connector::SinkConnectorCapabilities::new(
+                Duration::from_secs(5),
+            );
+            if self.preserves {
+                caps.with_preserves_pending_on_abandon()
+            } else {
+                caps
+            }
+        }
+    }
+
+    /// The abandon/rollback decision matrix: a healthy sink that
+    /// declares `preserves_pending_on_abandon` keeps its pending output
+    /// (no connector rollback); without the capability — or once the
+    /// epoch is poisoned — the connector rolls back. Forced rollback
+    /// (restart/recovery) always rolls back.
+    #[tokio::test]
+    async fn abandon_rollback_decision_matrix() {
+        // Preserving + healthy → abandon keeps pending output.
+        let (sink, rollbacks) = RollbackProbeSink::new(true, false);
+        let (handle, _ev) = spawn_with_defaults("p", Box::new(sink), Duration::from_secs(5));
+        handle.abandon_epoch(1).await.unwrap();
+        assert_eq!(
+            rollbacks.load(Ordering::Relaxed),
+            0,
+            "preserving sink kept output"
+        );
+        // …but a forced rollback still rolls back.
+        handle.rollback_epoch(1).await.unwrap();
+        assert_eq!(
+            rollbacks.load(Ordering::Relaxed),
+            1,
+            "forced rollback is unconditional"
+        );
+        handle.close().await;
+
+        // Non-preserving + healthy → abandon rolls back.
+        let (sink, rollbacks) = RollbackProbeSink::new(false, false);
+        let (handle, _ev) = spawn_with_defaults("np", Box::new(sink), Duration::from_secs(5));
+        handle.abandon_epoch(1).await.unwrap();
+        assert_eq!(
+            rollbacks.load(Ordering::Relaxed),
+            1,
+            "non-preserving sink rolled back"
+        );
+        handle.close().await;
+
+        // Preserving + poisoned epoch → abandon rolls back anyway.
+        let (sink, rollbacks) = RollbackProbeSink::new(true, true);
+        let (handle, _ev) = spawn_with_defaults("poison", Box::new(sink), Duration::from_secs(5));
+        handle.write_batch(test_batch()).await.unwrap();
+        handle.sync().await.unwrap(); // write error lands → epoch poisoned
+        handle.abandon_epoch(1).await.unwrap();
+        assert_eq!(
+            rollbacks.load(Ordering::Relaxed),
+            1,
+            "poisoned epoch forces a real rollback even on a preserving sink",
+        );
+        handle.close().await;
+    }
+
     /// Sink whose `write_batch` sleeps longer than the configured timeout.
     struct SlowSink {
         schema: arrow::datatypes::SchemaRef,

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -338,6 +338,7 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
     // Skip the first immediate tick.
     flush_timer.tick().await;
 
+    let preserves_pending_on_abandon = inner.sink.capabilities().preserves_pending_on_abandon;
     let mut current_epoch: u64 = 0;
     let epoch_poisoned = AtomicBool::new(false);
 
@@ -431,12 +432,18 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                         ack.send(result);
                     }
                     SinkCommand::RollbackEpoch { epoch, force, ack } => {
-                        let result = if force || epoch_poisoned.load(Ordering::Acquire) {
+                        // Keeping pending output across an abandoned
+                        // epoch is only sound when the CONNECTOR says
+                        // so (`preserves_pending_on_abandon`, e.g. a
+                        // Kafka transactional producer); a staging-style
+                        // sink must roll back or its per-epoch state
+                        // diverges.
+                        let result = if force
+                            || !preserves_pending_on_abandon
+                            || epoch_poisoned.load(Ordering::Acquire)
+                        {
                             inner.sink.rollback_epoch(epoch).await
                         } else {
-                            // Healthy sink, live coordination failure:
-                            // keep the pending output (see the command
-                            // docs above).
                             tracing::debug!(
                                 sink = %inner.name, epoch,
                                 "coordination rollback — keeping pending sink \

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -435,9 +435,8 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                             inner.sink.rollback_epoch(epoch).await
                         } else {
                             // Healthy sink, live coordination failure:
-                            // keep the pending output (see the command's
-                            // docs — the exactly-once soak measured the
-                            // gaps an unconditional abort produced).
+                            // keep the pending output (see the command
+                            // docs above).
                             tracing::debug!(
                                 sink = %inner.name, epoch,
                                 "coordination rollback — keeping pending sink \

--- a/crates/laminar-db/src/vnode_partial.rs
+++ b/crates/laminar-db/src/vnode_partial.rs
@@ -21,8 +21,8 @@ use crate::error::DbError;
 /// (e.g. an rkyv-encoded `AggStateCheckpoint` holding only this vnode's
 /// groups), so the apply path can hand them straight back to the operator.
 ///
-/// `base_epoch = Some(N)` makes this a *reference* artifact (ADR-003
-/// Phase 3): the vnode's state is byte-identical to the full partial it
+/// `base_epoch = Some(N)` makes this a *reference* artifact: the
+/// vnode's state is byte-identical to the full partial it
 /// uploaded at epoch `N`, so `operators` is empty and the reader follows
 /// the reference (a single hop — references always point at a full
 /// artifact, never at another reference). The writer re-emits a full

--- a/crates/laminar-db/src/vnode_partial.rs
+++ b/crates/laminar-db/src/vnode_partial.rs
@@ -20,12 +20,21 @@ use crate::error::DbError;
 /// The bytes are exactly what the operator's per-vnode checkpoint produced
 /// (e.g. an rkyv-encoded `AggStateCheckpoint` holding only this vnode's
 /// groups), so the apply path can hand them straight back to the operator.
+///
+/// `base_epoch = Some(N)` makes this a *reference* artifact (ADR-003
+/// Phase 3): the vnode's state is byte-identical to the full partial it
+/// uploaded at epoch `N`, so `operators` is empty and the reader follows
+/// the reference (a single hop — references always point at a full
+/// artifact, never at another reference). The writer re-emits a full
+/// partial before the base can leave the prune retention window.
 #[derive(Debug, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub(crate) struct VnodePartial {
     /// Checkpoint id this partial was sealed under — for audit/logging.
     pub checkpoint_id: u64,
-    /// `(operator_name, vnode-slice bytes)`.
+    /// `(operator_name, vnode-slice bytes)`. Empty for references.
     pub operators: Vec<(String, Vec<u8>)>,
+    /// `Some(epoch)` = unchanged since that epoch's full partial.
+    pub base_epoch: Option<u64>,
 }
 
 impl VnodePartial {
@@ -64,6 +73,7 @@ mod tests {
                 ("agg".to_string(), vec![1, 2, 3]),
                 ("other".to_string(), vec![]),
             ],
+            base_epoch: None,
         };
         let bytes = p.encode().unwrap();
         let back = VnodePartial::decode(&bytes).unwrap();
@@ -78,10 +88,24 @@ mod tests {
         let p = VnodePartial {
             checkpoint_id: 7,
             operators: Vec::new(),
+            base_epoch: None,
         };
         let bytes = p.encode().unwrap();
         let back = VnodePartial::decode(&bytes).unwrap();
         assert_eq!(back.checkpoint_id, 7);
+        assert!(back.operators.is_empty());
+    }
+
+    #[test]
+    fn reference_round_trips() {
+        let p = VnodePartial {
+            checkpoint_id: 9,
+            operators: Vec::new(),
+            base_epoch: Some(4),
+        };
+        let bytes = p.encode().unwrap();
+        let back = VnodePartial::decode(&bytes).unwrap();
+        assert_eq!(back.base_epoch, Some(4));
         assert!(back.operators.is_empty());
     }
 

--- a/crates/laminar-db/tests/checkpoint_integration.rs
+++ b/crates/laminar-db/tests/checkpoint_integration.rs
@@ -194,6 +194,7 @@ mod exactly_once {
         async fn checkpoint_with_barrier(
             &mut self,
             source_checkpoints: FxHashMap<String, SourceCheckpoint>,
+            _checkpoint_id: u64,
         ) -> laminar_db::pipeline::BarrierOutcome {
             let epoch = self.barrier_checkpoints.len() as u64 + 1;
             self.barrier_checkpoints.push(source_checkpoints);

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -304,8 +304,14 @@ mod failures {
         out
     }
 
+    /// A hard crash sheds the dead node''s vnodes to the survivor,
+    /// which rehydrates their checkpointed state and takes over their
+    /// keys (rows in flight at the crash are lost — the at-least-once
+    /// failover window). Before dead-node rotation engaged, the
+    /// survivor kept only its own keys and the cluster could not
+    /// commit at all until the node returned.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn crash_mid_stream_loses_in_flight() {
+    async fn crash_sheds_vnodes_to_survivor() {
         let mut harness = ClusterEngineHarness::spawn(N_NODES, VNODE_COUNT).await;
         let leader_idx = harness.leader_idx();
         let follower_idx = harness.follower_idxs()[0];
@@ -370,7 +376,13 @@ mod failures {
         let post_crash_leader_keys: HashSet<i64> =
             post_crash_leader.iter().map(|(k, _)| *k).collect();
 
-        let expected_keys: HashSet<i64> = key_buckets[0].1.iter().copied().collect();
+        // Rotation handed the crashed node''s vnodes to the survivor,
+        // which rehydrated their phase-A state and processed phase C
+        // for them — so the survivor now serves EVERY key.
+        let expected_keys: HashSet<i64> = key_buckets
+            .iter()
+            .flat_map(|(_, ks)| ks.iter().copied())
+            .collect();
         assert_eq!(post_crash_leader_keys, expected_keys);
 
         harness.shutdown().await;

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -129,7 +129,6 @@ mod smoke {
 }
 
 mod failures {
-    use std::collections::HashSet;
     use std::time::Duration;
     use tokio::time::sleep;
 
@@ -385,21 +384,29 @@ mod failures {
 
         // Rotation handed the crashed node's vnodes to the survivor,
         // which rehydrated their phase-A state and processed phase C
-        // for them — so the survivor now serves EVERY key.
-        let expected_keys: HashSet<i64> = key_buckets
-            .iter()
-            .flat_map(|(_, ks)| ks.iter().copied())
-            .collect();
+        // for them — so the survivor now serves EVERY key, and the
+        // crashed node's keys total phase A + phase C (`input_batch`
+        // pushes value = key*10). Asserting TOTALS, not just presence:
+        // a lost rehydration would still show the key (phase C creates
+        // the group) but with only phase C's contribution.
+        let mut expected: std::collections::HashMap<i64, i64> =
+            key_buckets[0].1.iter().map(|&k| (k, k * 10)).collect();
+        for &k in &follower_keys {
+            expected.insert(k, k * 10 * 2);
+        }
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         loop {
-            let post_crash_leader = read_mv_sums(&harness.nodes[0].db, "sums").await;
-            let keys: HashSet<i64> = post_crash_leader.iter().map(|(k, _)| *k).collect();
-            if keys == expected_keys {
+            let got: std::collections::HashMap<i64, i64> =
+                read_mv_sums(&harness.nodes[0].db, "sums")
+                    .await
+                    .into_iter()
+                    .collect();
+            if got == expected {
                 break;
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "survivor never served all keys: got {keys:?}, want {expected_keys:?}",
+                "survivor never served all recovered totals: got {got:?}, want {expected:?}",
             );
             sleep(Duration::from_millis(200)).await;
         }

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -796,6 +796,7 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
 
         let follower_handle = tokio::spawn(async move {
@@ -878,6 +879,7 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
         let follower_handle = tokio::spawn(async move {
             follower_coord
@@ -938,6 +940,7 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
         let committed = follower_coord
             .follower_checkpoint(
@@ -985,6 +988,7 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
         let committed = follower_coord
             .follower_checkpoint(
@@ -1111,6 +1115,7 @@ mod minio {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
+            seq: 0,
         };
 
         let follower_handle = tokio::spawn(async move {

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -796,7 +796,6 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
 
         let follower_handle = tokio::spawn(async move {
@@ -879,7 +878,6 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let follower_handle = tokio::spawn(async move {
             follower_coord
@@ -940,7 +938,6 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let committed = follower_coord
             .follower_checkpoint(
@@ -988,7 +985,6 @@ mod two_pc {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
         let committed = follower_coord
             .follower_checkpoint(
@@ -1115,7 +1111,6 @@ mod minio {
             phase: Phase::Prepare,
             flags: 0,
             min_watermark_ms: None,
-            seq: 0,
         };
 
         let follower_handle = tokio::spawn(async move {

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -362,7 +362,19 @@ mod failures {
         let crashed_node = harness.cluster.nodes.swap_remove(follower_idx);
         drop(crashed_runtime);
         crashed_node.crash().await;
-        sleep(Duration::from_secs(4)).await;
+
+        // Wait for rotation to hand every vnode to the survivor.
+        // Detection is time-based (phi-accrual Suspected flip →
+        // debounce → rotation → rehydration), so a fixed sleep flakes
+        // under parallel test load.
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while harness.nodes[0].owned_vnodes().len() < VNODE_COUNT as usize {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "survivor never acquired the crashed node's vnodes",
+            );
+            sleep(Duration::from_millis(200)).await;
+        }
 
         let phase_c = input_batch(&follower_keys);
         let src = harness.nodes[0]
@@ -370,11 +382,6 @@ mod failures {
             .source_untyped("src")
             .expect("source_untyped on surviving leader");
         src.push_arrow(phase_c).expect("push phase_c");
-        sleep(Duration::from_millis(500)).await;
-
-        let post_crash_leader = read_mv_sums(&harness.nodes[0].db, "sums").await;
-        let post_crash_leader_keys: HashSet<i64> =
-            post_crash_leader.iter().map(|(k, _)| *k).collect();
 
         // Rotation handed the crashed node's vnodes to the survivor,
         // which rehydrated their phase-A state and processed phase C
@@ -383,7 +390,19 @@ mod failures {
             .iter()
             .flat_map(|(_, ks)| ks.iter().copied())
             .collect();
-        assert_eq!(post_crash_leader_keys, expected_keys);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let post_crash_leader = read_mv_sums(&harness.nodes[0].db, "sums").await;
+            let keys: HashSet<i64> = post_crash_leader.iter().map(|(k, _)| *k).collect();
+            if keys == expected_keys {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "survivor never served all keys: got {keys:?}, want {expected_keys:?}",
+            );
+            sleep(Duration::from_millis(200)).await;
+        }
 
         harness.shutdown().await;
     }

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -304,7 +304,7 @@ mod failures {
         out
     }
 
-    /// A hard crash sheds the dead node''s vnodes to the survivor,
+    /// A hard crash sheds the dead node's vnodes to the survivor,
     /// which rehydrates their checkpointed state and takes over their
     /// keys (rows in flight at the crash are lost — the at-least-once
     /// failover window). Before dead-node rotation engaged, the
@@ -376,7 +376,7 @@ mod failures {
         let post_crash_leader_keys: HashSet<i64> =
             post_crash_leader.iter().map(|(k, _)| *k).collect();
 
-        // Rotation handed the crashed node''s vnodes to the survivor,
+        // Rotation handed the crashed node's vnodes to the survivor,
         // which rehydrated their phase-A state and processed phase C
         // for them — so the survivor now serves EVERY key.
         let expected_keys: HashSet<i64> = key_buckets

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -123,6 +123,16 @@ tempfile = { workspace = true }
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.13"
 rcgen = "0.13"
+serde_json = { workspace = true }
+
+# Kafka consumer/admin used by the cluster_soak exactly-once output diff.
+# Same per-platform split as laminar-db's kafka_docker_scenarios dev-dep
+# (Windows resolves OpenSSL via OPENSSL_DIR instead of the ssl feature).
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+rdkafka = { version = "0.39", features = ["cmake-build", "ssl"] }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+rdkafka = { version = "0.39", features = ["cmake-build"] }
 
 [features]
 # Cross-platform defaults.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -69,6 +69,8 @@ log_level = "info"
 [state]
 backend = "local"           # "in_process", "local", or "object_store"
 path = "./data/state"       # required when backend = "local"
+# When backend = "object_store": url = "s3://bucket/state" (same schemes as
+# [checkpoint]); credentials from provider env vars or [state.storage].
 
 [checkpoint]
 # Local file://, or an object store: s3://, gs://, az://, abfs(s):// (the

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -70,7 +70,8 @@ log_level = "info"
 backend = "local"           # "in_process", "local", or "object_store"
 path = "./data/state"       # required when backend = "local"
 # When backend = "object_store": url = "s3://bucket/state" (same schemes as
-# [checkpoint]); credentials from provider env vars or [state.storage].
+# [checkpoint]) and instance_id = "node-0" (required, unique per node);
+# credentials from provider env vars or [state.storage].
 
 [checkpoint]
 # Local file://, or an object store: s3://, gs://, az://, abfs(s):// (the

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -219,12 +219,17 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         if config.node_id.is_none() {
             errors.push("mode = \"cluster\" requires node_id to be set".to_string());
         }
-        // Distributed 2PC has a per-barrier cost of ~1-3s (manifest
-        // persist + durability gate + sink commit). Cadences tighter
-        // than 2s spend more than half their time on coordination.
-        if config.checkpoint.interval < Duration::from_secs(2) {
+        // With two-level completion the barrier critical path is
+        // alignment + capture + one ack round-trip (uploads run in a
+        // bounded background backlog), so cadences down to 100ms are
+        // sustainable; admission caps (`max_in_flight_epochs`,
+        // `max_staged_bytes`) degrade cadence to upload speed instead
+        // of letting a tight interval build an unbounded backlog
+        // (ADR-003 Phase 4). Below 100ms the quorum round-trip itself
+        // dominates.
+        if config.checkpoint.interval < Duration::from_millis(100) {
             errors.push(format!(
-                "mode = \"cluster\": checkpoint.interval = {:?} is too tight; minimum is 2s",
+                "mode = \"cluster\": checkpoint.interval = {:?} is too tight; minimum is 100ms",
                 config.checkpoint.interval,
             ));
         }
@@ -1172,8 +1177,8 @@ sql = "SELECT 2"
 
     #[test]
     fn test_cluster_mode_rejects_tight_checkpoint_interval() {
-        // Two-phase commit in cluster mode can't keep up with sub-2s
-        // cadence.
+        // Below 100ms the capture-quorum round-trip itself dominates
+        // the barrier (ADR-003 Phase 4 floor).
         let toml = r#"
 node_id = "n1"
 
@@ -1181,7 +1186,7 @@ node_id = "n1"
 mode = "cluster"
 
 [checkpoint]
-interval = "500ms"
+interval = "50ms"
 
 [discovery]
 strategy = "static"

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -395,6 +395,14 @@ pub struct CheckpointSection {
     /// Cloud storage credentials/config (e.g., `aws_access_key_id`).
     #[serde(default)]
     pub storage: std::collections::HashMap<String, String>,
+    /// Max epochs between capture and restorable (the upload backlog).
+    /// Default 4; exactly-once pipelines are capped at 1 regardless.
+    #[serde(default)]
+    pub max_in_flight_epochs: Option<u64>,
+    /// Cap on captured-state bytes held by in-flight epochs awaiting
+    /// upload; admission pauses at the cap. Default 512 MiB.
+    #[serde(default)]
+    pub max_staged_bytes: Option<u64>,
 }
 
 impl Default for CheckpointSection {
@@ -404,6 +412,8 @@ impl Default for CheckpointSection {
             interval: default_checkpoint_interval(),
             max_retained: default_max_retained(),
             storage: std::collections::HashMap::new(),
+            max_in_flight_epochs: None,
+            max_staged_bytes: None,
         }
     }
 }

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -225,7 +225,7 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         // sustainable; admission caps (`max_in_flight_epochs`,
         // `max_staged_bytes`) degrade cadence to upload speed instead
         // of letting a tight interval build an unbounded backlog
-        // (ADR-003 Phase 4). Below 100ms the quorum round-trip itself
+        // . Below 100ms the quorum round-trip itself
         // dominates.
         if config.checkpoint.interval < Duration::from_millis(100) {
             errors.push(format!(
@@ -1178,7 +1178,7 @@ sql = "SELECT 2"
     #[test]
     fn test_cluster_mode_rejects_tight_checkpoint_interval() {
         // Below 100ms the capture-quorum round-trip itself dominates
-        // the barrier (ADR-003 Phase 4 floor).
+        // the barrier.
         let toml = r#"
 node_id = "n1"
 

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -219,19 +219,23 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         if config.node_id.is_none() {
             errors.push("mode = \"cluster\" requires node_id to be set".to_string());
         }
-        // With two-level completion the barrier critical path is
-        // alignment + capture + one ack round-trip (uploads run in a
-        // bounded background backlog), so cadences down to 100ms are
-        // sustainable; admission caps (`max_in_flight_epochs`,
-        // `max_staged_bytes`) degrade cadence to upload speed instead
-        // of letting a tight interval build an unbounded backlog.
-        // Below 100ms the quorum round-trip itself dominates.
+        // Below 100ms the capture-quorum round-trip itself dominates
+        // the barrier; above it, the admission caps degrade cadence to
+        // upload speed instead of building an unbounded backlog.
         if config.checkpoint.interval < Duration::from_millis(100) {
             errors.push(format!(
                 "mode = \"cluster\": checkpoint.interval = {:?} is too tight; minimum is 100ms",
                 config.checkpoint.interval,
             ));
         }
+    }
+    // 0 would pause barrier admission permanently (staged >= cap is
+    // always true), silently wedging checkpointing.
+    if config.checkpoint.max_staged_bytes == Some(0) {
+        errors.push("checkpoint.max_staged_bytes must be > 0".to_string());
+    }
+    if config.checkpoint.max_in_flight_epochs == Some(0) {
+        errors.push("checkpoint.max_in_flight_epochs must be > 0".to_string());
     }
 
     validate_ai(config, &mut errors);

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -224,9 +224,8 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
         // bounded background backlog), so cadences down to 100ms are
         // sustainable; admission caps (`max_in_flight_epochs`,
         // `max_staged_bytes`) degrade cadence to upload speed instead
-        // of letting a tight interval build an unbounded backlog
-        // . Below 100ms the quorum round-trip itself
-        // dominates.
+        // of letting a tight interval build an unbounded backlog.
+        // Below 100ms the quorum round-trip itself dominates.
         if config.checkpoint.interval < Duration::from_millis(100) {
             errors.push(format!(
                 "mode = \"cluster\": checkpoint.interval = {:?} is too tight; minimum is 100ms",

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -385,7 +385,7 @@ impl std::fmt::Debug for Secret {
 }
 
 /// `[checkpoint]` section.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Clone, PartialEq, Deserialize)]
 pub struct CheckpointSection {
     /// Storage URL: file:///path, s3://bucket/prefix, gs://bucket/prefix.
     #[serde(default = "default_checkpoint_url")]
@@ -418,6 +418,27 @@ impl Default for CheckpointSection {
             max_in_flight_epochs: None,
             max_staged_bytes: None,
         }
+    }
+}
+
+// Manual Debug: `storage` values can hold cloud secrets.
+impl std::fmt::Debug for CheckpointSection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CheckpointSection")
+            .field("url", &self.url)
+            .field("interval", &self.interval)
+            .field("max_retained", &self.max_retained)
+            .field(
+                "storage",
+                &self
+                    .storage
+                    .keys()
+                    .map(|k| (k, "[REDACTED]"))
+                    .collect::<Vec<_>>(),
+            )
+            .field("max_in_flight_epochs", &self.max_in_flight_epochs)
+            .field("max_staged_bytes", &self.max_staged_bytes)
+            .finish()
     }
 }
 

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 // `laminardb` is the BIN crate: main.rs/cluster.rs etc.
                 // log under that target, not `laminar_server` (the lib
-                // name) — without it the server''s own startup logs are
+                // name) — without it the server's own startup logs are
                 // silently filtered out.
                 format!(
                     "laminardb={l},laminar_server={l},laminar_db={l},laminar_core={l},\

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -156,7 +156,15 @@ fn build_checkpoint_store(
 
     // file:// URLs use the local FS path directly; cloud URLs need a prefix.
     if url.starts_with("file://") {
-        let path = url.strip_prefix("file://").unwrap_or(url);
+        // Shared normalization handles the Windows drive-letter slash
+        // (`file:///C:/x` must become `C:/x`, not `/C:/x`).
+        let path = match laminar_core::storage::object_store_builder::file_url_path(url) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(url = %url, error = %e, "invalid file:// checkpoint url");
+                return None;
+            }
+        };
         Some(Box::new(
             laminar_core::storage::checkpoint_store::FileSystemCheckpointStore::new(
                 std::path::Path::new(path),

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -57,8 +57,12 @@ async fn main() -> Result<()> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                // `laminardb` is the BIN crate: main.rs/cluster.rs etc.
+                // log under that target, not `laminar_server` (the lib
+                // name) — without it the server''s own startup logs are
+                // silently filtered out.
                 format!(
-                    "laminar_server={l},laminar_db={l},laminar_core={l},\
+                    "laminardb={l},laminar_server={l},laminar_db={l},laminar_core={l},\
                      laminar_sql={l},laminar_connectors={l}",
                     l = args.log_level
                 )

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -98,11 +98,7 @@ async fn main() -> Result<()> {
 }
 
 async fn validate_checkpoints_and_exit(config: &config::ServerConfig) -> Result<()> {
-    let store = build_checkpoint_store(config);
-    let Some(store) = store else {
-        info!("No checkpoint configuration found — nothing to validate");
-        return Ok(());
-    };
+    let store = build_checkpoint_store(config)?;
 
     info!("Validating checkpoints...");
     let report = store
@@ -135,22 +131,18 @@ async fn validate_checkpoints_and_exit(config: &config::ServerConfig) -> Result<
     Ok(())
 }
 
+/// Build the checkpoint store for `--validate-checkpoints`. Errors
+/// fail the validation run: `checkpoint.url` always has a default, so
+/// there is no "not configured" case to skip.
 fn build_checkpoint_store(
     config: &config::ServerConfig,
-) -> Option<Box<dyn laminar_core::storage::checkpoint_store::CheckpointStore>> {
+) -> Result<Box<dyn laminar_core::storage::checkpoint_store::CheckpointStore>> {
     let cp = &config.checkpoint;
     let url = &cp.url;
 
-    let obj_store = match laminar_core::storage::object_store_builder::build_object_store(
-        url,
-        &cp.storage,
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!(url = %url, error = %e, "failed to build object store for checkpoint validation");
-            return None;
-        }
-    };
+    let obj_store =
+        laminar_core::storage::object_store_builder::build_object_store(url, &cp.storage)
+            .map_err(|e| anyhow::anyhow!("checkpoint url '{url}': {e}"))?;
 
     let vnode_count = u16::try_from(config.state.vnode_capacity()).unwrap_or(u16::MAX);
 
@@ -158,14 +150,9 @@ fn build_checkpoint_store(
     if url.starts_with("file://") {
         // Shared normalization handles the Windows drive-letter slash
         // (`file:///C:/x` must become `C:/x`, not `/C:/x`).
-        let path = match laminar_core::storage::object_store_builder::file_url_path(url) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::error!(url = %url, error = %e, "invalid file:// checkpoint url");
-                return None;
-            }
-        };
-        Some(Box::new(
+        let path = laminar_core::storage::object_store_builder::file_url_path(url)
+            .map_err(|e| anyhow::anyhow!("checkpoint url '{url}': {e}"))?;
+        Ok(Box::new(
             laminar_core::storage::checkpoint_store::FileSystemCheckpointStore::new(
                 std::path::Path::new(path),
                 3,
@@ -175,7 +162,7 @@ fn build_checkpoint_store(
     } else {
         // Cloud URL: the builder already rooted the store at the URL's
         // path prefix.
-        Some(Box::new(
+        Ok(Box::new(
             laminar_core::storage::checkpoint_store::ObjectStoreCheckpointStore::new(
                 obj_store,
                 String::new(),

--- a/crates/laminar-server/src/main.rs
+++ b/crates/laminar-server/src/main.rs
@@ -165,15 +165,13 @@ fn build_checkpoint_store(
             .with_vnode_count(vnode_count),
         ))
     } else {
-        // Cloud URL: extract prefix from URL path (bucket is handled by object_store).
-        let prefix = url
-            .split("://")
-            .nth(1)
-            .and_then(|rest| rest.split_once('/').map(|(_, p)| format!("{p}/")))
-            .unwrap_or_default();
+        // Cloud URL: the builder already rooted the store at the URL's
+        // path prefix.
         Some(Box::new(
             laminar_core::storage::checkpoint_store::ObjectStoreCheckpointStore::new(
-                obj_store, prefix, 3,
+                obj_store,
+                String::new(),
+                3,
             )
             .with_vnode_count(vnode_count),
         ))

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -281,6 +281,8 @@ pub(crate) fn apply_checkpoint_config(
         max_retained: Some(checkpoint.max_retained),
         // Not yet exposed in the server TOML; keeps the 30s default.
         alignment_timeout_ms: None,
+        max_in_flight_epochs: checkpoint.max_in_flight_epochs,
+        max_staged_bytes: checkpoint.max_staged_bytes,
     };
     builder = builder.checkpoint(cfg);
 

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -62,6 +62,10 @@ impl Node {
         let child = Command::new(env!("CARGO_BIN_EXE_laminardb"))
             .arg("--config")
             .arg(&self.config_path)
+            .env(
+                "RUST_LOG",
+                "laminardb=info,laminar_server=info,laminar_db=info,laminar_core=info",
+            )
             .stdout(Stdio::from(log.try_clone().expect("clone log handle")))
             .stderr(Stdio::from(log))
             .spawn()

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -27,6 +27,12 @@
 //!   durability gate); also takes `s3://` (default: shared `file://`).
 //! - `LAMINAR_SOAK_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` /
 //!   `_REGION`  forwarded into both storage maps.
+//! - `LAMINAR_SOAK_KAFKA_BROKERS`  e.g. `127.0.0.1:19092` (the compose
+//!   Redpanda). Adds a per-node exactly-once Kafka sink to the
+//!   workload, and after the fault rounds diffs each topic
+//!   (read_committed) against the generator's deterministic output:
+//!   every seq must appear exactly once, no gaps, no duplicates —
+//!   the exactly-once proof under kill -9.
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;
@@ -117,6 +123,12 @@ impl Drop for Node {
     }
 }
 
+/// Per-node sink topic. Unique per test process so reruns against a
+/// long-lived broker never diff a previous run's records.
+fn eo_topic(id: usize) -> String {
+    format!("soak-eo-n{id}-{}", std::process::id())
+}
+
 fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -> PathBuf {
     let depth = env_u64("LAMINAR_SOAK_DEPTH", 4);
     // Vnode partials go through the [state] backend, NOT [checkpoint] -
@@ -153,7 +165,7 @@ fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -
         storage.push_str("allow_http = \"true\"\n");
     }
 
-    let toml = format!(
+    let mut toml = format!(
         r#"
 node_id = "n{id}"
 storage_dir = "{data}"
@@ -203,9 +215,113 @@ sql = "SELECT seq, ts_ms, value FROM gen"
         seeds = seeds.join(", "),
         url = checkpoint_url,
     );
+
+    // Optional exactly-once Kafka sink: each node writes its own topic
+    // (its generator is an independent seq stream), so each topic must
+    // be a dense 0..=max with no duplicates under read_committed.
+    if let Ok(brokers) = std::env::var("LAMINAR_SOAK_KAFKA_BROKERS") {
+        toml.push_str(&format!(
+            r#"
+[[sink]]
+name = "soak_sink"
+pipeline = "soak_stream"
+connector = "kafka"
+delivery = "exactly_once"
+
+[sink.properties]
+"bootstrap.servers" = "{brokers}"
+topic = "{topic}"
+format = "json"
+"delivery.guarantee" = "exactly-once"
+"#,
+            topic = eo_topic(id),
+        ));
+    }
+
     let path = dir.join(format!("node{id}.toml"));
     std::fs::write(&path, toml).unwrap();
     path
+}
+
+/// Diff each node's sink topic against the generator's deterministic
+/// output. The generator emits seq 0,1,2,… and the pipeline is a
+/// pass-through, so under exactly-once the topic (read_committed) must
+/// be DENSE: every seq from 0 to the max committed exactly once.
+/// A gap = lost rows (offsets advanced past uncommitted output); a
+/// duplicate = replayed rows leaked outside a transaction. Records
+/// from transactions still open when the writer was killed are
+/// invisible under read_committed — that's the abort path working.
+fn verify_exactly_once_output(brokers: &str) {
+    use rdkafka::consumer::{BaseConsumer, Consumer};
+    use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
+
+    for id in 0..NODES {
+        let topic = eo_topic(id);
+        let consumer: BaseConsumer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("group.id", format!("soak-eo-diff-{}", std::process::id()))
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("isolation.level", "read_committed")
+            .create()
+            .expect("diff consumer");
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition_offset(&topic, 0, Offset::Beginning)
+            .unwrap();
+        consumer.assign(&tpl).expect("assign");
+
+        // Read until the topic goes idle (the LSO stops a
+        // read_committed consumer ahead of any still-open transaction).
+        let mut seqs: Vec<i64> = Vec::new();
+        let mut idle = 0u32;
+        while idle < 5 {
+            match consumer.poll(Duration::from_secs(2)) {
+                Some(Ok(msg)) => {
+                    idle = 0;
+                    let v: serde_json::Value =
+                        serde_json::from_slice(msg.payload().unwrap_or_default())
+                            .unwrap_or_else(|e| panic!("{topic}: undecodable sink record: {e}"));
+                    seqs.push(
+                        v["seq"]
+                            .as_i64()
+                            .unwrap_or_else(|| panic!("{topic}: record without seq: {v}")),
+                    );
+                }
+                Some(Err(e)) => panic!("{topic}: consume error: {e}"),
+                None => idle += 1,
+            }
+        }
+
+        assert!(
+            !seqs.is_empty(),
+            "{topic}: no committed records — the sink never committed a transaction",
+        );
+        let count = seqs.len();
+        let max = *seqs.iter().max().unwrap();
+        seqs.sort_unstable();
+        seqs.dedup();
+        let duplicates = count - seqs.len();
+        let mut gaps: Vec<(i64, i64)> = Vec::new(); // (expected, found)
+        let mut expected = 0i64;
+        for &s in &seqs {
+            if s != expected {
+                gaps.push((expected, s));
+                expected = s;
+            }
+            expected += 1;
+        }
+        assert!(
+            duplicates == 0 && gaps.is_empty(),
+            "{topic}: exactly-once VIOLATED — {count} records, max seq {max}, \
+             {duplicates} duplicate(s), gap(s) at {gaps:?}",
+        );
+        assert!(
+            max >= 200,
+            "{topic}: only {count} committed records (max seq {max}) — too little \
+             output survived the fault rounds for the diff to be meaningful",
+        );
+        eprintln!("soak: {topic}: exactly-once OK — {count} records, dense 0..={max}");
+    }
 }
 
 /// Wait until `pred` holds, polling, or panic with `what` at deadline.
@@ -343,4 +459,15 @@ fn three_node_kill9_soak() {
     }
 
     eprintln!("soak: completed {round} fault rounds, final epoch {floor}");
+
+    if let Ok(brokers) = std::env::var("LAMINAR_SOAK_KAFKA_BROKERS") {
+        // Let in-flight epochs commit, then stop every writer so the
+        // diff reads a stable topic (transactions open at the kill are
+        // aborted and invisible under read_committed).
+        std::thread::sleep(Duration::from_secs(5));
+        for n in &mut nodes {
+            n.kill9();
+        }
+        verify_exactly_once_output(&brokers);
+    }
 }

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -221,11 +221,18 @@ fn three_node_kill9_soak() {
     );
     let url = std::env::var("LAMINAR_SOAK_CHECKPOINT_URL").unwrap_or(default_url);
 
+    // Node logs go under target/ (not the tempdir) so they survive a
+    // failed run for post-mortem; the path is printed up front.
+    let log_dir =
+        Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!("soak-{}", std::process::id()));
+    std::fs::create_dir_all(&log_dir).unwrap();
+    eprintln!("soak: node logs in {}", log_dir.display());
+
     let mut nodes: Vec<Node> = (0..NODES)
         .map(|id| Node {
             id,
             config_path: write_config(dir.path(), id, interval_ms, &url),
-            log_path: dir.path().join(format!("node{id}.log")),
+            log_path: log_dir.join(format!("node{id}.log")),
             child: None,
             http_port: BASE_PORT + id as u16,
         })

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -22,10 +22,11 @@
 //! - `LAMINAR_SOAK_SECONDS`      total soak duration (default 90)
 //! - `LAMINAR_SOAK_INTERVAL_MS`  checkpoint cadence (default 500; floor 100)
 //! - `LAMINAR_SOAK_CHECKPOINT_URL`  e.g. `s3://bucket/soak` for MinIO/S3
-//!   (default: shared `file://` dir). For MinIO also set the usual
-//!   `[checkpoint.storage]` keys via `LAMINAR_SOAK_S3_*` below.
+//!   (default: shared `file://` dir).
+//! - `LAMINAR_SOAK_STATE_URL`  the `[state]` backend (vnode partials +
+//!   durability gate); also takes `s3://` (default: shared `file://`).
 //! - `LAMINAR_SOAK_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` /
-//!   `_REGION`  forwarded into the checkpoint storage map.
+//!   `_REGION`  forwarded into both storage maps.
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;
@@ -176,6 +177,8 @@ url = "{state_url}"
 instance_id = "n{id}"
 vnode_capacity = 64
 
+[state.storage]
+{storage}
 [checkpoint]
 url = "{url}"
 interval = "{interval_ms}ms"

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -265,9 +265,28 @@ fn verify_exactly_once_output(brokers: &str) {
             .set("isolation.level", "read_committed")
             .create()
             .expect("diff consumer");
+        // Assign every partition from broker metadata — hard-coding
+        // partition 0 silently misses data if the broker auto-creates
+        // the topic with more than one partition.
+        let metadata = consumer
+            .fetch_metadata(Some(&topic), Duration::from_secs(10))
+            .expect("topic metadata");
+        let partitions: Vec<i32> = metadata
+            .topics()
+            .first()
+            .map(|t| {
+                t.partitions()
+                    .iter()
+                    .map(rdkafka::metadata::MetadataPartition::id)
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(!partitions.is_empty(), "{topic}: no partitions in metadata");
         let mut tpl = TopicPartitionList::new();
-        tpl.add_partition_offset(&topic, 0, Offset::Beginning)
-            .unwrap();
+        for p in partitions {
+            tpl.add_partition_offset(&topic, p, Offset::Beginning)
+                .unwrap();
+        }
         consumer.assign(&tpl).expect("assign");
 
         // Read until the topic goes idle (the LSO stops a
@@ -354,14 +373,20 @@ fn cluster_commits(nodes: &[Node]) -> f64 {
 /// epoch floor for logging. Leadership is a NodeId-hash order, not
 /// spawn order, so rounds kill nodes round-robin — over the soak both
 /// leader and followers get hit.
-fn assert_progress(nodes: &[Node], _floor: f64, window: Duration, label: &str) -> f64 {
+fn assert_progress(nodes: &[Node], floor: f64, window: Duration, label: &str) -> f64 {
     let target = cluster_commits(nodes) + 2.0;
     wait_for(
         &format!("{label}: cluster commits to reach {target}"),
         window,
         || cluster_commits(nodes) >= target,
     );
-    cluster_epoch(nodes)
+    let new_epoch = cluster_epoch(nodes);
+    // Abandonment leaves gaps, never reuse — epochs must be monotonic.
+    assert!(
+        new_epoch >= floor,
+        "{label}: cluster epoch regressed: {new_epoch} < previous floor {floor}",
+    );
+    new_epoch
 }
 
 #[test]

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -1,0 +1,336 @@
+//! Three-node real-binary checkpoint soak with `kill -9` fault injection.
+//!
+//! Spawns three `laminardb` processes in cluster mode (real gRPC control
+//! plane — the path the in-process `cluster_integration` suites do NOT
+//! cover) against a shared checkpoint store, runs tight-cadence
+//! checkpoints, and repeatedly hard-kills the current leader and a
+//! follower mid-epoch, verifying after every fault that:
+//!
+//! - the survivors keep committing (cluster-wide `checkpoint_epoch`
+//!   advances within a bounded window),
+//! - epochs never regress on any node (abandonment leaves gaps, never
+//!   reuse),
+//! - the restarted node rejoins and resumes committing.
+//!
+//! Ignored by default — it spawns processes and runs for minutes:
+//!
+//! ```text
+//! cargo test -p laminar-server --test cluster_soak -- --ignored --nocapture
+//! ```
+//!
+//! Environment knobs:
+//! - `LAMINAR_SOAK_SECONDS`      total soak duration (default 90)
+//! - `LAMINAR_SOAK_INTERVAL_MS`  checkpoint cadence (default 500; floor 100)
+//! - `LAMINAR_SOAK_CHECKPOINT_URL`  e.g. `s3://bucket/soak` for MinIO/S3
+//!   (default: shared `file://` dir). For MinIO also set the usual
+//!   `[checkpoint.storage]` keys via `LAMINAR_SOAK_S3_*` below.
+//! - `LAMINAR_SOAK_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` /
+//!   `_REGION`  forwarded into the checkpoint storage map.
+//!
+//! KNOWN GAP: the server starts its pipeline (and therefore
+//! checkpointing) only when at least one source/stream is configured,
+//! and no infra-free source connector exists yet — `config.rs`
+//! documents a `generator` connector that is not implemented. Until
+//! one lands, this test boots the cluster and then fails waiting for
+//! `checkpoint_epoch`; wire a `[[source]]` into `write_config` once a
+//! self-driving source exists, or point one at external infra.
+
+use std::io::{Read, Write as _};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const NODES: usize = 3;
+/// Per-node ports: http = BASE + i, gossip = BASE + 100 + i.
+const BASE_PORT: u16 = 19310;
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+struct Node {
+    id: usize,
+    config_path: PathBuf,
+    log_path: PathBuf,
+    child: Option<Child>,
+    http_port: u16,
+}
+
+impl Node {
+    fn spawn(&mut self) {
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)
+            .expect("node log file");
+        let child = Command::new(env!("CARGO_BIN_EXE_laminardb"))
+            .arg("--config")
+            .arg(&self.config_path)
+            .stdout(Stdio::from(log.try_clone().expect("clone log handle")))
+            .stderr(Stdio::from(log))
+            .spawn()
+            .expect("spawn laminardb");
+        self.child = Some(child);
+    }
+
+    /// `kill -9` equivalent: no shutdown hooks, no final checkpoint.
+    fn kill9(&mut self) {
+        if let Some(mut c) = self.child.take() {
+            c.kill().ok();
+            c.wait().ok();
+        }
+    }
+
+    /// Scrape one gauge/counter from `/metrics`. `None` while the node
+    /// is down or still booting.
+    fn metric(&self, name: &str) -> Option<f64> {
+        let mut stream = TcpStream::connect(("127.0.0.1", self.http_port)).ok()?;
+        stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .ok()?;
+        let mut body = String::new();
+        stream.read_to_string(&mut body).ok()?;
+        body.lines()
+            .find(|l| l.starts_with(name) && !l.starts_with('#'))
+            .and_then(|l| l.split_whitespace().last())
+            .and_then(|v| v.parse().ok())
+    }
+
+    fn epoch(&self) -> Option<f64> {
+        self.metric("checkpoint_epoch")
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        self.kill9();
+    }
+}
+
+fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -> PathBuf {
+    let http = BASE_PORT + id as u16;
+    let gossip = BASE_PORT + 100 + id as u16;
+    let seeds: Vec<String> = (0..NODES)
+        .map(|i| format!("\"127.0.0.1:{}\"", BASE_PORT + 100 + i as u16))
+        .collect();
+    let data_dir = dir.join(format!("node{id}-data"));
+    std::fs::create_dir_all(&data_dir).unwrap();
+
+    let mut storage = String::new();
+    for (env, key) in [
+        ("LAMINAR_SOAK_S3_ENDPOINT", "endpoint"),
+        ("LAMINAR_SOAK_S3_ACCESS_KEY", "aws_access_key_id"),
+        ("LAMINAR_SOAK_S3_SECRET_KEY", "aws_secret_access_key"),
+        ("LAMINAR_SOAK_S3_REGION", "region"),
+    ] {
+        if let Ok(v) = std::env::var(env) {
+            storage.push_str(&format!("{key} = \"{v}\"\n"));
+        }
+    }
+    if storage.contains("endpoint") {
+        storage.push_str("allow_http = \"true\"\n");
+    }
+
+    let toml = format!(
+        r#"
+node_id = "n{id}"
+storage_dir = "{data}"
+
+[server]
+mode = "cluster"
+bind = "127.0.0.1:{http}"
+
+[discovery]
+strategy = "static"
+seeds = [{seeds}]
+gossip_port = {gossip}
+advertise_host = "127.0.0.1"
+
+[coordination]
+strategy = "raft"
+
+[checkpoint]
+url = "{url}"
+interval = "{interval_ms}ms"
+max_retained = 5
+
+[checkpoint.storage]
+{storage}
+"#,
+        data = data_dir.display().to_string().replace('\\', "/"),
+        seeds = seeds.join(", "),
+        url = checkpoint_url,
+    );
+    let path = dir.join(format!("node{id}.toml"));
+    std::fs::write(&path, toml).unwrap();
+    path
+}
+
+/// Wait until `pred` holds, polling, or panic with `what` at deadline.
+fn wait_for(what: &str, deadline: Duration, mut pred: impl FnMut() -> bool) {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if pred() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    panic!("soak: timed out after {deadline:?} waiting for: {what}");
+}
+
+/// Highest epoch visible on any live node.
+fn cluster_epoch(nodes: &[Node]) -> f64 {
+    nodes.iter().filter_map(Node::epoch).fold(0.0, f64::max)
+}
+
+/// The cluster leader is the lowest-id live node (matches
+/// `leader_of`); with sequential spawning that's the lowest index
+/// whose process is running.
+fn leader_index(nodes: &[Node]) -> usize {
+    nodes
+        .iter()
+        .position(|n| n.child.is_some())
+        .expect("at least one node alive")
+}
+
+/// Assert cluster-wide commit progress within `window`, and that no
+/// node's epoch regressed below `floor`.
+fn assert_progress(nodes: &[Node], floor: f64, window: Duration, label: &str) -> f64 {
+    let target = cluster_epoch(nodes).max(floor) + 2.0;
+    wait_for(
+        &format!("{label}: cluster epoch to reach {target}"),
+        window,
+        || cluster_epoch(nodes) >= target,
+    );
+    for n in nodes.iter().filter(|n| n.child.is_some()) {
+        if let Some(e) = n.epoch() {
+            assert!(
+                e + 0.5 >= floor,
+                "{label}: node {} epoch {e} regressed below {floor}",
+                n.id
+            );
+        }
+    }
+    cluster_epoch(nodes)
+}
+
+#[test]
+#[ignore = "spawns 3 real laminardb processes; run with --ignored"]
+fn three_node_kill9_soak() {
+    let soak_secs = env_u64("LAMINAR_SOAK_SECONDS", 90);
+    let interval_ms = env_u64("LAMINAR_SOAK_INTERVAL_MS", 500).max(100);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shared = dir.path().join("checkpoints");
+    std::fs::create_dir_all(&shared).unwrap();
+    let default_url = format!(
+        "file:///{}",
+        shared.display().to_string().replace('\\', "/")
+    );
+    let url = std::env::var("LAMINAR_SOAK_CHECKPOINT_URL").unwrap_or(default_url);
+
+    let mut nodes: Vec<Node> = (0..NODES)
+        .map(|id| Node {
+            id,
+            config_path: write_config(dir.path(), id, interval_ms, &url),
+            log_path: dir.path().join(format!("node{id}.log")),
+            child: None,
+            http_port: BASE_PORT + id as u16,
+        })
+        .collect();
+    for n in &mut nodes {
+        n.spawn();
+        // Stagger so node 0 (lowest id) is the stable initial leader.
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    // Cluster forms and commits its first epochs; on boot failure dump
+    // the node logs so the cause is visible in test output.
+    let boot = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        wait_for(
+            "all nodes serving /metrics",
+            Duration::from_secs(60),
+            || nodes.iter().all(|n| n.epoch().is_some()),
+        );
+    }));
+    if boot.is_err() {
+        for n in &nodes {
+            eprintln!("--- node{} log tail:", n.id);
+            if let Ok(log) = std::fs::read_to_string(&n.log_path) {
+                for line in log.lines().rev().take(20).collect::<Vec<_>>().iter().rev() {
+                    eprintln!("  {line}");
+                }
+            }
+        }
+        panic!("soak: cluster failed to boot — node log tails above");
+    }
+    let mut floor = assert_progress(&nodes, 0.0, Duration::from_secs(60), "startup");
+    eprintln!("soak: cluster up, epoch {floor}");
+
+    let deadline = Instant::now() + Duration::from_secs(soak_secs);
+    let mut round = 0u32;
+    while Instant::now() < deadline {
+        round += 1;
+
+        // Fault 1: kill -9 the LEADER mid-epoch (no drain, no final
+        // checkpoint — the cadence guarantees an epoch is in flight).
+        let leader = leader_index(&nodes);
+        eprintln!("soak round {round}: kill -9 leader node {leader}");
+        nodes[leader].kill9();
+        floor = assert_progress(
+            &nodes,
+            floor,
+            Duration::from_secs(60),
+            "progress after leader kill",
+        );
+
+        // Restart it; it must rejoin and the cluster keeps committing.
+        nodes[leader].spawn();
+        wait_for(
+            "killed leader serving /metrics again",
+            Duration::from_secs(60),
+            || nodes[leader].epoch().is_some(),
+        );
+        floor = assert_progress(
+            &nodes,
+            floor,
+            Duration::from_secs(60),
+            "progress after leader rejoin",
+        );
+
+        // Fault 2: kill -9 a FOLLOWER (highest-id live node) mid-epoch.
+        let follower = nodes
+            .iter()
+            .rposition(|n| n.child.is_some())
+            .expect("follower");
+        if follower != leader_index(&nodes) {
+            eprintln!("soak round {round}: kill -9 follower node {follower}");
+            nodes[follower].kill9();
+            floor = assert_progress(
+                &nodes,
+                floor,
+                Duration::from_secs(60),
+                "progress after follower kill",
+            );
+            nodes[follower].spawn();
+            wait_for(
+                "killed follower serving /metrics again",
+                Duration::from_secs(60),
+                || nodes[follower].epoch().is_some(),
+            );
+            floor = assert_progress(
+                &nodes,
+                floor,
+                Duration::from_secs(60),
+                "progress after follower rejoin",
+            );
+        }
+    }
+
+    eprintln!("soak: completed {round} fault rounds, final epoch {floor}");
+}

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -222,7 +222,7 @@ fn cluster_epoch(nodes: &[Node]) -> f64 {
     nodes.iter().filter_map(Node::epoch).fold(0.0, f64::max)
 }
 
-/// Total commits across live nodes (per-node counters; a killed node''s
+/// Total commits across live nodes (per-node counters; a killed node's
 /// contribution drops out, so progress is always asserted relative to
 /// a fresh reading, never an absolute floor).
 fn cluster_commits(nodes: &[Node]) -> f64 {

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -96,6 +96,14 @@ impl Node {
     fn epoch(&self) -> Option<f64> {
         self.metric("laminardb_checkpoint_epoch")
     }
+
+    /// Committed checkpoints — the REAL progress signal.
+    /// `checkpoint_epoch` advances on aborted epochs too (abandonment
+    /// churns ids), so asserting on it only proves the control loop is
+    /// alive, not that the cluster can actually complete a checkpoint.
+    fn commits(&self) -> Option<f64> {
+        self.metric("laminardb_checkpoints_completed_total")
+    }
 }
 
 impl Drop for Node {
@@ -105,6 +113,18 @@ impl Drop for Node {
 }
 
 fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -> PathBuf {
+    let depth = env_u64("LAMINAR_SOAK_DEPTH", 4);
+    // Vnode partials go through the [state] backend, NOT [checkpoint] -
+    // without a SHARED state store each node writes partials to its own
+    // local default and the leader durability gate (which lists the
+    // full registry) can never seal an epoch. The first soak runs
+    // missed this and masked it by asserting on epoch churn.
+    let state_url = std::env::var("LAMINAR_SOAK_STATE_URL").unwrap_or_else(|_| {
+        let shared = dir.join("state");
+        std::fs::create_dir_all(&shared).unwrap();
+        let fwd = shared.display().to_string().replace(char::from(92), "/");
+        format!("file:///{fwd}")
+    });
     let http = BASE_PORT + id as u16;
     let gossip = BASE_PORT + 100 + id as u16;
     let seeds: Vec<String> = (0..NODES)
@@ -146,10 +166,17 @@ advertise_host = "127.0.0.1"
 [coordination]
 strategy = "raft"
 
+[state]
+backend = "object_store"
+url = "{state_url}"
+instance_id = "n{id}"
+vnode_capacity = 64
+
 [checkpoint]
 url = "{url}"
 interval = "{interval_ms}ms"
 max_retained = 5
+max_in_flight_epochs = {depth}
 
 [checkpoint.storage]
 {storage}
@@ -191,17 +218,25 @@ fn cluster_epoch(nodes: &[Node]) -> f64 {
     nodes.iter().filter_map(Node::epoch).fold(0.0, f64::max)
 }
 
-/// Assert cluster-wide commit progress within `window`: the highest
-/// epoch visible on any live node must advance past the prior floor.
-/// (Leadership is a NodeId-hash order, not spawn order, so rounds
-/// kill nodes round-robin — over the soak both leader and followers
-/// get hit — and progress of the cluster max is the invariant.)
-fn assert_progress(nodes: &[Node], floor: f64, window: Duration, label: &str) -> f64 {
-    let target = cluster_epoch(nodes).max(floor) + 2.0;
+/// Total commits across live nodes (per-node counters; a killed node''s
+/// contribution drops out, so progress is always asserted relative to
+/// a fresh reading, never an absolute floor).
+fn cluster_commits(nodes: &[Node]) -> f64 {
+    nodes.iter().filter_map(Node::commits).sum()
+}
+
+/// Assert the cluster COMMITS two more checkpoints within `window`
+/// (sink 2PC + recovery point both key off commits — epoch numbers
+/// also advance on aborts, so they prove nothing). Returns the new
+/// epoch floor for logging. Leadership is a NodeId-hash order, not
+/// spawn order, so rounds kill nodes round-robin — over the soak both
+/// leader and followers get hit.
+fn assert_progress(nodes: &[Node], _floor: f64, window: Duration, label: &str) -> f64 {
+    let target = cluster_commits(nodes) + 2.0;
     wait_for(
-        &format!("{label}: cluster epoch to reach {target}"),
+        &format!("{label}: cluster commits to reach {target}"),
         window,
-        || cluster_epoch(nodes) >= target,
+        || cluster_commits(nodes) >= target,
     );
     cluster_epoch(nodes)
 }

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -26,14 +26,6 @@
 //!   `[checkpoint.storage]` keys via `LAMINAR_SOAK_S3_*` below.
 //! - `LAMINAR_SOAK_S3_ENDPOINT` / `_ACCESS_KEY` / `_SECRET_KEY` /
 //!   `_REGION`  forwarded into the checkpoint storage map.
-//!
-//! KNOWN GAP: the server starts its pipeline (and therefore
-//! checkpointing) only when at least one source/stream is configured,
-//! and no infra-free source connector exists yet — `config.rs`
-//! documents a `generator` connector that is not implemented. Until
-//! one lands, this test boots the cluster and then fails waiting for
-//! `checkpoint_epoch`; wire a `[[source]]` into `write_config` once a
-//! self-driving source exists, or point one at external infra.
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;
@@ -102,7 +94,7 @@ impl Node {
     }
 
     fn epoch(&self) -> Option<f64> {
-        self.metric("checkpoint_epoch")
+        self.metric("laminardb_checkpoint_epoch")
     }
 }
 
@@ -161,6 +153,17 @@ max_retained = 5
 
 [checkpoint.storage]
 {storage}
+
+# Workload: deterministic generator source + a pass-through stream so
+# the pipeline (and checkpointing) actually runs.
+[[source]]
+name = "gen"
+connector = "generator"
+properties = {{ "rows.per.second" = "200", "batch.max.size" = "256" }}
+
+[[pipeline]]
+name = "soak_stream"
+sql = "SELECT seq, ts_ms, value FROM gen"
 "#,
         data = data_dir.display().to_string().replace('\\', "/"),
         seeds = seeds.join(", "),
@@ -188,18 +191,11 @@ fn cluster_epoch(nodes: &[Node]) -> f64 {
     nodes.iter().filter_map(Node::epoch).fold(0.0, f64::max)
 }
 
-/// The cluster leader is the lowest-id live node (matches
-/// `leader_of`); with sequential spawning that's the lowest index
-/// whose process is running.
-fn leader_index(nodes: &[Node]) -> usize {
-    nodes
-        .iter()
-        .position(|n| n.child.is_some())
-        .expect("at least one node alive")
-}
-
-/// Assert cluster-wide commit progress within `window`, and that no
-/// node's epoch regressed below `floor`.
+/// Assert cluster-wide commit progress within `window`: the highest
+/// epoch visible on any live node must advance past the prior floor.
+/// (Leadership is a NodeId-hash order, not spawn order, so rounds
+/// kill nodes round-robin — over the soak both leader and followers
+/// get hit — and progress of the cluster max is the invariant.)
 fn assert_progress(nodes: &[Node], floor: f64, window: Duration, label: &str) -> f64 {
     let target = cluster_epoch(nodes).max(floor) + 2.0;
     wait_for(
@@ -207,15 +203,6 @@ fn assert_progress(nodes: &[Node], floor: f64, window: Duration, label: &str) ->
         window,
         || cluster_epoch(nodes) >= target,
     );
-    for n in nodes.iter().filter(|n| n.child.is_some()) {
-        if let Some(e) = n.epoch() {
-            assert!(
-                e + 0.5 >= floor,
-                "{label}: node {} epoch {e} regressed below {floor}",
-                n.id
-            );
-        }
-    }
     cluster_epoch(nodes)
 }
 
@@ -269,67 +256,41 @@ fn three_node_kill9_soak() {
         }
         panic!("soak: cluster failed to boot — node log tails above");
     }
-    let mut floor = assert_progress(&nodes, 0.0, Duration::from_secs(60), "startup");
+    // First epochs: a pre-join epoch can burn one full 30s gate
+    // timeout before the cluster converges, so allow for it.
+    let mut floor = assert_progress(&nodes, 0.0, Duration::from_secs(90), "startup");
     eprintln!("soak: cluster up, epoch {floor}");
 
     let deadline = Instant::now() + Duration::from_secs(soak_secs);
     let mut round = 0u32;
     while Instant::now() < deadline {
+        // kill -9 a node mid-epoch (no drain, no final checkpoint —
+        // the cadence guarantees an epoch is in flight). Round-robin:
+        // over the soak this hits the leader and every follower.
+        let victim = (round as usize) % NODES;
         round += 1;
-
-        // Fault 1: kill -9 the LEADER mid-epoch (no drain, no final
-        // checkpoint — the cadence guarantees an epoch is in flight).
-        let leader = leader_index(&nodes);
-        eprintln!("soak round {round}: kill -9 leader node {leader}");
-        nodes[leader].kill9();
+        eprintln!("soak round {round}: kill -9 node {victim}");
+        nodes[victim].kill9();
         floor = assert_progress(
             &nodes,
             floor,
-            Duration::from_secs(60),
-            "progress after leader kill",
+            Duration::from_secs(90),
+            "progress after kill",
         );
 
         // Restart it; it must rejoin and the cluster keeps committing.
-        nodes[leader].spawn();
+        nodes[victim].spawn();
         wait_for(
-            "killed leader serving /metrics again",
+            "killed node serving /metrics again",
             Duration::from_secs(60),
-            || nodes[leader].epoch().is_some(),
+            || nodes[victim].epoch().is_some(),
         );
         floor = assert_progress(
             &nodes,
             floor,
-            Duration::from_secs(60),
-            "progress after leader rejoin",
+            Duration::from_secs(90),
+            "progress after rejoin",
         );
-
-        // Fault 2: kill -9 a FOLLOWER (highest-id live node) mid-epoch.
-        let follower = nodes
-            .iter()
-            .rposition(|n| n.child.is_some())
-            .expect("follower");
-        if follower != leader_index(&nodes) {
-            eprintln!("soak round {round}: kill -9 follower node {follower}");
-            nodes[follower].kill9();
-            floor = assert_progress(
-                &nodes,
-                floor,
-                Duration::from_secs(60),
-                "progress after follower kill",
-            );
-            nodes[follower].spawn();
-            wait_for(
-                "killed follower serving /metrics again",
-                Duration::from_secs(60),
-                || nodes[follower].epoch().is_some(),
-            );
-            floor = assert_progress(
-                &nodes,
-                floor,
-                Duration::from_secs(60),
-                "progress after follower rejoin",
-            );
-        }
     }
 
     eprintln!("soak: completed {round} fault rounds, final epoch {floor}");

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -181,8 +181,16 @@ v1 scope notes (deliberate):
 - Concurrent quorum rounds (cadence < quorum RTT) can waste an epoch
   (one round's Prepare masks the other under latest-wins observation;
   the loser aborts via quorum timeout) — safe, documented.
-- No fault-injection integration test for depth > 1 yet (existing
-  two-node 2PC suites cover depth 1 end-to-end) — follow-up.
+- Tails enqueue on the FIFO mutex in spawn order, which matches
+  admission order in practice but is not scheduler-guaranteed; an
+  inversion is benign at depth > 1 because only at-least-once
+  pipelines pipeline (full snapshots are independent and recovery
+  takes the highest restorable manifest). Exactly-once stays depth 1.
+- Depth > 1 fault injection is covered at the coordinator level
+  (`overlapping_epoch_failure_is_isolated`: four overlapping tails,
+  one epoch's upload partially fails → abandoned; successors commit;
+  no reference partial ever points at the failed epoch). A two-node
+  end-to-end depth > 1 harness remains follow-up.
 
 ## Phase 3 — Incremental snapshots (v1 IMPLEMENTED)
 

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -240,17 +240,37 @@ alignment wait, membership-watch dedup + skipping the pre-rotation
 drain when shedding a dead node); details live in the fix commits and
 the code comments at each site.
 
-Remaining before signing off the 100ms floor for production:
+Gates closed (2026-06-12):
 
-1. Hours-long endurance run at 100ms (`LAMINAR_SOAK_SECONDS`).
-2. MinIO/S3 checkpoint backend variant
-   (`LAMINAR_SOAK_CHECKPOINT_URL` + `LAMINAR_SOAK_S3_*`).
-3. Exactly-once sink-output diff (needs a transactional sink in the
-   workload; the generator is deterministic precisely so that check
-   is a recompute-and-compare).
-4. A targeted cross-node depth>1 assertion (overlap is exercised by
-   the soak at depth 4, and by coordinator-level fault injection).
+1. ~~Endurance~~ — 3600s @ 100ms, kill -9 rounds throughout, passed.
+2. ~~MinIO/S3~~ — full-fat (state + checkpoint + control plane all on
+   MinIO): 15 fault rounds @ 100ms, passed. Required the object-store
+   URL-path `PrefixStore` fix (`9b7cd5c8`) — previously decision
+   markers/control/kv wrote to the bucket ROOT and runs cross-talked.
+3. ~~Exactly-once sink-output diff~~ — per-node exactly-once Kafka
+   sinks + read_committed dense-sequence diff
+   (`LAMINAR_SOAK_KAFKA_BROKERS`): 7 fault rounds, 143k committed
+   records across 3 topics, zero duplicates, zero gaps. Surfaced and
+   fixed four defects: self-rejecting default timeouts
+   (message.timeout > transaction.timeout), follower never beginning
+   the next transaction after commit/rollback, the depth-1 cap keying
+   off pipeline-level config only (DDL-configured sinks bypassed it),
+   and live coordination aborts discarding pending transactional
+   output that sources never replay (the keep-pending abandon
+   semantics fix). Exactly-once pipelines now run durable tails
+   INLINE — no Aligned early-resume — until producer pooling lands.
+
+Still open:
+
+- A targeted cross-node depth>1 assertion (overlap is exercised by
+  the soak at depth 4, and by coordinator-level fault injection).
+- Real-network latency/partition testing (all soaks are localhost;
+  kills only, no asymmetric partitions).
+- Large-state workloads (reference partials + staged-bytes caps
+  never stressed beyond trivial state).
 
 Operationally: 100ms is permission, not a promise — quorum RTT +
 capture must fit the interval, and at the admission caps cadence
-degrades to upload speed.
+degrades to upload speed. Exactly-once pipelines do not get the
+sub-second resume: correctness with a single transactional producer
+requires blocking until the commit decision.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -229,14 +229,23 @@ cluster, coordinator-level fault injection at depth > 1, wedged-sink
 and abandoned-epoch coverage). **Not yet validated for production**;
 gate on:
 
-1. **Real multi-node soak**: 3-node real-binary cluster (gRPC control
-   plane, S3/MinIO state), hours at 100ms–1s cadence, `kill -9` of
-   leader and follower mid-epoch, verifying exactly-once sink output
-   and recovery point after each fault. The in-process harness runs
-   the gossip-KV path; the gRPC path (Aligned RPC, push-driven waits)
-   has only unit coverage.
-2. **Depth > 1 end-to-end**: enabled only for at-least-once pipelines
-   and admission-capped, but never exercised across real nodes.
+1. **Real multi-node soak** — HARNESS BUILT + PASSING:
+   `cluster_soak.rs` (laminar-server) spawns 3 real binaries over the
+   real gRPC control plane with a deterministic `generator` workload
+   and kills nodes round-robin mid-epoch. Verified runs: 3 fault
+   rounds, every node (incl. leader) killed + rejoined, epochs
+   committing throughout (2 → 16). Node logs confirm cross-node
+   shuffle alignment and pipelined epochs (N+1..N+3 aligning while
+   N's tail held the durability gate). Remaining before flipping the
+   100ms floor on in production: long-duration runs (hours, via
+   `LAMINAR_SOAK_SECONDS`), 100ms cadence (`LAMINAR_SOAK_INTERVAL_MS`),
+   MinIO/S3 backend (`LAMINAR_SOAK_CHECKPOINT_URL` + `_S3_*`), and an
+   exactly-once sink-output diff (needs a transactional sink in the
+   workload; the generator is deterministic precisely so that check is
+   a recompute-and-compare).
+2. **Depth > 1 end-to-end**: exercised implicitly by the soak
+   (at-least-once workload, default depth 4 — logs show overlapping
+   epochs); a targeted cross-node depth assertion is follow-up.
 3. ~~Cap tuning exposure~~ — DONE: `max_in_flight_epochs` /
    `max_staged_bytes` are settable in the server `[checkpoint]` TOML.
 4. ~~Aborted-manifest recovery audit~~ — DONE: recovery already skips

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -237,14 +237,13 @@ gate on:
    has only unit coverage.
 2. **Depth > 1 end-to-end**: enabled only for at-least-once pipelines
    and admission-capped, but never exercised across real nodes.
-3. **Cap tuning exposure**: `max_in_flight_epochs`/`max_staged_bytes`
-   are default-only (no server TOML) — wire before anyone needs to
-   tune them live.
-4. **Pre-existing recovery sharp edge** (not a regression): followers
-   persist manifests before the decision, so an aborted epoch's
-   manifest can be the highest on disk; reconcile handles Pending
-   sinks, but the restore-from-aborted-manifest path deserves an
-   audit of its own.
+3. ~~Cap tuning exposure~~ — DONE: `max_in_flight_epochs` /
+   `max_staged_bytes` are settable in the server `[checkpoint]` TOML.
+4. ~~Aborted-manifest recovery audit~~ — DONE: recovery already skips
+   Pending-sink manifests (tested); the real hazard found was recovery
+   walking allocator ids *back* below an aborted epoch's seed,
+   re-allocating it over stale artifacts — ids are now strictly
+   monotonic (`recovery_never_walks_ids_back_onto_aborted_epochs`).
 
 Operationally: 100ms is permission, not a promise — quorum RTT +
 capture must fit the interval, and at the caps cadence degrades to

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -1,0 +1,191 @@
+# Sub-Second Checkpointing — Implementation Plan (ADR-003)
+
+Companion to `docs/adr/ADR-003-sub-second-checkpointing.md`. Phases are
+independently deployable and ordered by risk/value; each must keep
+`cluster_integration` (laminar-db + laminar-core) green.
+
+## Status
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| 1 | Two-level completion — resume on `Aligned`, durable tail off the pipeline task | **DONE** (2026-06-10) |
+| 2 | Local staging + async upload + virtual manifest commits | not started |
+| 3 | Incremental (delta) snapshots, opt-in per operator | not started |
+| 4 | Lower the 2s floor to ~100ms + adaptive guard; remove polling floors | not started |
+
+## Phase 1 — Two-level completion (IMPLEMENTED)
+
+### Protocol
+
+The single barrier "Commit" is split into two cluster-visible levels:
+
+- **Aligned(N)** — every node has aligned the cross-node shuffle and
+  captured epoch N's state locally. The leader announces it after a
+  *full-membership* quorum of capture acks (no object-store I/O on this
+  path). Pipelines resume epoch N+1 processing on observing it.
+- **Restorable(N)** — every artifact N references is durable: each
+  node's sink pre-commit + manifest save + per-vnode partial uploads
+  finished, the leader's durability gate sealed the epoch `_COMMIT`
+  CAS marker, and the decision marker is written. Drives sink 2PC
+  commit, the recovery point, pruning, and rebalance rehydration.
+
+The shuffle-alignment invariant ("no peer ships epoch-N+1 rows while
+another node is still folding pre-barrier rows into its epoch-N
+snapshot", required by the no-post-barrier-buffering drain in
+`operator_graph.rs::align_shuffle_barriers`) is **re-keyed, not
+removed**: the resume gate moves from full-membership *Commit* to
+full-membership *Aligned*. This also closes a latent leader-side
+window — previously the leader resumed right after its own capture,
+before knowing every peer had finished aligning.
+
+### What changed where
+
+Control plane (`laminar-core/src/cluster/control/`):
+
+- `Phase::Aligned` variant + `Aligned` RPC in `proto/barrier.proto`
+  (carries `min_watermark_ms` so resuming pipelines see cluster-wide
+  event-time progress before the upload-gated Commit; the controller
+  publishes it from `Aligned` as well as `Commit`).
+- `BarrierCoordinator::observe` is now **latest-wins** in gRPC mode
+  too (a relay task drains the incoming queue into a `watch`),
+  matching the gossip-KV fallback the callers were already written
+  for. This makes observation non-destructive, so the pipeline's
+  resume gate and the background durable tail can watch concurrently
+  without stealing announcements from each other.
+- `BarrierAnnouncement.seq`: a leader-stamped monotonic announce
+  sequence (stamped in `announce()` and per `wait_for_quorum` Prepare
+  round; carried through the proto). The gRPC and KV values merge by
+  `(epoch, seq)` — required because a retry of an aborted epoch reuses
+  the same epoch/checkpoint id, so without `seq` a stale
+  gRPC-delivered `Abort(N)` would mask the retry's gossiped
+  `Prepare(N)` forever (livelock; regression test
+  `kv_retry_prepare_supersedes_stale_grpc_abort`).
+- `Aligned` fan-out is best-effort per peer: a missed delivery only
+  delays that peer's resume until Commit or its gate timeout.
+
+Coordinator (`laminar-db/src/checkpoint_coordinator.rs`):
+
+- Leader (`checkpoint_inner`, cluster): `await_prepare_quorum` moved
+  **before** the leader's own pre-commit/manifest/partial writes; on
+  quorum it announces `Aligned`. The durability gate became
+  `await_restorable_gate`: it **polls** `epoch_complete` (100ms, up to
+  `CheckpointConfig::restorable_gate_timeout`, default 30s) because
+  followers now upload after acking. Split-brain commit markers still
+  abort immediately; transient I/O errors retry until the deadline.
+- Follower (`follower_checkpoint`): the ack moved **before**
+  `follower_prepare` — it now means "aligned + captured", not
+  "durably prepared". On a prepare failure after acking, a
+  best-effort `ok=false` ack overwrites the capture ack (fast abort
+  in KV mode; in gRPC mode the leader learns via gate timeout). The
+  decision wait also recognizes epoch advancement (latest-wins
+  observation can supersede Commit(N) with Prepare(N+1)): a newer
+  epoch's announcement triggers an immediate decision-store check.
+
+Pipeline (`laminar-db/src/pipeline_callback.rs`):
+
+- Followers hand the durable tail (prepare + decision wait + 2PC
+  commit/rollback) to a spawned task (`spawn_follower_tail`); the
+  pipeline blocks only in `wait_for_aligned_resume` (10ms poll, 30s
+  bound, no-op without a cross-node shuffle). Tail bookkeeping lives
+  in the shared `FollowerTailState` (in-flight epoch dedups the
+  leader's idempotent Prepare re-announcements; committed epoch
+  advances only on commit so retries are reprocessed). Commit
+  completion flows through `checkpoint_complete_tx` — the same
+  channel the leader's background persist uses — so `EpochCommitted`
+  fan-out to sources and the wire-barrier publish are unchanged.
+- The leader pipeline now also gates its resume on `Aligned`
+  (bounded by quorum timeout + abort).
+- New metric: `checkpoint_pipeline_stall_duration_seconds` — the
+  ADR's Phase-1 success measure (stall = align + capture + resume
+  gate, excluding the durable tail).
+
+### Why partial-presence implies prepare-complete
+
+`follower_prepare` runs strictly in the order sink pre-commit →
+manifest save → vnode-partial writes. The leader's gate checks the
+**full registry** of vnode partials, so full presence proves every
+node finished its entire durable prepare — the leader's Commit
+decision still waits for cluster-wide durability even though acks no
+longer carry that meaning. (Caveat: a node owning zero vnodes is
+invisible to the gate; today every node owns vnodes outside of
+drain, and drain has its own checkpoint barrier.)
+
+### Failure matrix (Phase 1)
+
+| Failure | Outcome |
+|---|---|
+| Follower capture/alignment fails | No ack → leader quorum timeout (3s) → Abort → retry same epoch |
+| Follower prepare fails after ack | `ok=false` ack overwrite (KV fast path) or leader gate timeout → Abort; follower already rolled back its sinks |
+| Leader upload/gate/marker fails after Aligned | Abort announced; pipelines already resumed — epoch N is simply not restorable; retry same epoch |
+| Aligned RPC lost to one peer | That peer resumes on Commit or its 30s gate timeout; epoch unaffected |
+| Follower tail misses Commit (gossip lag + RPC loss) | Decision timeout → durable marker check → commit (pre-existing fallback); epoch advancement check accelerates it |
+| Leader dies between Aligned and Commit | Followers' decision timeout → marker absent → rollback; new leader reconciles via `reconcile_prepared_on_init` |
+
+Known accepted race (pre-existing class, now documented): a *stale*
+`Aligned(N)` from an attempt that aborted **after** Aligned can
+release a retry attempt's resume gate early. It requires an abort
+after full capture quorum (gate timeout / marker failure) plus a
+peer still mid-alignment on the retry within the announcement-
+propagation window; consequences are bounded by the same
+duplication-on-restore window that the leader's early resume had
+before this change.
+
+### Tests
+
+- `barrier.rs`: gRPC Prepare→ack→Aligned→Commit flow (sequenced
+  handshake because observation is latest-wins).
+- `checkpoint_coordinator.rs`: `leader_announces_aligned_between_prepare_and_commit`
+  (RecordingKv ordering), `restorable_gate_waits_for_async_follower_uploads`,
+  `follower_prepare_failure_overwrites_capture_ack`, plus the
+  existing gate/registry/abort suite re-validated.
+- `pipeline_callback.rs`: resume-gate release on Aligned / newer
+  epoch / no-shuffle; `FollowerTailState` lifecycle; dedup matrix.
+- `tests/cluster_integration.rs` (16) and laminar-core
+  `cluster_integration` (9): unchanged and green — the two-node 2PC
+  mirrors exercise the new protocol end-to-end in KV mode.
+
+## Phase 2 — Local staging + async upload + virtual manifests
+
+Goal: decouple barrier cadence from upload latency entirely; multiple
+epochs in flight between Aligned and Restorable.
+
+- Staging area `<data_dir>/staging/` (ephemeral; wiped at boot; the
+  Helm `persistence.state` volume, never a new mount). Capture writes
+  serialized state there (or memory) and the barrier acks immediately.
+- A background uploader drains staged artifacts to the object store;
+  caps on staged bytes/epochs backpressure the barrier cadence when
+  hit (degrade to upload speed, never OOM).
+- Manifest commits become *virtual*: an epoch is restorable when its
+  manifest commits referencing uploaded artifacts (which may be shared
+  across epochs). Restorability stays strictly in-order and gap-free
+  (N commits only after N−1).
+- Sinks declare `max_in_flight_epochs` (default 1 — a Kafka
+  transactional producer cannot overlap epochs); visibility cadence
+  for capability-1 sinks stays upload-bound until producer pooling.
+- Fence: staged artifacts are stamped with the capture-time
+  `assignment_version`; a `StaleVersion` rejection abandons the
+  backlog (never re-stamp — the new owner rehydrates from the last
+  restorable epoch).
+
+## Phase 3 — Incremental snapshots
+
+- `VnodePartial` v2: per-operator artifact kind `Full | Delta{base_epoch}`;
+  mixed manifests valid (per-operator slices are independent).
+- Opt-in per operator (agg operator first: dirty-group tracking
+  between barriers); default stays full-snapshot.
+- Compaction: full capture every K epochs bounds recovery replay and
+  delta-chain length. Rebalance rehydration reconstructs base + chain.
+- Pruning must track artifact liveness via manifest references, not
+  `epoch < horizon` (interacts with the incremental prune cursor in
+  `state/object_store.rs`).
+
+## Phase 4 — Lower the floor
+
+- Drop the 2s cluster minimum (`laminar-server/src/config.rs`) to
+  100ms with a runtime adaptive guard (skip a barrier when the
+  staging backlog or upload lag exceeds caps).
+- Remove the polling floors: the follower decision wait (50ms) and
+  the per-cycle `observe_barrier` become push-driven (the
+  announcement `watch` from Phase 1 is the natural carrier); the
+  resume-gate 10ms poll likewise.
+- Micro-batch cycle time then bounds barrier frequency.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -52,14 +52,11 @@ Control plane (`laminar-core/src/cluster/control/`):
   for. This makes observation non-destructive, so the pipeline's
   resume gate and the background durable tail can watch concurrently
   without stealing announcements from each other.
-- `BarrierAnnouncement.seq`: a leader-stamped monotonic announce
-  sequence (stamped in `announce()` and per `wait_for_quorum` Prepare
-  round; carried through the proto). The gRPC and KV values merge by
-  `(epoch, seq)` — required because a retry of an aborted epoch reuses
-  the same epoch/checkpoint id, so without `seq` a stale
-  gRPC-delivered `Abort(N)` would mask the retry's gossiped
-  `Prepare(N)` forever (livelock; regression test
-  `kv_retry_prepare_supersedes_stale_grpc_abort`).
+- The gRPC and KV values merge by epoch (higher wins; same-epoch ties
+  prefer gRPC arrival order). A `seq` ordering field briefly existed to
+  disambiguate same-epoch retries, but Phase 2's allocate-at-admission
+  abandonment removed epoch reuse, so it was deleted (merge test:
+  `observe_merges_grpc_and_gossip_by_epoch`).
 - `Aligned` fan-out is best-effort per peer: a missed delivery only
   delays that peer's resume until Commit or its gate timeout.
 
@@ -68,7 +65,7 @@ Coordinator (`laminar-db/src/checkpoint_coordinator.rs`):
 - Leader (`checkpoint_inner`, cluster): `await_prepare_quorum` moved
   **before** the leader's own pre-commit/manifest/partial writes; on
   quorum it announces `Aligned`. The durability gate became
-  `await_restorable_gate`: it **polls** `epoch_complete` (100ms, up to
+  `await_restorable_gate`: it **polls** `epoch_complete` (100ms with exponential backoff to 1s, up to
   `CheckpointConfig::restorable_gate_timeout`, default 30s) because
   followers now upload after acking. Split-brain commit markers still
   abort immediately; transient I/O errors retry until the deadline.
@@ -85,7 +82,7 @@ Pipeline (`laminar-db/src/pipeline_callback.rs`):
 
 - Followers hand the durable tail (prepare + decision wait + 2PC
   commit/rollback) to a spawned task (`spawn_follower_tail`); the
-  pipeline blocks only in `wait_for_aligned_resume` (10ms poll, 30s
+  pipeline blocks only in `wait_for_aligned_resume` (push-driven, 30s
   bound, no-op without a cross-node shuffle). Tail bookkeeping lives
   in the shared `FollowerTailState` (in-flight epoch dedups the
   leader's idempotent Prepare re-announcements; committed epoch
@@ -114,9 +111,9 @@ drain, and drain has its own checkpoint barrier.)
 
 | Failure | Outcome |
 |---|---|
-| Follower capture/alignment fails | No ack → leader quorum timeout (3s) → Abort → retry same epoch |
+| Follower capture/alignment fails | No ack → leader quorum timeout (3s) → Abort; epoch abandoned, next barrier gets fresh ids |
 | Follower prepare fails after ack | `ok=false` ack overwrite (KV fast path) or leader gate timeout → Abort; follower already rolled back its sinks |
-| Leader upload/gate/marker fails after Aligned | Abort announced; pipelines already resumed — epoch N is simply not restorable; retry same epoch |
+| Leader upload/gate/marker fails after Aligned | Abort announced; pipelines already resumed — epoch N is simply not restorable and is abandoned |
 | Aligned RPC lost to one peer | That peer resumes on Commit or its 30s gate timeout; epoch unaffected |
 | Follower tail misses Commit (gossip lag + RPC loss) | Decision timeout → durable marker check → commit (pre-existing fallback); epoch advancement check accelerates it |
 | Leader dies between Aligned and Commit | Followers' decision timeout → marker absent → rollback; new leader reconciles via `reconcile_prepared_on_init` |

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -9,9 +9,9 @@ independently deployable and ordered by risk/value; each must keep
 | Phase | Description | Status |
 |-------|-------------|--------|
 | 1 | Two-level completion — resume on `Aligned`, durable tail off the pipeline task | **DONE** (2026-06-10) |
-| 2 | Local staging + async upload + virtual manifest commits | not started |
-| 3 | Incremental (delta) snapshots, opt-in per operator | not started |
-| 4 | Lower the 2s floor to ~100ms + adaptive guard; remove polling floors | not started |
+| 2 | Pipelined epochs: allocate-at-admission ids, pre-mutex quorum stage, in-flight/staged-bytes caps | **DONE** (2026-06-10; see scope notes) |
+| 3 | Incremental snapshots: `Full \| reference` vnode partials | **DONE** v1 (2026-06-10; group-level deltas = follow-up) |
+| 4 | 100ms floor + admission guard; push-driven decision/resume waits | **DONE** (2026-06-10) |
 
 ## Phase 1 — Two-level completion (IMPLEMENTED)
 
@@ -144,48 +144,75 @@ before this change.
   `cluster_integration` (9): unchanged and green — the two-node 2PC
   mirrors exercise the new protocol end-to-end in KV mode.
 
-## Phase 2 — Local staging + async upload + virtual manifests
+## Phase 2 — Pipelined epochs (IMPLEMENTED)
 
-Goal: decouple barrier cadence from upload latency entirely; multiple
-epochs in flight between Aligned and Restorable.
+Barrier cadence is decoupled from upload completion; epochs overlap
+between `Aligned` and restorable, bounded by
+`CheckpointConfig::max_in_flight_epochs` (default 4) and
+`max_staged_bytes` (default 512 MiB; staging is in-memory `Bytes` —
+the ADR allows "local disk (or memory)", and the byte cap is the
+backlog bound). Admission lives in the streaming coordinator and
+pauses at either cap (cadence degrades to upload speed).
 
-- Staging area `<data_dir>/staging/` (ephemeral; wiped at boot; the
-  Helm `persistence.state` volume, never a new mount). Capture writes
-  serialized state there (or memory) and the barrier acks immediately.
-- A background uploader drains staged artifacts to the object store;
-  caps on staged bytes/epochs backpressure the barrier cadence when
-  hit (degrade to upload speed, never OOM).
-- Manifest commits become *virtual*: an epoch is restorable when its
-  manifest commits referencing uploaded artifacts (which may be shared
-  across epochs). Restorability stays strictly in-order and gap-free
-  (N commits only after N−1).
-- Sinks declare `max_in_flight_epochs` (default 1 — a Kafka
-  transactional producer cannot overlap epochs); visibility cadence
-  for capability-1 sinks stays upload-bound until producer pooling.
-- Fence: staged artifacts are stamped with the capture-time
-  `assignment_version`; a `StaleVersion` rejection abandons the
-  backlog (never re-stamp — the new owner rehydrates from the last
-  restorable epoch).
+What made it possible:
+- **Allocate-at-admission ids** (`EpochAllocator`, lock-free): a failed
+  epoch is *abandoned* (Flink semantics), never retried under the same
+  ids, so an epoch's identity no longer depends on its predecessor's
+  outcome. Failure paths consolidated in `fail_epoch` (announce Abort,
+  rollback, begin the next epoch's sink transactions bounded by
+  `rollback_timeout`).
+- **Two-stage tails**: the capture quorum + `Aligned` announce run
+  *before* the coordinator mutex (`run_prepare_quorum`), so resume is
+  never queued behind an earlier epoch's uploads; followers ack
+  pre-mutex for the same reason. The durable remainder serializes on
+  the FIFO mutex → in-order restorability.
+- **Mislabel guard**: `checkpoint_with_barrier` carries the barrier
+  round's `checkpoint_id`; a slow follower round whose announcement
+  was superseded (possible only with abandonment) is rejected instead
+  of attributing its offsets to the newer epoch.
 
-## Phase 3 — Incremental snapshots
+v1 scope notes (deliberate):
+- Exactly-once pipelines are capped at depth 1 (a single-open-
+  transaction sink cannot overlap epochs). Per-sink
+  `max_in_flight_epochs` capability + producer pooling = follow-up.
+- Follower tails serialize uploads *and* decision waits on their
+  coordinator mutex; their backlog is bounded by the leader's caps.
+  Splitting follower upload/commit drivers = follow-up.
+- Concurrent quorum rounds (cadence < quorum RTT) can waste an epoch
+  (one round's Prepare masks the other under latest-wins observation;
+  the loser aborts via quorum timeout) — safe, documented.
+- No fault-injection integration test for depth > 1 yet (existing
+  two-node 2PC suites cover depth 1 end-to-end) — follow-up.
 
-- `VnodePartial` v2: per-operator artifact kind `Full | Delta{base_epoch}`;
-  mixed manifests valid (per-operator slices are independent).
-- Opt-in per operator (agg operator first: dirty-group tracking
-  between barriers); default stays full-snapshot.
-- Compaction: full capture every K epochs bounds recovery replay and
-  delta-chain length. Rebalance rehydration reconstructs base + chain.
-- Pruning must track artifact liveness via manifest references, not
-  `epoch < horizon` (interacts with the incremental prune cursor in
-  `state/object_store.rs`).
+## Phase 3 — Incremental snapshots (v1 IMPLEMENTED)
 
-## Phase 4 — Lower the floor
+Per-vnode artifacts gained the `Full | reference` kind
+(`VnodePartial.base_epoch`): a vnode whose serialized slices are
+byte-identical to its last full upload writes a tiny reference
+instead of re-uploading state — upload cost ∝ changed vnodes, which
+is the dominant win under key skew. References resolve in one hop
+(never chain), are forced back to full before the base ages out of
+the `max_retained` prune window (prune only runs after a successful
+checkpoint, so a restorable epoch's references are always above the
+horizon), and bases are recorded only after every write in the epoch
+lands. Counter: `checkpoint_unchanged_vnodes_total`.
 
-- Drop the 2s cluster minimum (`laminar-server/src/config.rs`) to
-  100ms with a runtime adaptive guard (skip a barrier when the
-  staging backlog or upload lag exceeds caps).
-- Remove the polling floors: the follower decision wait (50ms) and
-  the per-cycle `observe_barrier` become push-driven (the
-  announcement `watch` from Phase 1 is the natural carrier); the
-  resume-gate 10ms poll likewise.
-- Micro-batch cycle time then bounds barrier frequency.
+Follow-up (the ADR's full vision): group-level delta changelogs
+inside the agg operator (`Delta{base_epoch}` carrying changed/removed
+groups), compaction every K epochs, chain reconstruction on
+rehydration, and reference-liveness-aware pruning. The artifact kind
+and reader plumbing landed here are forward-compatible with it.
+
+## Phase 4 — Floor + polling removal (IMPLEMENTED)
+
+- Cluster checkpoint-interval floor lowered 2s → 100ms; the Phase-2
+  admission caps are the runtime guard (a tight interval degrades to
+  upload speed at the caps instead of building an unbounded backlog).
+- The follower decision wait (was a flat 50ms poll) and the Aligned
+  resume gate (was 10ms) are push-driven off the gRPC announcement
+  watch (`ClusterController::wait_for_barrier`), with a 250ms
+  KV-fallback poll (25ms when no gRPC server is wired — gossip-only
+  deployments).
+- The per-cycle `observe_barrier` Prepare pickup remains poll-per-cycle
+  (cheap in-memory read; the micro-batch cycle time bounds barrier
+  frequency, as the ADR notes).

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -222,113 +222,35 @@ and reader plumbing landed here are forward-compatible with it.
   (cheap in-memory read; the micro-batch cycle time bounds barrier
   frequency, as the ADR notes).
 
-## Production readiness (assessed 2026-06-10)
+## Production readiness
 
-Code-complete and internally verified (unit, two-node in-process
-cluster, coordinator-level fault injection at depth > 1, wedged-sink
-and abandoned-epoch coverage). **Not yet validated for production**;
-gate on:
+Soak harness: `cluster_soak.rs` (laminar-server, `#[ignore]`d) spawns
+3 real `laminardb` binaries over the real gRPC control plane with a
+deterministic `generator` workload, kills nodes round-robin with
+`kill -9` mid-epoch, and asserts **commit** progress (epoch numbers
+advance on aborts too, so they prove nothing).
 
-1. **Real multi-node soak** — HARNESS BUILT + PASSING:
-   `cluster_soak.rs` (laminar-server) spawns 3 real binaries over the
-   real gRPC control plane with a deterministic `generator` workload
-   and kills nodes round-robin mid-epoch. Verified runs: 3 fault
-   rounds, every node (incl. leader) killed + rejoined, epochs
-   committing throughout (2 → 16). Node logs confirm cross-node
-   shuffle alignment and pipelined epochs (N+1..N+3 aligning while
-   N's tail held the durability gate). Remaining before flipping the
-   100ms floor on in production: long-duration runs (hours, via
-   `LAMINAR_SOAK_SECONDS`), 100ms cadence (`LAMINAR_SOAK_INTERVAL_MS`),
-   MinIO/S3 backend (`LAMINAR_SOAK_CHECKPOINT_URL` + `_S3_*`), and an
-   exactly-once sink-output diff (needs a transactional sink in the
-   workload; the generator is deterministic precisely so that check is
-   a recompute-and-compare).
-2. **Depth > 1 end-to-end**: exercised implicitly by the soak
-   (at-least-once workload, default depth 4 — logs show overlapping
-   epochs); a targeted cross-node depth assertion is follow-up.
-3. ~~Cap tuning exposure~~ — DONE: `max_in_flight_epochs` /
-   `max_staged_bytes` are settable in the server `[checkpoint]` TOML.
-4. ~~Aborted-manifest recovery audit~~ — DONE: recovery already skips
-   Pending-sink manifests (tested); the real hazard found was recovery
-   walking allocator ids *back* below an aborted epoch's seed,
-   re-allocating it over stale artifacts — ids are now strictly
-   monotonic (`recovery_never_walks_ids_back_onto_aborted_epochs`).
+Status (2026-06-11): both target cadences pass — 500ms and 100ms —
+with every node (including the leader) killed and recovered each
+round, and dead-node vnode rotation shedding + rehydrating every
+round. Getting there surfaced and fixed five defects (fail-fast gates
+on dead capture participants, quorum-miss unresponsive tracking,
+transport-error classification, supersession release inside the
+alignment wait, membership-watch dedup + skipping the pre-rotation
+drain when shedding a dead node); details live in the fix commits and
+the code comments at each site.
+
+Remaining before signing off the 100ms floor for production:
+
+1. Hours-long endurance run at 100ms (`LAMINAR_SOAK_SECONDS`).
+2. MinIO/S3 checkpoint backend variant
+   (`LAMINAR_SOAK_CHECKPOINT_URL` + `LAMINAR_SOAK_S3_*`).
+3. Exactly-once sink-output diff (needs a transactional sink in the
+   workload; the generator is deterministic precisely so that check
+   is a recompute-and-compare).
+4. A targeted cross-node depth>1 assertion (overlap is exercised by
+   the soak at depth 4, and by coordinator-level fault injection).
 
 Operationally: 100ms is permission, not a promise — quorum RTT +
-capture must fit the interval, and at the caps cadence degrades to
-upload speed. Two documented benign races: a stale `Aligned` from an
-attempt aborted post-quorum can release a successor's resume gate
-early, and overlapping quorum rounds (cadence < quorum RTT) burn an
-epoch.
-## 100ms-cadence soak findings (2026-06-11)
-
-The kill -9 soak at 100ms cadence (vs the passing 500ms runs) peeled
-four distinct defects; three are fixed (`e0e95242`), one is open:
-
-1. FIXED — serial doomed-gate burn: in-flight epochs each waited the
-   full 30s durability gate for a dead node''s uploads, serialized on
-   the coordinator mutex (depth 4 → ~2min commit stall). Gate now
-   fail-fasts on unhealthy capture participants.
-2. FIXED — gossip detection lag: membership can show a killed node
-   Active for >30s, muting fix 1. Capture-quorum misses now mark peers
-   unresponsive on the controller (TTL 60s, cleared on ack); gates
-   consult it.
-3. FIXED — quorum misclassification: connection-refused RPC errors
-   counted as `Failed` (live NACK) instead of unreachable, bypassing
-   the unresponsive signal. Transport errors now classify into
-   `TimedOut{missing}`.
-4. FIXED (`dc4376bd`) — rejoin lockstep livelock:
-   a restarted node can start aligning checkpoint N after peers already
-   sent their N barriers (lost while its transport was down), time out
-   the full 30s, and land one epoch behind forever; the leader''s
-   quorums miss its ack every epoch and nothing commits. The newer
-   Prepare(N+1)/Abort(N) announcement releases the alignment wait
-   *between* attempts but NOT mid-wait — `align_shuffle_barriers` (or
-   its pipeline_callback wrapper) needs an announcement-driven release
-   inside the wait loop. Soak evidence: run `soak-225504`, node0
-   aligning ckpt 15 19:39:41→19:40:11 straight through Abort(15) +
-   Prepare(16) at 19:39:44. Repro: `LAMINAR_SOAK_INTERVAL_MS=100`,
-   fails within ~10 fault rounds at "progress after rejoin".
-
-Survival progression at 100ms as fixes landed: 2 → 5 → 8 full fault
-rounds. 500ms cadence: passes (3+ rounds, all nodes). Fix item 4, then
-re-run 900s+ at 100ms until clean, before production sign-off on the
-100ms floor.
-### Remaining open defect (5) — orphaned-vnode window
-
-Epochs admitted after membership drops a dead node but before the
-(debounced, barrier-gated) rebalance rotates its vnodes away are
-unsealable: every capture participant is healthy (no fail-fast
-applies), but the dead node''s vnodes were captured by nobody, so the
-durability gate burns its full 30s per epoch until rotation lands
-(`set_vnode_set` → rotation floor then clears the backlog). Soak
-evidence: run `soak-254772`, epoch 14 gate burn while epochs 15-18
-reached quorum two-node. Candidate fixes, in design order:
-(a) pause barrier admission while live membership disagrees with
-vnode-assignment ownership (cheap, bounded stall = rotation latency;
-matches the existing admission-cap machinery), or (b) gate epochs on
-the vnodes owned by their capture participants only — protocol-level
-change to `epoch_complete` semantics; interacts with recovery and
-rehydration expectations of a sealed epoch. Also worth measuring: the
-rebalance controller''s rotation latency after a hard kill — it waits
-on a checkpoint barrier that may itself be stuck behind doomed gates.
-
-At 100ms the soak now survives kills and rejoins until it hits this
-window (~round 4); at 500ms all rounds pass. Sign-off order: fix (5),
-then 900s+ clean at 100ms, then hours-long + MinIO + exactly-once
-sink diff.
-## SOAK GREEN (2026-06-11, honest commit assertions)
-
-Both target cadences pass the 3-node real-binary kill -9 soak with
-commit-based progress assertions: 500ms — 5 fault rounds (final epoch
-45); 100ms — 6 fault rounds (final epoch 57); every node including the
-leader killed and recovered each cycle, dead-node vnode rotation
-shedding + rehydrating every round. Fixes that got here (`cd4fde0f`):
-membership-watch dedup (heartbeat ticks starved the rebalance
-debounce forever), skip the pre-rotation drain when shedding a dead
-node (it deadlocked rotation against the durability gate), recovery
-budgets cut (drain 60→15s, retry 10→2s, the four 30s last-resort
-bounds → 10s — fail-fasts are the primary path now). Endurance run
-(3600s @ 100ms) launched detached → target/soak-endurance-100ms.log.
-Remaining for full sign-off: that endurance result, MinIO/S3 variant,
-exactly-once sink-output diff.
+capture must fit the interval, and at the admission caps cadence
+degrades to upload speed.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -277,7 +277,7 @@ four distinct defects; three are fixed (`e0e95242`), one is open:
    counted as `Failed` (live NACK) instead of unreachable, bypassing
    the unresponsive signal. Transport errors now classify into
    `TimedOut{missing}`.
-4. OPEN — rejoin lockstep livelock (pre-existing alignment mechanics):
+4. FIXED (`dc4376bd`) — rejoin lockstep livelock:
    a restarted node can start aligning checkpoint N after peers already
    sent their N barriers (lost while its transport was down), time out
    the full 30s, and land one epoch behind forever; the leader''s
@@ -294,3 +294,26 @@ Survival progression at 100ms as fixes landed: 2 → 5 → 8 full fault
 rounds. 500ms cadence: passes (3+ rounds, all nodes). Fix item 4, then
 re-run 900s+ at 100ms until clean, before production sign-off on the
 100ms floor.
+### Remaining open defect (5) — orphaned-vnode window
+
+Epochs admitted after membership drops a dead node but before the
+(debounced, barrier-gated) rebalance rotates its vnodes away are
+unsealable: every capture participant is healthy (no fail-fast
+applies), but the dead node''s vnodes were captured by nobody, so the
+durability gate burns its full 30s per epoch until rotation lands
+(`set_vnode_set` → rotation floor then clears the backlog). Soak
+evidence: run `soak-254772`, epoch 14 gate burn while epochs 15-18
+reached quorum two-node. Candidate fixes, in design order:
+(a) pause barrier admission while live membership disagrees with
+vnode-assignment ownership (cheap, bounded stall = rotation latency;
+matches the existing admission-cap machinery), or (b) gate epochs on
+the vnodes owned by their capture participants only — protocol-level
+change to `epoch_complete` semantics; interacts with recovery and
+rehydration expectations of a sealed epoch. Also worth measuring: the
+rebalance controller''s rotation latency after a hard kill — it waits
+on a checkpoint barrier that may itself be stuck behind doomed gates.
+
+At 100ms the soak now survives kills and rejoins until it hits this
+window (~round 4); at 500ms all rounds pass. Sign-off order: fix (5),
+then 900s+ clean at 100ms, then hours-long + MinIO + exactly-once
+sink diff.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -65,10 +65,16 @@ Coordinator (`laminar-db/src/checkpoint_coordinator.rs`):
 - Leader (`checkpoint_inner`, cluster): `await_prepare_quorum` moved
   **before** the leader's own pre-commit/manifest/partial writes; on
   quorum it announces `Aligned`. The durability gate became
-  `await_restorable_gate`: it **polls** `epoch_complete` (100ms with exponential backoff to 1s, up to
-  `CheckpointConfig::restorable_gate_timeout`, default 30s) because
+  `await_restorable_gate`: it **polls** `epoch_complete` (100ms with
+  exponential backoff to 1s, up to
+  `CheckpointConfig::restorable_gate_timeout`, default 10s) because
   followers now upload after acking. Split-brain commit markers still
   abort immediately; transient I/O errors retry until the deadline.
+  Replacing the poll with push-driven follower upload-completion acks
+  (a second, "restorable" ack on the barrier channel once a node's
+  partials land) is the protocol-level follow-up — it removes the
+  steady-state object-store LISTs and shrinks commit latency to one
+  ack round-trip.
 - Follower (`follower_checkpoint`): the ack moved **before**
   `follower_prepare` — it now means "aligned + captured", not
   "durably prepared". On a prepare failure after acking, a

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -221,3 +221,34 @@ and reader plumbing landed here are forward-compatible with it.
 - The per-cycle `observe_barrier` Prepare pickup remains poll-per-cycle
   (cheap in-memory read; the micro-batch cycle time bounds barrier
   frequency, as the ADR notes).
+
+## Production readiness (assessed 2026-06-10)
+
+Code-complete and internally verified (unit, two-node in-process
+cluster, coordinator-level fault injection at depth > 1, wedged-sink
+and abandoned-epoch coverage). **Not yet validated for production**;
+gate on:
+
+1. **Real multi-node soak**: 3-node real-binary cluster (gRPC control
+   plane, S3/MinIO state), hours at 100ms–1s cadence, `kill -9` of
+   leader and follower mid-epoch, verifying exactly-once sink output
+   and recovery point after each fault. The in-process harness runs
+   the gossip-KV path; the gRPC path (Aligned RPC, push-driven waits)
+   has only unit coverage.
+2. **Depth > 1 end-to-end**: enabled only for at-least-once pipelines
+   and admission-capped, but never exercised across real nodes.
+3. **Cap tuning exposure**: `max_in_flight_epochs`/`max_staged_bytes`
+   are default-only (no server TOML) — wire before anyone needs to
+   tune them live.
+4. **Pre-existing recovery sharp edge** (not a regression): followers
+   persist manifests before the decision, so an aborted epoch's
+   manifest can be the highest on disk; reconcile handles Pending
+   sinks, but the restore-from-aborted-manifest path deserves an
+   audit of its own.
+
+Operationally: 100ms is permission, not a promise — quorum RTT +
+capture must fit the interval, and at the caps cadence degrades to
+upload speed. Two documented benign races: a stale `Aligned` from an
+attempt aborted post-quorum can release a successor's resume gate
+early, and overlapping quorum rounds (cadence < quorum RTT) burn an
+epoch.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -317,3 +317,18 @@ At 100ms the soak now survives kills and rejoins until it hits this
 window (~round 4); at 500ms all rounds pass. Sign-off order: fix (5),
 then 900s+ clean at 100ms, then hours-long + MinIO + exactly-once
 sink diff.
+## SOAK GREEN (2026-06-11, honest commit assertions)
+
+Both target cadences pass the 3-node real-binary kill -9 soak with
+commit-based progress assertions: 500ms — 5 fault rounds (final epoch
+45); 100ms — 6 fault rounds (final epoch 57); every node including the
+leader killed and recovered each cycle, dead-node vnode rotation
+shedding + rehydrating every round. Fixes that got here (`cd4fde0f`):
+membership-watch dedup (heartbeat ticks starved the rebalance
+debounce forever), skip the pre-rotation drain when shedding a dead
+node (it deadlocked rotation against the durability gate), recovery
+budgets cut (drain 60→15s, retry 10→2s, the four 30s last-resort
+bounds → 10s — fail-fasts are the primary path now). Endurance run
+(3600s @ 100ms) launched detached → target/soak-endurance-100ms.log.
+Remaining for full sign-off: that endurance result, MinIO/S3 variant,
+exactly-once sink-output diff.

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -250,15 +250,11 @@ Gates closed (2026-06-12):
 3. ~~Exactly-once sink-output diff~~ — per-node exactly-once Kafka
    sinks + read_committed dense-sequence diff
    (`LAMINAR_SOAK_KAFKA_BROKERS`): 7 fault rounds, 143k committed
-   records across 3 topics, zero duplicates, zero gaps. Surfaced and
-   fixed four defects: self-rejecting default timeouts
-   (message.timeout > transaction.timeout), follower never beginning
-   the next transaction after commit/rollback, the depth-1 cap keying
-   off pipeline-level config only (DDL-configured sinks bypassed it),
-   and live coordination aborts discarding pending transactional
-   output that sources never replay (the keep-pending abandon
-   semantics fix). Exactly-once pipelines now run durable tails
-   INLINE — no Aligned early-resume — until producer pooling lands.
+   records across 3 topics, zero duplicates, zero gaps. Surfaced four
+   pre-existing exactly-once defects, fixed in `a0250aad` (the
+   cluster exactly-once path had never run end-to-end before this
+   gate). Exactly-once pipelines now run durable tails INLINE — no
+   Aligned early-resume — until producer pooling lands.
 
 Still open:
 

--- a/docs/plans/sub-second-checkpointing.md
+++ b/docs/plans/sub-second-checkpointing.md
@@ -260,3 +260,37 @@ upload speed. Two documented benign races: a stale `Aligned` from an
 attempt aborted post-quorum can release a successor's resume gate
 early, and overlapping quorum rounds (cadence < quorum RTT) burn an
 epoch.
+## 100ms-cadence soak findings (2026-06-11)
+
+The kill -9 soak at 100ms cadence (vs the passing 500ms runs) peeled
+four distinct defects; three are fixed (`e0e95242`), one is open:
+
+1. FIXED — serial doomed-gate burn: in-flight epochs each waited the
+   full 30s durability gate for a dead node''s uploads, serialized on
+   the coordinator mutex (depth 4 → ~2min commit stall). Gate now
+   fail-fasts on unhealthy capture participants.
+2. FIXED — gossip detection lag: membership can show a killed node
+   Active for >30s, muting fix 1. Capture-quorum misses now mark peers
+   unresponsive on the controller (TTL 60s, cleared on ack); gates
+   consult it.
+3. FIXED — quorum misclassification: connection-refused RPC errors
+   counted as `Failed` (live NACK) instead of unreachable, bypassing
+   the unresponsive signal. Transport errors now classify into
+   `TimedOut{missing}`.
+4. OPEN — rejoin lockstep livelock (pre-existing alignment mechanics):
+   a restarted node can start aligning checkpoint N after peers already
+   sent their N barriers (lost while its transport was down), time out
+   the full 30s, and land one epoch behind forever; the leader''s
+   quorums miss its ack every epoch and nothing commits. The newer
+   Prepare(N+1)/Abort(N) announcement releases the alignment wait
+   *between* attempts but NOT mid-wait — `align_shuffle_barriers` (or
+   its pipeline_callback wrapper) needs an announcement-driven release
+   inside the wait loop. Soak evidence: run `soak-225504`, node0
+   aligning ckpt 15 19:39:41→19:40:11 straight through Abort(15) +
+   Prepare(16) at 19:39:44. Repro: `LAMINAR_SOAK_INTERVAL_MS=100`,
+   fails within ~10 fault rounds at "progress after rejoin".
+
+Survival progression at 100ms as fixes landed: 2 → 5 → 8 full fault
+rounds. 500ms cadence: passes (3+ rounds, all nodes). Fix item 4, then
+re-run 900s+ at 100ms until clean, before production sign-off on the
+100ms floor.


### PR DESCRIPTION
Implements all four phases of ADR-003 plus the validation work and the defects it surfaced. Plan with per-phase detail: `docs/plans/sub-second-checkpointing.md`.

## Protocol

- **Two-level completion**: the single barrier Commit splits into `Aligned` (full-membership capture quorum — pipelines resume) and restorable (every artifact durable — sinks commit, recovery point advances). Followers ack at capture and upload asynchronously; the leader durability gate polls partial presence.
- **Pipelined epochs**: checkpoint ids allocate at barrier admission (lock-free `EpochAllocator`); failed epochs are abandoned Flink-style, never reused. Admission caps (`max_in_flight_epochs`, default 4; `max_staged_bytes`, default 512 MiB) bound the upload backlog — at the caps, cadence degrades to upload speed.
- **Incremental snapshots v1**: a vnode whose serialized state is byte-identical to its last full upload writes a tiny reference partial; references resolve in one hop and are forced full before their base leaves the prune window.
- **100ms floor**: cluster checkpoint-interval floor drops 2s → 100ms; the follower decision wait and the resume gate are push-driven off the gRPC announcement watch instead of polling.

## Also in this branch

- **Multi-cloud state backend**: `[state]` accepts `s3://`/`gs://`/`az://` URLs + a `[state.storage]` credentials map by delegating to the shared checkpoint object-store builder.
- **Object-store URL prefix fix**: the shared builder now roots every store at the URL path via `PrefixStore`. Previously only checkpoint manifests honored the path — decision markers, leader leases, assignment snapshots, gossip KV, and catalog all wrote to the bucket root, so two clusters sharing a bucket corrupted each other''s 2PC state.
- **Cluster exactly-once actually works**: the exactly-once Kafka path had never run end-to-end. Four pre-existing defects fixed: self-rejecting default timeouts, followers never beginning the next transaction after 2PC commit, the depth-1 cap bypassed by DDL-configured sinks, and live coordination aborts discarding pending transactional output that sources never replay (live failures now abandon the epoch — a healthy sink keeps its open transaction and the next commit covers it).
- **`generator` source**: deterministic, replayable, infra-free synthetic source (closes a documented-but-unimplemented connector).
- **Soak harness**: `cluster_soak.rs` — 3 real binaries, real gRPC control plane, round-robin kill -9, commit-based progress assertions, optional MinIO backends and an exactly-once output diff.

## Validation

| Gate | Result |
|---|---|
| Endurance | 3600s @ 100ms cadence, continuous kill -9 rounds — pass |
| Full-fat MinIO (state + checkpoint + control plane on S3) | 15 fault rounds @ 100ms — pass, bucket layout fully prefixed |
| Exactly-once diff (read_committed, dense-sequence) | 7 fault rounds, 143k records across 3 topics, 0 duplicates, 0 gaps |
| Unit/integration | 2,7xx lib tests, cluster_integration 16/16, clippy -D warnings, fmt |

## Behavioral notes

- **Exactly-once pipelines do not get the sub-second resume**: with a single transactional producer, the pipeline must block from barrier to commit decision (post-barrier rows must not enter the open transaction). Producer pooling is the follow-up that lifts this. At-least-once pipelines resume on `Aligned`.
- Two documented benign races (plan doc): a stale `Aligned` from a post-quorum abort can release a successor''s resume gate early; overlapping quorum rounds at cadence < quorum RTT burn an epoch.

## Still open before production sign-off

Real-network latency/partition testing (all soaks are localhost, kills only), large-state workloads (reference partials and the staged-bytes cap never stressed beyond trivial state), and a targeted cross-node depth>1 assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers ADR-003: sub-second checkpointing with two-level completion, pipelined epochs, incremental snapshots, and a 100ms floor. Also adds a multi-cloud state backend, a deterministic `generator` source, and a 3-node kill -9 soak; fixes make the exactly-once Kafka path work end to end. Object-store writes are now rooted under URL path prefixes across the control plane to prevent cross-cluster collisions.

- **New Features**
  - Connector capability `preserves_pending_on_abandon` declares whether pending output survives a live abort; Kafka opts in (single open transaction).
  - `[state.storage]` options are now a Debug-redacted newtype; values like credentials never print.

- **Bug Fixes**
  - Quorum prepare failures are typed by gRPC status (unreachable vs live NACK) for correct abort handling.
  - Follower durable tails now count toward admission caps (`max_in_flight_epochs`, `max_staged_bytes`) via an in-flight guard.
  - Exactly-once Kafka: re-apply the timeout clamp after user `kafka.*` pass-throughs to prevent `message.timeout.ms > transaction.timeout.ms`.
  - `[checkpoint.storage]` values are Debug-redacted; `file://` URL path normalization fixed across platforms.
  - Gossip announce corruption no longer blocks observation when a valid gRPC announcement exists.
  - Dead-node drain skip is based on membership (Suspected/Left/missing or recently unresponsive). Draining nodes still require a pre-rotation checkpoint.
  - Membership watch now publishes only on real changes (ignores heartbeat churn) so rebalances trigger reliably.
  - Barrier wait fallback poll tightens to the no-watch cadence if the gRPC watch drops mid-wait.
  - Config guards: `checkpoint.max_in_flight_epochs` and `checkpoint.max_staged_bytes` must be > 0; runtime floors enforced.
  - Server CLI: `--validate-checkpoints` now fails on invalid config instead of exiting 0.

<sup>Written for commit bfde3d0801f712db03a77540cddfc29def329bd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Always-available synthetic generator source for deterministic data and replay.
  * Public API to abandon sink epochs without forcing rollback (preserves pending output when supported).

* **Improvements**
  * Three-phase checkpoint coordination (Aligned/Prepare/Commit) for safer resume.
  * Capacity-based checkpoint admission and staged-bytes throttling; shorter barrier alignment timeout (10s).
  * Better checkpoint metrics and logging throttling.

* **Configuration**
  * Added max_in_flight_epochs and max_staged_bytes; cluster checkpoint interval minimum tightened to 100ms.

* **Tests / Docs**
  * Added long-running cluster soak test and sub-second-checkpointing design doc.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->