### PR TITLE
feat: tiered operator state (ADR-005) — in-memory hot tier + fjall cold tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,10 @@ laminardb.toml
 data/
 checkpoints/
 wal/
-/tools
+/tools/*
+!/tools/state-tier-bench
+/tools/state-tier-bench/target
+/tools/state-tier-bench/Cargo.lock
 
 # Private configs (symlinked from private repo)
 CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "laminar-connectors",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.12.1",
  "zstd",
 ]
 
@@ -1497,6 +1497,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1520,12 @@ dependencies = [
  "bytes",
  "either",
 ]
+
+[[package]]
+name = "byteview"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "bzip2"
@@ -1740,6 +1752,12 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "compression-codecs"
@@ -1986,6 +2004,16 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -3603,6 +3631,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "fjall"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038acd422d607e0eca09e093f299f9eccf9bd097554343d93746afff81a45113"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "dashmap",
+ "flume",
+ "log",
+ "lsm-tree",
+ "lz4_flex 0.13.1",
+ "tempfile",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,6 +3672,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -4600,6 +4654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4966,6 +5029,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-optimizer",
+ "fjall",
  "futures",
  "futures-util",
  "governor",
@@ -5328,10 +5392,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsm-tree"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef86c3c797c10eefcc73407c43ae48c19d4df686131a8334b2895a513e91df4"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "crossbeam-skiplist",
+ "enum_dispatch",
+ "interval-heap",
+ "log",
+ "lz4_flex 0.13.1",
+ "quick_cache",
+ "rustc-hash",
+ "self_cell",
+ "sfa",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -6325,7 +6420,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex",
+ "lz4_flex 0.12.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -8001,6 +8096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8159,6 +8260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8301,6 +8413,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -9551,6 +9672,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varint-rs"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa6c38708f6257f1ec2ca7e5a11f9bbf58a27d7060078b6b333624968183d96"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 ]
 exclude = [
     "examples/*",
+    "tools/*",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.95"

--- a/crates/laminar-connectors/Cargo.toml
+++ b/crates/laminar-connectors/Cargo.toml
@@ -11,7 +11,7 @@ description = "External system connectors for LaminarDB - Kafka, CDC, lookup tab
 
 [dependencies]
 # Core dependencies
-laminar-core = { path = "../laminar-core", version = "0.25.1" }
+laminar-core = { path = "../laminar-core", version = "0.26.0" }
 
 # Kafka
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"], optional = true }

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -56,9 +56,9 @@ remote = ["dep:reqwest", "dep:governor"]
 local = ["dep:ort", "dep:tokenizers", "dep:reqwest", "dep:hf-hub"]
 
 [dependencies]
-laminar-core = { path = "../laminar-core", version = "0.25.1" }
-laminar-sql = { path = "../laminar-sql", version = "0.25.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.1" }
+laminar-core = { path = "../laminar-core", version = "0.26.0" }
+laminar-sql = { path = "../laminar-sql", version = "0.26.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.26.0" }
 
 # AI Inference Dependencies (Consolidated from laminar-ai)
 quick_cache = { workspace = true }
@@ -145,8 +145,8 @@ tempfile = { workspace = true }
 # no openssl); the `remote` feature exposes the real AnthropicProvider so the
 # test drives the actual HTTP path (request build, 500/retry, response parse).
 wiremock = "0.6"
-laminar-derive = { path = "../laminar-derive", version = "0.25.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.1", features = ["testing"] }
+laminar-derive = { path = "../laminar-derive", version = "0.26.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.26.0", features = ["testing"] }
 criterion = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -47,7 +47,10 @@ nats = ["laminar-connectors/nats"]
 cluster = ["laminar-core/cluster", "laminar-sql/cluster", "dep:reqwest"]
 # Disk cold tier for demoted operator state. Implies `cluster` because the
 # demotion unit is the (operator, vnode) checkpoint slice. fjall's major
-# version is pinned: its on-disk format is a storage-format commitment.
+# version is pinned: its on-disk format is a storage-format commitment. The
+# tier is rebuildable scratch (truth lives in checkpoints; wiped and replayed
+# on restart), so a storage-engine fault costs a rehydration, not data — which
+# bounds the integrity risk of the embedded LSM.
 state-tier = ["cluster", "dep:fjall"]
 aws = ["laminar-core/aws"]
 gcs = ["laminar-core/gcs"]

--- a/crates/laminar-db/Cargo.toml
+++ b/crates/laminar-db/Cargo.toml
@@ -45,6 +45,10 @@ files = ["laminar-connectors/files"]
 otel = ["laminar-connectors/otel"]
 nats = ["laminar-connectors/nats"]
 cluster = ["laminar-core/cluster", "laminar-sql/cluster", "dep:reqwest"]
+# Disk cold tier for demoted operator state. Implies `cluster` because the
+# demotion unit is the (operator, vnode) checkpoint slice. fjall's major
+# version is pinned: its on-disk format is a storage-format commitment.
+state-tier = ["cluster", "dep:fjall"]
 aws = ["laminar-core/aws"]
 gcs = ["laminar-core/gcs"]
 azure = ["laminar-core/azure"]
@@ -126,6 +130,9 @@ prometheus = { workspace = true }
 
 # Zero-copy byte buffers (used by state backend payloads).
 bytes = { workspace = true }
+
+# Cold tier for demoted operator state (feature `state-tier`).
+fjall = { version = "3.1", optional = true }
 
 # Object-store handle for the auto-wired 2PC decision store (single-instance
 # uses `LocalFileSystem`; cluster reuses the configured remote store).

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -1585,12 +1585,10 @@ impl IncrementalAggState {
 
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
-        // Merged-in state changes an unknown set of vnodes; refuse
-        // demotions until the next capture re-baselines.
-        #[cfg(feature = "state-tier")]
-        {
-            self.dirty_all = true;
-        }
+        // No `dirty_all` here: every caller (`apply_vnode_state`) merges exactly
+        // one vnode and marks *that* vnode dirty itself, so demotion of other
+        // clean vnodes stays available. Blanket-dirtying here would block all
+        // demotion after a single promotion or rebalance-acquired vnode.
         Ok(checkpoint.groups.len())
     }
 }
@@ -1616,13 +1614,20 @@ impl IncrementalAggState {
     /// No retractions are emitted: unlike eviction, demotion is invisible
     /// downstream — the materialized rows stay, and a future update for a
     /// cold group goes through promotion first.
+    /// The eligibility guard for [`Self::demote_vnode`], without dropping
+    /// anything: a changelog agg, clean since the last per-vnode capture, whose
+    /// capture baseline used this `vnode_count`. The demotion pass checks this
+    /// before writing the slice to the tier so a dirty vnode costs no I/O.
+    pub(crate) fn can_demote(&self, vnode: u32, vnode_count: u32) -> bool {
+        self.emit_changelog
+            && !self.dirty_all
+            && !self.dirty_vnodes.contains(&vnode)
+            && self.tier_vnode_count == Some(vnode_count)
+    }
+
     #[allow(dead_code)] // called once the demotion trigger lands with promotion
     pub(crate) fn demote_vnode(&mut self, vnode: u32, vnode_count: u32) -> bool {
-        if !self.emit_changelog
-            || self.dirty_all
-            || self.dirty_vnodes.contains(&vnode)
-            || self.tier_vnode_count != Some(vnode_count)
-        {
+        if !self.can_demote(vnode, vnode_count) {
             return false;
         }
         let global = self.num_group_cols == 0;
@@ -1660,6 +1665,15 @@ impl IncrementalAggState {
         if self.cold_vnodes.remove(&vnode) {
             self.dirty_vnodes.insert(vnode);
         }
+    }
+
+    /// Mark one vnode dirty (touched since the last capture) so it cannot be
+    /// demoted until the next capture re-baselines it. Called after merging a
+    /// vnode's state in (promotion or rebalance acquisition): `mark_vnode_hot`
+    /// only marks vnodes that were cold, so a rebalance-acquired vnode — never
+    /// cold here — needs this to be protected from demotion against stale bytes.
+    pub(crate) fn mark_vnode_dirty(&mut self, vnode: u32) {
+        self.dirty_vnodes.insert(vnode);
     }
 }
 
@@ -2730,6 +2744,74 @@ mod tests {
         assert!(
             !state.demote_vnode(v, VNODES),
             "vnode touched since capture must refuse demotion"
+        );
+    }
+
+    #[cfg(feature = "state-tier")]
+    #[tokio::test]
+    async fn merge_groups_does_not_block_demotion_of_other_vnodes() {
+        // Regression: merge_groups used to set `dirty_all`, so a single
+        // promotion or rebalance-acquired vnode blocked demotion of *every*
+        // other clean vnode until the next capture. It must now leave other
+        // untouched vnodes demotable (per-vnode dirtying is the caller's job).
+        const VNODES: u32 = 8;
+        let ctx = laminar_sql::create_session_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let dummy = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["x"])),
+                Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+            .unwrap();
+        ctx.register_table("events", Arc::new(mem)).unwrap();
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT name, SUM(value) as total FROM events GROUP BY name",
+            true,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            pre_agg_schema,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "a", "b", "c", "d", "e", "f", "g", "h",
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+                ])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+
+        // Clean baseline spanning several vnodes.
+        let buckets = state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        let vnodes: Vec<u32> = buckets.keys().copied().collect();
+        assert!(vnodes.len() >= 2, "need groups in at least two vnodes");
+        let (v_merge, v_other) = (vnodes[0], vnodes[1]);
+        assert!(state.can_demote(v_merge, VNODES));
+        assert!(state.can_demote(v_other, VNODES));
+
+        // Merge a vnode's slice back (the promotion / rebalance apply path).
+        let slice = buckets.get(&v_merge).unwrap();
+        state.merge_groups(slice).unwrap();
+        assert!(
+            state.can_demote(v_other, VNODES),
+            "merge_groups must not block demotion of other clean vnodes",
         );
     }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -1,21 +1,8 @@
 //! Incremental aggregation state for streaming GROUP BY queries.
 //!
-//! ## Scope
-//!
-//! This module owns the **single-process** aggregate operator: one
-//! `IncrementalAggState` per pipeline, one `DataFusion` `Accumulator`
-//! per aggregate per group. State is captured for checkpointing via
-//! the DataFusion-canonical `Accumulator::state() -> Vec<ScalarValue>`
-//! / `merge_batch(&arrays)` pair (see `checkpoint_groups` /
-//! `restore_groups`), serialized through Arrow IPC.
-//!
-//! The cross-vnode fan-in path — where the same aggregate runs on many
-//! vnodes and a merger instance combines their partials — lives in
-//! [`laminar_core::state::partial_aggregate`] and is a distinct tool
-//! solving a distinct problem (monoid `merge`, not format round-trip).
-//! Do not try to unify the two contracts: `DataFusion` already covers
-//! DISTINCT / FILTER / HAVING / UDAs on the single-process path, which
-//! `PartialAggregate` deliberately does not attempt.
+//! One `IncrementalAggState` per pipeline; one `DataFusion` `Accumulator` per
+//! aggregate per group. Cross-vnode partial merges live in
+//! `laminar_core::state::partial_aggregate` and are a separate concern.
 
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -165,10 +152,7 @@ impl AggFuncSpec {
         })
     }
 
-    /// Create a weight-aware retractable accumulator for changelog streams.
-    ///
-    /// These accumulators receive the `__weight` column as the last input
-    /// in `update_batch` and handle retraction internally.
+    /// Create a retractable accumulator for changelog streams (`__weight` as last input).
     pub(crate) fn create_retractable_accumulator(
         &self,
     ) -> Result<Box<dyn datafusion_expr::Accumulator>, DbError> {
@@ -182,14 +166,9 @@ impl AggFuncSpec {
 
 /// Snapshot an accumulator's state for a checkpoint and rebuild it in place.
 ///
-/// `Accumulator::state()` may drain internal collections (e.g. the DISTINCT
-/// hash set) — `DataFusion` only requires it to be valid once, since partial
-/// accumulators are discarded after `state()`. The window/group checkpoint
-/// paths call it on the *live* accumulator that keeps running, so we rebuild
-/// it from the snapshot (the same constructor + `merge_batch` round-trip used
-/// on restore). `retractable` must match how this accumulator was created —
-/// changelog/`__weight` groups use the retractable accumulator, so rebuilding
-/// it as a plain one would drop retraction handling. Returns the IPC state.
+/// `Accumulator::state()` may drain internal state (e.g. DISTINCT hash sets);
+/// we rebuild the accumulator from the snapshot so it keeps running correctly.
+/// `retractable` must match how the accumulator was created.
 pub(crate) fn snapshot_and_rebuild(
     acc: &mut Box<dyn datafusion_expr::Accumulator>,
     spec: &AggFuncSpec,
@@ -198,8 +177,8 @@ pub(crate) fn snapshot_and_rebuild(
     let state = acc
         .state()
         .map_err(|e| DbError::Pipeline(format!("accumulator state: {e}")))?;
-    // `state()` already drained the accumulator; rebuild it before serializing
-    // so a `scalars_to_ipc` failure can't leave it empty for the next cycle.
+    // Rebuild before serializing: a scalars_to_ipc failure must not leave
+    // the accumulator empty for the next cycle.
     let arrays: Vec<ArrayRef> = state
         .iter()
         .map(|sv| {
@@ -220,9 +199,6 @@ pub(crate) fn snapshot_and_rebuild(
     Ok(ipc)
 }
 
-/// Convert an accumulator's restored state tuple to the `ArrayRef`s
-/// `Accumulator::merge_batch` expects. Mirrors the inline conversion in
-/// [`IncrementalAggState::restore_groups`].
 #[cfg(feature = "cluster")]
 fn scalars_to_arrays(scalars: &[ScalarValue]) -> Result<Vec<ArrayRef>, DbError> {
     scalars
@@ -234,20 +210,14 @@ fn scalars_to_arrays(scalars: &[ScalarValue]) -> Result<Vec<ArrayRef>, DbError> 
         .collect()
 }
 
-/// Minimum interval between full size re-walks in
-/// [`IncrementalAggState::estimated_size_bytes`]. The walk is O(groups);
-/// between walks the cached figure is served, so a per-cycle memory-budget
-/// probe stays O(1) while staleness stays bounded.
+/// Minimum interval between full O(groups) size re-walks.
 const SIZE_REWALK_MIN_INTERVAL_MS: u64 = 2_000;
 
-/// Cached result of the O(groups) size walk. Atomic because the read path
-/// (`estimated_size_bytes`) takes `&self` but refreshes the cache lazily,
-/// and the operator's `process` future must stay `Send` (which demands
-/// `Sync` of state held across awaits). Single-threaded in practice;
-/// `Relaxed` ordering suffices.
+// Atomic fields let `estimated_size_bytes` update the cache through `&self`
+// without requiring a write lock. Single-threaded in practice; Relaxed suffices.
 struct SizeEstimateCache {
     bytes: AtomicUsize,
-    /// `state_gen` at the last walk; `u64::MAX` forces the next read to walk.
+    // u64::MAX forces the next read to re-walk regardless of elapsed time.
     walked_gen: AtomicU64,
     walked_at_ms: AtomicU64,
 }
@@ -261,8 +231,7 @@ impl SizeEstimateCache {
         }
     }
 
-    /// Force the next `estimated_size_bytes` call to re-walk, bypassing the
-    /// rewalk-interval throttle. For bulk-replacement paths (restore, merge).
+    /// Force the next size probe to re-walk, bypassing the interval throttle.
     fn invalidate(&self) {
         self.walked_gen.store(u64::MAX, Ordering::Relaxed);
     }
@@ -280,14 +249,11 @@ pub(crate) struct IncrementalAggState {
     group_types: Vec<DataType>,
     agg_specs: Vec<AggFuncSpec>,
     groups: AHashMap<arrow::row::OwnedRow, GroupEntry>,
-    /// Monotonic count of mutations to `groups`; lets the size cache skip
-    /// re-walking idle state entirely.
     state_gen: u64,
     size_cache: SizeEstimateCache,
     row_converter: arrow::row::RowConverter,
     output_schema: SchemaRef,
     compiled_projection: Option<CompiledProjection>,
-    /// Built once; `LiveSourceExec` leaves carry fresh data per execute.
     cached_pre_agg_physical: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
     having_filter: Option<Arc<dyn PhysicalExpr>>,
     having_sql: Option<String>,
@@ -296,31 +262,22 @@ pub(crate) struct IncrementalAggState {
     last_emitted: AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>>,
     pub(crate) idle_ttl_ms: Option<u64>,
     weight_col_idx: Option<usize>,
-    /// Vnode count for dirty tracking, learned at the first per-vnode
-    /// capture. `None` = no captures yet, so nothing can be demoted and
-    /// dirty tracking is off.
+    // None = no per-vnode capture yet; dirty tracking is off.
     #[cfg(feature = "state-tier")]
     tier_vnode_count: Option<u32>,
-    /// Vnodes whose groups changed since the last per-vnode capture —
-    /// their in-memory state no longer matches the captured bytes, so
-    /// demoting them would lose the changes.
+    // Vnodes touched since the last capture; demoting them would lose changes.
     #[cfg(feature = "state-tier")]
     dirty_vnodes: rustc_hash::FxHashSet<u32>,
-    /// Set when state was bulk-replaced (restore/merge) since the last
-    /// capture: every vnode is suspect, refuse all demotions until the
-    /// next capture re-baselines.
+    // Bulk restore/merge happened since the last capture; block all demotions.
     #[cfg(feature = "state-tier")]
     dirty_all: bool,
-    /// Vnodes demoted to the cold tier: their groups are not in memory and
-    /// per-vnode captures stage a cold marker for them.
+    // Groups for these vnodes were dropped; captures stage a cold marker.
     #[cfg(feature = "state-tier")]
     cold_vnodes: rustc_hash::FxHashSet<u32>,
 }
 
 impl IncrementalAggState {
-    /// Number of leading GROUP BY columns in this aggregate's pre-agg
-    /// output. Used by the cluster row-shuffle path to know which
-    /// columns to hash.
+    /// Number of leading GROUP BY columns; used by the shuffle path for hashing.
     #[cfg(feature = "cluster")]
     #[must_use]
     pub(crate) fn num_group_cols(&self) -> usize {
@@ -328,10 +285,7 @@ impl IncrementalAggState {
     }
 }
 
-/// Name of the Z-set weight column appended to changelog output.
-///
-/// Re-exported from the shared changelog contract in `laminar-core` so the MV
-/// producer and the upsert-sink consumers agree on the column name.
+/// Z-set weight column name shared between the MV producer and upsert-sink consumers.
 pub(crate) use laminar_core::changelog::WEIGHT_COLUMN;
 
 /// Build a weighted `RecordBatch` from collected keys, values, and weights.
@@ -399,8 +353,7 @@ impl IncrementalAggState {
 
         let plan = df.logical_plan();
 
-        // Use the top-level plan's output schema for column names — this
-        // includes user-specified aliases (e.g., `SUM(x) AS total`).
+        // Top-level schema preserves user aliases (e.g. `SUM(x) AS total`).
         let top_schema = Arc::new(plan.schema().as_arrow().clone());
 
         let Some(agg_info) = find_aggregate(plan) else {
@@ -417,15 +370,9 @@ impl IncrementalAggState {
             return Ok(None);
         }
 
-        // Bail out if the top-level plan has a non-trivial projection above
-        // the Aggregate (e.g., SUM(a)/SUM(b) AS ratio, CASE WHEN ... END).
-        // The incremental accumulator emits raw aggregate outputs and cannot
-        // apply post-aggregate projections.  Fall through to EOWC raw-batch.
-        //
-        // Check both field count AND types — a coincidental count match (e.g.,
-        // 2 group keys + 3 aggregates == 5 SELECT items after projection drops
-        // a group key and adds a computed column) can mask a projection that
-        // remaps group columns to aggregate aliases.
+        // Bail if there's a non-trivial projection above the Aggregate
+        // (e.g. SUM(a)/SUM(b) AS ratio). Check field count AND types: a
+        // coincidental count match can still hide a remapping projection.
         if top_schema.fields().len() != agg_schema.fields().len() {
             return Ok(None);
         }
@@ -437,9 +384,6 @@ impl IncrementalAggState {
 
         let num_group_cols = group_exprs.len();
 
-        // Resolve group-by column names and types.
-        // Use top-level schema for names (preserves aliases) and agg schema
-        // for types (accurate data types from the aggregate node).
         let mut group_col_names = Vec::new();
         let mut group_types = Vec::new();
         for i in 0..num_group_cols {
@@ -449,8 +393,7 @@ impl IncrementalAggState {
             group_types.push(agg_field.data_type().clone());
         }
 
-        // Determine if we should attempt to compile pre-agg expressions.
-        // Use single_source_table (counts occurrences) to reject self-joins.
+        // single_source_table rejects self-joins where compilation is unsafe.
         let compile_source = crate::sql_analysis::single_source_table(sql);
         let state = ctx.state();
         let props = state.execution_props();
@@ -462,9 +405,6 @@ impl IncrementalAggState {
         let mut agg_specs = Vec::new();
         let mut pre_agg_select_items: Vec<String> = Vec::new();
 
-        // For simple column refs, quote as identifier. For complex
-        // expressions (EXTRACT, CASE WHEN, etc.), generate the SQL
-        // expression with an alias so the source query evaluates it.
         for (i, group_expr) in group_exprs.iter().enumerate() {
             if let datafusion_expr::Expr::Column(col) = group_expr {
                 pre_agg_select_items.push(format!("\"{}\"", col.name));
@@ -473,7 +413,6 @@ impl IncrementalAggState {
                 pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
             }
 
-            // Compile group expression
             if compile_ok {
                 match create_physical_expr(group_expr, input_df_schema, props) {
                     Ok(phys) => {
@@ -492,7 +431,6 @@ impl IncrementalAggState {
             }
         }
 
-        // Column index tracker for pre-agg output
         let mut next_col_idx = num_group_cols;
 
         for (i, expr) in aggr_exprs.iter().enumerate() {
@@ -509,20 +447,17 @@ impl IncrementalAggState {
                 let udf = Arc::clone(&agg_func.func);
                 let is_distinct = agg_func.params.distinct;
 
-                // Collect input column indices and add input expressions
-                // to the pre-agg SELECT
                 let mut input_col_indices = Vec::new();
                 let mut input_types = Vec::new();
 
                 if agg_func.params.args.is_empty() {
-                    // COUNT(*) — no input columns needed, pass a dummy boolean
+                    // COUNT(*): no input column needed; pass a dummy boolean.
                     let col_idx = next_col_idx;
                     next_col_idx += 1;
                     pre_agg_select_items.push(format!("TRUE AS \"__agg_input_{col_idx}\""));
                     input_col_indices.push(col_idx);
                     input_types.push(DataType::Boolean);
 
-                    // Compile literal TRUE
                     if compile_ok {
                         match create_physical_expr(
                             &datafusion_expr::lit(true),
@@ -546,16 +481,13 @@ impl IncrementalAggState {
                         next_col_idx += 1;
                         let expr_sql = expr_to_sql(arg_expr);
 
-                        // If FILTER clause present, wrap input with
-                        // CASE WHEN so filtered rows become NULL (ignored
-                        // by accumulators)
+                        // FILTER: wrap with CASE WHEN so filtered rows become NULL.
                         if let Some(filter_expr) = &agg_func.params.filter {
                             let filter_sql = expr_to_sql(filter_expr);
                             pre_agg_select_items.push(format!(
                                 "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
                             ));
 
-                            // Compile: CASE WHEN filter THEN arg ELSE NULL END
                             if compile_ok {
                                 let case_expr =
                                     datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
@@ -589,7 +521,6 @@ impl IncrementalAggState {
                             pre_agg_select_items
                                 .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
 
-                            // Compile the arg expression directly
                             if compile_ok {
                                 match create_physical_expr(arg_expr, input_df_schema, props) {
                                     Ok(phys) => {
@@ -616,8 +547,6 @@ impl IncrementalAggState {
                     }
                 }
 
-                // Add a boolean filter column for masking rows
-                // in process_batch when FILTER clause is present
                 let filter_col_index = if let Some(filter_expr) = &agg_func.params.filter {
                     let col_idx = next_col_idx;
                     next_col_idx += 1;
@@ -626,7 +555,6 @@ impl IncrementalAggState {
                             "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
                         ));
 
-                    // Compile: CASE WHEN filter THEN TRUE ELSE FALSE END
                     if compile_ok {
                         let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
                             expr: None,
@@ -669,17 +597,13 @@ impl IncrementalAggState {
                     filter_col_index,
                 });
             } else {
-                // Non-aggregate expression in the aggregate output —
-                // this shouldn't happen for well-formed plans.
                 return Ok(None);
             }
         }
 
         let clauses = extract_clauses(sql);
 
-        // Detect __weight in upstream source for cascaded changelog aggregation.
-        // Check the registered table schema (not the pruned plan schema, which
-        // may have dropped unreferenced columns).
+        // Check the registered schema, not the pruned plan schema, to detect __weight.
         let source_has_weight = if let Ok(tp) = ctx
             .table_provider(clauses.from_clause.trim_matches('"'))
             .await
@@ -690,9 +614,6 @@ impl IncrementalAggState {
         };
 
         let weight_col_idx = if source_has_weight {
-            // Validate that all aggregates support retractable changelog
-            // semantics. Retractable accumulators handle the weight column
-            // internally (SUM, COUNT, AVG, MIN, MAX).
             for spec in &agg_specs {
                 if spec.distinct {
                     return Err(DbError::Pipeline(format!(
@@ -724,12 +645,9 @@ impl IncrementalAggState {
             clauses.where_clause,
         );
 
-        // Build compiled projection for single-source queries.
-        // Skip compilation when upstream has __weight — the compiled path
-        // doesn't include the weight column, so process_batch would read
-        // the wrong index. The cached plan path handles it via pre_agg_sql.
+        // Skip compilation when upstream has __weight: the compiled path omits
+        // it, which would shift column indices in process_batch.
         let compiled_projection = if compile_ok && weight_col_idx.is_none() {
-            // Compile WHERE predicate
             let filter = if let Some(where_pred) = &agg_info.where_predicate {
                 if let Ok(phys) = create_physical_expr(where_pred, input_df_schema, props) {
                     Some(phys)
@@ -769,7 +687,6 @@ impl IncrementalAggState {
         }
         let output_schema = Arc::new(Schema::new(output_fields));
 
-        // Compile HAVING filter.
         let having_filter = compile_having_filter(ctx, having_predicate.as_ref(), &output_schema);
         let having_sql = if having_filter.is_none() {
             having_predicate.as_ref().map(expr_to_sql)
@@ -777,7 +694,7 @@ impl IncrementalAggState {
             None
         };
 
-        // Plan once at init; `LiveSourceProvider` leaves carry fresh data.
+        // Plan once at init; LiveSourceProvider leaves carry fresh data per execute.
         let cached_pre_agg_physical =
             if compiled_projection.is_none() {
                 let logical = ctx.sql(&pre_agg_sql).await.map_err(|e| {
@@ -828,8 +745,7 @@ impl IncrementalAggState {
         }))
     }
 
-    /// Evict idle groups and return retraction records. Only produces output
-    /// when both `emit_changelog` and `idle_ttl_ms` are set.
+    /// Evict idle groups and return retraction records. Requires both `emit_changelog` and `idle_ttl_ms`.
     pub fn evict_idle(&mut self, watermark: i64) -> Result<Vec<RecordBatch>, DbError> {
         let Some(ttl) = self.idle_ttl_ms else {
             return Ok(Vec::new());
@@ -852,7 +768,6 @@ impl IncrementalAggState {
             return Ok(Vec::new());
         }
 
-        // Collect retraction data from last_emitted before removing.
         let mut retract_keys: Vec<arrow::row::OwnedRow> = Vec::new();
         let mut retract_vals: Vec<Vec<ScalarValue>> = Vec::new();
 
@@ -912,8 +827,7 @@ impl IncrementalAggState {
             .convert_columns(&group_cols)
             .map_err(|e| DbError::Pipeline(format!("row conversion: {e}")))?;
 
-        // Local map keyed by borrowed Row: one OwnedRow alloc per unique
-        // group, not per row.
+        // One OwnedRow alloc per unique group, not per row.
         let estimated_groups = (batch.num_rows() / 4).max(16);
         let mut group_indices: FxHashMap<arrow::row::Row<'_>, Vec<u32>> =
             FxHashMap::with_capacity_and_hasher(estimated_groups, rustc_hash::FxBuildHasher);
@@ -975,13 +889,12 @@ impl IncrementalAggState {
         Ok(())
     }
 
-    /// Fast path for global aggregates (COUNT(*), SUM(x), etc. with no GROUP BY).
+    /// Fast path for global aggregates (no GROUP BY).
     fn process_batch_no_groups(
         &mut self,
         batch: &RecordBatch,
         watermark_ms: i64,
     ) -> Result<(), DbError> {
-        // Global aggregates capture into vnode 0.
         #[cfg(feature = "state-tier")]
         if self.tier_vnode_count.is_some() {
             self.dirty_vnodes.insert(0);
@@ -1019,11 +932,7 @@ impl IncrementalAggState {
         )
     }
 
-    /// Update accumulators for a single group given the row indices.
-    ///
-    /// Takes a batch and a slice of row indices, does a single `take()` per
-    /// column per accumulator, and feeds the resulting sub-arrays to
-    /// `Accumulator::update_batch`. This avoids per-row allocation.
+    /// Update accumulators for a group: one `take()` per column per accumulator, no per-row allocation.
     pub(crate) fn update_group_accumulators(
         accs: &mut [Box<dyn datafusion_expr::Accumulator>],
         batch: &RecordBatch,
@@ -1050,7 +959,6 @@ impl IncrementalAggState {
                 input_arrays.push(arr);
             }
 
-            // Apply per-accumulator FILTER mask.
             let filtered_weight = if let Some(filter_idx) = spec.filter_col_index {
                 let filter_arr = compute::take(batch.column(filter_idx), &index_array, None)
                     .map_err(|e| DbError::Pipeline(format!("filter take: {e}")))?;
@@ -1066,7 +974,6 @@ impl IncrementalAggState {
                         );
                     }
                     input_arrays = filtered;
-                    // Also filter weight array through the same mask.
                     weight_arr
                         .as_ref()
                         .map(|w| {
@@ -1081,7 +988,6 @@ impl IncrementalAggState {
                 weight_arr.clone()
             };
 
-            // Retractable accumulators receive weight as the last input.
             if let Some(w) = &filtered_weight {
                 input_arrays.push(Arc::clone(w));
             }
@@ -1093,8 +999,7 @@ impl IncrementalAggState {
         Ok(())
     }
 
-    /// Does NOT reset the accumulators — they continue accumulating for the
-    /// next cycle (running totals).
+    /// Emit current aggregate state; accumulators keep running (no reset).
     pub fn emit(&mut self) -> Result<Vec<RecordBatch>, DbError> {
         if self.emit_changelog {
             return self.emit_changelog_delta();
@@ -1102,7 +1007,6 @@ impl IncrementalAggState {
         self.emit_running_state()
     }
 
-    /// Emit full running state (all groups, every cycle). No __weight column.
     fn emit_running_state(&mut self) -> Result<Vec<RecordBatch>, DbError> {
         if self.groups.is_empty() {
             return Ok(Vec::new());
@@ -1147,8 +1051,7 @@ impl IncrementalAggState {
     }
 
     fn emit_changelog_delta(&mut self) -> Result<Vec<RecordBatch>, DbError> {
-        // Without `idle_ttl_ms`, `last_emitted` never shrinks. Warn once
-        // every ~5min so operators see the leak before OOM.
+        // Without idle_ttl_ms, last_emitted never shrinks; warn periodically.
         if self.idle_ttl_ms.is_none() && self.last_emitted.len() > 10_000 {
             use std::sync::atomic::{AtomicI64, Ordering};
             static LAST_WARN_S: AtomicI64 = AtomicI64::new(0);
@@ -1165,7 +1068,6 @@ impl IncrementalAggState {
                 );
             }
         }
-        // Collect retractions and inserts.
         let mut retract_keys: Vec<arrow::row::OwnedRow> = Vec::new();
         let mut retract_vals: Vec<Vec<ScalarValue>> = Vec::new();
         let mut insert_keys: Vec<arrow::row::OwnedRow> = Vec::new();
@@ -1180,8 +1082,8 @@ impl IncrementalAggState {
                 .map_err(|e| DbError::Pipeline(format!("accumulator evaluate: {e}")))?;
 
             if let Some(old) = self.last_emitted.get(key) {
-                // `ScalarValue::eq` says NaN != NaN; treat both-NaN as
-                // equal to avoid an infinite retract+insert loop.
+                // ScalarValue::eq treats NaN != NaN; short-circuit to avoid
+                // an infinite retract+insert loop on float aggregates.
                 let changed = old.iter().zip(current.iter()).any(|(a, b)| match (a, b) {
                     (ScalarValue::Float64(Some(x)), ScalarValue::Float64(Some(y)))
                         if x.is_nan() && y.is_nan() =>
@@ -1202,7 +1104,6 @@ impl IncrementalAggState {
                     insert_vals.push(current.clone());
                     self.last_emitted.insert(key.clone(), current);
                 }
-                // Unchanged: skip (true delta semantics).
             } else {
                 insert_keys.push(key.clone());
                 insert_vals.push(current.clone());
@@ -1210,7 +1111,6 @@ impl IncrementalAggState {
             }
         }
 
-        // Detect deleted groups (in last_emitted but not in groups).
         let deleted: Vec<arrow::row::OwnedRow> = self
             .last_emitted
             .keys()
@@ -1228,7 +1128,6 @@ impl IncrementalAggState {
             return Ok(Vec::new());
         }
 
-        // Build batch: retracts first (-1), then inserts (+1).
         let mut all_keys = Vec::with_capacity(total);
         let mut all_vals = Vec::with_capacity(total);
         let mut weights = Vec::with_capacity(total);
@@ -1278,12 +1177,7 @@ impl IncrementalAggState {
         query_fingerprint(&self.pre_agg_sql, &self.output_schema)
     }
 
-    /// Approximate bytes held by group state, from a lazily-refreshed cache.
-    ///
-    /// The underlying walk is O(groups), so the cache re-walks only when the
-    /// state has mutated since the last walk AND at least
-    /// [`SIZE_REWALK_MIN_INTERVAL_MS`] has elapsed — idle state is never
-    /// re-walked, and a per-cycle caller pays O(1) with bounded staleness.
+    /// Approximate bytes held by group state (lazily refreshed; O(1) between re-walks).
     pub(crate) fn estimated_size_bytes(&self) -> usize {
         let gen = self.state_gen;
         let walked_gen = self.size_cache.walked_gen.load(Ordering::Relaxed);
@@ -1328,7 +1222,6 @@ impl IncrementalAggState {
                 last_updated_ms: entry.last_updated_ms,
             });
         }
-        // Serialize last_emitted for changelog recovery.
         let mut last_emitted_cp = Vec::new();
         if self.emit_changelog {
             for (row_key, vals) in &self.last_emitted {
@@ -1359,8 +1252,8 @@ impl IncrementalAggState {
                 checkpoint.fingerprint, current_fp
             )));
         }
-        // Two-phase: build maps locally then swap, so a mid-list decode
-        // error doesn't leave `last_emitted` partially populated.
+        // Build locally then swap so a mid-list decode error can't leave
+        // last_emitted partially populated.
         let mut new_groups: AHashMap<arrow::row::OwnedRow, GroupEntry> =
             AHashMap::with_capacity(checkpoint.groups.len());
         for gc in &checkpoint.groups {
@@ -1410,8 +1303,7 @@ impl IncrementalAggState {
         self.last_emitted = new_last_emitted;
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
-        // Restored state lives fully in memory: no vnode is cold anymore,
-        // and none can be demoted until the next capture re-baselines.
+        // All state is in memory; block demotion until the next capture re-baselines.
         #[cfg(feature = "state-tier")]
         {
             self.cold_vnodes.clear();
@@ -1420,19 +1312,7 @@ impl IncrementalAggState {
         Ok(checkpoint.groups.len())
     }
 
-    /// Partition this state into one [`AggStateCheckpoint`] per vnode.
-    ///
-    /// Each group key is mapped to its vnode with the **same** hashing the
-    /// cluster shuffle uses to route rows
-    /// (`laminar_core::state::key_hash(row_key.as_ref()) % vnode_count`), so a
-    /// vnode's slice here is exactly the set of groups whose rows the shuffle
-    /// delivered to this node. A global aggregate (`num_group_cols == 0`)
-    /// hashes to vnode 0, mirroring the routing fast-path.
-    ///
-    /// Reuses the per-group serialization of [`Self::checkpoint_groups`]; the
-    /// union of the returned slices is byte-for-byte the groups that method
-    /// would emit. Only vnodes with at least one group (or emitted entry) are
-    /// present in the result.
+    /// Partition state into one [`AggStateCheckpoint`] per vnode using the same hash as the shuffle.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // cold checkpoint path; vnode-keyed map
     pub(crate) fn checkpoint_groups_by_vnode(
@@ -1500,9 +1380,7 @@ impl IncrementalAggState {
             }
         }
 
-        // This capture is the new clean baseline: the staged bytes match
-        // memory exactly as of now, so dirty tracking restarts here (and
-        // the vnode count it is keyed to is pinned).
+        // New baseline: staged bytes match memory; dirty tracking restarts.
         #[cfg(feature = "state-tier")]
         {
             self.tier_vnode_count = Some(vnode_count);
@@ -1513,14 +1391,10 @@ impl IncrementalAggState {
         Ok(buckets)
     }
 
-    /// Merge a restored [`AggStateCheckpoint`] into the live state.
+    /// Fold a checkpoint's accumulator states into live state via `merge_batch`.
     ///
-    /// Unlike [`Self::restore_groups`] (which replaces wholesale), this folds
-    /// the checkpoint's accumulator states **into** any groups already present
-    /// via `Accumulator::merge_batch`, and inserts the rest. Because standard
-    /// accumulators merge associatively, the result is correct regardless of
-    /// how many rows the operator already processed for these keys before the
-    /// rebalanced state arrived. Used by the cross-node vnode rehydration path.
+    /// Unlike `restore_groups` (wholesale replace), this merges into existing
+    /// groups associatively. Used by the cross-node vnode rehydration path.
     #[cfg(feature = "cluster")]
     pub(crate) fn merge_groups(
         &mut self,
@@ -1585,34 +1459,21 @@ impl IncrementalAggState {
 
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
-        // No `dirty_all` here: every caller (`apply_vnode_state`) merges exactly
-        // one vnode and marks *that* vnode dirty itself, so demotion of other
-        // clean vnodes stays available. Blanket-dirtying here would block all
-        // demotion after a single promotion or rebalance-acquired vnode.
+        // No dirty_all: callers mark only the merged vnode dirty, so other
+        // clean vnodes remain demotable.
         Ok(checkpoint.groups.len())
     }
 }
 
 #[cfg(feature = "state-tier")]
 impl IncrementalAggState {
-    /// Vnodes currently demoted to the cold tier.
+    /// Vnodes demoted to the cold tier.
     pub(crate) fn cold_vnodes(&self) -> &rustc_hash::FxHashSet<u32> {
         &self.cold_vnodes
     }
 
-    /// Whether [`Self::demote_vnode`] would succeed for `vnode` now, without
-    /// dropping anything. Refuses (`false`) unless it is provably safe:
-    ///
-    /// - the agg emits a changelog — a full-emit agg rebuilds its entire
-    ///   result from memory each cycle, so dropping groups would shrink
-    ///   the query output (same restriction as idle-TTL eviction);
-    /// - the vnode is untouched since the last per-vnode capture, and no
-    ///   bulk restore/merge happened since — otherwise memory has moved
-    ///   past the bytes sitting in the tier;
-    /// - the capture baseline used this `vnode_count`.
-    ///
-    /// Checked before writing the slice to the tier, so a dirty candidate
-    /// costs no I/O.
+    /// Whether demotion of `vnode` is safe: changelog mode, untouched since last capture,
+    /// and the capture used this `vnode_count`.
     pub(crate) fn can_demote(&self, vnode: u32, vnode_count: u32) -> bool {
         self.emit_changelog
             && !self.dirty_all
@@ -1620,10 +1481,7 @@ impl IncrementalAggState {
             && self.tier_vnode_count == Some(vnode_count)
     }
 
-    /// Drop one vnode's groups after their captured bytes were confirmed in
-    /// the cold tier. No retractions are emitted: unlike eviction, demotion is
-    /// invisible downstream — the materialized rows stay, and a future update
-    /// for a cold group goes through promotion first.
+    /// Drop a vnode's groups after cold-tier confirmation. No retractions; materialized rows stay.
     pub(crate) fn demote_vnode(&mut self, vnode: u32, vnode_count: u32) -> bool {
         if !self.can_demote(vnode, vnode_count) {
             return false;
@@ -1655,19 +1513,14 @@ impl IncrementalAggState {
         true
     }
 
-    /// The vnode's state is back in memory (promotion applied) or never
-    /// left (tier write failed after the drop was rolled back): captures
-    /// stage bytes again, and the slice counts as changed until the next
-    /// capture re-baselines it.
+    /// Mark a vnode hot (promoted or tier write rolled back); dirty until next capture.
     pub(crate) fn mark_vnode_hot(&mut self, vnode: u32) {
         if self.cold_vnodes.remove(&vnode) {
             self.dirty_vnodes.insert(vnode);
         }
     }
 
-    /// Mark one vnode dirty so it can't be demoted until the next capture.
-    /// `apply_vnode_state` calls this after merging a vnode in; `mark_vnode_hot`
-    /// only dirties vnodes that were *cold*, so a rebalance-acquired one needs it.
+    /// Mark a vnode dirty to block demotion until the next capture.
     pub(crate) fn mark_vnode_dirty(&mut self, vnode: u32) {
         self.dirty_vnodes.insert(vnode);
     }

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -17,6 +17,7 @@
 //! DISTINCT / FILTER / HAVING / UDAs on the single-process path, which
 //! `PartialAggregate` deliberately does not attempt.
 
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use ahash::AHashMap;
@@ -233,12 +234,56 @@ fn scalars_to_arrays(scalars: &[ScalarValue]) -> Result<Vec<ArrayRef>, DbError> 
         .collect()
 }
 
+/// Minimum interval between full size re-walks in
+/// [`IncrementalAggState::estimated_size_bytes`]. The walk is O(groups);
+/// between walks the cached figure is served, so a per-cycle memory-budget
+/// probe stays O(1) while staleness stays bounded.
+const SIZE_REWALK_MIN_INTERVAL_MS: u64 = 2_000;
+
+/// Cached result of the O(groups) size walk. Atomic because the read path
+/// (`estimated_size_bytes`) takes `&self` but refreshes the cache lazily,
+/// and the operator's `process` future must stay `Send` (which demands
+/// `Sync` of state held across awaits). Single-threaded in practice;
+/// `Relaxed` ordering suffices.
+struct SizeEstimateCache {
+    bytes: AtomicUsize,
+    /// `state_gen` at the last walk; `u64::MAX` forces the next read to walk.
+    walked_gen: AtomicU64,
+    walked_at_ms: AtomicU64,
+}
+
+impl SizeEstimateCache {
+    fn new() -> Self {
+        Self {
+            bytes: AtomicUsize::new(0),
+            walked_gen: AtomicU64::new(u64::MAX),
+            walked_at_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Force the next `estimated_size_bytes` call to re-walk, bypassing the
+    /// rewalk-interval throttle. For bulk-replacement paths (restore, merge).
+    fn invalidate(&self) {
+        self.walked_gen.store(u64::MAX, Ordering::Relaxed);
+    }
+}
+
+fn epoch_ms_coarse() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
 pub(crate) struct IncrementalAggState {
     pre_agg_sql: String,
     num_group_cols: usize,
     group_types: Vec<DataType>,
     agg_specs: Vec<AggFuncSpec>,
     groups: AHashMap<arrow::row::OwnedRow, GroupEntry>,
+    /// Monotonic count of mutations to `groups`; lets the size cache skip
+    /// re-walking idle state entirely.
+    state_gen: u64,
+    size_cache: SizeEstimateCache,
     row_converter: arrow::row::RowConverter,
     output_schema: SchemaRef,
     compiled_projection: Option<CompiledProjection>,
@@ -740,6 +785,8 @@ impl IncrementalAggState {
             group_types,
             agg_specs,
             groups: AHashMap::new(),
+            state_gen: 0,
+            size_cache: SizeEstimateCache::new(),
             row_converter,
             output_schema,
             compiled_projection,
@@ -789,6 +836,7 @@ impl IncrementalAggState {
             }
             self.groups.remove(key);
         }
+        self.state_gen = self.state_gen.wrapping_add(1);
 
         if retract_keys.is_empty() {
             return Ok(Vec::new());
@@ -877,6 +925,7 @@ impl IncrementalAggState {
             )?;
             entry.last_updated_ms = watermark_ms;
         }
+        self.state_gen = self.state_gen.wrapping_add(1);
 
         Ok(())
     }
@@ -910,6 +959,7 @@ impl IncrementalAggState {
         entry.last_updated_ms = watermark_ms;
         #[allow(clippy::cast_possible_truncation)]
         let all_indices: Vec<u32> = (0..batch.num_rows() as u32).collect();
+        self.state_gen = self.state_gen.wrapping_add(1);
         Self::update_group_accumulators(
             &mut entry.accs,
             batch,
@@ -1178,7 +1228,25 @@ impl IncrementalAggState {
         query_fingerprint(&self.pre_agg_sql, &self.output_schema)
     }
 
+    /// Approximate bytes held by group state, from a lazily-refreshed cache.
+    ///
+    /// The underlying walk is O(groups), so the cache re-walks only when the
+    /// state has mutated since the last walk AND at least
+    /// [`SIZE_REWALK_MIN_INTERVAL_MS`] has elapsed — idle state is never
+    /// re-walked, and a per-cycle caller pays O(1) with bounded staleness.
     pub(crate) fn estimated_size_bytes(&self) -> usize {
+        let gen = self.state_gen;
+        let walked_gen = self.size_cache.walked_gen.load(Ordering::Relaxed);
+        if walked_gen == gen {
+            return self.size_cache.bytes.load(Ordering::Relaxed);
+        }
+        let now = epoch_ms_coarse();
+        if walked_gen != u64::MAX
+            && now.saturating_sub(self.size_cache.walked_at_ms.load(Ordering::Relaxed))
+                < SIZE_REWALK_MIN_INTERVAL_MS
+        {
+            return self.size_cache.bytes.load(Ordering::Relaxed);
+        }
         let mut total = 0;
         for (key, entry) in &self.groups {
             total += key.as_ref().len();
@@ -1186,6 +1254,9 @@ impl IncrementalAggState {
                 total += acc.size();
             }
         }
+        self.size_cache.bytes.store(total, Ordering::Relaxed);
+        self.size_cache.walked_gen.store(gen, Ordering::Relaxed);
+        self.size_cache.walked_at_ms.store(now, Ordering::Relaxed);
         total
     }
 
@@ -1287,6 +1358,8 @@ impl IncrementalAggState {
 
         self.groups = new_groups;
         self.last_emitted = new_last_emitted;
+        self.state_gen = self.state_gen.wrapping_add(1);
+        self.size_cache.invalidate();
         Ok(checkpoint.groups.len())
     }
 
@@ -1443,6 +1516,8 @@ impl IncrementalAggState {
             self.last_emitted.entry(row_key).or_insert(vals);
         }
 
+        self.state_gen = self.state_gen.wrapping_add(1);
+        self.size_cache.invalidate();
         Ok(checkpoint.groups.len())
     }
 }
@@ -2366,6 +2441,80 @@ mod tests {
             result[0].num_rows() <= 3,
             "should have at most 3 groups, got {}",
             result[0].num_rows()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_size_estimate_throttled_cache_and_invalidate() {
+        let (_, mut state) =
+            setup_agg_state("SELECT name, SUM(value) as total FROM events GROUP BY name").await;
+        assert_eq!(state.estimated_size_bytes(), 0);
+
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+
+        // Mutated state still serves the previous walk's figure inside the
+        // rewalk interval.
+        assert_eq!(state.estimated_size_bytes(), 0);
+
+        state.size_cache.invalidate();
+        let two_groups = state.estimated_size_bytes();
+        assert!(two_groups > 0, "walk after invalidate must see the groups");
+
+        // Idle reads are stable (gen unchanged → cached, no walk).
+        assert_eq!(state.estimated_size_bytes(), two_groups);
+
+        let batch2 = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["c"])),
+                Arc::new(arrow::array::Float64Array::from(vec![3.0])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch2, i64::MIN).unwrap();
+        // Cached inside the interval, fresh once forced.
+        assert_eq!(state.estimated_size_bytes(), two_groups);
+        state.size_cache.invalidate();
+        assert!(state.estimated_size_bytes() > two_groups);
+    }
+
+    #[tokio::test]
+    async fn test_size_estimate_refreshes_after_restore() {
+        let sql = "SELECT name, SUM(value) as total FROM events GROUP BY name";
+        let (_, mut donor) = setup_agg_state(sql).await;
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+        donor.process_batch(&batch, i64::MIN).unwrap();
+        let cp = donor.checkpoint_groups().unwrap();
+
+        let (_, mut fresh) = setup_agg_state(sql).await;
+        assert_eq!(fresh.estimated_size_bytes(), 0);
+        fresh.restore_groups(&cp).unwrap();
+        assert!(
+            fresh.estimated_size_bytes() > 0,
+            "restore must invalidate the size cache so the next read re-walks"
         );
     }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -296,6 +296,25 @@ pub(crate) struct IncrementalAggState {
     last_emitted: AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>>,
     pub(crate) idle_ttl_ms: Option<u64>,
     weight_col_idx: Option<usize>,
+    /// Vnode count for dirty tracking, learned at the first per-vnode
+    /// capture. `None` = no captures yet, so nothing can be demoted and
+    /// dirty tracking is off.
+    #[cfg(feature = "state-tier")]
+    tier_vnode_count: Option<u32>,
+    /// Vnodes whose groups changed since the last per-vnode capture —
+    /// their in-memory state no longer matches the captured bytes, so
+    /// demoting them would lose the changes.
+    #[cfg(feature = "state-tier")]
+    dirty_vnodes: rustc_hash::FxHashSet<u32>,
+    /// Set when state was bulk-replaced (restore/merge) since the last
+    /// capture: every vnode is suspect, refuse all demotions until the
+    /// next capture re-baselines.
+    #[cfg(feature = "state-tier")]
+    dirty_all: bool,
+    /// Vnodes demoted to the cold tier: their groups are not in memory and
+    /// per-vnode captures stage a cold marker for them.
+    #[cfg(feature = "state-tier")]
+    cold_vnodes: rustc_hash::FxHashSet<u32>,
 }
 
 impl IncrementalAggState {
@@ -798,6 +817,14 @@ impl IncrementalAggState {
             last_emitted: AHashMap::new(),
             idle_ttl_ms: None,
             weight_col_idx,
+            #[cfg(feature = "state-tier")]
+            tier_vnode_count: None,
+            #[cfg(feature = "state-tier")]
+            dirty_vnodes: rustc_hash::FxHashSet::default(),
+            #[cfg(feature = "state-tier")]
+            dirty_all: false,
+            #[cfg(feature = "state-tier")]
+            cold_vnodes: rustc_hash::FxHashSet::default(),
         }))
     }
 
@@ -830,6 +857,18 @@ impl IncrementalAggState {
         let mut retract_vals: Vec<Vec<ScalarValue>> = Vec::new();
 
         for key in &idle_keys {
+            #[cfg(feature = "state-tier")]
+            if let Some(count) = self.tier_vnode_count {
+                let v = if self.num_group_cols == 0 {
+                    0
+                } else {
+                    #[allow(clippy::cast_possible_truncation)]
+                    {
+                        (laminar_core::state::key_hash(key.as_ref()) % u64::from(count)) as u32
+                    }
+                };
+                self.dirty_vnodes.insert(v);
+            }
             if let Some(old) = self.last_emitted.remove(key) {
                 retract_keys.push(key.clone());
                 retract_vals.push(old);
@@ -889,6 +928,12 @@ impl IncrementalAggState {
         let max_groups = self.max_groups;
         let mut groups_len = self.groups.len();
         for (row_ref, indices) in &group_indices {
+            #[cfg(feature = "state-tier")]
+            if let Some(count) = self.tier_vnode_count {
+                #[allow(clippy::cast_possible_truncation)]
+                let v = (laminar_core::state::key_hash(row_ref.as_ref()) % u64::from(count)) as u32;
+                self.dirty_vnodes.insert(v);
+            }
             let entry = match self.groups.entry(row_ref.owned()) {
                 std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
                 std::collections::hash_map::Entry::Vacant(e) => {
@@ -936,6 +981,11 @@ impl IncrementalAggState {
         batch: &RecordBatch,
         watermark_ms: i64,
     ) -> Result<(), DbError> {
+        // Global aggregates capture into vnode 0.
+        #[cfg(feature = "state-tier")]
+        if self.tier_vnode_count.is_some() {
+            self.dirty_vnodes.insert(0);
+        }
         let empty_key = global_aggregate_key();
         if !self.groups.contains_key(&empty_key) {
             let mut accs = Vec::with_capacity(self.agg_specs.len());
@@ -1360,6 +1410,13 @@ impl IncrementalAggState {
         self.last_emitted = new_last_emitted;
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
+        // Restored state lives fully in memory: no vnode is cold anymore,
+        // and none can be demoted until the next capture re-baselines.
+        #[cfg(feature = "state-tier")]
+        {
+            self.cold_vnodes.clear();
+            self.dirty_all = true;
+        }
         Ok(checkpoint.groups.len())
     }
 
@@ -1443,6 +1500,16 @@ impl IncrementalAggState {
             }
         }
 
+        // This capture is the new clean baseline: the staged bytes match
+        // memory exactly as of now, so dirty tracking restarts here (and
+        // the vnode count it is keyed to is pinned).
+        #[cfg(feature = "state-tier")]
+        {
+            self.tier_vnode_count = Some(vnode_count);
+            self.dirty_vnodes.clear();
+            self.dirty_all = false;
+        }
+
         Ok(buckets)
     }
 
@@ -1518,7 +1585,81 @@ impl IncrementalAggState {
 
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
+        // Merged-in state changes an unknown set of vnodes; refuse
+        // demotions until the next capture re-baselines.
+        #[cfg(feature = "state-tier")]
+        {
+            self.dirty_all = true;
+        }
         Ok(checkpoint.groups.len())
+    }
+}
+
+#[cfg(feature = "state-tier")]
+impl IncrementalAggState {
+    /// Vnodes currently demoted to the cold tier.
+    pub(crate) fn cold_vnodes(&self) -> &rustc_hash::FxHashSet<u32> {
+        &self.cold_vnodes
+    }
+
+    /// Drop one vnode's groups after their captured bytes were confirmed
+    /// in the cold tier. Refuses (`false`) unless it is provably safe:
+    ///
+    /// - the agg emits a changelog — a full-emit agg rebuilds its entire
+    ///   result from memory each cycle, so dropping groups would shrink
+    ///   the query output (same restriction as idle-TTL eviction);
+    /// - the vnode is untouched since the last per-vnode capture, and no
+    ///   bulk restore/merge happened since — otherwise memory has moved
+    ///   past the bytes sitting in the tier;
+    /// - the capture baseline used this `vnode_count`.
+    ///
+    /// No retractions are emitted: unlike eviction, demotion is invisible
+    /// downstream — the materialized rows stay, and a future update for a
+    /// cold group goes through promotion first.
+    #[allow(dead_code)] // called once the demotion trigger lands with promotion
+    pub(crate) fn demote_vnode(&mut self, vnode: u32, vnode_count: u32) -> bool {
+        if !self.emit_changelog
+            || self.dirty_all
+            || self.dirty_vnodes.contains(&vnode)
+            || self.tier_vnode_count != Some(vnode_count)
+        {
+            return false;
+        }
+        let global = self.num_group_cols == 0;
+        let keys: Vec<arrow::row::OwnedRow> = self
+            .groups
+            .keys()
+            .filter(|k| {
+                let v = if global {
+                    0
+                } else {
+                    #[allow(clippy::cast_possible_truncation)]
+                    {
+                        (laminar_core::state::key_hash(k.as_ref()) % u64::from(vnode_count)) as u32
+                    }
+                };
+                v == vnode
+            })
+            .cloned()
+            .collect();
+        for k in &keys {
+            self.groups.remove(k);
+            self.last_emitted.remove(k);
+        }
+        self.cold_vnodes.insert(vnode);
+        self.state_gen = self.state_gen.wrapping_add(1);
+        self.size_cache.invalidate();
+        true
+    }
+
+    /// The vnode's state is back in memory (promotion applied) or never
+    /// left (tier write failed after the drop was rolled back): captures
+    /// stage bytes again, and the slice counts as changed until the next
+    /// capture re-baselines it.
+    pub(crate) fn mark_vnode_hot(&mut self, vnode: u32) {
+        if self.cold_vnodes.remove(&vnode) {
+            self.dirty_vnodes.insert(vnode);
+        }
     }
 }
 
@@ -2441,6 +2582,154 @@ mod tests {
             result[0].num_rows() <= 3,
             "should have at most 3 groups, got {}",
             result[0].num_rows()
+        );
+    }
+
+    #[cfg(feature = "state-tier")]
+    #[tokio::test]
+    async fn test_demote_vnode_lifecycle() {
+        const VNODES: u32 = 4;
+        // Changelog mode: demotion is only legal when downstream holds the
+        // materialized rows.
+        let ctx = laminar_sql::create_session_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let dummy = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["x"])),
+                Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+        let mem_table =
+            datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+                .unwrap();
+        ctx.register_table("events", Arc::new(mem_table)).unwrap();
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT name, SUM(value) as total FROM events GROUP BY name",
+            true,
+        )
+        .await
+        .unwrap()
+        .expect("expected aggregate state");
+
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c", "d"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0, 4.0])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+
+        // No capture yet: nothing is provably durable, demotion refuses.
+        assert!(!state.demote_vnode(0, VNODES));
+
+        let buckets = state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        let (&v, slice) = buckets.iter().next().unwrap();
+        let demoted_groups = slice.groups.len();
+        assert!(demoted_groups > 0);
+        let groups_before = state.groups.len();
+
+        // Untouched since capture → demote drops exactly that vnode's groups.
+        assert!(state.demote_vnode(v, VNODES));
+        assert!(state.cold_vnodes().contains(&v));
+        assert_eq!(state.groups.len(), groups_before - demoted_groups);
+
+        // The demoted vnode is absent from the next capture's buckets
+        // (its cold marker is staged by the operator wrapper instead).
+        let buckets2 = state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        assert!(!buckets2.contains_key(&v));
+
+        // A vnode-count mismatch (rebalance changed the layout) refuses.
+        let other = buckets2.keys().next().copied();
+        if let Some(other) = other {
+            assert!(!state.demote_vnode(other, VNODES + 1));
+        }
+
+        // Promotion path: hot again, and dirty until the next capture.
+        state.mark_vnode_hot(v);
+        assert!(!state.cold_vnodes().contains(&v));
+        assert!(!state.demote_vnode(v, VNODES), "hot-but-dirty must refuse");
+        let _ = state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        // Clean again after re-baselining (no groups in memory for v, but
+        // the refusal must now come from emptiness, not dirtiness — demote
+        // of an empty vnode is a no-op that still marks it cold).
+        assert!(state.demote_vnode(v, VNODES));
+    }
+
+    #[cfg(feature = "state-tier")]
+    #[tokio::test]
+    async fn test_demote_refused_when_dirty_or_full_emit() {
+        const VNODES: u32 = 4;
+        // Full-emit agg (emit_changelog = false): demotion always refuses —
+        // it rebuilds its whole result from memory, dropping groups would
+        // shrink the output.
+        let (_, mut full) =
+            setup_agg_state("SELECT name, SUM(value) as total FROM events GROUP BY name").await;
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+        full.process_batch(&batch, i64::MIN).unwrap();
+        let buckets = full.checkpoint_groups_by_vnode(VNODES).unwrap();
+        let (&v, _) = buckets.iter().next().unwrap();
+        assert!(
+            !full.demote_vnode(v, VNODES),
+            "full-emit agg must never demote"
+        );
+
+        // Changelog agg with rows since the capture: the touched vnode is
+        // dirty and refuses; an untouched one (if any) still demotes.
+        let ctx = laminar_sql::create_session_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let dummy = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["x"])),
+                Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+        let mem_table =
+            datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+                .unwrap();
+        ctx.register_table("events", Arc::new(mem_table)).unwrap();
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT name, SUM(value) as total FROM events GROUP BY name",
+            true,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+        let buckets = state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        let (&v, _) = buckets.iter().next().unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+        assert!(
+            !state.demote_vnode(v, VNODES),
+            "vnode touched since capture must refuse demotion"
         );
     }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -1600,8 +1600,8 @@ impl IncrementalAggState {
         &self.cold_vnodes
     }
 
-    /// Drop one vnode's groups after their captured bytes were confirmed
-    /// in the cold tier. Refuses (`false`) unless it is provably safe:
+    /// Whether [`Self::demote_vnode`] would succeed for `vnode` now, without
+    /// dropping anything. Refuses (`false`) unless it is provably safe:
     ///
     /// - the agg emits a changelog — a full-emit agg rebuilds its entire
     ///   result from memory each cycle, so dropping groups would shrink
@@ -1611,13 +1611,8 @@ impl IncrementalAggState {
     ///   past the bytes sitting in the tier;
     /// - the capture baseline used this `vnode_count`.
     ///
-    /// No retractions are emitted: unlike eviction, demotion is invisible
-    /// downstream — the materialized rows stay, and a future update for a
-    /// cold group goes through promotion first.
-    /// The eligibility guard for [`Self::demote_vnode`], without dropping
-    /// anything: a changelog agg, clean since the last per-vnode capture, whose
-    /// capture baseline used this `vnode_count`. The demotion pass checks this
-    /// before writing the slice to the tier so a dirty vnode costs no I/O.
+    /// Checked before writing the slice to the tier, so a dirty candidate
+    /// costs no I/O.
     pub(crate) fn can_demote(&self, vnode: u32, vnode_count: u32) -> bool {
         self.emit_changelog
             && !self.dirty_all
@@ -1625,7 +1620,10 @@ impl IncrementalAggState {
             && self.tier_vnode_count == Some(vnode_count)
     }
 
-    #[allow(dead_code)] // called once the demotion trigger lands with promotion
+    /// Drop one vnode's groups after their captured bytes were confirmed in
+    /// the cold tier. No retractions are emitted: unlike eviction, demotion is
+    /// invisible downstream — the materialized rows stay, and a future update
+    /// for a cold group goes through promotion first.
     pub(crate) fn demote_vnode(&mut self, vnode: u32, vnode_count: u32) -> bool {
         if !self.can_demote(vnode, vnode_count) {
             return false;
@@ -1667,11 +1665,9 @@ impl IncrementalAggState {
         }
     }
 
-    /// Mark one vnode dirty (touched since the last capture) so it cannot be
-    /// demoted until the next capture re-baselines it. Called after merging a
-    /// vnode's state in (promotion or rebalance acquisition): `mark_vnode_hot`
-    /// only marks vnodes that were cold, so a rebalance-acquired vnode — never
-    /// cold here — needs this to be protected from demotion against stale bytes.
+    /// Mark one vnode dirty so it can't be demoted until the next capture.
+    /// `apply_vnode_state` calls this after merging a vnode in; `mark_vnode_hot`
+    /// only dirties vnodes that were *cold*, so a rebalance-acquired one needs it.
     pub(crate) fn mark_vnode_dirty(&mut self, vnode: u32) {
         self.dirty_vnodes.insert(vnode);
     }

--- a/crates/laminar-db/src/aggregate_state/checkpoints.rs
+++ b/crates/laminar-db/src/aggregate_state/checkpoints.rs
@@ -1,16 +1,7 @@
-//! Serializable checkpoint shapes.
+//! Serializable checkpoint shapes for aggregate, join, and window state.
 //!
-//! **Wire format note:** scalar aggregate fields (`GroupCheckpoint.key`,
-//! `GroupCheckpoint.acc_states`, `EmittedCheckpoint.key`,
-//! `EmittedCheckpoint.values`) are Arrow IPC streams produced by
-//! [`scalars_to_ipc`](super::scalars_to_ipc) — one-row batches encoding
-//! a tuple of `ScalarValue`s. Historically these were
-//! `Vec<serde_json::Value>` / `Vec<Vec<serde_json::Value>>`; see
-//! [`scalar_ipc`](super::scalar_ipc) for the rationale.
-//!
-//! `JoinStateCheckpoint.left_batches` / `right_batches` are a different
-//! shape: they hold Arrow IPC streams of full multi-row `RecordBatch`es
-//! and are *not* produced by `scalars_to_ipc`.
+//! Scalar fields (`key`, `acc_states`, `values`) hold Arrow IPC one-row batches
+//! from `scalars_to_ipc`. Join buffer fields hold full multi-row IPC batches.
 
 use std::hash::{Hash, Hasher};
 
@@ -20,10 +11,7 @@ use arrow::datatypes::Schema;
     Clone, serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 pub(crate) struct GroupCheckpoint {
-    /// IPC bytes encoding the group key tuple (`Vec<ScalarValue>`).
     pub key: Vec<u8>,
-    /// One IPC blob per aggregate, each encoding that aggregate's
-    /// `Accumulator::state()` tuple.
     pub acc_states: Vec<Vec<u8>>,
     #[serde(default = "default_last_updated")]
     pub last_updated_ms: i64,
@@ -47,9 +35,7 @@ pub(crate) struct AggStateCheckpoint {
     Clone, serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 pub(crate) struct EmittedCheckpoint {
-    /// IPC bytes for the key tuple.
     pub key: Vec<u8>,
-    /// IPC bytes for the emitted value tuple.
     pub values: Vec<u8>,
 }
 
@@ -67,9 +53,7 @@ pub(crate) struct WindowCheckpoint {
 pub(crate) struct EowcStateCheckpoint {
     pub fingerprint: u64,
     pub windows: Vec<WindowCheckpoint>,
-    /// Highest watermark at checkpoint time. Bumps the rkyv schema —
-    /// pre-feature checkpoints fail to deserialize and the recovery
-    /// path falls back to a fresh start.
+    // Bumps the rkyv schema; old checkpoints fail to deserialize and recovery restarts fresh.
     pub high_watermark_ms: i64,
 }
 
@@ -95,8 +79,7 @@ fn default_evicted_watermark() -> i64 {
     i64::MIN
 }
 
-/// Stable hash of the pre-aggregate SQL + output schema shape. Used to
-/// invalidate restored state when the query has changed.
+/// Stable hash of the pre-agg SQL and output schema; invalidates restored state on query change.
 pub(crate) fn query_fingerprint(pre_agg_sql: &str, output_schema: &Schema) -> u64 {
     let mut hasher = std::hash::DefaultHasher::new();
     pre_agg_sql.hash(&mut hasher);

--- a/crates/laminar-db/src/aggregate_state/compile.rs
+++ b/crates/laminar-db/src/aggregate_state/compile.rs
@@ -15,13 +15,9 @@ pub(crate) struct AggregateInfo {
     pub(crate) group_exprs: Vec<datafusion_expr::Expr>,
     pub(crate) aggr_exprs: Vec<datafusion_expr::Expr>,
     pub(crate) schema: Arc<Schema>,
-    /// Input schema (pre-widening) for resolving aggregate argument types.
     pub(crate) input_schema: Arc<Schema>,
-    /// HAVING predicate (from a Filter node directly above the Aggregate).
     pub(crate) having_predicate: Option<datafusion_expr::Expr>,
-    /// `DFSchema` of the Aggregate's input (for compiling pre-agg expressions).
     pub(crate) input_df_schema: Arc<DFSchema>,
-    /// WHERE predicate from a Filter node below the Aggregate, if any.
     pub(crate) where_predicate: Option<datafusion_expr::Expr>,
 }
 
@@ -49,7 +45,7 @@ fn find_aggregate_inner(
                 where_predicate,
             })
         }
-        // A Filter directly above an Aggregate is a HAVING clause
+        // Filter directly above an Aggregate is a HAVING clause.
         LogicalPlan::Filter(filter) => {
             if matches!(&*filter.input, LogicalPlan::Aggregate(_)) {
                 find_aggregate_inner(&filter.input, Some(&filter.predicate))
@@ -57,7 +53,6 @@ fn find_aggregate_inner(
                 find_aggregate_inner(&filter.input, None)
             }
         }
-        // Walk through wrappers that don't change aggregation semantics
         LogicalPlan::Projection(proj) => find_aggregate_inner(&proj.input, None),
         LogicalPlan::Sort(sort) => find_aggregate_inner(&sort.input, None),
         LogicalPlan::Limit(limit) => find_aggregate_inner(&limit.input, None),
@@ -262,11 +257,8 @@ pub(crate) fn expr_to_sql(expr: &datafusion_expr::Expr) -> String {
     }
 }
 
-/// Pre-compiled projection for evaluating pre-agg expressions without SQL.
-///
-/// Replaces the `ctx.sql(pre_agg_sql).await.collect().await` hot-path call
-/// with direct `PhysicalExpr::evaluate()` on the source batch, eliminating
-/// SQL parsing, logical planning, physical planning, and `MemTable` overhead.
+/// Pre-compiled projection: evaluates pre-agg expressions via `PhysicalExpr::evaluate`
+/// instead of re-planning SQL each cycle.
 pub(crate) struct CompiledProjection {
     pub(crate) exprs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) filter: Option<Arc<dyn PhysicalExpr>>,
@@ -274,16 +266,12 @@ pub(crate) struct CompiledProjection {
 }
 
 impl CompiledProjection {
-    /// Evaluate the projection against a source batch.
-    ///
-    /// Applies the WHERE filter (if any), then evaluates each expression
-    /// to produce the projected output batch.
+    /// Apply the WHERE filter then evaluate each projection expression.
     pub(crate) fn evaluate(&self, batch: &RecordBatch) -> Result<RecordBatch, DbError> {
         if batch.num_rows() == 0 {
             return Ok(RecordBatch::new_empty(Arc::clone(&self.output_schema)));
         }
 
-        // Apply WHERE filter first
         let filtered = if let Some(ref filter) = self.filter {
             let result = filter
                 .evaluate(batch)
@@ -305,7 +293,6 @@ impl CompiledProjection {
             return Ok(RecordBatch::new_empty(Arc::clone(&self.output_schema)));
         }
 
-        // Evaluate each projection expression
         let mut arrays = Vec::with_capacity(self.exprs.len());
         for expr in &self.exprs {
             let result = expr
@@ -371,7 +358,7 @@ pub(crate) fn extract_clauses(sql: &str) -> SqlClauses {
     if let Ok(clauses) = extract_clauses_ast(sql) {
         return clauses;
     }
-    // Fallback: heuristic extraction for non-standard SQL
+    // Fallback for non-standard SQL.
     SqlClauses {
         from_clause: extract_from_clause_heuristic(sql),
         where_clause: extract_where_clause_heuristic(sql),
@@ -463,13 +450,10 @@ pub(crate) fn resolve_expr_type(
         datafusion_expr::Expr::Cast(cast) => cast.data_type.clone(),
         datafusion_expr::Expr::TryCast(cast) => cast.data_type.clone(),
         datafusion_expr::Expr::BinaryExpr(bin) => {
-            // For arithmetic, the result type is typically the wider
-            // of the two operands. Resolve the left side as a
-            // reasonable approximation.
+            // Approximate: resolve the left operand's type.
             resolve_expr_type(&bin.left, input_schema, fallback_type)
         }
         datafusion_expr::Expr::ScalarFunction(func) => {
-            // Try to get return type from input types
             let arg_types: Vec<DataType> = func
                 .args
                 .iter()

--- a/crates/laminar-db/src/aggregate_state/keys.rs
+++ b/crates/laminar-db/src/aggregate_state/keys.rs
@@ -30,7 +30,7 @@ pub(crate) fn row_to_scalar_key_with_types(
     Ok(sv_key)
 }
 
-/// Singleton row used as the group key when `GROUP BY` is absent.
+/// Stable singleton row key for global aggregates (no GROUP BY).
 pub(crate) fn global_aggregate_key() -> arrow::row::OwnedRow {
     static SENTINEL: OnceLock<arrow::row::OwnedRow> = OnceLock::new();
     SENTINEL

--- a/crates/laminar-db/src/aggregate_state/scalar_ipc.rs
+++ b/crates/laminar-db/src/aggregate_state/scalar_ipc.rs
@@ -1,17 +1,7 @@
 //! Arrow IPC round-trip for `Vec<ScalarValue>`.
 //!
-//! Each tuple is packed as a one-row `RecordBatch` (one column per
-//! scalar, column types inferred from the scalar's `data_type()`), then
-//! encoded via the IPC stream format. This is strictly faster and more
-//! compact than the previous `serde_json` encoding and avoids the
-//! open-coded type-tag match — Arrow already knows how to round-trip
-//! every `ScalarValue` variant.
-//!
-//! Checkpoint format note: field types on the checkpoint structs
-//! (`GroupCheckpoint::key`, `GroupCheckpoint::acc_states`, …) are
-//! `Vec<u8>` / `Vec<Vec<u8>>` and contain these IPC payloads.
-//! Old-format (`serde_json`) checkpoints do not restore under this
-//! version — per project policy, no external users, clean cut.
+//! Each tuple is a one-row `RecordBatch` encoded via the IPC stream format.
+//! Old `serde_json` checkpoints are incompatible; no migration.
 
 use std::sync::Arc;
 
@@ -22,8 +12,7 @@ use datafusion_common::ScalarValue;
 
 use crate::error::DbError;
 
-/// Encode a tuple of scalars as a one-row Arrow IPC stream. Returns an
-/// empty `Vec` iff `scalars` is empty (no schema to emit).
+/// Encode a scalar tuple as a one-row Arrow IPC stream; empty input → empty `Vec`.
 pub(crate) fn scalars_to_ipc(scalars: &[ScalarValue]) -> Result<Vec<u8>, DbError> {
     if scalars.is_empty() {
         return Ok(Vec::new());
@@ -47,8 +36,7 @@ pub(crate) fn scalars_to_ipc(scalars: &[ScalarValue]) -> Result<Vec<u8>, DbError
         .map_err(|e| DbError::Pipeline(format!("scalar IPC encode: {e}")))
 }
 
-/// Decode a tuple previously produced by [`scalars_to_ipc`]. Empty
-/// input round-trips to an empty `Vec`.
+/// Decode bytes previously produced by [`scalars_to_ipc`]; empty input → empty `Vec`.
 pub(crate) fn ipc_to_scalars(bytes: &[u8]) -> Result<Vec<ScalarValue>, DbError> {
     if bytes.is_empty() {
         return Ok(Vec::new());

--- a/crates/laminar-db/src/ai/adapter.rs
+++ b/crates/laminar-db/src/ai/adapter.rs
@@ -1,9 +1,5 @@
-//! Resolve a raw provider response into a task's per-row output, given the
-//! `(task, backend)` pair. Local classification takes argmax over logits (equal
-//! to argmax of softmax — classify returns only the label, so no softmax).
-//! Sentiment is numeric: local softmaxes the logits to `P(pos) − P(neg)`, remote
-//! parses a number from the reply — a continuous score in `[-1, 1]`. Stays
-//! Arrow-free: returns [`InferenceOutputs`]; the operator builds the column.
+//! Adapt a raw provider response to a task's per-row output. Stays Arrow-free;
+//! the operator builds the column from the returned [`InferenceOutputs`].
 
 use thiserror::Error;
 
@@ -23,7 +19,7 @@ pub enum AdapterError {
     LabelIndexOutOfRange {
         /// The chosen index.
         index: usize,
-        /// The number of labels available.
+        /// Number of available labels.
         len: usize,
     },
 
@@ -31,20 +27,19 @@ pub enum AdapterError {
     #[error("classifier returned no logits for a row")]
     EmptyLogits,
 
-    /// Sentiment scoring needs both a `positive` and a `negative` label among
-    /// the model's labels to map logits to a signed score.
+    /// Sentiment scoring needs both a `positive` and a `negative` label.
     #[error(
         "sentiment scoring requires 'positive' and 'negative' among the labels, got {labels:?}"
     )]
     SentimentLabelsUnusable {
-        /// The labels that were available.
+        /// Labels that were available.
         labels: Vec<String>,
     },
 
     /// A remote sentiment reply contained no parseable number.
     #[error("remote sentiment reply had no parseable score: {reply:?}")]
     UnparseableScore {
-        /// The reply that could not be parsed.
+        /// The unparseable reply string.
         reply: String,
     },
 
@@ -55,9 +50,9 @@ pub enum AdapterError {
         task: Task,
         /// The backend kind.
         kind: BackendKind,
-        /// The shape that was expected (`text` or `vectors`).
+        /// Expected shape name.
         expected: &'static str,
-        /// The shape actually produced.
+        /// Actual shape name.
         got: &'static str,
     },
 
@@ -71,16 +66,16 @@ pub enum AdapterError {
     },
 }
 
-/// Resolve a raw provider response into the task's per-row output column.
+/// Map a raw provider response to the task's per-row output.
 ///
-/// `labels` carries the candidate/intrinsic label set for classification — the
-/// model's `id2label` for a local classifier (required), ignored otherwise.
+/// `labels` is the candidate/intrinsic label set for classification; required
+/// for local classifiers, ignored otherwise.
 ///
 /// # Errors
 ///
-/// Returns [`AdapterError`] if the output shape is wrong for the task, a local
-/// classifier has no labels or argmaxes out of range, or the task cannot run on
-/// the given backend kind.
+/// Returns [`AdapterError`] if the output shape is wrong, a local classifier
+/// has no labels or an out-of-range argmax, or the task/backend combination is
+/// unsupported.
 pub fn parse_response(
     task: Task,
     kind: BackendKind,
@@ -99,8 +94,6 @@ pub fn parse_response(
         Task::Embed => expect_vectors(task, kind, raw),
         Task::Complete | Task::Summarize | Task::Translate | Task::Gen | Task::Extract => {
             if kind != BackendKind::Remote {
-                // Narrow ONNX token-classification extraction is out of v0.1
-                // scope; generation is remote by definition.
                 return Err(AdapterError::UnsupportedCombination { task, kind });
             }
             expect_text(task, kind, raw)
@@ -108,7 +101,7 @@ pub fn parse_response(
     }
 }
 
-/// argmax over each row's logits, mapped to the model's labels.
+/// argmax over each row's logits, mapped to labels.
 fn classify_from_logits(
     kind: BackendKind,
     raw: InferenceOutputs,
@@ -140,12 +133,8 @@ fn classify_from_logits(
     Ok(InferenceOutputs::Text(out))
 }
 
-/// Coerce a remote model's free text toward the candidate label set.
-///
-/// LLMs sometimes wrap the answer ("The sentiment is Positive."). When labels
-/// are known, normalize each reply to a canonical label by exact (case-
-/// insensitive) match, then by containment; otherwise fall back to the trimmed
-/// raw text rather than dropping the row.
+/// Normalize each reply to a canonical label (exact then containment match),
+/// or fall back to trimmed raw text if none matches.
 fn coerce_remote_classification(
     raw: InferenceOutputs,
     labels: Option<&[String]>,
@@ -171,7 +160,7 @@ fn coerce_remote_classification(
     Ok(InferenceOutputs::Text(coerced))
 }
 
-/// Map free text to a canonical label, or the trimmed text if none matches.
+/// Exact (case-insensitive) then containment match; falls back to trimmed text.
 fn coerce_label(text: &str, labels: &[String]) -> String {
     let trimmed = text.trim();
     if let Some(label) = labels.iter().find(|l| l.eq_ignore_ascii_case(trimmed)) {
@@ -187,7 +176,7 @@ fn coerce_label(text: &str, labels: &[String]) -> String {
     trimmed.to_string()
 }
 
-/// Pass text outputs through, rejecting a vector shape.
+/// Pass text outputs through unchanged, rejecting other shapes.
 fn expect_text(
     task: Task,
     kind: BackendKind,
@@ -204,7 +193,7 @@ fn expect_text(
     }
 }
 
-/// Pass vector outputs through, rejecting a text shape.
+/// Pass vector outputs through unchanged, rejecting other shapes.
 fn expect_vectors(
     task: Task,
     kind: BackendKind,
@@ -221,7 +210,7 @@ fn expect_vectors(
     }
 }
 
-/// Static name of an output shape, for error messages.
+/// Static shape name for error messages.
 fn shape_name(raw: &InferenceOutputs) -> &'static str {
     match raw {
         InferenceOutputs::Text(_) => "text",
@@ -230,9 +219,7 @@ fn shape_name(raw: &InferenceOutputs) -> &'static str {
     }
 }
 
-/// Local sentiment: softmax each row's logits, then `P(positive) − P(negative)`,
-/// a signed score in `[-1, 1]`. The model's labels locate the positive and
-/// negative classes; a neutral class (if present) pulls the score toward 0.
+/// Softmax each row's logits, return `P(positive) − P(negative)` in `[-1, 1]`.
 fn sentiment_from_logits(
     raw: InferenceOutputs,
     labels: Option<&[String]>,
@@ -273,7 +260,7 @@ fn sentiment_from_logits(
     Ok(InferenceOutputs::Scores(scores))
 }
 
-/// Remote sentiment: parse a number from each reply and clamp to `[-1, 1]`.
+/// Parse a number from each reply and clamp to `[-1, 1]`.
 fn sentiment_from_text(raw: InferenceOutputs) -> Result<InferenceOutputs, AdapterError> {
     let texts = match raw {
         InferenceOutputs::Text(texts) => texts,
@@ -294,7 +281,7 @@ fn sentiment_from_text(raw: InferenceOutputs) -> Result<InferenceOutputs, Adapte
     Ok(InferenceOutputs::Scores(scores))
 }
 
-/// Numerically stable softmax over a row of logits.
+/// Numerically stable softmax.
 fn softmax(logits: &[f32]) -> Vec<f32> {
     let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
     let mut exps: Vec<f32> = logits.iter().map(|&v| (v - max).exp()).collect();
@@ -307,16 +294,15 @@ fn softmax(logits: &[f32]) -> Vec<f32> {
     exps
 }
 
-/// Parse the first number out of a reply (`"0.8"`, `"The sentiment is -0.5."`),
-/// or `None` if there is none.
+/// Extract the first number from a reply string, or `None`.
 fn parse_score(reply: &str) -> Option<f64> {
     let trimmed = reply.trim();
     if let Ok(v) = trimmed.parse::<f64>() {
         return Some(v);
     }
     trimmed.split_whitespace().find_map(|token| {
-        // Strip surrounding punctuation: a leading sign/digit may start it, but
-        // only a digit may end it (so a sentence-final '.' isn't kept).
+        // Strip punctuation: leading sign/digit may start; only a digit may end
+        // (so a sentence-final '.' isn't kept).
         token
             .trim_start_matches(|c: char| !(c.is_ascii_digit() || c == '-'))
             .trim_end_matches(|c: char| !c.is_ascii_digit())
@@ -325,7 +311,7 @@ fn parse_score(reply: &str) -> Option<f64> {
     })
 }
 
-/// Index of the maximum value, or `None` for an empty slice.
+/// Index of the maximum value, or `None` if empty.
 fn argmax(values: &[f32]) -> Option<usize> {
     let mut best: Option<(usize, f32)> = None;
     for (index, &value) in values.iter().enumerate() {

--- a/crates/laminar-db/src/ai/backends/anthropic.rs
+++ b/crates/laminar-db/src/ai/backends/anthropic.rs
@@ -1,8 +1,5 @@
-//! Anthropic Messages API provider.
-//!
-//! Drives the discriminative and generative tasks (one bounded-concurrent call
-//! per input row). Anthropic exposes no embeddings endpoint, so `ai_embed` is
-//! rejected — use the OpenAI-compatible provider for embeddings.
+//! Anthropic Messages API provider. One bounded-concurrent call per input row.
+//! `ai_embed` is unsupported — use the OpenAI-compatible provider for embeddings.
 
 use std::time::Duration;
 
@@ -19,7 +16,7 @@ use crate::ai::registry::Task;
 const REQUEST_TIMEOUT_MS: u64 = 60_000;
 const MAX_RETRIES: u32 = 2;
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-/// Messages API requires `max_tokens`; this caps a single reply.
+/// Messages API requires `max_tokens`.
 const DEFAULT_MAX_TOKENS: u32 = 1024;
 
 /// Anthropic Messages provider.
@@ -31,9 +28,7 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
-    /// Build a provider for `base_url` (e.g. `https://api.anthropic.com`),
-    /// authenticating with `api_key` and issuing at most `max_concurrency`
-    /// concurrent requests per batch.
+    /// Build an Anthropic provider.
     ///
     /// # Errors
     ///
@@ -164,7 +159,7 @@ struct AnthropicUsage {
     output_tokens: u64,
 }
 
-/// Take the first text content block and token usage from a messages response.
+/// Extract the first text block and usage from a messages response.
 fn parse_message(response: MessageResponse) -> Result<(String, Usage), ProviderError> {
     let text = response
         .content

--- a/crates/laminar-db/src/ai/backends/local.rs
+++ b/crates/laminar-db/src/ai/backends/local.rs
@@ -1,12 +1,7 @@
-//! Local inference via ONNX Runtime (`ort`, loaded dynamically): encoder models
-//! only (BERT/DistilBERT/MiniLM) — classify/sentiment return logits, embed
-//! returns a mean-pooled vector; generative tasks are rejected. A model is loaded
-//! once per source and cached; the forward pass runs on `spawn_blocking` under
-//! a deadline so a wedged model can't stall the worker. ORT loads at
-//! runtime — `onnxruntime.{dll,so}` (>= 1.24) must be on the search path or named
-//! by `ORT_DYLIB_PATH`. A `source` is `hf:org/repo` (downloaded on first use),
-//! `file://<path>`, or a bare path; labels come from the model's `config.json`
-//! `id2label`.
+//! Local inference via ONNX Runtime (loaded dynamically). Encoder models only:
+//! classify/sentiment return logits, embed returns a mean-pooled vector. Sources:
+//! `hf:org/repo` (downloaded on first use), `file://<path>`, or a bare path.
+//! `onnxruntime.{dll,so}` >= 1.24 must be on the search path or via `ORT_DYLIB_PATH`.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -24,35 +19,30 @@ use crate::ai::provider::{
 };
 use crate::ai::registry::Task;
 
-/// Per-batch deadline for the synchronous ONNX Runtime forward pass. Bounds the
-/// inference worker (and the held watermark) against a wedged model. On timeout
-/// the blocking thread is abandoned — it cannot be cancelled — and the batch
-/// fails, releasing the hold.
+/// Deadline for the synchronous ORT forward pass. On timeout the blocking thread
+/// is abandoned (it cannot be cancelled) and the batch fails.
 const INFERENCE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// A loaded model: an ONNX Runtime session, its tokenizer, and the model's input
-/// names (`input_ids`, `attention_mask`, and optionally `token_type_ids`) that
-/// drive how each row is fed. `Session::run` takes `&mut`, so it sits behind a
-/// mutex — a model serves one batch at a time.
+/// A loaded ORT session with its tokenizer and input names. `Session::run` takes
+/// `&mut`, so the session is behind a mutex.
 struct LoadedModel {
     session: Mutex<Session>,
     tokenizer: tokenizers::Tokenizer,
     input_names: Vec<String>,
-    /// `config.json` `id2label`, read once at load; empty if absent.
+    /// `id2label` from config.json; empty if absent.
     labels: Vec<String>,
 }
 
-/// Local ONNX provider, backed by a model cache directory.
+/// Local ONNX provider backed by a model cache directory.
 pub struct LocalProvider {
     cache_dir: PathBuf,
     loaded: Mutex<HashMap<String, Arc<LoadedModel>>>,
-    /// Serializes the download-and-compile path so concurrent misses for the
-    /// same model don't fetch and build it more than once.
+    /// Serializes download+compile so concurrent misses don't fetch the same model twice.
     load_lock: tokio::sync::Mutex<()>,
 }
 
 impl LocalProvider {
-    /// Create a provider that resolves models under `cache_dir`.
+    /// Create a provider that caches models under `cache_dir`.
     #[must_use]
     pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -62,14 +52,12 @@ impl LocalProvider {
         }
     }
 
-    /// Resolve a model to a loaded, cached plan: serve from cache, else download
-    /// (for an absent `hf:` repo) and compile on the blocking pool.
+    /// Serve from cache; otherwise download (for `hf:`) and compile on the blocking pool.
     async fn ensure_model(&self, source: &str) -> Result<Arc<LoadedModel>, ProviderError> {
         if let Some(model) = self.loaded.lock().get(source) {
             return Ok(Arc::clone(model));
         }
-        // Hold the load lock across download+compile and re-check the cache: a
-        // concurrent miss may have finished loading this model while we waited.
+        // Re-check after acquiring the lock: a concurrent miss may have just finished.
         let _load = self.load_lock.lock().await;
         if let Some(model) = self.loaded.lock().get(source) {
             return Ok(Arc::clone(model));
@@ -97,7 +85,7 @@ impl LocalProvider {
 
             let config_path = repo.get("config.json").await.ok();
 
-            // Compiling the ONNX graph is heavy, blocking work — keep it off Ring 1.
+            // Graph compilation is CPU-heavy — keep it off Ring 1.
             tokio::task::spawn_blocking(move || {
                 load_model_from_paths(&onnx_path, &tokenizer_path, config_path.as_deref())
             })
@@ -105,7 +93,7 @@ impl LocalProvider {
             .map_err(|e| ProviderError::Transport(format!("model load task: {e}")))??
         } else {
             let dir = model_dir(&self.cache_dir, source);
-            // Compiling the ONNX graph is heavy, blocking work — keep it off Ring 1.
+            // Graph compilation is CPU-heavy — keep it off Ring 1.
             tokio::task::spawn_blocking(move || load_model(&dir))
                 .await
                 .map_err(|e| ProviderError::Transport(format!("model load task: {e}")))??
@@ -119,8 +107,8 @@ impl LocalProvider {
     }
 }
 
-/// On-disk directory for a model `source`: `hf:org/repo` → `<cache_dir>/org/repo`,
-/// `file://<path>` or a bare path used as-is.
+/// On-disk directory for a source: `hf:org/repo` → `<cache_dir>/org/repo`;
+/// `file://<path>` or bare path used as-is.
 #[must_use]
 pub fn model_dir(cache_dir: &Path, source: &str) -> PathBuf {
     if let Some(repo) = source.strip_prefix("hf:") {
@@ -132,17 +120,14 @@ pub fn model_dir(cache_dir: &Path, source: &str) -> PathBuf {
     }
 }
 
-/// Classifier labels from a model's `config.json` `id2label`, ordered by index.
-/// Empty if the file is absent or has no `id2label` — the registry uses this to
-/// auto-derive a local classifier's labels.
+/// Classifier labels from `config.json` `id2label`, ordered by index. Empty if
+/// absent or unparseable.
 #[must_use]
 pub fn load_labels(cache_dir: &Path, source: &str) -> Vec<String> {
-    // A config.json placed directly under the model dir (hand-placed exports,
-    // `file://`/path sources, and the legacy hf cache layout) wins.
     if let Ok(text) = std::fs::read_to_string(model_dir(cache_dir, source).join("config.json")) {
         return parse_id2label(&text);
     }
-    // Otherwise resolve an hf-hub-downloaded model from its cache snapshot.
+    // Fall back to the hf-hub cache snapshot.
     if let Some(repo_id) = source.strip_prefix("hf:") {
         let cache = hf_hub::Cache::new(cache_dir.to_path_buf());
         let repo = cache.repo(hf_hub::Repo::model(repo_id.to_string()));
@@ -185,8 +170,7 @@ impl InferenceProvider for LocalProvider {
         let loaded = self.ensure_model(&request.model).await?;
         let task = request.task;
         let inputs = request.inputs;
-        // The forward pass is synchronous CPU work — keep it off the Ring 1 task,
-        // under a deadline so a wedged model cannot stall the worker indefinitely.
+        // Synchronous CPU work — keep it off Ring 1, with a deadline.
         let run = tokio::task::spawn_blocking(move || run(&loaded, task, &inputs));
         let outputs = match tokio::time::timeout(INFERENCE_TIMEOUT, run).await {
             Ok(joined) => {
@@ -209,8 +193,7 @@ impl InferenceProvider for LocalProvider {
     }
 
     fn intrinsic_labels(&self, model: &str) -> Option<Vec<String>> {
-        // Served from the loaded model (read once at load); only an unloaded model
-        // — i.e. before its first inference — touches disk here.
+        // Falls back to disk only for a model not yet loaded.
         let labels = self
             .loaded
             .lock()
@@ -220,8 +203,8 @@ impl InferenceProvider for LocalProvider {
     }
 }
 
-/// The model graph: the `onnx/model.onnx` that Optimum / transformers.js exports
-/// produce, falling back to a flat `model.onnx` for a hand-placed directory.
+/// Prefer the nested `onnx/model.onnx` (Optimum/transformers.js layout), fall
+/// back to `model.onnx` at the directory root.
 fn onnx_path(dir: &Path) -> PathBuf {
     let nested = dir.join("onnx").join("model.onnx");
     if nested.exists() {
@@ -352,7 +335,7 @@ fn run(
 
     let mut vectors = Vec::with_capacity(batch_size);
     if task == Task::Embed && shape.len() == 3 {
-        // last_hidden_state [batch_size, seq_out, hidden] → mean-pool over real tokens.
+        // last_hidden_state [batch, seq, hidden] → mean-pool over real tokens.
         let seq_out = usize::try_from(shape[1]).unwrap_or(0);
         let hidden = usize::try_from(shape[2]).unwrap_or(0);
         for (i, encoding) in encodings.iter().enumerate() {
@@ -367,7 +350,7 @@ fn run(
             vectors.push(mean_pool(slice, seq_out, hidden, &mask));
         }
     } else {
-        // classify/sentiment logits, or a pre-pooled embedding.
+        // classify/sentiment logits or a pre-pooled embedding.
         let dim: usize = shape[1..]
             .iter()
             .map(|&d| usize::try_from(d).unwrap_or(0))
@@ -383,7 +366,7 @@ fn run(
     Ok(InferenceOutputs::Vectors(vectors))
 }
 
-/// Mean-pool a row-major `[seq, hidden]` block over non-masked tokens.
+/// Mean-pool a `[seq, hidden]` block over non-masked tokens.
 fn mean_pool(data: &[f32], seq: usize, hidden: usize, mask: &[i64]) -> Vec<f32> {
     let mut pooled = vec![0.0_f32; hidden];
     let mut count = 0.0_f32;

--- a/crates/laminar-db/src/ai/backends/mod.rs
+++ b/crates/laminar-db/src/ai/backends/mod.rs
@@ -1,13 +1,5 @@
-//! Concrete inference backends.
-//!
-//! Each backend is feature-gated so the default build carries zero HTTP or ML
-//! weight. Backends are transport only: they turn an [`InferenceRequest`] into
-//! provider calls and the responses back into [`InferenceOutputs`]. Task
-//! framing (the chat prompt) and any numeric post-processing live in the shared
-//! helpers and the adapter, not in the wire layer.
-//!
-//! [`InferenceRequest`]: crate::ai::provider::InferenceRequest
-//! [`InferenceOutputs`]: crate::ai::provider::InferenceOutputs
+//! Concrete inference backends, feature-gated so the default build has no HTTP
+//! or ML weight. Transport only: task framing lives in the adapter, not here.
 
 #[cfg(feature = "remote")]
 pub mod anthropic;

--- a/crates/laminar-db/src/ai/backends/openai.rs
+++ b/crates/laminar-db/src/ai/backends/openai.rs
@@ -1,10 +1,6 @@
-//! OpenAI-compatible remote provider.
-//!
-//! Covers OpenAI, Azure OpenAI, vLLM, and local OpenAI-style servers via
-//! `base_url`. Chat completions drive the discriminative and generative tasks
-//! (one bounded-concurrent call per input row); the embeddings endpoint serves
-//! `ai_embed` in a single batched call. This is the embeddings path for the
-//! whole feature — Anthropic exposes no embeddings endpoint.
+//! OpenAI-compatible remote provider (OpenAI, Azure, vLLM, local servers).
+//! Chat completions for discriminative/generative tasks; the embeddings endpoint
+//! for `ai_embed` (the only provider that supports it).
 
 use std::time::Duration;
 
@@ -30,9 +26,7 @@ pub struct OpenAiProvider {
 }
 
 impl OpenAiProvider {
-    /// Build a provider for `base_url` (e.g. `https://api.openai.com/v1`),
-    /// authenticating with `api_key` and issuing at most `max_concurrency`
-    /// concurrent chat requests per batch.
+    /// Build an OpenAI-compatible provider.
     ///
     /// # Errors
     ///
@@ -57,9 +51,7 @@ impl OpenAiProvider {
     async fn chat(&self, request: &InferenceRequest) -> Result<InferenceResponse, ProviderError> {
         let url = format!("{}/chat/completions", self.base_url);
 
-        // Build owned request bodies first, then map each to a future. Mapping
-        // over owned `ChatBody` (not `&input`) keeps the future-producing
-        // closure free of an input lifetime to generalize over.
+        // Build owned bodies first so the async closure captures by value, not by reference.
         let bodies: Vec<ChatBody> = request
             .inputs
             .iter()
@@ -206,9 +198,8 @@ struct TokenUsage {
     completion_tokens: u64,
 }
 
-/// Pull the first choice's text and token usage from a chat response. Cost is
-/// left at zero — converting tokens to dollars needs a per-model price table,
-/// which is configured separately.
+/// Extract the first choice's text and token usage. Cost is left at zero;
+/// token-to-dollar conversion needs a per-model price table.
 fn parse_chat(response: ChatResponse) -> Result<(String, Usage), ProviderError> {
     let content = response
         .choices
@@ -219,7 +210,7 @@ fn parse_chat(response: ChatResponse) -> Result<(String, Usage), ProviderError> 
     Ok((content, token_usage(response.usage)))
 }
 
-/// Collect embeddings in input order (sorted by `index`) plus usage.
+/// Sort embeddings by `index` (API may return out of order) and collect usage.
 fn parse_embed(mut response: EmbedResponse) -> (Vec<Vec<f32>>, Usage) {
     response.data.sort_by_key(|d| d.index);
     let usage = token_usage(response.usage);

--- a/crates/laminar-db/src/ai/backends/rate_limited.rs
+++ b/crates/laminar-db/src/ai/backends/rate_limited.rs
@@ -1,11 +1,5 @@
-//! Client-side rate limiting for remote providers.
-//!
-//! Wraps any [`InferenceProvider`] in a token bucket (`governor`, the standard
-//! Rust limiter) so request bursts are shaped to a steady requests-per-second
-//! rather than sent unbounded. One cell is acquired per input row before the
-//! batch is dispatched. The wait happens on the Ring 1 inference worker — the
-//! only place `infer_batch` is awaited — never on Ring 0; the limiter itself is
-//! lock-free (atomics), so nothing blocking is reachable from the compute thread.
+//! Client-side token-bucket rate limiting for remote providers. One cell is
+//! acquired per input row before dispatch; the wait happens on Ring 1 only.
 
 use std::num::NonZeroU32;
 use std::sync::Arc;
@@ -22,7 +16,7 @@ pub struct RateLimitedProvider {
 }
 
 impl RateLimitedProvider {
-    /// Wrap `inner`, limiting to `requests_per_second` (burst up to the same).
+    /// Wrap `inner`, limiting to `requests_per_second`.
     #[must_use]
     pub fn new(inner: Arc<dyn InferenceProvider>, requests_per_second: NonZeroU32) -> Self {
         Self {
@@ -38,7 +32,6 @@ impl InferenceProvider for RateLimitedProvider {
         &self,
         request: InferenceRequest,
     ) -> Result<InferenceResponse, ProviderError> {
-        // One permit per row: the batch waits until the bucket has paced it.
         for _ in 0..request.inputs.len().max(1) {
             self.limiter.until_ready().await;
         }

--- a/crates/laminar-db/src/ai/backends/remote.rs
+++ b/crates/laminar-db/src/ai/backends/remote.rs
@@ -1,6 +1,5 @@
-//! Shared helpers for remote (HTTP) providers: task chat prompts and the
-//! retry/backoff policy. Provider-specific request bodies, auth, and response
-//! parsing live in each provider module.
+//! Shared helpers for HTTP providers: chat prompts and retry/backoff.
+//! Provider-specific bodies and auth live in each provider module.
 
 use std::time::Duration;
 
@@ -9,8 +8,7 @@ use serde::de::DeserializeOwned;
 use crate::ai::provider::{ProviderError, Usage};
 use crate::ai::registry::Task;
 
-/// Sum two usage records, saturating. Used to fold per-row chat usage into a
-/// batch total.
+/// Sum two usage records, saturating.
 pub(crate) fn add_usage(a: Usage, b: Usage) -> Usage {
     Usage {
         input_tokens: a.input_tokens.saturating_add(b.input_tokens),
@@ -19,12 +17,8 @@ pub(crate) fn add_usage(a: Usage, b: Usage) -> Usage {
     }
 }
 
-/// Build the `(system, user)` chat messages for a task. `labels` is the
-/// candidate set for classification.
-///
-/// For classification the system prompt constrains the model to emit exactly
-/// one label; the adapter still coerces the reply to the label set as a
-/// backstop. `Embed` never reaches here (it uses the embeddings endpoint).
+/// Build the `(system, user)` chat messages for a task.
+/// `Embed` never reaches here — it uses the embeddings endpoint.
 pub(crate) fn chat_prompt(task: Task, input: &str, labels: Option<&[String]>) -> (String, String) {
     let system = match task {
         Task::Classify => {
@@ -49,8 +43,7 @@ pub(crate) fn chat_prompt(task: Task, input: &str, labels: Option<&[String]>) ->
     (system, input.to_string())
 }
 
-/// Whether an error is worth retrying — transient transport, timeout, or rate
-/// limiting. A malformed response or unsupported task is not.
+/// Whether an error warrants a retry (transport failures, timeout, rate-limited).
 pub(crate) fn retryable(error: &ProviderError) -> bool {
     matches!(
         error,
@@ -58,17 +51,13 @@ pub(crate) fn retryable(error: &ProviderError) -> bool {
     )
 }
 
-/// Exponential backoff for retry `attempt` (1-based), capped at ~3.2s.
+/// Exponential backoff for retry `attempt` (1-based), capped at ~3.2 s.
 pub(crate) fn backoff(attempt: u32) -> Duration {
     Duration::from_millis(100u64.saturating_mul(1u64 << attempt.min(5)))
 }
 
-/// POST a pre-built request (already authenticated, with a JSON body) and decode
-/// the response, retrying transient failures with backoff. `timeout_ms` is used
-/// only to label timeout errors — the client enforces the actual deadline.
-///
-/// Shared by every HTTP provider; each builds its own auth + body, so this stays
-/// vendor-neutral.
+/// POST a request and decode the response, retrying transient failures with
+/// backoff. `timeout_ms` labels timeout errors; the client enforces the deadline.
 pub(crate) async fn post_json<R: DeserializeOwned>(
     builder: reqwest::RequestBuilder,
     max_retries: u32,

--- a/crates/laminar-db/src/ai/cache.rs
+++ b/crates/laminar-db/src/ai/cache.rs
@@ -1,16 +1,7 @@
-//! Result cache for AI inference, keyed `(content_hash, model_id,
-//! params_version)`.
+//! Per-row inference result cache, keyed `(content_hash, model_id, params_version)`.
 //!
-//! The key versions on both the model and its parameters, so a local model and
-//! a remote model — or the same model under different parameters — never
-//! collide on the same input text. Local results are deterministic and cacheable
-//! permanently for correctness; remote results are cached as a cost-saver. The
-//! cache itself does not distinguish the two — that policy lives in the caller.
-//!
-//! The cache is an in-memory [`quick_cache::sync::Cache`] with S3-FIFO-style
-//! eviction, the same crate the lookup and schema-registry caches use. A lookup
-//! is a memory op: cheap enough to gate the inference worker from the operator
-//! without doing the model call inline.
+//! The composite key ensures different models and parameter sets never collide on
+//! the same input. Backed by `quick_cache::sync::Cache` with S3-FIFO eviction.
 
 use quick_cache::sync::{Cache, DefaultLifecycle};
 use quick_cache::{DefaultHashBuilder, Weighter};
@@ -18,55 +9,41 @@ use quick_cache::{DefaultHashBuilder, Weighter};
 use crate::ai::provider::InferenceParams;
 use crate::ai::registry::Task;
 
-/// Cache key. All fields are `Copy`, so lookups need no allocation and no
-/// borrowed-key indirection.
-///
-/// - `content_hash`: xxh3-128 of the input text (see [`content_hash`]).
-/// - `model_id`: a stable per-model integer assigned by the caller (the
-///   registry), distinguishing models without hashing their names on lookup.
-/// - `params_version`: a hash of the request parameters (see [`params_version`]).
+/// Cache key. All fields are `Copy`; lookups need no allocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AiCacheKey {
-    /// xxh3-128 hash of the input content.
+    /// xxh3-128 of the input text.
     pub content_hash: u128,
-    /// Stable integer id of the model.
+    /// Stable per-model integer assigned by the registry.
     pub model_id: u32,
-    /// The task — a model can serve several (e.g. classify and sentiment), and
-    /// they produce different outputs for the same input, so it must key the
-    /// cache or results would collide across tasks.
+    /// Task is part of the key because the same model returns different outputs
+    /// for classify vs sentiment on the same input.
     pub task: Task,
-    /// Hash of the request parameters that affect the output.
+    /// Hash of the request parameters (see [`params_version`]).
     pub params_version: u64,
 }
 
-/// One row's cached inference output. Mirrors the per-row shape of
-/// [`crate::ai::provider::InferenceOutputs`] but singular, since the cache is keyed
-/// per row of input.
+/// One row's cached inference output.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CachedOutput {
     /// A text output (label, completion, summary, …).
     Text(String),
-    /// A numeric vector output (embedding).
+    /// A numeric embedding vector.
     Vector(Vec<f32>),
-    /// A scalar score output (`ai_sentiment`, continuous in `[-1, 1]`).
+    /// A scalar sentiment score in `[-1, 1]`.
     Score(f64),
 }
 
-/// xxh3-128 of the input content. Not cryptographic; a fast, collision-negligible
-/// key for a result cache.
+/// xxh3-128 of the input content.
 #[must_use]
 pub fn content_hash(input: &str) -> u128 {
     xxhash_rust::xxh3::xxh3_128(input.as_bytes())
 }
 
-/// A stable hash of the parameters that change a model's output for the same
-/// input — currently the candidate label set. Computed once per batch (all rows
-/// in a batch share parameters), not per row.
+/// Hash of the parameters that affect model output (currently the label set).
 ///
-/// Maintenance contract: every field of [`InferenceParams`] that can change the
-/// output must be folded in here. It is hashed field-by-field rather than via a
-/// derived `Hash` because parameters added later (e.g. an `f32` temperature)
-/// are not `Hash`; fold those in explicitly (e.g. `to_bits()`).
+/// Fold every output-affecting field of [`InferenceParams`] here explicitly —
+/// non-`Hash` fields like `f32` temperature must use `to_bits()`.
 #[must_use]
 pub fn params_version(params: &InferenceParams) -> u64 {
     use std::hash::{Hash, Hasher};
@@ -78,9 +55,8 @@ pub fn params_version(params: &InferenceParams) -> u64 {
 /// Configuration for [`AiResultCache`].
 #[derive(Debug, Clone, Copy)]
 pub struct AiResultCacheConfig {
-    /// Memory budget in bytes. Entries are weighted by payload size, so this
-    /// bounds memory directly — an entry count would not, since an embedding
-    /// vector is orders of magnitude larger than a one-word label.
+    /// Memory budget. Entries are weighted by payload size, not count, so
+    /// large embeddings and small labels are both bounded correctly.
     pub capacity_bytes: usize,
 }
 
@@ -92,8 +68,7 @@ impl Default for AiResultCacheConfig {
     }
 }
 
-/// Weight of one cache entry: its payload bytes plus fixed key/bookkeeping
-/// overhead, so tiny entries still count against the budget.
+/// Payload bytes plus key/overhead so tiny entries still count against the budget.
 #[derive(Debug, Clone)]
 struct OutputWeighter;
 
@@ -109,10 +84,6 @@ impl Weighter<AiCacheKey, CachedOutput> for OutputWeighter {
 }
 
 /// `quick_cache`-backed in-memory cache of per-row inference results.
-///
-/// `quick_cache::sync::Cache` is internally sharded with per-shard locks held
-/// only for the duration of a map operation, so [`AiResultCache`] is
-/// `Send + Sync`.
 pub struct AiResultCache {
     cache: Cache<AiCacheKey, CachedOutput, OutputWeighter>,
 }
@@ -121,9 +92,7 @@ impl AiResultCache {
     /// Create a cache with the given configuration.
     #[must_use]
     pub fn new(config: AiResultCacheConfig) -> Self {
-        // Estimated entry count only sizes internal tables; within an order
-        // of magnitude is fine. Assume ~256 B/entry (labels are small,
-        // embeddings large; the byte weighter enforces the real bound).
+        // Rough item count for internal table sizing; ~256 B/entry assumed.
         let estimated_items = (config.capacity_bytes / 256).max(64);
         let cache = Cache::with(
             estimated_items,
@@ -135,7 +104,7 @@ impl AiResultCache {
         Self { cache }
     }
 
-    /// Create a cache with default configuration.
+    /// Create a cache with default configuration (64 MiB).
     #[must_use]
     pub fn with_defaults() -> Self {
         Self::new(AiResultCacheConfig::default())
@@ -147,18 +116,18 @@ impl AiResultCache {
         self.cache.get(key)
     }
 
-    /// Insert or update a cached result.
+    /// Insert a result.
     pub fn insert(&self, key: AiCacheKey, value: CachedOutput) {
         self.cache.insert(key, value);
     }
 
-    /// Number of entries currently cached.
+    /// Number of cached entries.
     #[must_use]
     pub fn len(&self) -> usize {
         self.cache.len()
     }
 
-    /// Whether the cache is empty.
+    /// Whether the cache holds no entries.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/crates/laminar-db/src/ai/call_log.rs
+++ b/crates/laminar-db/src/ai/call_log.rs
@@ -1,11 +1,6 @@
 //! Bounded in-memory log of inference calls, surfaced as `laminar.ai_calls`.
-//!
-//! One record per batch call — local and remote alike. Remote calls carry
-//! tokens and cost; local calls report [`Usage::ZERO`](crate::ai::provider::Usage::ZERO).
-//! The log is written from the Ring 1 inference worker and read by queries
-//! against `laminar.ai_calls`, so it is behind a lock; it is never touched on
-//! Ring 0. The buffer is bounded — the oldest record is dropped once full — and
-//! a monotonic counter records how many calls were ever logged.
+//! One record per batch; written from Ring 1, never Ring 0. Oldest record is
+//! dropped when full; a monotonic counter tracks lifetime call count.
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -38,27 +33,27 @@ impl CallOutcome {
 /// One logged inference call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AiCallRecord {
-    /// Wall-clock time the call completed (epoch milliseconds).
+    /// Epoch milliseconds at call completion.
     pub timestamp_ms: i64,
-    /// Registry model name (e.g. `finbert`, `haiku`).
+    /// Registry model name.
     pub model: String,
-    /// Backend-kind identity reported by the provider (e.g. `anthropic`).
+    /// Provider name (e.g. `anthropic`).
     pub provider: &'static str,
-    /// The task performed.
+    /// Task performed.
     pub task: Task,
-    /// The backend kind.
+    /// Backend kind.
     pub kind: BackendKind,
     /// Number of rows in the batch.
     pub batch_size: u32,
-    /// Token/cost accounting (zero for local).
+    /// Zero for local calls.
     pub usage: Usage,
-    /// End-to-end latency of the batch call.
+    /// End-to-end latency.
     pub latency_ms: u64,
     /// Outcome.
     pub outcome: CallOutcome,
 }
 
-/// Bounded ring buffer of [`AiCallRecord`]s.
+/// Bounded ring buffer of call records.
 #[derive(Debug)]
 pub struct AiCallLog {
     records: Mutex<VecDeque<AiCallRecord>>,
@@ -67,7 +62,7 @@ pub struct AiCallLog {
 }
 
 impl AiCallLog {
-    /// Create a log retaining at most `capacity` of the most recent records.
+    /// Retain at most `capacity` of the most recent records.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         Self {
@@ -77,13 +72,13 @@ impl AiCallLog {
         }
     }
 
-    /// Create a log with a default capacity of 2,000 records.
+    /// Create a log with a default capacity of 2 000 records.
     #[must_use]
     pub fn with_defaults() -> Self {
         Self::new(2_000)
     }
 
-    /// Append a record, evicting the oldest if at capacity.
+    /// Append a record; evicts the oldest if at capacity.
     pub fn record(&self, record: AiCallRecord) {
         let mut records = self.records.lock();
         if records.len() >= self.capacity {
@@ -93,25 +88,25 @@ impl AiCallLog {
         self.recorded.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Snapshot the retained records, oldest first. Backs `laminar.ai_calls`.
+    /// Snapshot retained records (oldest first). Backs `laminar.ai_calls`.
     #[must_use]
     pub fn snapshot(&self) -> Vec<AiCallRecord> {
         self.records.lock().iter().cloned().collect()
     }
 
-    /// Number of records currently retained.
+    /// Number of retained records.
     #[must_use]
     pub fn len(&self) -> usize {
         self.records.lock().len()
     }
 
-    /// Whether the log currently holds no records.
+    /// Whether the log holds no records.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.records.lock().is_empty()
     }
 
-    /// Total calls ever logged, including those evicted from the buffer.
+    /// Total calls ever logged, including evicted records.
     #[must_use]
     pub fn total_recorded(&self) -> u64 {
         self.recorded.load(Ordering::Relaxed)

--- a/crates/laminar-db/src/ai/mod.rs
+++ b/crates/laminar-db/src/ai/mod.rs
@@ -1,15 +1,5 @@
-//! Backend-agnostic AI inference for `LaminarDB`.
-//!
-//! AI SQL functions (`ai_classify`, `ai_embed`, `ai_complete`, …) are task
-//! contracts with fixed input/output. A named model from the [`ModelRegistry`](crate::ai::registry::ModelRegistry)
-//! satisfies a contract; the model's backend — local ONNX or a remote LLM — is
-//! hidden behind a single [`InferenceProvider`](crate::ai::provider::InferenceProvider). This crate holds the pieces
-//! that know nothing about Ring 0: the registry, the provider trait, request
-//! and response types, and (in later batches) the result cache, call log,
-//! adapters, and concrete backends.
-//!
-//! Nothing here runs on the hot path. Inference is driven from a Ring 1 worker
-//! off the compute thread; see the operator in `laminar-db`.
+//! Backend-agnostic AI inference types: registry, provider trait, cache, call
+//! log, adapters, and backends. Inference runs on a Ring 1 worker, never Ring 0.
 
 #![deny(missing_docs)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/crates/laminar-db/src/ai/provider.rs
+++ b/crates/laminar-db/src/ai/provider.rs
@@ -1,62 +1,48 @@
-//! The single transport abstraction over a model backend.
+//! [`InferenceProvider`] trait and request/response types.
 //!
-//! An [`InferenceProvider`] does I/O only: a homogeneous batch of inputs in, a
-//! homogeneous batch of outputs plus usage out. It knows nothing about SQL tasks
-//! or output columns — framing a request and turning the response into a task's
-//! output column is the adapter's job. Implementors: Anthropic, an
-//! OpenAI-compatible provider (OpenAI / Azure / vLLM via `base_url`), and a
-//! local ONNX Runtime provider.
+//! Providers are I/O only: inputs in, outputs + usage out. Task framing and
+//! response parsing belong to the adapter.
 
 use async_trait::async_trait;
 use thiserror::Error;
 
 use crate::ai::registry::Task;
 
-/// One batch of inputs to run through a model. A request is homogeneous: a
-/// single task, a single model, and one input string per row in order.
+/// One homogeneous batch of inputs for a single task and model.
 #[derive(Debug, Clone, PartialEq)]
 pub struct InferenceRequest {
-    /// The task being performed.
+    /// Task to perform.
     pub task: Task,
-    /// Runtime model identifier — the vendor model id for remote backends, or
-    /// the weight source for local backends.
+    /// Vendor model id for remote backends; weight source for local.
     pub model: String,
     /// One input string per row, in row order.
     pub inputs: Vec<String>,
-    /// Task-shaping parameters that also version the result cache.
+    /// Task-shaping parameters; also versions the result cache.
     pub params: InferenceParams,
 }
 
-/// Knobs that shape a request and contribute to the cache's `params_version`,
-/// so the same text under different parameters never collides. Generation knobs
-/// (`max_tokens`, `temperature`, …) are added here as backends consume them.
+/// Parameters that shape a request and version the result cache.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct InferenceParams {
-    /// Candidate label set for classification (required for remote classify;
-    /// for local classifiers it must match or be a subset of the model's
-    /// intrinsic labels, validated at plan time).
+    /// Candidate labels for classification. Required for remote classify;
+    /// must match or be a subset of a local classifier's intrinsic labels.
     pub labels: Option<Vec<String>>,
 }
 
-/// Per-row outputs of a batch. Homogeneous for a given request: a classify or
-/// generate batch yields text; an embed batch — or a local classifier's raw
-/// logits awaiting softmax in the adapter — yields numeric vectors; a sentiment
-/// batch yields one scalar score per row (the adapter's output, never a raw
-/// provider shape).
+/// Per-row outputs of a batch. Shape is homogeneous within a request.
 #[derive(Debug, Clone, PartialEq)]
 pub enum InferenceOutputs {
-    /// One text output per input row.
+    /// Text outputs (classify, complete, …).
     Text(Vec<String>),
-    /// One numeric vector per input row (embeddings, or classifier logits).
+    /// Numeric vectors (embeddings, or classifier logits before adapter post-processing).
     Vectors(Vec<Vec<f32>>),
-    /// One scalar score per input row. Produced by the adapter for
-    /// `ai_sentiment` (continuous, in `[-1, 1]`); providers never return this
-    /// shape directly.
+    /// Scalar sentiment scores in `[-1, 1]`. Produced by the adapter; providers
+    /// never return this shape directly.
     Scores(Vec<f64>),
 }
 
 impl InferenceOutputs {
-    /// Number of rows produced. Must equal the request's input count.
+    /// Number of output rows.
     #[must_use]
     pub fn len(&self) -> usize {
         match self {
@@ -66,27 +52,26 @@ impl InferenceOutputs {
         }
     }
 
-    /// Whether no rows were produced.
+    /// Whether no rows are present.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
-/// Token and cost accounting for a single batch call. Local backends report
-/// [`Usage::ZERO`]; remote backends report what the provider charged.
+/// Token and cost accounting for a batch call. Local backends report [`Usage::ZERO`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Usage {
     /// Prompt/input tokens billed.
     pub input_tokens: u64,
     /// Completion/output tokens billed.
     pub output_tokens: u64,
-    /// Metered cost in micro-USD (millionths of a dollar); 0 for local.
+    /// Micro-USD (millionths); 0 for local.
     pub cost_micros: u64,
 }
 
 impl Usage {
-    /// Zero usage — what local, deterministic backends report.
+    /// Zero usage for local backends.
     pub const ZERO: Usage = Usage {
         input_tokens: 0,
         output_tokens: 0,
@@ -94,19 +79,17 @@ impl Usage {
     };
 }
 
-/// The result of a batch inference call: outputs aligned 1:1 with the request's
-/// inputs, plus usage.
+/// Result of a batch inference call.
 #[derive(Debug, Clone, PartialEq)]
 pub struct InferenceResponse {
     /// Per-row outputs, in input order.
     pub outputs: InferenceOutputs,
-    /// Token/cost accounting for the call.
+    /// Token/cost accounting.
     pub usage: Usage,
 }
 
-/// Transport over a model backend. Implementors perform I/O only — no task
-/// framing, no result parsing. Shared as `Arc<dyn InferenceProvider>` and
-/// driven from the Ring 1 inference worker, never from Ring 0.
+/// I/O transport over a model backend. Shared as `Arc<dyn InferenceProvider>`;
+/// driven from Ring 1, never Ring 0.
 #[async_trait]
 pub trait InferenceProvider: Send + Sync {
     /// Run one batch of inputs through the model.
@@ -120,15 +103,12 @@ pub trait InferenceProvider: Send + Sync {
         request: InferenceRequest,
     ) -> Result<InferenceResponse, ProviderError>;
 
-    /// Stable backend-kind identity for logging and the `laminar.ai_calls`
-    /// log (e.g. `anthropic`, `openai`, `local`). Constant per implementor.
+    /// Backend name for logging (e.g. `anthropic`, `openai`, `local`).
     fn name(&self) -> &'static str;
 
-    /// Classifier labels intrinsic to a model, discovered from its own metadata.
-    /// Returns `None` for backends that have none (remote providers, embedding
-    /// models). A local classifier returns its `config.json` `id2label` once the
-    /// model is on disk — the seam that lets a lazily downloaded classifier score
-    /// without the labels having been known at startup. The default is `None`.
+    /// Labels intrinsic to a local classifier (`config.json` `id2label`).
+    /// Returns `None` for remote providers and embedding models. Lets a lazily
+    /// downloaded classifier return labels without them being known at startup.
     fn intrinsic_labels(&self, _model: &str) -> Option<Vec<String>> {
         None
     }

--- a/crates/laminar-db/src/ai/registry.rs
+++ b/crates/laminar-db/src/ai/registry.rs
@@ -1,10 +1,5 @@
-//! The model registry: the curated catalog that maps a SQL-referenced model
-//! name to the backend that runs it and the tasks it can serve.
-//!
-//! The registry is built once at startup from server configuration and is
-//! immutable thereafter. AI functions resolve `model => '<name>'` against it at
-//! plan time and fail the query if the model is unknown or cannot perform the
-//! requested task — never per event.
+//! Model registry: maps SQL-referenced model names to backends and tasks.
+//! Built once at startup; AI functions resolve against it at plan time.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -12,30 +7,29 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-/// A task contract an AI SQL function fulfils. Each `ai_*` function maps to
-/// exactly one task; a model declares the subset of tasks it supports.
+/// Task contract for an AI SQL function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Task {
-    /// Assign one label from a candidate set (`ai_classify`).
+    /// `ai_classify`
     Classify,
-    /// Classify over a fixed sentiment label set (`ai_sentiment`).
+    /// `ai_sentiment`
     Sentiment,
-    /// Produce a dense embedding vector (`ai_embed`).
+    /// `ai_embed`
     Embed,
-    /// Pull structured fields out of text (`ai_extract`).
+    /// `ai_extract`
     Extract,
-    /// Free-form completion (`ai_complete`).
+    /// `ai_complete`
     Complete,
-    /// Summarize text (`ai_summarize`).
+    /// `ai_summarize`
     Summarize,
-    /// Translate text (`ai_translate`).
+    /// `ai_translate`
     Translate,
-    /// Open-ended generation (`ai_gen`).
+    /// `ai_gen`
     Gen,
 }
 
 impl Task {
-    /// Canonical lower-case name, matching the `task = "…"` config spelling.
+    /// Canonical name matching the `task = "…"` config spelling.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
@@ -78,46 +72,44 @@ impl FromStr for Task {
 /// Which runtime executes a model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BackendKind {
-    /// Local ONNX model run in-process via tract.
+    /// In-process ONNX Runtime.
     Local,
-    /// Model served by a configured remote provider.
+    /// Configured remote provider.
     Remote,
 }
 
 /// Backend-specific wiring for a registered model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModelBackend {
-    /// A local ONNX model.
+    /// In-process ONNX model.
     Local {
-        /// Weight source — e.g. `hf:onnx-community/finbert`, or a file /
-        /// object_store URI. Resolved and mmapped by the local backend.
+        /// `hf:org/repo`, `file://<path>`, or a bare path.
         source: String,
-        /// Intrinsic classifier labels (`id2label`), when known at
-        /// registration. `None` until derived from the model's `config.json`.
+        /// `id2label` from config.json; `None` until derived at load time.
         labels: Option<Vec<String>>,
     },
-    /// A model served by a remote provider.
+    /// Remote provider model.
     Remote {
-        /// Key into the configured providers map (e.g. `anthropic`).
+        /// Key into the configured providers map.
         provider: String,
-        /// Provider-specific model id (e.g. `claude-haiku-4-5-20251001`).
+        /// Provider-specific model id.
         model: String,
     },
 }
 
-/// One registered model: its name, the tasks it serves, and its backend.
+/// One registered model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelEntry {
-    /// Registry key — the name referenced as `model => '<id>'` in SQL.
+    /// Name referenced as `model => '<id>'` in SQL.
     pub id: String,
     /// Tasks this model can perform.
     pub tasks: Vec<Task>,
-    /// The backend that runs it.
+    /// Backend that runs it.
     pub backend: ModelBackend,
 }
 
 impl ModelEntry {
-    /// The backend kind (local vs remote).
+    /// Backend kind for this entry.
     #[must_use]
     pub fn kind(&self) -> BackendKind {
         match self.backend {
@@ -126,27 +118,25 @@ impl ModelEntry {
         }
     }
 
-    /// Whether this model can perform `task`.
+    /// Whether this model supports `task`.
     #[must_use]
     pub fn supports(&self, task: Task) -> bool {
         self.tasks.contains(&task)
     }
 
-    /// Deterministic results are cacheable permanently for correctness; only
-    /// local backends are deterministic.
+    /// Whether results are deterministic (local only) and permanently cacheable.
     #[must_use]
     pub fn is_deterministic(&self) -> bool {
         matches!(self.kind(), BackendKind::Local)
     }
 
-    /// Whether calls incur metered cost (remote) versus free (local). Costed
-    /// calls are logged to `laminar.ai_calls` with tokens and cost.
+    /// Whether calls incur metered cost (remote providers).
     #[must_use]
     pub fn is_costed(&self) -> bool {
         matches!(self.kind(), BackendKind::Remote)
     }
 
-    /// Intrinsic labels of a local classifier, if any.
+    /// Intrinsic labels of a local classifier, if known.
     #[must_use]
     pub fn labels(&self) -> Option<&[String]> {
         match &self.backend {
@@ -156,7 +146,7 @@ impl ModelEntry {
     }
 }
 
-/// Curated map of model name → entry, plus a default model per task.
+/// Map of model name to entry, with optional per-task defaults.
 #[derive(Debug, Default)]
 pub struct ModelRegistry {
     models: HashMap<String, ModelEntry>,
@@ -164,7 +154,7 @@ pub struct ModelRegistry {
 }
 
 impl ModelRegistry {
-    /// An empty registry.
+    /// Create an empty registry.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -174,8 +164,7 @@ impl ModelRegistry {
     ///
     /// # Errors
     ///
-    /// Returns [`RegistryError::DuplicateModel`] if a model with the same id is
-    /// already registered.
+    /// Returns [`RegistryError::DuplicateModel`] if the id is already registered.
     pub fn register(&mut self, entry: ModelEntry) -> Result<(), RegistryError> {
         if self.models.contains_key(&entry.id) {
             return Err(RegistryError::DuplicateModel(entry.id.clone()));
@@ -184,12 +173,12 @@ impl ModelRegistry {
         Ok(())
     }
 
-    /// Set the default model for a task (the `[ai.defaults]` config block).
+    /// Set the default model for a task (`[ai.defaults]` config block).
     pub fn set_default(&mut self, task: Task, model: impl Into<String>) {
         self.defaults.insert(task, model.into());
     }
 
-    /// Default model name for a task, if one is configured.
+    /// Default model for a task, if configured.
     #[must_use]
     pub fn default_for(&self, task: Task) -> Option<&str> {
         self.defaults.get(&task).map(String::as_str)
@@ -199,21 +188,18 @@ impl ModelRegistry {
     ///
     /// # Errors
     ///
-    /// Returns [`RegistryError::UnknownModel`] if no model with that name is
-    /// registered.
+    /// Returns [`RegistryError::UnknownModel`] if not registered.
     pub fn resolve(&self, name: &str) -> Result<&ModelEntry, RegistryError> {
         self.models
             .get(name)
             .ok_or_else(|| RegistryError::UnknownModel(name.to_string()))
     }
 
-    /// Resolve a model and confirm it supports `task`. This is the plan-time
-    /// gate behind every AI function call.
+    /// Resolve a model and confirm it supports `task`.
     ///
     /// # Errors
     ///
-    /// Returns [`RegistryError::UnknownModel`] if the model is not registered,
-    /// or [`RegistryError::TaskUnsupported`] if it cannot perform `task`.
+    /// Returns [`RegistryError::UnknownModel`] or [`RegistryError::TaskUnsupported`].
     pub fn validate(&self, name: &str, task: Task) -> Result<&ModelEntry, RegistryError> {
         let entry = self.resolve(name)?;
         if entry.supports(task) {
@@ -233,19 +219,19 @@ impl ModelRegistry {
         self.models.len()
     }
 
-    /// Whether no models are registered.
+    /// Whether the registry is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.models.is_empty()
     }
 
-    /// Iterate registered entries in unspecified order. Backs `laminar.models`.
+    /// Iterate entries in unspecified order. Backs `laminar.models`.
     pub fn iter(&self) -> impl Iterator<Item = &ModelEntry> {
         self.models.values()
     }
 }
 
-/// Errors from resolving or validating a model. Surfaced at plan time.
+/// Errors from resolving or validating a model.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum RegistryError {
     /// No model with the given name is registered.
@@ -255,11 +241,11 @@ pub enum RegistryError {
     /// The model exists but does not support the requested task.
     #[error("model '{model}' does not support task '{task}' (supports: {supported:?})")]
     TaskUnsupported {
-        /// The referenced model name.
+        /// The model name.
         model: String,
-        /// The task that was requested.
+        /// The requested task.
         task: Task,
-        /// The tasks the model actually supports.
+        /// Tasks the model actually supports.
         supported: Vec<Task>,
     },
 
@@ -267,7 +253,7 @@ pub enum RegistryError {
     #[error("model '{0}' is already registered")]
     DuplicateModel(String),
 
-    /// A `task = "…"` string did not name a known task.
+    /// A `task = "…"` config string named an unknown task.
     #[error("unknown task '{0}'")]
     UnknownTask(String),
 }

--- a/crates/laminar-db/src/ai/runtime.rs
+++ b/crates/laminar-db/src/ai/runtime.rs
@@ -1,12 +1,6 @@
-//! The assembled AI subsystem: the model registry, the provider clients that
-//! back it, the shared result cache, and the call log.
-//!
-//! Built once from server configuration and threaded into the engine. Given a
-//! model name referenced in SQL, [`AiRuntime::resolve`] returns everything the
-//! inference operator needs to run it: the backend kind, a stable cache id, the
-//! provider client, the provider-side model id, and any labels. The registry is
-//! kept whole (it also backs the `laminar.models` catalog view), even for models
-//! whose backend has no provider wired yet.
+//! Assembled AI subsystem: registry, provider clients, result cache, and call log.
+//! Built once at startup; [`AiRuntime::resolve`] returns everything the inference
+//! operator needs to run a named model.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,24 +17,24 @@ use crate::ai::registry::{BackendKind, ModelBackend, ModelRegistry, RegistryErro
 pub struct ResolvedModel {
     /// Backend kind (selects the adapter path).
     pub kind: BackendKind,
-    /// Stable per-run integer id for the result-cache key.
+    /// Stable per-run integer for the result-cache key.
     pub model_id: u32,
-    /// The transport client.
+    /// Transport client.
     pub provider: Arc<dyn InferenceProvider>,
-    /// The provider-side model identifier passed in the request.
+    /// Provider-side model identifier.
     pub provider_model: String,
-    /// Intrinsic labels (local classifiers), if known.
+    /// Intrinsic labels for local classifiers.
     pub labels: Option<Vec<String>>,
 }
 
 /// Errors from resolving a model to a runnable backend.
 #[derive(Debug, Error)]
 pub enum AiRuntimeError {
-    /// The model is not registered, or it cannot perform the requested task.
+    /// The model is not registered or cannot perform the requested task.
     #[error(transparent)]
     Registry(#[from] RegistryError),
 
-    /// A remote model names a provider that was not configured.
+    /// A remote model references an unconfigured provider.
     #[error("model '{model}' references provider '{provider}', which is not configured")]
     UnknownProvider {
         /// The model name.
@@ -49,7 +43,7 @@ pub enum AiRuntimeError {
         provider: String,
     },
 
-    /// A local model was referenced but the local backend is not available.
+    /// Local model referenced but the local backend is not enabled.
     #[error("model '{0}' is local, but the local backend is not enabled in this build")]
     LocalBackendUnavailable(String),
 }
@@ -65,9 +59,8 @@ pub struct AiRuntime {
 }
 
 impl AiRuntime {
-    /// Assemble a runtime. `providers` is keyed by provider name (matching a
-    /// model's `provider`); `local_provider`, when present, serves every local
-    /// model. Each registered model is assigned a stable cache id.
+    /// Assemble a runtime. `providers` is keyed by provider name; `local_provider`
+    /// serves all local models. Each model gets a stable cache id.
     #[must_use]
     pub fn new(
         registry: ModelRegistry,
@@ -91,19 +84,19 @@ impl AiRuntime {
         }
     }
 
-    /// The model registry (backs `laminar.models` and plan-time validation).
+    /// Model registry (backs `laminar.models`).
     #[must_use]
     pub fn registry(&self) -> &ModelRegistry {
         &self.registry
     }
 
-    /// The shared result cache.
+    /// Shared result cache.
     #[must_use]
     pub fn cache(&self) -> &Arc<AiResultCache> {
         &self.cache
     }
 
-    /// The call log (backs `laminar.ai_calls`).
+    /// Call log (backs `laminar.ai_calls`).
     #[must_use]
     pub fn call_log(&self) -> &Arc<AiCallLog> {
         &self.call_log
@@ -113,8 +106,8 @@ impl AiRuntime {
     ///
     /// # Errors
     ///
-    /// Returns [`AiRuntimeError`] if the model is unknown, names an unconfigured
-    /// provider, or is local while the local backend is unavailable.
+    /// Returns [`AiRuntimeError`] if the model is unknown, the provider is not
+    /// configured, or the local backend is unavailable.
     pub fn resolve(&self, model_name: &str) -> Result<ResolvedModel, AiRuntimeError> {
         let entry = self.registry.resolve(model_name)?;
         let model_id = self.model_ids.get(model_name).copied().unwrap_or(u32::MAX);

--- a/crates/laminar-db/src/ai_catalog.rs
+++ b/crates/laminar-db/src/ai_catalog.rs
@@ -1,13 +1,5 @@
-//! Read-only `laminar.*` AI catalog views.
-//!
-//! - `laminar.models` — the model registry: each model's kind, tasks, source,
-//!   and determinism/cost properties.
-//! - `laminar.ai_calls` — the inference call log: one row per batch call, with
-//!   tokens, cost, latency, and status.
-//!
-//! Both are a single [`SystemView`] parameterized by a column-builder, registered
-//! as a `laminar` schema on the query context. Each `scan()` reads the live
-//! [`AiRuntime`], so the views always reflect current state.
+//! Read-only `laminar.models` and `laminar.ai_calls` catalog views.
+//! Each is a [`SystemView`] that snapshots the live [`AiRuntime`] on every scan.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -26,10 +18,8 @@ use crate::ai::{AiRuntime, BackendKind, ModelBackend};
 
 use crate::error::DbError;
 
-/// Reserved schema for AI catalog views.
 pub(crate) const LAMINAR_SCHEMA: &str = "laminar";
 
-/// Snapshots the live runtime into a view's columns (schema order).
 type ColumnBuilder = fn(&AiRuntime) -> Vec<ArrayRef>;
 
 /// Register `laminar.models` and `laminar.ai_calls` on `ctx`.
@@ -67,8 +57,7 @@ pub(crate) fn register_ai_catalog(
     Ok(())
 }
 
-/// A read-only catalog view: a fixed schema plus a function that snapshots the
-/// live [`AiRuntime`] into its columns on each scan.
+/// A read-only catalog view backed by a live runtime snapshot.
 struct SystemView {
     schema: SchemaRef,
     columns: ColumnBuilder,

--- a/crates/laminar-db/src/ai_worker.rs
+++ b/crates/laminar-db/src/ai_worker.rs
@@ -38,6 +38,13 @@ pub(crate) struct WorkItem {
     pub rows: Vec<MissRow>,
 }
 
+/// Submit (request) channel to the worker. Crossfire, like the engine's other
+/// compute-thread/runtime channels (the `MAsyncTx` is `Send + Sync`, so the
+/// operator stores it). The result channel stays tokio mpsc — the operator
+/// stores its *receiver*, which must be `Sync`, and crossfire's is `!Sync`.
+pub(crate) type SubmitTx = crossfire::MAsyncTx<crossfire::mpsc::Array<WorkItem>>;
+pub(crate) type SubmitRx = crossfire::AsyncRx<crossfire::mpsc::Array<WorkItem>>;
+
 /// The worker's reply for one [`WorkItem`].
 pub(crate) struct WorkResult {
     /// Id of the originating pending batch.
@@ -72,10 +79,11 @@ pub(crate) struct WorkerContext {
 /// Drive the worker until the submit channel closes (operator dropped).
 pub(crate) async fn run_worker(
     ctx: WorkerContext,
-    mut submit_rx: mpsc::Receiver<WorkItem>,
+    submit_rx: SubmitRx,
     result_tx: mpsc::Sender<WorkResult>,
 ) {
-    while let Some(item) = submit_rx.recv().await {
+    // `recv` errors once the operator drops its submit sender.
+    while let Ok(item) = submit_rx.recv().await {
         let result = infer_one(&ctx, item).await;
         if result_tx.send(result).await.is_err() {
             break;

--- a/crates/laminar-db/src/ai_worker.rs
+++ b/crates/laminar-db/src/ai_worker.rs
@@ -1,13 +1,6 @@
-//! Ring 1 inference worker.
-//!
-//! Runs off the compute thread on the main tokio runtime. It pulls cache-miss
-//! batches submitted by [`AiInferenceOperator`](crate::operator::ai_inference),
-//! runs them through the provider, parses the response into the task's output,
-//! writes the result cache and the `laminar.ai_calls` log, and returns the
-//! per-row outputs over a channel. The operator never blocks on any of this —
-//! it submits and later drains, so the model call never touches Ring 0.
-//!
-//! One `infer_batch` call per work item; cross-item concurrency, retry,
+//! Ring 1 inference worker: pulls cache-miss batches off the compute thread,
+//! runs them through the provider, writes the result cache + `laminar.ai_calls`
+//! log, and returns per-row outputs. One `infer_batch` per work item; retry,
 //! backoff, and timeout are the provider's concern.
 
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -20,59 +13,41 @@ use crate::ai::{
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-/// A row that missed the cache and needs inference.
+/// A cache-miss row awaiting inference.
 pub(crate) struct MissRow {
-    /// Row index within the originating batch.
     pub row_index: usize,
-    /// Input text to run through the model.
     pub text: String,
-    /// Cache key under which the result is stored.
     pub key: AiCacheKey,
 }
 
 /// A batch of cache-miss rows submitted to the worker.
 pub(crate) struct WorkItem {
-    /// Id of the originating pending batch.
     pub batch_id: u64,
-    /// The miss rows, in input order.
     pub rows: Vec<MissRow>,
 }
 
-/// Submit (request) channel to the worker. Crossfire, like the engine's other
-/// compute-thread/runtime channels (the `MAsyncTx` is `Send + Sync`, so the
-/// operator stores it). The result channel stays tokio mpsc — the operator
-/// stores its *receiver*, which must be `Sync`, and crossfire's is `!Sync`.
+// Crossfire submit channel (its `MAsyncTx` is `Send + Sync`, so the operator can
+// hold it); results come back over tokio mpsc, whose receiver is `Sync`.
 pub(crate) type SubmitTx = crossfire::MAsyncTx<crossfire::mpsc::Array<WorkItem>>;
 pub(crate) type SubmitRx = crossfire::AsyncRx<crossfire::mpsc::Array<WorkItem>>;
 
 /// The worker's reply for one [`WorkItem`].
 pub(crate) struct WorkResult {
-    /// Id of the originating pending batch.
     pub batch_id: u64,
-    /// Row indices the item covered, in order — present even on failure so the
-    /// operator knows which rows to resolve (to NULL on failure).
+    /// Present even on failure, so the operator knows which rows to NULL out.
     pub row_indices: Vec<usize>,
-    /// Per-row outputs aligned to `row_indices`, or a batch-level error message.
     pub outputs: Result<Vec<CachedOutput>, String>,
 }
 
 /// Immutable inference context shared by the worker across items.
 pub(crate) struct WorkerContext {
-    /// Transport backend.
     pub provider: Arc<dyn InferenceProvider>,
-    /// Result cache (written on success).
     pub cache: Arc<AiResultCache>,
-    /// Call log (written for every call, success or failure).
     pub call_log: Arc<AiCallLog>,
-    /// The task performed.
     pub task: Task,
-    /// The backend kind (selects the adapter path).
     pub kind: BackendKind,
-    /// Provider/runtime model identifier.
     pub model: String,
-    /// Request parameters (labels).
     pub params: InferenceParams,
-    /// Effective labels for local classification.
     pub labels: Option<Vec<String>>,
 }
 
@@ -82,7 +57,6 @@ pub(crate) async fn run_worker(
     submit_rx: SubmitRx,
     result_tx: mpsc::Sender<WorkResult>,
 ) {
-    // `recv` errors once the operator drops its submit sender.
     while let Ok(item) = submit_rx.recv().await {
         let result = infer_one(&ctx, item).await;
         if result_tx.send(result).await.is_err() {
@@ -150,9 +124,8 @@ async fn run_request(
         .await
         .map_err(|e| e.to_string())?;
     let usage = response.usage;
-    // Labels known at startup win; otherwise fall back to the backend's intrinsic
-    // labels, now resolvable since the call above ensured the model is on disk —
-    // this is what lets a lazily downloaded local classifier score.
+    // Startup labels win; else the backend's intrinsic labels, resolvable now
+    // that the call above ensured the model is on disk (lazy local classifiers).
     let labels = ctx
         .labels
         .clone()

--- a/crates/laminar-db/src/api/connection.rs
+++ b/crates/laminar-db/src/api/connection.rs
@@ -375,6 +375,13 @@ impl Connection {
         self.inner.metrics()
     }
 
+    /// Cold-tier demotion/promotion metrics (single-node observability).
+    #[cfg(feature = "state-tier")]
+    #[must_use]
+    pub fn tier_metrics(&self) -> crate::TierMetrics {
+        self.inner.tier_metrics()
+    }
+
     /// Get metrics for a specific source.
     #[must_use]
     pub fn source_metrics(&self, name: &str) -> Option<crate::SourceMetrics> {

--- a/crates/laminar-db/src/api/connection.rs
+++ b/crates/laminar-db/src/api/connection.rs
@@ -11,25 +11,6 @@ use super::query::{QueryResult, QueryStream};
 use crate::{LaminarConfig, LaminarDB};
 
 /// Thread-safe database connection for FFI.
-///
-/// This is a wrapper around `LaminarDB` that provides:
-/// - Explicit `Send + Sync` markers for FFI safety
-/// - `close()` method returning `Result` for error handling
-/// - Untyped Arrow API without Rust trait bounds
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use laminar_db::api::Connection;
-///
-/// let conn = Connection::open()?;
-/// conn.execute("CREATE SOURCE trades (symbol VARCHAR, price DOUBLE)")?;
-///
-/// let result = conn.query("SELECT * FROM trades")?;
-/// println!("Got {} rows", result.num_rows());
-///
-/// conn.close()?;
-/// ```
 pub struct Connection {
     inner: Arc<LaminarDB>,
 }
@@ -61,9 +42,6 @@ impl Connection {
 
     /// Execute a SQL statement (blocking wrapper around async).
     ///
-    /// Supports: `CREATE SOURCE/SINK/STREAM`, `DROP`, `SELECT`, `INSERT INTO`,
-    /// `SHOW`, `DESCRIBE`, `EXPLAIN`, `CREATE MATERIALIZED VIEW`.
-    ///
     /// # Errors
     ///
     /// Returns `ApiError` if SQL parsing, planning, or execution fails.
@@ -76,9 +54,7 @@ impl Connection {
             return Err(ApiError::shutdown());
         }
 
-        // Create or use existing runtime for blocking
         let result = if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            // Already in async context - use spawn_blocking to avoid nesting
             std::thread::scope(|s| {
                 s.spawn(|| {
                     let inner = Arc::clone(&self.inner);
@@ -89,7 +65,6 @@ impl Connection {
                 .unwrap()
             })
         } else {
-            // No runtime - create one
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -176,7 +151,6 @@ impl Connection {
     ///
     /// Returns `ApiError::table_not_found` if the name is not found.
     pub fn get_schema(&self, name: &str) -> Result<SchemaRef, ApiError> {
-        // Check sources
         for source in self.inner.sources() {
             if source.name == name {
                 return Ok(source.schema);
@@ -242,19 +216,11 @@ impl Connection {
     /// Currently always succeeds.
     #[allow(clippy::unnecessary_wraps)]
     pub fn close(self) -> Result<(), ApiError> {
-        // Signal shutdown
         self.inner.close();
-
-        // Try to get exclusive ownership for cleanup
+        // Exclusive ownership → cleanup runs in drop; else other handles persist.
         match Arc::try_unwrap(self.inner) {
-            Ok(_db) => {
-                // Exclusive ownership - cleanup happens in drop
-                Ok(())
-            }
-            Err(_arc) => {
-                // Other references exist - still marked as closed
-                Ok(())
-            }
+            Ok(_db) => Ok(()),
+            Err(_arc) => Ok(()),
         }
     }
 
@@ -333,7 +299,7 @@ impl Connection {
         self.inner.pipeline_topology()
     }
 
-    /// Get the pipeline state as a string ("Created", "Running", "Stopped", etc.).
+    /// Get the pipeline state as a string.
     #[must_use]
     pub fn pipeline_state(&self) -> String {
         self.inner.pipeline_state().to_string()
@@ -446,11 +412,7 @@ impl Connection {
         result.map_err(ApiError::from)
     }
 
-    /// Subscribe to a named stream, returning an `ArrowSubscription`.
-    ///
-    /// The stream must already exist (created via `CREATE STREAM ... AS SELECT ...`).
-    /// Returns a channel-based subscription that delivers `RecordBatch`es as
-    /// they are produced by the streaming pipeline.
+    /// Subscribe to a named stream.
     ///
     /// # Errors
     ///
@@ -470,20 +432,18 @@ impl Connection {
     }
 }
 
-// Thread safety guarantees for FFI.
 // SAFETY: LaminarDB uses Arc, Mutex, and atomic types internally.
-// All public methods take &self and use internal synchronization.
 unsafe impl Send for Connection {}
 unsafe impl Sync for Connection {}
 
-/// Result of executing a SQL statement (API variant).
+/// Result of executing a SQL statement.
 #[derive(Debug)]
 pub enum ExecuteResult {
-    /// DDL statement completed (CREATE, DROP, ALTER).
+    /// DDL statement completed.
     Ddl(crate::DdlInfo),
-    /// Query is running, results available via stream.
+    /// Query running; results available via stream.
     Query(QueryStream),
-    /// Rows were affected (INSERT INTO).
+    /// Rows affected (INSERT INTO).
     RowsAffected(u64),
     /// Metadata result (SHOW, DESCRIBE).
     Metadata(RecordBatch),

--- a/crates/laminar-db/src/api/ingestion.rs
+++ b/crates/laminar-db/src/api/ingestion.rs
@@ -6,20 +6,7 @@ use arrow::datatypes::SchemaRef;
 use super::error::{codes, ApiError};
 use crate::UntypedSourceHandle;
 
-/// Writer for inserting data into a source.
-///
-/// Provides explicit lifecycle management for FFI. Unlike using
-/// `UntypedSourceHandle` directly, `Writer` tracks closed state
-/// and validates schemas before writes.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// let writer = conn.writer("trades")?;
-/// writer.write(batch)?;
-/// writer.flush()?;
-/// writer.close()?;
-/// ```
+/// Writer for inserting data into a source, with explicit lifecycle management for FFI.
 pub struct Writer {
     handle: UntypedSourceHandle,
     closed: bool,
@@ -38,10 +25,7 @@ impl Writer {
     ///
     /// # Errors
     ///
-    /// Returns `ApiError::Ingestion` if:
-    /// - The writer is closed
-    /// - The batch schema doesn't match the source schema
-    /// - The underlying channel is full or closed
+    /// Returns `ApiError::Ingestion` if the writer is closed, schemas differ, or the channel is full.
     pub fn write(&mut self, batch: RecordBatch) -> Result<(), ApiError> {
         if self.closed {
             return Err(ApiError::Ingestion {
@@ -50,7 +34,6 @@ impl Writer {
             });
         }
 
-        // Validate schema matches (compare field count and types)
         let expected = self.handle.schema();
         let actual = batch.schema();
         if expected.fields().len() != actual.fields().len() {
@@ -69,10 +52,7 @@ impl Writer {
             .map_err(|e| ApiError::ingestion(e.to_string()))
     }
 
-    /// Flush pending data.
-    ///
-    /// For in-memory sources this is a no-op, but external connectors
-    /// may buffer data and require explicit flushing.
+    /// Flush pending data. No-op for in-memory sources.
     ///
     /// # Errors
     ///
@@ -84,18 +64,14 @@ impl Writer {
                 message: "Writer is closed".into(),
             });
         }
-        // In-memory sources don't buffer, but this is part of the API contract
         Ok(())
     }
 
-    /// Explicitly close the writer.
-    ///
-    /// After closing, no more writes are allowed.
+    /// Close the writer. No more writes allowed after this.
     ///
     /// # Errors
     ///
-    /// Currently always succeeds, but may return errors in the future
-    /// for external connectors that need cleanup.
+    /// Currently always succeeds.
     #[allow(clippy::unnecessary_wraps)]
     pub fn close(mut self) -> Result<(), ApiError> {
         self.closed = true;
@@ -115,9 +91,6 @@ impl Writer {
     }
 
     /// Emit a watermark timestamp.
-    ///
-    /// Watermarks indicate that all events with timestamps less than or equal
-    /// to the watermark have been seen.
     pub fn watermark(&self, timestamp: i64) {
         self.handle.watermark(timestamp);
     }
@@ -129,8 +102,7 @@ impl Writer {
     }
 }
 
-// SAFETY: Writer wraps UntypedSourceHandle which uses Arc<SourceEntry>.
-// All operations are thread-safe via internal synchronization.
+// SAFETY: Writer wraps UntypedSourceHandle which uses Arc internally.
 unsafe impl Send for Writer {}
 
 #[cfg(test)]

--- a/crates/laminar-db/src/api/mod.rs
+++ b/crates/laminar-db/src/api/mod.rs
@@ -13,10 +13,8 @@ pub use ingestion::Writer;
 pub use query::{QueryResult, QueryStream};
 pub use subscription::ArrowSubscription;
 
-// Re-export LaminarConfig for open_with_config
 pub use crate::LaminarConfig;
 
-// Re-export catalog, pipeline, and metrics types for language bindings
 pub use crate::{
     PipelineEdge, PipelineNode, PipelineNodeType, PipelineTopology, QueryInfo, SinkInfo,
     SourceInfo, StreamInfo,

--- a/crates/laminar-db/src/api/query.rs
+++ b/crates/laminar-db/src/api/query.rs
@@ -8,10 +8,7 @@ use arrow::datatypes::SchemaRef;
 use super::error::ApiError;
 use crate::catalog::ArrowRecord;
 
-/// Materialized query result containing all batches.
-///
-/// This is the result of collecting all streaming results into memory.
-/// Use [`QueryStream`] for streaming consumption.
+/// Materialized query result (all batches in memory). Use [`QueryStream`] for streaming.
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     schema: SchemaRef,
@@ -78,10 +75,7 @@ impl QueryResult {
     }
 }
 
-/// Streaming query result.
-///
-/// Provides access to query results as they become available.
-/// Use [`QueryResult`] if you need all results at once.
+/// Streaming query result. Use [`QueryResult`] if you need all results at once.
 #[derive(Debug)]
 pub struct QueryStream {
     schema: SchemaRef,
@@ -170,8 +164,7 @@ impl QueryStream {
     }
 }
 
-// SAFETY: QueryStream uses Arc and Mutex internally for thread safety.
-// The subscription is based on lock-free channels.
+// SAFETY: QueryStream uses Arc and lock-free channels internally.
 unsafe impl Send for QueryStream {}
 
 #[cfg(test)]

--- a/crates/laminar-db/src/api/subscription.rs
+++ b/crates/laminar-db/src/api/subscription.rs
@@ -8,19 +8,7 @@ use arrow::datatypes::SchemaRef;
 use super::error::ApiError;
 use crate::catalog::ArrowRecord;
 
-/// Untyped subscription returning Arrow `RecordBatch`es.
-///
-/// Unlike `TypedSubscription<T>`, this doesn't require Rust trait bounds,
-/// making it suitable for FFI where the binding language handles deserialization.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// let sub = conn.subscribe("ohlc_stream")?;
-/// while let Some(batch) = sub.try_next()? {
-///     // Process batch via Arrow C Data Interface
-/// }
-/// ```
+/// Untyped subscription returning Arrow `RecordBatch`es; no Rust trait bounds, suitable for FFI.
 pub struct ArrowSubscription {
     inner: laminar_core::streaming::Subscription<ArrowRecord>,
     schema: SchemaRef,
@@ -120,8 +108,7 @@ impl ArrowSubscription {
     }
 }
 
-// SAFETY: ArrowSubscription wraps Subscription<ArrowRecord> which uses
-// lock-free channels with atomic operations.
+// SAFETY: ArrowSubscription wraps Subscription<ArrowRecord> which uses lock-free channels.
 unsafe impl Send for ArrowSubscription {}
 
 #[cfg(test)]

--- a/crates/laminar-db/src/asof_batch.rs
+++ b/crates/laminar-db/src/asof_batch.rs
@@ -1,9 +1,6 @@
 #![deny(clippy::disallowed_types)]
 
-//! Batch-level ASOF join execution on `RecordBatch`es.
-//!
-//! Implements the ASOF join algorithm for batch data, matching each left row
-//! to the closest right row by timestamp within the same key partition.
+//! Batch-level ASOF join: matches each left row to the closest right row by timestamp within the same key.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -23,9 +20,6 @@ use crate::key_column::{
 };
 
 /// Execute an ASOF join on two sets of `RecordBatch`es.
-///
-/// Matches each left row to the closest right row by timestamp, partitioned
-/// by key column, according to the direction and tolerance in `config`.
 ///
 /// # Errors
 ///
@@ -53,7 +47,6 @@ pub(crate) fn execute_asof_join_batch(
         .map_err(|e| DbError::query_pipeline_arrow("ASOF join (left)", &e))?;
 
     let right_schema = if right_batches.is_empty() {
-        // Build a schema with the same structure but no rows
         Arc::new(Schema::empty())
     } else {
         right_batches[0].schema()
@@ -68,8 +61,6 @@ pub(crate) fn execute_asof_join_batch(
 
     let output_schema = build_output_schema(&left_schema, &right_schema, config);
 
-    // Build right-side index: key_hash -> BTreeMap<timestamp, row_index>
-    // Keyed by hash to avoid per-row String allocations.
     let mut right_index: FxHashMap<u64, BTreeMap<i64, Vec<usize>>> =
         FxHashMap::with_capacity_and_hasher(right.num_rows(), rustc_hash::FxBuildHasher);
     let right_keys_col;
@@ -87,13 +78,12 @@ pub(crate) fn execute_asof_join_batch(
                     .or_default()
                     .push(i);
             }
-            // Null keys are skipped — they can never match per SQL three-valued logic
+            // null keys never match
         }
     } else {
         right_keys_col = None;
     }
 
-    // Extract left key and timestamp columns (zero-alloc borrow)
     let left_keys_col = extract_key_column(&left, &config.key_column)?;
     let left_timestamps = extract_column_as_timestamps(&left, &config.left_time_column)?;
 
@@ -101,7 +91,6 @@ pub(crate) fn execute_asof_join_batch(
         .tolerance
         .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX));
 
-    // For each left row, find matching right row
     let mut left_indices: Vec<usize> = Vec::with_capacity(left.num_rows());
     let mut right_indices: Vec<Option<usize>> = Vec::with_capacity(left.num_rows());
 
@@ -115,9 +104,7 @@ pub(crate) fn execute_asof_join_batch(
             continue;
         };
 
-        // Walk timestamps in direction order, verifying key equality at each.
-        // This handles hash collisions: if a different key occupies the closest
-        // timestamp, we continue to the next timestamp rather than giving up.
+        // Verify key equality at each candidate to handle hash collisions.
         let matched_right = right_index.get(&left_hash).and_then(|btree| {
             if let Some(ref rk) = right_keys_col {
                 find_verified_match(
@@ -143,13 +130,10 @@ pub(crate) fn execute_asof_join_batch(
                 left_indices.push(left_idx);
                 right_indices.push(None);
             }
-            (AsofSqlJoinType::Inner, None) => {
-                // Skip unmatched rows for inner join
-            }
+            (AsofSqlJoinType::Inner, None) => {}
         }
     }
 
-    // Build output columns
     build_output_batch(
         &left,
         &right,
@@ -160,9 +144,7 @@ pub(crate) fn execute_asof_join_batch(
     )
 }
 
-/// Walk timestamps in direction order, returning the first row index where the
-/// key matches. Handles hash collisions by continuing to the next-best timestamp
-/// when no key match is found at the closest one.
+/// Closest timestamp match with key-equality verification (handles hash collisions).
 fn find_verified_match(
     btree: &BTreeMap<i64, Vec<usize>>,
     left_ts: i64,
@@ -244,11 +226,7 @@ fn find_verified_match(
     }
 }
 
-/// Build the merged output schema from left and right schemas.
-///
-/// Right-side columns are made nullable for Left joins. Duplicate column
-/// names (collisions between left and right) are disambiguated by appending
-/// `_{right_table}` to the right-side field.
+/// Right columns are made nullable for Left joins; duplicate names get `_{right_table}` suffix.
 fn build_output_schema(
     left_schema: &SchemaRef,
     right_schema: &SchemaRef,
@@ -267,7 +245,6 @@ fn build_output_schema(
         .collect();
     let make_nullable = config.join_type == AsofSqlJoinType::Left;
     for field in right_schema.fields() {
-        // Skip duplicate key column (already in left side)
         if field.name() == &config.key_column {
             continue;
         }
@@ -275,7 +252,6 @@ fn build_output_schema(
         if make_nullable {
             f = f.with_nullable(true);
         }
-        // Disambiguate duplicate names by appending _{right_table}
         if left_names.contains(f.name().as_str()) {
             let suffixed_name = format!("{}_{}", f.name(), config.right_table);
             f = f.with_name(suffixed_name);
@@ -286,7 +262,6 @@ fn build_output_schema(
     Arc::new(Schema::new(fields))
 }
 
-/// Build the output `RecordBatch` from matched indices.
 fn build_output_batch(
     left: &RecordBatch,
     right: &RecordBatch,
@@ -298,7 +273,6 @@ fn build_output_batch(
     let num_rows = left_indices.len();
     let mut columns: Vec<ArrayRef> = Vec::with_capacity(left.num_columns() + right.num_columns());
 
-    // Left-side columns: take selected rows
     #[allow(clippy::cast_possible_truncation)]
     let left_idx_array =
         arrow::array::UInt32Array::from(left_indices.iter().map(|&i| i as u32).collect::<Vec<_>>());
@@ -309,11 +283,9 @@ fn build_output_batch(
         columns.push(taken);
     }
 
-    // Right-side columns: take selected rows (with nulls for unmatched)
     let right_schema = right.schema();
     for col_idx in 0..right.num_columns() {
         let field_name = right_schema.field(col_idx).name();
-        // Skip duplicate key column
         if field_name == &config.key_column {
             continue;
         }
@@ -329,10 +301,9 @@ fn build_output_batch(
 
 const ASOF_COMPACTION_THRESHOLD: u32 = 32;
 
-/// Right-side index: `key_hash → BTreeMap<timestamp, Vec<row_index>>`.
 type RightIndex = FxHashMap<u64, BTreeMap<i64, Vec<usize>>>;
 
-/// Right-side state for streaming ASOF joins. Persists across execution cycles.
+/// Right-side buffer for streaming ASOF joins. Persists across cycles.
 #[derive(Default)]
 pub(crate) struct AsofRightBuffer {
     index: RightIndex,
@@ -341,8 +312,6 @@ pub(crate) struct AsofRightBuffer {
 }
 
 impl AsofRightBuffer {
-    /// Ingest new right-side batches, appending to the concatenated batch and
-    /// updating the index.
     pub fn ingest(
         &mut self,
         batches: &[RecordBatch],
@@ -353,7 +322,6 @@ impl AsofRightBuffer {
             return Ok(());
         }
 
-        // Filter out CDC negative events (D, U-) before buffering
         let filtered: Vec<RecordBatch> = batches
             .iter()
             .map(crate::changelog_filter::filter_positive_events)
@@ -371,7 +339,7 @@ impl AsofRightBuffer {
         }
 
         let timestamps = extract_column_as_timestamps(&new_batch, time_col)?;
-        // Pre-compute hashes before new_batch is moved into concat.
+        // Pre-compute hashes before new_batch is moved into the concat.
         let key_hashes: Vec<Option<u64>> = {
             let keys = extract_key_column(&new_batch, key_col)?;
             (0..new_batch.num_rows()).map(|i| keys.hash_at(i)).collect()
@@ -402,7 +370,6 @@ impl AsofRightBuffer {
         Ok(())
     }
 
-    /// Evict all rows with `ts < cutoff`.
     pub fn evict_before(&mut self, cutoff: i64) -> Result<(), DbError> {
         for btree in self.index.values_mut() {
             let keep = btree.split_off(&cutoff);
@@ -416,16 +383,12 @@ impl AsofRightBuffer {
         Ok(())
     }
 
-    /// Keep, per key, the latest right row at or below `watermark` plus every
-    /// newer row; drop the rest. A future left (`ts >= watermark`) backward- or
-    /// nearest-matches the latest right `<= its ts`, which is never older than
-    /// the latest right `<= watermark`, so older rows are unreachable. Unlike
-    /// [`Self::evict_before`] this retains the boundary row, making it safe with
-    /// no tolerance.
+    /// Per key, keep the latest row at or below `watermark` plus all newer rows.
+    /// Unlike `evict_before`, retains the boundary row so backward/nearest joins
+    /// with no tolerance still find a match.
     pub fn evict_superseded(&mut self, watermark: i64) -> Result<(), DbError> {
         for btree in self.index.values_mut() {
-            // Greatest ts <= watermark; keep it and everything newer, drop the
-            // rest. `split_off(&keep_ts)` returns the `>= keep_ts` tail.
+            // split_off(&keep_ts) returns the >= keep_ts tail.
             if let Some((&keep_ts, _)) = btree.range(..=watermark).next_back() {
                 *btree = btree.split_off(&keep_ts);
             }
@@ -505,8 +468,7 @@ impl AsofRightBuffer {
     }
 }
 
-/// Execute an ASOF join of left batches against a stateful right buffer.
-/// The right buffer must have been pre-populated via `AsofRightBuffer::ingest`.
+/// ASOF join of left batches against a pre-populated `AsofRightBuffer`.
 pub(crate) fn execute_asof_join_with_state(
     left_batches: &[RecordBatch],
     right_buffer: &AsofRightBuffer,
@@ -522,12 +484,9 @@ pub(crate) fn execute_asof_join_with_state(
         .map_err(|e| DbError::query_pipeline_arrow("ASOF join (left)", &e))?;
 
     let Some(right) = right_buffer.right_concat.clone() else {
-        // No right data buffered. A Left join emits left rows with null right
-        // columns — but only once the right schema is known (captured from an
-        // earlier batch). Keeping those columns is essential: a downstream
-        // projection that references a right column (e.g. a spike ratio over a
-        // slow-warming baseline) fails to plan if they're dropped. Until the
-        // right schema is known, emit nothing rather than a malformed batch.
+        // Left join: once the right schema is known, emit nulls for unmatched left rows so
+        // downstream projections referencing right columns can still resolve. Before the schema
+        // is known, emit nothing rather than a schema-incomplete batch.
         if config.join_type == AsofSqlJoinType::Left {
             if let Some(right_schema) = right_schema_hint {
                 let output_schema = build_output_schema(&left_schema, right_schema, config);
@@ -604,11 +563,7 @@ pub(crate) fn execute_asof_join_with_state(
     )
 }
 
-/// Serializable checkpoint for `AsofRightBuffer`.
-///
-/// Row indices are `u32` because they index into a single `RecordBatch`
-/// whose row count is itself `u32`-bounded; using `u32` halves the
-/// in-memory footprint of the index-entries vec compared to `usize`.
+/// Serializable checkpoint for `AsofRightBuffer`. Row indices are `u32` (half the footprint of `usize`).
 #[derive(
     serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
@@ -647,9 +602,6 @@ impl AsofRightBuffer {
         let mut index_entries = Vec::new();
         for (&key_hash, btree) in &self.index {
             for (&ts, indices) in btree {
-                // Compact via u32. `compact()` was just called above, so indices
-                // are bounded by the row count of `right_concat`, which is itself
-                // u32-bounded.
                 #[allow(clippy::cast_possible_truncation)]
                 let narrow: Vec<u32> = indices.iter().map(|&i| i as u32).collect();
                 index_entries.push((key_hash, ts, narrow));

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -274,6 +274,14 @@ impl LaminarDbBuilder {
         self
     }
 
+    /// Cap total operator state held in memory. Crossing the budget pauses
+    /// source intake (backpressure, not failure) until state drains below it.
+    #[must_use]
+    pub fn state_memory_budget_bytes(mut self, bytes: usize) -> Self {
+        self.config.state_memory_budget_bytes = Some(bytes);
+        self
+    }
+
     /// Set checkpoint configuration.
     #[must_use]
     pub fn checkpoint(mut self, config: StreamCheckpointConfig) -> Self {

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -283,9 +283,9 @@ impl LaminarDbBuilder {
     }
 
     /// Enable the disk cold tier at `dir`. With a memory budget set, operator
-    /// state approaching the budget is demoted here instead of
-    /// backpressuring, and fetched back on demand. Requires the `state-tier`
-    /// build feature; ignored without it.
+    /// state approaching the budget is demoted here instead of backpressuring,
+    /// and fetched back on demand. Requires the `state-tier` build feature.
+    #[cfg(feature = "state-tier")]
     #[must_use]
     pub fn state_tier_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.config.state_tier_dir = Some(dir.into());

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -282,6 +282,16 @@ impl LaminarDbBuilder {
         self
     }
 
+    /// Enable the disk cold tier at `dir`. With a memory budget set, operator
+    /// state approaching the budget is demoted here instead of
+    /// backpressuring, and fetched back on demand. Requires the `state-tier`
+    /// build feature; ignored without it.
+    #[must_use]
+    pub fn state_tier_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.config.state_tier_dir = Some(dir.into());
+        self
+    }
+
     /// Set checkpoint configuration.
     #[must_use]
     pub fn checkpoint(mut self, config: StreamCheckpointConfig) -> Self {

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -36,44 +36,26 @@ pub struct LaminarDbBuilder {
     object_store_options: HashMap<String, String>,
     custom_udfs: Vec<ScalarUDF>,
     custom_udafs: Vec<AggregateUDF>,
-    /// Cluster control facade installed at cluster-mode startup.
-    /// Stays `None` in embedded / single-instance builds.
     #[cfg(feature = "cluster")]
     cluster_controller: Option<std::sync::Arc<laminar_core::cluster::control::ClusterController>>,
-    /// Outbound shuffle handle for cluster-mode streaming aggregates.
-    /// Pair with `shuffle_receiver`; without it, streaming aggregates
-    /// run single-node even when the cluster controller is installed.
     #[cfg(feature = "cluster")]
     shuffle_sender: Option<std::sync::Arc<laminar_core::shuffle::ShuffleSender>>,
-    /// Inbound shuffle handle for cluster-mode streaming aggregates.
     #[cfg(feature = "cluster")]
     shuffle_receiver: Option<std::sync::Arc<laminar_core::shuffle::ShuffleReceiver>>,
-    /// Commit-marker store for cross-instance 2PC.
     #[cfg(feature = "cluster")]
     decision_store: Option<std::sync::Arc<laminar_core::cluster::control::CheckpointDecisionStore>>,
-    /// Assignment-snapshot store for dynamic rebalance.
     #[cfg(feature = "cluster")]
     assignment_snapshot_store:
         Option<std::sync::Arc<laminar_core::cluster::control::AssignmentSnapshotStore>>,
-    /// Catalog-manifest store for cluster-wide DDL replay on boot/rebalance.
     #[cfg(feature = "cluster")]
     catalog_manifest_store:
         Option<std::sync::Arc<laminar_core::cluster::control::CatalogManifestStore>>,
-    /// Optional state backend. When paired with `vnode_registry`, the
-    /// coordinator writes per-vnode durability markers each checkpoint
-    /// and consults `epoch_complete` before committing sinks.
     state_backend: Option<std::sync::Arc<dyn laminar_core::state::StateBackend>>,
-    /// Optional vnode topology. See `state_backend`.
     vnode_registry: Option<std::sync::Arc<laminar_core::state::VnodeRegistry>>,
-    /// Extra physical optimizer rules installed on the `SessionState`
-    /// at construction.
     physical_optimizer_rules: Vec<
         std::sync::Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>,
     >,
-    /// Override for `target_partitions`; cluster mode sets this to
-    /// `vnode_count`. Default 1 for single-instance streaming.
     target_partitions: Option<usize>,
-    /// Assembled AI subsystem; installed when `[ai]`/`[models]` are configured.
     ai_runtime: Option<std::sync::Arc<crate::ai::AiRuntime>>,
 }
 
@@ -111,17 +93,14 @@ impl LaminarDbBuilder {
         }
     }
 
-    /// Install the assembled AI subsystem (model registry + provider clients +
-    /// result cache + call log). Without it, `ai_*` SQL functions fail at plan
-    /// time. Built from server `[ai]`/`[models]` configuration.
+    /// Install the AI subsystem; required for `ai_*` SQL functions.
     #[must_use]
     pub fn ai(mut self, runtime: std::sync::Arc<crate::ai::AiRuntime>) -> Self {
         self.ai_runtime = Some(runtime);
         self
     }
 
-    /// Override `target_partitions`; requires a distributed-aware
-    /// physical optimizer rule to replace `RepartitionExec`.
+    /// Override `target_partitions`.
     #[must_use]
     pub fn target_partitions(mut self, n: usize) -> Self {
         self.target_partitions = Some(n);
@@ -140,9 +119,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Install a state backend. Must be paired with
-    /// [`Self::vnode_registry`] — `build()` rejects a half-set
-    /// configuration.
+    /// Install a state backend; must be paired with [`Self::vnode_registry`].
     #[must_use]
     pub fn state_backend(
         mut self,
@@ -152,9 +129,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Install a vnode registry. Must be paired with
-    /// [`Self::state_backend`] — `build()` rejects a half-set
-    /// configuration.
+    /// Install a vnode registry; must be paired with [`Self::state_backend`].
     #[must_use]
     pub fn vnode_registry(
         mut self,
@@ -164,10 +139,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Install a cluster control facade. Activates cluster-mode
-    /// checkpoint / shuffle semantics inside the engine. Called from
-    /// `laminar-server`'s cluster startup path after discovery has
-    /// converged.
+    /// Install the cluster control facade; activates cluster-mode checkpoint/shuffle.
     #[cfg(feature = "cluster")]
     #[must_use]
     pub fn cluster_controller(
@@ -178,10 +150,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Install the outbound shuffle handle used by cluster-mode streaming
-    /// aggregates. Rows whose group key hashes to a remote vnode are
-    /// shipped through this sender. Pair with [`Self::shuffle_receiver`];
-    /// either alone is a no-op.
+    /// Install the outbound shuffle handle; pair with [`Self::shuffle_receiver`].
     #[cfg(feature = "cluster")]
     #[must_use]
     pub fn shuffle_sender(
@@ -192,9 +161,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Install the inbound shuffle handle used by cluster-mode streaming
-    /// aggregates. Remote partial-aggregate rows arrive here and are
-    /// drained into the local accumulator each cycle.
+    /// Install the inbound shuffle handle; pair with [`Self::shuffle_sender`].
     #[cfg(feature = "cluster")]
     #[must_use]
     pub fn shuffle_receiver(
@@ -339,72 +306,42 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Register a custom scalar UDF with the database.
-    ///
-    /// The UDF will be available in SQL queries after `build()`.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use datafusion_expr::ScalarUDF;
-    ///
-    /// let db = LaminarDB::builder()
-    ///     .register_udf(my_scalar_udf)
-    ///     .build()
-    ///     .await?;
-    /// ```
+    /// Register a custom scalar UDF; available in SQL after `build()`.
     #[must_use]
     pub fn register_udf(mut self, udf: ScalarUDF) -> Self {
         self.custom_udfs.push(udf);
         self
     }
 
-    /// Register a custom aggregate UDF (UDAF) with the database.
-    ///
-    /// The UDAF will be available in SQL queries after `build()`.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use datafusion_expr::AggregateUDF;
-    ///
-    /// let db = LaminarDB::builder()
-    ///     .register_udaf(my_aggregate_udf)
-    ///     .build()
-    ///     .await?;
-    /// ```
+    /// Register a custom aggregate UDF; available in SQL after `build()`.
     #[must_use]
     pub fn register_udaf(mut self, udaf: AggregateUDF) -> Self {
         self.custom_udafs.push(udaf);
         self
     }
 
-    /// Source → coordinator channel capacity (default 64). Increase for
-    /// burst absorption at the cost of memory.
+    /// Source → coordinator channel capacity (default 64).
     #[must_use]
     pub fn pipeline_channel_capacity(mut self, capacity: usize) -> Self {
         self.config.pipeline_channel_capacity = Some(capacity);
         self
     }
 
-    /// Micro-batch coalescing window (default 5ms for connectors, 0 for
-    /// embedded). Larger values amortize per-cycle SQL overhead.
+    /// Micro-batch coalescing window (default 5ms for connectors, 0 for embedded).
     #[must_use]
     pub fn pipeline_batch_window(mut self, window: std::time::Duration) -> Self {
         self.config.pipeline_batch_window = Some(window);
         self
     }
 
-    /// Max time draining the source channel per cycle, in nanoseconds
-    /// (default 1ms). Increase to process more messages per SQL execution.
+    /// Max drain time per cycle in nanoseconds (default 1ms).
     #[must_use]
     pub fn pipeline_drain_budget_ns(mut self, ns: u64) -> Self {
         self.config.pipeline_drain_budget_ns = Some(ns);
         self
     }
 
-    /// Per-query execution budget in nanoseconds (default 8ms). When
-    /// exceeded, remaining queries are deferred to the next cycle.
+    /// Per-query execution budget in nanoseconds (default 8ms).
     #[must_use]
     pub fn pipeline_query_budget_ns(mut self, ns: u64) -> Self {
         self.config.pipeline_query_budget_ns = Some(ns);
@@ -435,22 +372,7 @@ impl LaminarDbBuilder {
         self
     }
 
-    /// Register custom connectors with the `ConnectorRegistry`.
-    ///
-    /// The callback is invoked after the database is created and built-in
-    /// connectors are registered. Use it to add user-defined source/sink
-    /// implementations.
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// let db = LaminarDB::builder()
-    ///     .register_connector(|registry| {
-    ///         registry.register_source("my-source", info, factory);
-    ///     })
-    ///     .build()
-    ///     .await?;
-    /// ```
+    /// Register custom connectors; the callback runs after built-ins are wired.
     #[must_use]
     pub fn register_connector(
         mut self,
@@ -467,16 +389,13 @@ impl LaminarDbBuilder {
     /// Returns `DbError` if database creation fails.
     #[allow(clippy::unused_async)]
     pub async fn build(mut self) -> Result<LaminarDB, DbError> {
-        // Forward object store settings into the config before profile detection.
         self.config.object_store_url = self.object_store_url;
         self.config.object_store_options = self.object_store_options;
 
-        // Auto-detect profile from config if not explicitly set.
         if !self.profile_explicit {
             self.profile = Profile::from_config(&self.config, false);
         }
 
-        // Validate profile feature gates and config requirements.
         self.profile
             .validate_features()
             .map_err(|e| DbError::Config(e.to_string()))?;
@@ -486,9 +405,7 @@ impl LaminarDbBuilder {
 
         Self::validate_backpressure(&self.config)?;
 
-        // State backend and vnode registry must be paired. Single-node (no
-        // controller) tiering uses a single-owner registry — the durability
-        // gate wires the coordinator from it without a controller.
+        // state_backend and vnode_registry must be paired or both absent.
         match (&self.state_backend, &self.vnode_registry) {
             (Some(_), None) => {
                 return Err(DbError::Config(
@@ -503,7 +420,6 @@ impl LaminarDbBuilder {
             _ => {}
         }
 
-        // Apply profile defaults for fields the user hasn't set.
         self.profile.apply_defaults(&mut self.config);
 
         let mut db = LaminarDB::open_with_config_and_vars_and_rules(
@@ -513,7 +429,6 @@ impl LaminarDbBuilder {
             self.target_partitions,
         )?;
         if let Some(runtime) = self.ai_runtime {
-            // Inference workers require a running Tokio runtime.
             let handle = tokio::runtime::Handle::try_current().map_err(|_| {
                 DbError::InvalidOperation(
                     "LaminarDB::build() with an AI runtime must run inside a Tokio runtime"
@@ -573,7 +488,6 @@ impl LaminarDbBuilder {
             return Ok(());
         }
 
-        // Non-default policy needs at least one finite, non-zero cap.
         let has_count_cap = config.pipeline_max_input_buf_batches.is_none_or(|c| c > 0);
         let has_byte_cap = config.pipeline_max_input_buf_bytes.is_some_and(|b| b > 0);
         if !has_count_cap && !has_byte_cap {

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -486,7 +486,9 @@ impl LaminarDbBuilder {
 
         Self::validate_backpressure(&self.config)?;
 
-        // State backend and vnode registry must be paired.
+        // State backend and vnode registry must be paired. Single-node (no
+        // controller) tiering uses a single-owner registry — the durability
+        // gate wires the coordinator from it without a controller.
         match (&self.state_backend, &self.vnode_registry) {
             (Some(_), None) => {
                 return Err(DbError::Config(

--- a/crates/laminar-db/src/catalog_connector.rs
+++ b/crates/laminar-db/src/catalog_connector.rs
@@ -20,11 +20,7 @@ use laminar_core::streaming;
 
 use crate::catalog::ArrowRecord;
 
-/// A source connector that bridges catalog SPSC subscriptions into the pipeline.
-///
-/// Implements `SourceConnector` by polling a `streaming::Subscription<ArrowRecord>`
-/// so that `db.insert()` data participates in the fan-out/fan-in pipeline alongside
-/// external connectors (Kafka, WebSocket, etc.).
+/// Bridges a catalog SPSC subscription into the pipeline alongside external connectors.
 pub(crate) struct CatalogSourceConnector {
     subscription: streaming::Subscription<ArrowRecord>,
     schema: SchemaRef,
@@ -33,7 +29,6 @@ pub(crate) struct CatalogSourceConnector {
 }
 
 impl CatalogSourceConnector {
-    /// Create a new bridge connector.
     pub fn new(
         subscription: streaming::Subscription<ArrowRecord>,
         schema: SchemaRef,
@@ -51,7 +46,6 @@ impl CatalogSourceConnector {
 #[async_trait]
 impl SourceConnector for CatalogSourceConnector {
     async fn open(&mut self, _config: &ConnectorConfig) -> Result<(), ConnectorError> {
-        // Already connected via the subscription — nothing to do.
         Ok(())
     }
 
@@ -79,9 +73,7 @@ impl SourceConnector for CatalogSourceConnector {
             return Ok(None);
         }
 
-        // Fast path: skip concat_batches when there's only one batch
-        // (common case for embedded sources). Avoids a memcpy of the
-        // entire RecordBatch (~1-5μs for typical batch sizes).
+        // Skip concat when there's only one batch (common case; saves a memcpy).
         let records = if batches.len() == 1 {
             batches.into_iter().next().expect("len==1 checked above")
         } else {
@@ -111,7 +103,6 @@ impl SourceConnector for CatalogSourceConnector {
     }
 
     async fn restore(&mut self, _checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
-        // In-memory, non-replayable — nothing to restore.
         Ok(())
     }
 

--- a/crates/laminar-db/src/changelog_filter.rs
+++ b/crates/laminar-db/src/changelog_filter.rs
@@ -60,13 +60,8 @@ pub(crate) fn filter_positive_events(batch: &RecordBatch) -> Result<RecordBatch,
         .map_err(|e| DbError::Pipeline(format!("changelog filter: {e}")))
 }
 
-/// For non-changelog sinks, drop rows with non-positive `__weight` and strip
-/// the column. Otherwise the input is borrowed unchanged.
-///
-/// Fail-closed: any error on the filter/strip path returns an empty batch
-/// with `__weight` removed rather than leaking negative weights or an
-/// unexpected column into an append-only sink (which would either corrupt
-/// the table or break its schema).
+/// Drop rows with non-positive `__weight` and strip the column for non-changelog sinks.
+/// Fail-closed: errors return an empty batch rather than leaking negatives into the sink.
 pub(crate) fn prepare_for_sink(batch: &RecordBatch, changelog_sink: bool) -> Cow<'_, RecordBatch> {
     if changelog_sink {
         return Cow::Borrowed(batch);
@@ -77,8 +72,6 @@ pub(crate) fn prepare_for_sink(batch: &RecordBatch, changelog_sink: bool) -> Cow
     else {
         return Cow::Borrowed(batch);
     };
-    // Schema with `__weight` removed — the only safe fallback for an
-    // append-only sink when we can't filter properly.
     let stripped_schema = {
         let fields: Vec<_> = batch
             .schema()

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1,20 +1,6 @@
-//! Unified checkpoint coordinator.
+//! Checkpoint coordinator — Ring 2 control-plane orchestrator.
 //!
-//! Single orchestrator for checkpoint lifecycle. Lives in Ring 2 (control plane).
-//!
-//! The checkpoint manifest is the source of truth for source offsets.
-//! Kafka broker commits are advisory (for monitoring tools). On recovery,
-//! offsets restore from manifest, not consumer group state.
-//!
-//! ## Checkpoint Cycle
-//!
-//! 1. Barrier injection — `CheckpointBarrierInjector.trigger()`
-//! 2. Operator snapshot — `OperatorGraph.snapshot_state()` → operator states
-//! 3. Source snapshot — `source.checkpoint()` for each source
-//! 4. Sink pre-commit — `sink.pre_commit(epoch)` for each exactly-once sink
-//! 5. Manifest persist — `store.save(&manifest)` (atomic write)
-//! 6. Sink commit — `sink.commit_epoch(epoch)` for each exactly-once sink
-//! 7. On ANY failure at 6 — `sink.rollback_epoch()` on remaining sinks
+//! Checkpoint manifest is the source of truth for source offsets; broker commits are advisory.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -33,32 +19,19 @@ use tracing::{debug, error, info, warn};
 use crate::error::DbError;
 
 /// One operator's staged slice for one vnode of the next checkpoint.
-///
-/// Both variants are only constructed on the per-vnode capture path
-/// (`cluster`); without it the coordinator still carries the type but never
-/// builds one.
 #[cfg_attr(not(feature = "cluster"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub(crate) enum StagedSlice {
-    /// Freshly serialized memory-resident state.
     Bytes(bytes::Bytes),
-    /// Demoted to the cold tier and untouched since the upload recorded in
-    /// `last_vnode_uploads`: no bytes staged. The coordinator emits a
-    /// reference partial, or fetches the slice back from the tier when a
-    /// full re-upload is forced.
+    // No bytes; the coordinator emits a reference partial or fetches from the tier on a forced
+    // full re-upload.
     Cold,
 }
 
-/// Per-vnode staged slices, `vnode → operator → slice`.
 pub(crate) type StagedVnodeStates = HashMap<u32, HashMap<String, StagedSlice>>;
 
-/// What `last_vnode_uploads` records per operator slice of the last full
-/// upload: the exact bytes (the reference-partial comparison base, and the
-/// byte source for coordinator-driven demotion), or a cold marker once the
-/// slice was demoted — the bytes then live only in the tier, releasing the
-/// in-memory pin.
-/// `Cold` is only recorded when a demotion lands (`state-tier`); the plain
-/// `cluster` build records bytes but never a cold marker.
+/// Records the last full upload per operator slice: bytes for reference-partial comparison, or
+/// `Cold` after demotion (bytes live only in the tier).
 #[cfg_attr(not(feature = "state-tier"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub(crate) enum UploadedSlice {
@@ -67,13 +40,11 @@ pub(crate) enum UploadedSlice {
 }
 
 impl UploadedSlice {
-    /// Whether `staged` proves the slice unchanged since this upload.
+    /// Returns true if `staged` proves the slice unchanged since this upload.
     ///
-    /// `Cold` staged ⇒ unchanged by the demotion contract (a demoted slice
-    /// is byte-identical to its recorded upload, and any row for it
-    /// promotes the slice back to memory before processing). Fresh bytes
-    /// against a cold record are conservatively "changed" — the cold bytes
-    /// aren't here to compare, so the slice re-uploads full once.
+    /// `Cold` staged means unchanged (demotion contract: byte-identical to the recorded upload).
+    /// Fresh bytes against a `Cold` record are conservatively "changed" — the cold bytes are
+    /// unavailable for comparison, so the slice re-uploads full.
     fn matches(&self, staged: &StagedSlice) -> bool {
         match (staged, self) {
             (StagedSlice::Cold, _) => true,
@@ -83,13 +54,7 @@ impl UploadedSlice {
     }
 }
 
-/// Unified checkpoint configuration.
-///
-/// Timeouts prevent a stuck sink or hung filesystem from stalling the
-/// runtime. `state_inline_threshold` decides per-operator whether state
-/// inlines as base64 in the JSON manifest or lands in a sidecar file.
-/// `max_checkpoint_bytes` caps total sidecar size; an oversized
-/// checkpoint is rejected with `[LDB-6014]`.
+/// Checkpoint configuration.
 #[derive(Debug, Clone)]
 pub struct CheckpointConfig {
     /// Interval between checkpoints. `None` = manual only.
@@ -114,20 +79,14 @@ pub struct CheckpointConfig {
     pub max_checkpoint_bytes: Option<usize>,
     /// Quorum wait timeout for checkpoint coordination.
     pub quorum_timeout: Duration,
-    /// Max wait for every participating vnode's partial to land before
-    /// the epoch is declared restorable. Followers ack at *capture* and
-    /// upload asynchronously after acking, so the
-    /// leader's durability gate polls for partial presence instead of
-    /// checking once. Expiry aborts the epoch.
+    /// Max wait for every vnode's partial to land before the epoch is declared restorable.
+    ///
+    /// Followers upload asynchronously after the capture ack, so the durability gate polls
+    /// rather than checking once. Expiry aborts the epoch.
     pub restorable_gate_timeout: Duration,
-    /// Maximum epochs admitted between `Aligned` and restorable — the
-    /// upload backlog. Exactly-once pipelines are
-    /// capped at 1: a single-open-transaction sink (e.g. a Kafka
-    /// transactional producer) cannot overlap epochs.
+    /// Max pipelined epochs between `Aligned` and restorable. Exactly-once pipelines cap at 1.
     pub max_in_flight_epochs: u64,
-    /// Cap on captured-state bytes held in memory by in-flight epochs
-    /// awaiting upload. At the cap, barrier admission pauses — cadence
-    /// degrades to upload speed instead of exhausting memory.
+    /// Cap on in-flight captured-state bytes. At the cap, barrier admission pauses.
     pub max_staged_bytes: u64,
 }
 
@@ -145,9 +104,7 @@ impl Default for CheckpointConfig {
             state_inline_threshold: 1_048_576,
             max_checkpoint_bytes: None,
             quorum_timeout: Duration::from_secs(3),
-            // Last-resort bound only: membership/unresponsive/rotation
-            // fail-fasts catch dead participants in seconds. Long values
-            // serialize recovery (pipelined doomed epochs each burn it).
+            // Last-resort bound: fail-fasts catch dead participants in seconds.
             restorable_gate_timeout: Duration::from_secs(10),
             max_in_flight_epochs: 4,
             max_staged_bytes: 512 * 1024 * 1024,
@@ -158,9 +115,7 @@ impl Default for CheckpointConfig {
 /// Parameters for a checkpoint operation.
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointRequest {
-    /// Serialized operator states. `Bytes` (not `Vec<u8>`) so producers
-    /// (rkyv output, MV IPC bytes) can hand off the buffer without an
-    /// extra copy at each stage of the checkpoint pipeline.
+    /// Serialized operator states. `Bytes` avoids a copy at each pipeline stage.
     pub operator_states: HashMap<String, bytes::Bytes>,
     /// Current watermark timestamp.
     pub watermark: Option<i64>,
@@ -178,10 +133,8 @@ pub struct CheckpointRequest {
 
 /// Lock-free epoch/checkpoint-id allocator.
 ///
-/// Ids are handed out at barrier admission — possibly while an earlier
-/// epoch's durable tail still holds the coordinator mutex — so they
-/// live outside the coordinator's exclusive state. Failed epochs are
-/// abandoned, never re-allocated.
+/// Ids are allocated at barrier admission, outside the coordinator mutex, so pipelined tails
+/// can overlap. Failed epochs are abandoned, never re-allocated.
 #[derive(Debug)]
 pub(crate) struct EpochAllocator {
     epoch: std::sync::atomic::AtomicU64,
@@ -198,11 +151,8 @@ impl EpochAllocator {
 
     /// Claim the next `(epoch, checkpoint_id)` pair.
     ///
-    /// The two counters advance independently (not as one atomic unit):
-    /// every allocation site runs on the pipeline task or under the
-    /// coordinator mutex, so concurrent `allocate` calls cannot occur
-    /// today. A new call site off those paths would need this upgraded
-    /// to a single CAS over a packed pair.
+    /// The two counters advance independently; all callers today run on the pipeline task or
+    /// under the coordinator mutex, so concurrent calls do not occur.
     pub(crate) fn allocate(&self) -> (u64, u64) {
         use std::sync::atomic::Ordering;
         (
@@ -211,7 +161,7 @@ impl EpochAllocator {
         )
     }
 
-    /// The pair the next [`allocate`](Self::allocate) would return.
+    /// The pair the next `allocate` would return, without consuming it.
     pub(crate) fn peek(&self) -> (u64, u64) {
         use std::sync::atomic::Ordering;
         (
@@ -220,10 +170,8 @@ impl EpochAllocator {
         )
     }
 
-    /// Monotonic advance — ids never walk backwards. An aborted epoch
-    /// leaves artifacts behind (Pending manifest, uploaded partials);
-    /// recovery restoring an OLDER committed epoch must not pull ids
-    /// back down onto them and re-allocate the aborted epoch.
+    /// Monotonically advance. An aborted epoch leaves artifacts (Pending manifest, partials);
+    /// recovery from an older committed epoch must not re-allocate those ids.
     fn advance_to(&self, epoch: u64, next_checkpoint_id: u64) {
         use std::sync::atomic::Ordering;
         self.epoch.fetch_max(epoch, Ordering::AcqRel);
@@ -232,28 +180,21 @@ impl EpochAllocator {
     }
 }
 
-/// Capture-quorum participant id. Aliased so non-cluster builds (where
-/// `laminar_core::cluster` is compiled out and participant sets are
-/// always empty) still type-check the shared plumbing.
+/// Capture-quorum participant id. Aliased so non-cluster builds still type-check.
 #[cfg(feature = "cluster")]
 pub(crate) type QuorumPeer = laminar_core::cluster::discovery::NodeId;
 #[cfg(not(feature = "cluster"))]
 pub(crate) type QuorumPeer = u64;
 
-/// Whether `checkpoint_inner` still needs to run the cluster capture
-/// quorum, or a pipelined tail already ran it before taking the
-/// coordinator mutex.
+/// Whether the capture quorum still needs to run, or a pipelined tail already ran it.
 #[derive(Debug, Clone)]
 pub(crate) enum QuorumStage {
     /// Run the quorum + `Aligned` announce inline (forced/timer paths).
     RunInline,
-    /// Already reached before the coordinator lock; carries the merged
-    /// cluster-min watermark for the `Commit` announcement plus the
-    /// capture-time follower set, so the durability gate can fail fast
-    /// if one of them dies instead of burning its full timeout.
+    /// Quorum already reached before the coordinator lock.
     #[cfg_attr(not(feature = "cluster"), allow(dead_code))]
     Done {
-        /// Merged cluster-min watermark from the capture acks.
+        /// Cluster-min watermark from the capture acks.
         min_watermark_ms: Option<i64>,
         /// Followers that acked the capture quorum.
         participants: Vec<QuorumPeer>,
@@ -265,13 +206,13 @@ pub(crate) enum QuorumStage {
 pub enum CheckpointPhase {
     /// No checkpoint in progress.
     Idle,
-    /// Operators snapshotted, collecting source positions.
+    /// Collecting operator and source snapshots.
     Snapshotting,
-    /// Sinks pre-committing (phase 1).
+    /// Sinks running phase-1 pre-commit.
     PreCommitting,
-    /// Manifest being persisted.
+    /// Writing the manifest.
     Persisting,
-    /// Sinks committing (phase 2).
+    /// Sinks running phase-2 commit.
     Committing,
 }
 
@@ -292,11 +233,11 @@ impl std::fmt::Display for CheckpointPhase {
 pub struct CheckpointResult {
     /// Whether the checkpoint succeeded.
     pub success: bool,
-    /// Checkpoint ID (if created).
+    /// Checkpoint ID assigned to this attempt.
     pub checkpoint_id: u64,
     /// Epoch number.
     pub epoch: u64,
-    /// Duration of the checkpoint operation.
+    /// Wall time for the full checkpoint cycle.
     pub duration: Duration,
     /// Error message if failed.
     pub error: Option<String>,
@@ -304,38 +245,25 @@ pub struct CheckpointResult {
 
 /// Registered source for checkpoint coordination.
 pub(crate) struct RegisteredSource {
-    /// Source name.
     pub name: String,
-    /// Source connector handle.
     pub connector: Arc<tokio::sync::Mutex<Box<dyn SourceConnector>>>,
-    /// Whether this source supports replay from a checkpointed position.
-    ///
-    /// Sources that do not support replay (e.g., WebSocket) degrade
-    /// exactly-once semantics to at-most-once.
+    /// Sources without replay (e.g. WebSocket) degrade to at-most-once.
     pub supports_replay: bool,
 }
 
 /// Registered sink for checkpoint coordination.
 pub(crate) struct RegisteredSink {
-    /// Sink name.
     pub name: String,
-    /// Sink task handle (channel-based, no mutex contention).
     pub handle: crate::sink_task::SinkTaskHandle,
-    /// Whether this sink supports exactly-once / two-phase commit.
     pub exactly_once: bool,
 }
 
-/// Unified checkpoint coordinator.
-///
-/// Orchestrates the full checkpoint lifecycle across sources, sinks,
-/// and operator state, persisting everything in a single
-/// [`CheckpointManifest`].
+/// Orchestrates the checkpoint lifecycle across sources, sinks, and operator state.
 pub struct CheckpointCoordinator {
     config: CheckpointConfig,
     store: Arc<dyn CheckpointStore>,
     sinks: Vec<RegisteredSink>,
-    /// Shared with the pipeline callback, which allocates ids at
-    /// barrier admission without taking the coordinator mutex.
+    // Shared with the pipeline callback so barrier admission can claim ids without the mutex.
     allocator: Arc<EpochAllocator>,
     phase: CheckpointPhase,
     checkpoints_completed: u64,
@@ -344,63 +272,42 @@ pub struct CheckpointCoordinator {
     duration_histogram: DurationHistogram,
     prom: Option<Arc<crate::engine_metrics::EngineMetrics>>,
     total_bytes_written: u64,
-    /// Consulted between manifest persist and sink commit to verify
-    /// per-vnode durability.
+    // Consulted between manifest persist and sink commit for per-vnode durability.
     state_backend: Option<Arc<dyn StateBackend>>,
-    /// Stamped into every `write_partial` for the split-brain fence.
-    /// Zero = fence disabled.
+    // Stamped into every `write_partial` for the split-brain fence; zero = fence disabled.
     assignment_version: u64,
-    /// Durable commit marker, written before sinks are told to commit
-    /// so recovery can tell the 2PC verdict apart from a mid-flight
-    /// crash. `None` falls back to "rollback on recovery".
+    // Written before sink commits so recovery can distinguish a committed epoch from a crash.
     decision_store: Option<Arc<laminar_core::checkpoint_decision::CheckpointDecisionStore>>,
-    /// Reported in each `BarrierAck`; the leader folds these with its
-    /// own watermark to compute the cluster-wide min.
+    // Folded by the leader with follower watermarks to compute the cluster-wide min.
     local_watermark_ms: Option<i64>,
-    /// Cluster-wide min watermark as of the last committed epoch
-    /// (leader-side; fanned out in the Commit announcement).
+    // Leader-side cluster-wide min watermark, fanned out in the Commit announcement.
     #[cfg(feature = "cluster")]
     cluster_min_watermark: Option<i64>,
-    /// Vnodes this coordinator owns; drives per-vnode marker writes.
+    // Vnodes this coordinator owns; drives per-vnode marker writes.
     vnode_set: Vec<u32>,
-    /// Vnodes the leader's durability gate checks. In cluster mode the
-    /// full registry; single-instance mirrors `vnode_set`.
+    // In cluster mode: the full registry. Single-instance mirrors `vnode_set`.
     gate_vnode_set: Vec<u32>,
-    /// First epoch admitted at-or-after the latest vnode rotation. An
-    /// in-flight epoch BELOW this captured under the previous
-    /// assignment: vnodes that changed hands mid-epoch were captured by
-    /// nobody, so its durability gate can never seal — fail it fast
-    /// instead of burning the gate timeout (with pipelining, several
-    /// such epochs would burn serially).
+    // First epoch admitted after the latest vnode rotation. Epochs below this captured
+    // under the previous assignment can never seal their gate — fail them fast.
     rotation_epoch_floor: u64,
-    /// Per-vnode operator-state slices for the in-flight checkpoint,
-    /// `vnode → (operator_name → bytes)`. Set fresh before each checkpoint
-    /// by the pipeline callback from `OperatorGraph::snapshot_state_by_vnode`;
-    /// folded into each owned vnode's `partial.bin` by
-    /// [`write_vnode_partials`](Self::write_vnode_partials). Empty in
-    /// single-instance mode (the partial is then just a durability marker).
+    // Per-vnode operator-state slices for the in-flight checkpoint.
+    // Empty in single-instance mode (the partial is a durability marker only).
     #[allow(clippy::disallowed_types)] // matches the graph snapshot shape
     pending_vnode_states: StagedVnodeStates,
-    /// Per-vnode `(epoch, slices)` of the last *full* partial uploaded —
-    /// the bases for unchanged-vnode reference partials. Bytes are
-    /// refcounted, so this holds one serialized
-    /// snapshot's worth of memory, not a deep copy per epoch; demoted
-    /// slices hold a cold marker instead (their bytes live in the tier).
+    // Bases for reference partials. Bytes are refcounted; demoted slices hold a cold marker.
     #[allow(clippy::disallowed_types)]
     last_vnode_uploads:
         std::collections::HashMap<u32, (u64, std::collections::HashMap<String, UploadedSlice>)>,
-    /// Cold-tier request channel; lets a forced full re-upload of a
-    /// demoted slice fetch its bytes back from the tier.
+    // Channel to fetch demoted slice bytes back from the tier on a forced full re-upload.
     #[cfg(feature = "state-tier")]
     state_tier: Option<crate::state_tier::TierTx>,
-    /// `Some` in cluster mode, `None` in single-instance / embedded.
     #[cfg(feature = "cluster")]
     cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
-    /// Cached sorted sink names; invalidated on `register_sink`.
+    // Invalidated on `register_sink`; rebuilt on the next checkpoint.
     cached_sorted_sink_names: Option<Vec<String>>,
 }
 
-/// Highest-loadable manifest — tolerates a torn `latest.txt` pointer.
+/// Load the highest-id manifest, tolerating a torn `latest.txt` pointer.
 async fn load_highest(
     store: &dyn CheckpointStore,
 ) -> Result<Option<CheckpointManifest>, laminar_core::storage::checkpoint_store::CheckpointStoreError>
@@ -415,12 +322,11 @@ async fn load_highest(
 }
 
 impl CheckpointCoordinator {
-    /// Creates a new checkpoint coordinator, seeded from the highest
-    /// loadable stored checkpoint.
+    /// Create a coordinator seeded from the highest stored checkpoint.
     ///
     /// # Errors
-    /// Surfaces a store read failure rather than silently starting at
-    /// `(1, 1)` and clobbering on-disk state.
+    /// Returns a store read failure rather than silently starting at epoch 1 and clobbering
+    /// on-disk state.
     pub async fn new(
         config: CheckpointConfig,
         store: Box<dyn CheckpointStore>,
@@ -469,8 +375,7 @@ impl CheckpointCoordinator {
         })
     }
 
-    /// Activates cluster-mode 2PC. Without this the coordinator runs
-    /// single-instance semantics.
+    /// Activate cluster-mode 2PC. Without this the coordinator runs single-instance semantics.
     #[cfg(feature = "cluster")]
     pub fn set_cluster_controller(
         &mut self,
@@ -479,13 +384,12 @@ impl CheckpointCoordinator {
         self.cluster_controller = Some(controller);
     }
 
-    /// Wired with a non-empty `vnode_set` to enable per-vnode markers
-    /// and the `epoch_complete` durability gate.
+    /// Wire a state backend to enable per-vnode markers and the durability gate.
     pub fn set_state_backend(&mut self, backend: Arc<dyn StateBackend>) {
         self.state_backend = Some(backend);
     }
 
-    /// Install the durable commit-marker store.
+    /// Wire the durable commit-marker store.
     pub fn set_decision_store(
         &mut self,
         store: Arc<laminar_core::checkpoint_decision::CheckpointDecisionStore>,
@@ -493,65 +397,49 @@ impl CheckpointCoordinator {
         self.decision_store = Some(store);
     }
 
-    /// Record the assignment generation this coordinator is writing
-    /// with. Forwarded to `backend.write_partial` so the split-brain
-    /// fence can reject stale writers. Host sets this whenever a fresh
-    /// `AssignmentSnapshot` rotates in.
+    /// Set the assignment generation forwarded to `write_partial` for the split-brain fence.
     pub fn set_assignment_version(&mut self, version: u64) {
         self.assignment_version = version;
     }
 
-    /// Record this instance's current local watermark, reported in
-    /// every subsequent `BarrierAck` so the leader can compute the
-    /// cluster-wide minimum. `None` disables the per-follower
-    /// contribution — leader falls back to its own watermark (and
-    /// the other followers').
+    /// Set the local watermark reported in `BarrierAck` so the leader can fold it into the
+    /// cluster-wide minimum. `None` disables this instance's contribution.
     pub fn set_local_watermark_ms(&mut self, watermark: Option<i64>) {
         self.local_watermark_ms = watermark;
     }
 
-    /// Stage the per-vnode operator-state slices for the next checkpoint.
+    /// Stage per-vnode operator-state slices for the next checkpoint.
     ///
-    /// Each owned vnode's slice is folded into its `partial.bin` by
-    /// `write_vnode_partials` so a node that
-    /// later acquires the vnode can rehydrate exactly that vnode's state.
-    /// Call once per checkpoint (even with an empty map) so a prior epoch's
-    /// slices never leak forward.
+    /// Call once per checkpoint (even with an empty map) so prior epoch slices never leak.
     #[allow(clippy::disallowed_types)]
     pub(crate) fn set_pending_vnode_states(&mut self, states: StagedVnodeStates) {
         self.pending_vnode_states = states;
     }
 
-    /// Wire the cold-tier request channel (forced full re-uploads of
-    /// demoted slices fetch their bytes through it).
+    /// Wire the cold-tier channel for fetching demoted slice bytes on forced full re-uploads.
     #[cfg(feature = "state-tier")]
     #[allow(dead_code)] // wired once the demotion trigger lands with promotion
     pub(crate) fn set_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         self.state_tier = Some(tier);
     }
 
-    /// Vnodes this instance owns; drives marker writes. Also the
-    /// default gate set until [`Self::set_gate_vnode_set`] is called.
+    /// Set the owned vnodes. Also the default gate set until `set_gate_vnode_set` is called.
     pub fn set_vnode_set(&mut self, vnodes: Vec<u32>) {
         if self.gate_vnode_set.is_empty() {
             self.gate_vnode_set.clone_from(&vnodes);
         }
         self.rotation_epoch_floor = self.allocator.peek().0;
-        // Drop reference bases for vnodes shed in a rebalance — they
-        // hold refcounts on serialized state this node no longer owns
-        // (and the new owner builds its own bases from a full upload).
+        // Drop bases for shed vnodes; the new owner builds its own from a full upload.
         self.last_vnode_uploads.retain(|v, _| vnodes.contains(v));
         self.vnode_set = vnodes;
     }
 
-    /// Set the vnodes the leader's durability gate checks (the full
-    /// registry in cluster mode). Defaults to `vnode_set` when unset.
+    /// Set the vnodes the durability gate checks (the full registry in cluster mode).
     pub fn set_gate_vnode_set(&mut self, vnodes: Vec<u32>) {
         self.gate_vnode_set = vnodes;
     }
 
-    /// Fetch a demoted slice's bytes back from the cold tier for a forced
-    /// full re-upload.
+    /// Fetch a demoted slice from the cold tier for a forced full re-upload.
     #[cfg(feature = "state-tier")]
     async fn fetch_cold_slice(&self, operator: &str, vnode: u32) -> Result<bytes::Bytes, DbError> {
         let Some(ref tier) = self.state_tier else {
@@ -581,8 +469,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// `state-tier` off: a `Cold` slice can never be staged, so reaching
-    /// this is a logic error reported as a failed epoch.
+    /// Without `state-tier`, a `Cold` slice cannot be staged; reaching this is a logic error.
     #[cfg(not(feature = "state-tier"))]
     #[allow(clippy::unused_async)]
     async fn fetch_cold_slice(&self, operator: &str, vnode: u32) -> Result<bytes::Bytes, DbError> {
@@ -592,9 +479,7 @@ impl CheckpointCoordinator {
         )))
     }
 
-    /// Vnodes with at least one `Bytes` (memory-resident) slice, as
-    /// `(vnode, resident_bytes)` over those slices, largest first. Caller
-    /// invokes only with no checkpoint in flight, so every upload is durable.
+    /// Vnodes with memory-resident slices, as `(vnode, bytes)`, largest first.
     #[cfg(feature = "state-tier")]
     pub(crate) fn demotion_candidates(&self) -> Vec<(u32, usize)> {
         let mut out: Vec<(u32, usize)> = self
@@ -620,9 +505,7 @@ impl CheckpointCoordinator {
         out
     }
 
-    /// The recorded upload bytes for `vnode`, to hand to the tier. These
-    /// are exactly the bytes of the slice's last durable full upload, so a
-    /// demotion writes truth-identical state by construction.
+    /// The last durable upload bytes for `vnode`, to hand to the tier on demotion.
     #[cfg(feature = "state-tier")]
     pub(crate) fn slices_for_demotion(&self, vnode: u32) -> Vec<(String, bytes::Bytes)> {
         self.last_vnode_uploads
@@ -639,11 +522,8 @@ impl CheckpointCoordinator {
             .unwrap_or_default()
     }
 
-    /// Release one operator's byte pin for a demoted `(operator, vnode)`
-    /// slice — call only after the tier write is confirmed and the operator
-    /// dropped the groups. The reference-partial flow then keys off the cold
-    /// marker. Per operator (a vnode may carry several) so a refusal by one
-    /// doesn't strand the others' records.
+    /// Release the in-memory pin for a confirmed-demoted slice. Call after the tier write
+    /// lands and the operator drops the groups; reference partials then key off the cold marker.
     #[cfg(feature = "state-tier")]
     pub(crate) fn mark_slice_demoted(&mut self, vnode: u32, operator: &str) {
         if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
@@ -653,7 +533,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Registers a sink connector for checkpoint coordination.
+    /// Register a sink for checkpoint coordination.
     pub(crate) fn register_sink(
         &mut self,
         name: impl Into<String>,
@@ -665,33 +545,26 @@ impl CheckpointCoordinator {
             handle,
             exactly_once,
         });
-        // Invalidate the sorted-name cache; the next checkpoint will
-        // rebuild it.
         self.cached_sorted_sink_names = None;
     }
 
-    /// Begins the initial epoch on all exactly-once sinks.
+    /// Begin the initial epoch on all exactly-once sinks.
     ///
-    /// Must be called once after all sinks are registered and before any
-    /// writes occur. This starts the first Kafka transaction for exactly-once
-    /// sinks. Subsequent epochs are started automatically after each
-    /// successful checkpoint commit.
+    /// Must be called once after all sinks are registered and before any writes. Subsequent
+    /// epochs are started automatically after each successful checkpoint commit.
     ///
     /// # Errors
-    ///
-    /// Returns the first error from any sink that fails to begin the epoch.
+    /// Returns the first sink error.
     pub async fn begin_initial_epoch(&self) -> Result<(), DbError> {
         self.begin_epoch_for_sinks(self.allocator.peek().0).await
     }
 
-    /// Shared id allocator, cloned by the pipeline callback so barrier
-    /// admission can claim ids without the coordinator mutex.
+    /// Shared id allocator — the pipeline callback clones this to allocate without the mutex.
     pub(crate) fn epoch_allocator(&self) -> Arc<EpochAllocator> {
         Arc::clone(&self.allocator)
     }
 
-    /// Begins an epoch on all exactly-once sinks. If any sink fails,
-    /// rolls back sinks that already started the epoch.
+    /// Begin an epoch on all exactly-once sinks, rolling back already-started sinks on failure.
     async fn begin_epoch_for_sinks(&self, epoch: u64) -> Result<(), DbError> {
         let mut started: Vec<&RegisteredSink> = Vec::new();
         for sink in &self.sinks {
@@ -702,7 +575,6 @@ impl CheckpointCoordinator {
                         debug!(sink = %sink.name, epoch, "began epoch");
                     }
                     Err(e) => {
-                        // Roll back sinks that already started.
                         for s in &started {
                             if let Err(re) = s.handle.rollback_epoch(epoch).await {
                                 error!(sink = %s.name, epoch, error = %re,
@@ -720,12 +592,11 @@ impl CheckpointCoordinator {
         Ok(())
     }
 
-    /// Inject prometheus engine metrics.
+    /// Wire Prometheus engine metrics.
     pub fn set_metrics(&mut self, prom: Arc<crate::engine_metrics::EngineMetrics>) {
         self.prom = Some(prom);
     }
 
-    /// Emits checkpoint metrics to prometheus.
     fn emit_checkpoint_metrics(&self, success: bool, epoch: u64, duration: Duration) {
         if let Some(ref m) = self.prom {
             if success {
@@ -739,13 +610,12 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Performs a full checkpoint cycle (steps 3-7).
+    /// Run a full checkpoint cycle.
     ///
-    /// Steps 1-2 (barrier propagation + operator snapshots) are handled
-    /// externally by the DAG executor and passed in via [`CheckpointRequest`].
+    /// Barrier propagation and operator snapshots (steps 1-2) are handled by the caller and
+    /// passed in via `CheckpointRequest`.
     ///
     /// # Errors
-    ///
     /// Returns `DbError::Checkpoint` if any phase fails.
     pub async fn checkpoint(
         &mut self,
@@ -755,10 +625,7 @@ impl CheckpointCoordinator {
             .await
     }
 
-    /// Pre-commits all exactly-once sinks (phase 1) with a timeout.
-    ///
-    /// A stuck sink will not block checkpointing indefinitely. The timeout
-    /// is configured via [`CheckpointConfig::pre_commit_timeout`].
+    /// Pre-commit all exactly-once sinks (phase 1), bounded by `pre_commit_timeout`.
     async fn pre_commit_sinks(&self, epoch: u64) -> Result<(), DbError> {
         let timeout_dur = self.config.pre_commit_timeout;
         let start = std::time::Instant::now();
@@ -772,7 +639,6 @@ impl CheckpointCoordinator {
                 ))),
             };
 
-        // Record pre-commit duration regardless of success/failure.
         if let Some(ref m) = self.prom {
             m.sink_precommit_duration
                 .observe(start.elapsed().as_secs_f64());
@@ -781,16 +647,7 @@ impl CheckpointCoordinator {
         result
     }
 
-    /// Inner pre-commit loop (no timeout).
-    ///
-    /// Only sinks with `exactly_once = true` participate in two-phase commit.
-    /// At-most-once sinks are skipped — they receive no `pre_commit`/`commit`
-    /// calls and provide no transactional guarantees.
-    ///
-    /// Fires every sink's `pre_commit` concurrently via `try_join_all` —
-    /// matching the rollback path's shape. The serial version was
-    /// `sum(per-sink pre-commit latency)`; with 4 Delta sinks at ~200ms
-    /// S3 write each, that was 800ms serial. Concurrent = 200ms.
+    /// Inner pre-commit loop (no timeout). Fires all exactly-once sinks concurrently.
     async fn pre_commit_sinks_inner(&self, epoch: u64) -> Result<(), DbError> {
         let futures = self.sinks.iter().filter(|s| s.exactly_once).map(|sink| {
             let handle = sink.handle.clone();
@@ -811,11 +668,10 @@ impl CheckpointCoordinator {
         futures::future::try_join_all(futures).await.map(|_| ())
     }
 
-    /// Commit each exactly-once sink in its own task, bounded by
-    /// `commit_timeout`. Per-sink isolation avoids a slow sink blanket-
-    /// failing the whole batch; cancellation lives inside the spawned
-    /// task so an outer drop doesn't leave the sink-task with a dropped
-    /// oneshot ack.
+    /// Commit each exactly-once sink in its own task, bounded by `commit_timeout`.
+    ///
+    /// Per-sink tasks isolate failures; cancellation is internal so an outer drop
+    /// never leaves a dangling oneshot ack on the sink side.
     async fn commit_sinks_tracked(&self, epoch: u64) -> HashMap<String, SinkCommitStatus> {
         let timeout_dur = self.config.commit_timeout;
         let start = std::time::Instant::now();
@@ -868,15 +724,10 @@ impl CheckpointCoordinator {
         statuses
     }
 
-    /// Saves a manifest to the checkpoint store.
+    /// Save a manifest (and optional sidecar) to the store, bounded by `persist_timeout`.
     ///
-    /// Uses [`CheckpointStore::save_with_state`] to write optional sidecar
-    /// data **before** the manifest, ensuring atomicity: if the sidecar write
-    /// fails, the manifest is never persisted.
-    ///
-    /// Takes `Arc<CheckpointManifest>` so the caller can retain its own copy
-    /// without a deep clone. Bounded by [`CheckpointConfig::persist_timeout`]
-    /// to prevent a hung filesystem from stalling the runtime indefinitely.
+    /// Sidecar is written before the manifest: a failed sidecar write never leaves a
+    /// manifest referencing missing state.
     async fn save_manifest(
         &self,
         manifest: Arc<CheckpointManifest>,
@@ -895,25 +746,12 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Writes each owned vnode's `partial.bin` so the leader's
-    /// `epoch_complete` gate returns true and sinks can commit.
+    /// Write each owned vnode's `partial.bin` to seal the durability gate.
     ///
-    /// The payload is a [`VnodePartial`](crate::vnode_partial::VnodePartial)
-    /// carrying the operator-state slices staged via
-    /// [`set_pending_vnode_states`](Self::set_pending_vnode_states) for that
-    /// vnode. A vnode with no staged state writes an empty `VnodePartial`,
-    /// which still seals the durability gate (presence is all the gate checks).
-    ///
-    /// A vnode whose slices are byte-identical to its last full upload
-    /// writes a tiny *reference* partial instead — upload cost scales
-    /// with changed vnodes. References are forced back to full before
-    /// their base leaves the `max_retained` prune window; bases record
-    /// only after every write lands, so a partially-failed epoch
-    /// re-uploads full.
-    ///
-    /// Fires every vnode write concurrently via `try_join_all`: the serial
-    /// version was O(`vnode_count` × per-write latency) — trivial CPU but each
-    /// a scheduling hop (and tens-to-hundreds of ms on a remote object store).
+    /// Unchanged vnodes emit a reference partial; changed vnodes do a full upload. References
+    /// are forced back to full before their base ages out of the prune window. All writes run
+    /// concurrently. Bases are recorded only after every write in an epoch lands, so a partially
+    /// failed epoch re-uploads full on the next attempt.
     async fn write_vnode_partials(
         &mut self,
         epoch: u64,
@@ -925,20 +763,13 @@ impl CheckpointCoordinator {
         if self.vnode_set.is_empty() {
             return Ok(());
         }
-        // Stamp every write with the current assignment generation. Zero
-        // means the host hasn't wired a version (single-instance path) and
-        // the fence is a no-op.
+        // Zero version = single-instance path; the fence is a no-op.
         let caller_version = self.assignment_version;
         let max_ref_age = (self.config.max_retained as u64).max(1);
 
-        // Step 1: classify each vnode as reference or full and encode its
-        // payload. A staged `Cold` slice counts as unchanged (the demotion
-        // contract guarantees byte identity with the recorded upload); when
-        // a full upload is forced anyway — another operator's slice changed,
-        // or the reference base is aging out — the cold bytes are fetched
-        // back from the tier. A fetch failure fails the epoch: writing a
-        // partial without the demoted slice would silently drop it from the
-        // recovery truth.
+        // Classify each vnode as reference or full. A staged `Cold` slice counts as unchanged;
+        // on a forced full upload the cold bytes are fetched back from the tier.
+        // A fetch failure fails the epoch: silently dropping a demoted slice breaks recovery.
         let mut full_uploads: Vec<(u32, std::collections::HashMap<String, UploadedSlice>)> =
             Vec::new();
         let mut emptied: Vec<u32> = Vec::new();
@@ -976,8 +807,7 @@ impl CheckpointCoordinator {
                             StagedSlice::Cold => self.fetch_cold_slice(name, v).await?,
                         };
                         resolved.push((name.clone(), bytes.to_vec()));
-                        // Record cold slices as cold: their bytes go into
-                        // this upload but stay pinned only in the tier.
+                        // Cold slices contribute bytes to this upload but stay pinned in the tier.
                         recorded.insert(
                             name.clone(),
                             match slice {
@@ -1001,7 +831,6 @@ impl CheckpointCoordinator {
             encoded.push((v, bytes::Bytes::from(partial.encode()?)));
         }
 
-        // Step 2 (async): upload concurrently.
         let writes = encoded.into_iter().map(|(v, payload)| {
             let backend = Arc::clone(backend);
             async move {
@@ -1017,7 +846,6 @@ impl CheckpointCoordinator {
         });
         futures::future::try_join_all(writes).await?;
 
-        // Step 3 (sync): record the new bases / clear emptied vnodes.
         for (v, ops) in full_uploads {
             self.last_vnode_uploads.insert(v, (epoch, ops));
         }
@@ -1032,15 +860,8 @@ impl CheckpointCoordinator {
         Ok(())
     }
 
-    /// Poll the state backend's durability gate until every vnode in
-    /// `gate_vnode_set` has its partial for `epoch` persisted (sealing
-    /// the epoch's `_COMMIT` marker), or `restorable_gate_timeout`
-    /// expires. No-op without a backend or with an empty gate set.
-    ///
-    /// Each node writes its partials *after* sink pre-commit + manifest
-    /// save, so full presence proves every node finished its durable
-    /// prepare. Transient backend errors retry until the deadline; a
-    /// split-brain commit marker aborts immediately.
+    /// Poll until every vnode in `gate_vnode_set` has its partial for `epoch`, or the
+    /// gate timeout expires. Transient errors retry; a split-brain commit marker aborts.
     async fn await_restorable_gate(
         &self,
         epoch: u64,
@@ -1048,13 +869,8 @@ impl CheckpointCoordinator {
     ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
-        // Each poll LISTs the epoch prefix on the object store, so back
-        // off exponentially: fast for the common local/in-process case,
-        // ~1 LIST/s steady-state per slow epoch on S3 (gates also
-        // serialize on the coordinator mutex, so at most one loop polls
-        // at a time regardless of pipelining depth). Push-driven
-        // follower upload-completion acks are the protocol-level
-        // replacement for this poll (tracked in the plan).
+        // Each poll LISTs the epoch prefix; back off exponentially. Gates serialize on the
+        // coordinator mutex so at most one loop runs at a time regardless of pipeline depth.
         const INITIAL_POLL: Duration = Duration::from_millis(100);
         const MAX_POLL: Duration = Duration::from_secs(1);
 
@@ -1078,23 +894,17 @@ impl CheckpointCoordinator {
             }
             match backend.epoch_complete(epoch, &self.gate_vnode_set).await {
                 Ok(true) => return Ok(()),
-                // Keep the default/previous message; a lingering
-                // transient-error string is more informative than
-                // resetting it.
                 Ok(false) => {}
                 Err(e @ StateBackendError::SplitBrainCommit { .. }) => {
                     return Err(format!("state durability gate: {e}"));
                 }
                 Err(e) => {
-                    // Transient I/O — keep polling until the deadline.
                     debug!(epoch, error = %e, "durability gate poll error; retrying");
                     last_state = e.to_string();
                 }
             }
-            // Fail fast when a capture participant dies: its uploads
-            // will never arrive, so waiting out the timeout only
-            // stalls the pipeline — and with pipelining, queued doomed
-            // epochs would each burn the full timeout serially.
+            // Fail fast when a capture participant dies; doomed pipelined epochs each burn the
+            // full timeout otherwise.
             #[cfg(feature = "cluster")]
             if let Some(cc) = self.cluster_controller.as_ref() {
                 if let Some(reason) =
@@ -1125,13 +935,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Common abandon path for a failed checkpoint attempt: announce
-    /// `Abort` so prepared followers release immediately, roll the
-    /// epoch's sink transactions back, and begin the next epoch's
-    /// transactions so writes arriving after the failure are not
-    /// orphaned in a rolled-back transaction. Ids were allocated at the
-    /// start of [`checkpoint_inner`](Self::checkpoint_inner), so the
-    /// failed epoch is abandoned, never retried.
+    /// Abandon a failed epoch: announce `Abort`, roll back sinks, and open the next epoch.
     async fn fail_epoch(
         &mut self,
         checkpoint_id: u64,
@@ -1168,11 +972,9 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Begin the (already-allocated) next epoch's sink transactions
-    /// after a failed or partially-committed checkpoint, bounded by
-    /// `rollback_timeout` — the sink that just failed may be wedged,
-    /// and an unbounded `begin_epoch` await would hang the coordinator
-    /// on it.
+    /// Begin the next epoch's sink transactions, bounded by `rollback_timeout`.
+    ///
+    /// The failing sink may be wedged; an unbounded await would hang the coordinator.
     async fn begin_next_epoch_bounded(&self) {
         let next_epoch = self.allocator.peek().0;
         match tokio::time::timeout(
@@ -1196,11 +998,10 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// On startup, reconcile any Pending sinks in the last manifest
-    /// against the durable commit marker. Marker present → drive
-    /// local commit (idempotent); marker absent → rollback. Runs on
-    /// every node; in cluster mode the leader additionally
-    /// re-announces the decision.
+    /// On startup, reconcile any Pending sinks in the last manifest.
+    ///
+    /// Commit marker present → drive local commit; marker absent → rollback. In cluster mode
+    /// the leader re-announces the decision.
     pub async fn reconcile_prepared_on_init(&self) {
         let last = match load_highest(self.store.as_ref()).await {
             Ok(Some(m)) => m,
@@ -1280,15 +1081,14 @@ impl CheckpointCoordinator {
             }
         }
 
-        // Brief pause so the announcement gossips before the next checkpoint tick.
+        // Let the announcement gossip before the next tick.
         #[cfg(feature = "cluster")]
         if is_leader {
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
 
-    /// Overwrite the Pending sink statuses on the last manifest with
-    /// the outcomes produced during recovery.
+    /// Overwrite Pending sink statuses in the manifest with recovery outcomes.
     async fn persist_recovered_statuses(
         &self,
         checkpoint_id: u64,
@@ -1307,14 +1107,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// No-op when not the leader. Errors are logged — worst case is a
-    /// longer follower timeout, not a correctness issue.
-    ///
-    /// `min_watermark_ms` is typically `None` on `Prepare`/`Abort` and
-    /// `Some(cluster_min)` on `Commit` (computed from follower acks +
-    /// local watermark). Downstream operators read the published
-    /// value from [`ClusterController`] so event-time decisions stay
-    /// consistent across the cluster.
+    /// No-op when not the leader. Errors are logged; worst case is a longer follower timeout.
     #[cfg(feature = "cluster")]
     async fn announce_if_leader(
         &self,
@@ -1347,12 +1140,10 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Announce PREPARE and block for follower acks. On quorum (or
-    /// no-op — not leader / no controller) returns the capture-time
-    /// follower set for the durability gate fail-fast and writes the
-    /// cluster-wide minimum watermark into `self.cluster_min_watermark`
-    /// so the subsequent `Commit` announcement can fan it out. On
-    /// failure, announces `Abort` and returns the failure message.
+    /// Announce PREPARE and wait for follower acks.
+    ///
+    /// On quorum, returns the capture-time follower set and writes the cluster-wide min into
+    /// `cluster_min_watermark` for the Commit announcement. On failure, announces Abort.
     #[cfg(feature = "cluster")]
     async fn await_prepare_quorum(
         &mut self,
@@ -1387,10 +1178,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Shared health predicate for the capture quorum and the
-    /// durability gate: a participant that is suspected, draining,
-    /// left, or vanished can no longer contribute to this epoch, so
-    /// waiting out the full timeout only stalls the pipeline.
+    /// Returns a failure reason if any participant is suspected, draining, left, or missing.
     #[cfg(feature = "cluster")]
     fn unhealthy_participant(
         members: &[laminar_core::cluster::discovery::NodeInfo],
@@ -1419,13 +1207,11 @@ impl CheckpointCoordinator {
         None
     }
 
-    /// The capture-quorum stage, callable without the coordinator mutex
-    /// so pipelined barrier tails can reach `Aligned` while an earlier
-    /// epoch's durable tail still holds it. Announces `Prepare`, waits
-    /// for every live follower's capture ack (failing fast on unhealthy
-    /// membership), and returns the merged cluster-min watermark. The
-    /// caller announces `Aligned` on success / `Abort` on failure and
-    /// publishes the watermark via the announcement.
+    /// Run the capture-quorum stage outside the coordinator mutex so pipelined tails can
+    /// reach `Aligned` while an earlier epoch's durable tail holds the lock.
+    ///
+    /// Announces `Prepare`, waits for live-follower acks, returns the merged cluster-min
+    /// watermark. Caller announces `Aligned` on success or `Abort` on failure.
     #[cfg(feature = "cluster")]
     pub(crate) async fn run_prepare_quorum(
         cc: &laminar_core::cluster::control::ClusterController,
@@ -1452,8 +1238,7 @@ impl CheckpointCoordinator {
         let mut followers = cc.live_instances();
         followers.retain(|id| *id != cc.instance_id());
         if followers.is_empty() {
-            // Leader-only cluster — cluster-wide min is just the
-            // leader's local watermark (if any).
+            // Leader-only cluster; min is the leader's local watermark.
             if let Some(wm) = local_watermark_ms {
                 cc.publish_cluster_min_watermark(wm);
             }
@@ -1470,11 +1255,7 @@ impl CheckpointCoordinator {
                     return reason;
                 }
                 if members_rx.changed().await.is_err() {
-                    // Membership watch closed (host shutting down): this
-                    // arm can no longer fail fast, so park it and let the
-                    // sibling `select!` arm — the deadline-bounded quorum
-                    // wait — decide the outcome. Not a leak: the select
-                    // always completes via that arm.
+                    // Watch closed (shutting down): park this arm so the quorum deadline decides.
                     futures::future::pending::<()>().await;
                 }
             }
@@ -1490,9 +1271,7 @@ impl CheckpointCoordinator {
                 min_follower_watermark_ms,
                 ref acks,
             }) => {
-                // Demonstrably alive — clear any quorum-miss suspicion.
                 cc.note_responsive(acks);
-                // Fold follower min with the leader's own watermark.
                 let merged = match (local_watermark_ms, min_follower_watermark_ms) {
                     (Some(a), Some(b)) => Some(a.min(b)),
                     (Some(a), None) => Some(a),
@@ -1505,10 +1284,8 @@ impl CheckpointCoordinator {
                 Ok((merged, followers))
             }
             Ok(QuorumOutcome::TimedOut { missing, .. }) => {
-                // Gossip failure detection can lag a hard kill by tens
-                // of seconds; record the leader's own faster signal so
-                // the durability gates of already-captured epochs fail
-                // fast instead of each burning their full timeout.
+                // Gossip can lag a hard kill; record the leader's faster signal so gate
+                // fail-fasts kick in before each captured epoch burns its full timeout.
                 cc.note_unresponsive(&missing);
                 Err(format!(
                     "quorum timeout: {} follower(s) did not ack",
@@ -1526,9 +1303,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Overwrites an existing manifest with updated fields (e.g., sink commit
-    /// statuses after Step 6). Uses [`CheckpointStore::update_manifest`] which
-    /// does NOT use conditional PUT, so the overwrite always succeeds.
+    /// Overwrite an existing manifest (e.g. sink commit statuses after phase 2).
     async fn update_manifest_only(&self, manifest: Arc<CheckpointManifest>) -> Result<(), DbError> {
         let timeout_dur = self.config.persist_timeout;
         let fut = self.store.update_manifest(&manifest);
@@ -1542,7 +1317,6 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Returns initial sink commit statuses (all `Pending`) for the manifest.
     fn initial_sink_commit_statuses(&self) -> HashMap<String, SinkCommitStatus> {
         self.sinks
             .iter()
@@ -1551,14 +1325,8 @@ impl CheckpointCoordinator {
             .collect()
     }
 
-    /// Packs operator states into a manifest with optional sidecar chunks.
-    ///
-    /// States larger than `threshold` are stored in a sidecar blob rather
-    /// than base64-inlined in the JSON manifest. The returned `Vec<Bytes>`
-    /// is handed to `save_with_state` as a chain — the object-store path
-    /// builds a multi-chunk `PutPayload` (no contiguous buffer), the FS
-    /// path writes chunks sequentially. Either way no full-state copy
-    /// happens here.
+    /// Pack operator states into the manifest; large states go to a sidecar rather than
+    /// base64 JSON. The returned chunks are handed to `save_with_state` without a full copy.
     fn pack_operator_states(
         manifest: &mut CheckpointManifest,
         operator_states: &HashMap<String, bytes::Bytes>,
@@ -1587,8 +1355,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Rolls back all exactly-once sinks in parallel, bounded by
-    /// [`CheckpointConfig::rollback_timeout`].
+    /// Roll back all exactly-once sinks in parallel, bounded by `rollback_timeout`.
     async fn rollback_sinks(&self, epoch: u64) -> Result<(), DbError> {
         let timeout_dur = self.config.rollback_timeout;
         match tokio::time::timeout(timeout_dur, self.rollback_sinks_inner(epoch)).await {
@@ -1612,9 +1379,8 @@ impl CheckpointCoordinator {
             let handle = sink.handle.clone();
             let name = sink.name.clone();
             async move {
-                // Live abandon, not a hard rollback — a healthy sink
-                // keeps its pending output (see `SinkCommand::RollbackEpoch`).
-                // Restart-time rollback (recovery manager) stays hard.
+                // Live abandon: a healthy sink keeps pending output; hard rollback
+                // is reserved for the recovery manager on restart.
                 let result = handle.abandon_epoch(epoch).await;
                 (name, result)
             }
@@ -1638,9 +1404,6 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Per-sink epoch map for the manifest: every exactly-once sink is
-    /// committing `epoch` (passed in — `self.epoch` already points at
-    /// the next epoch once a checkpoint is underway).
     fn collect_sink_epochs(&self, epoch: u64) -> HashMap<String, u64> {
         let mut epochs = HashMap::with_capacity(self.sinks.len());
         for sink in &self.sinks {
@@ -1651,50 +1414,45 @@ impl CheckpointCoordinator {
         epochs
     }
 
-    /// Returns sorted sink names for topology tracking in the manifest.
-    ///
-    /// Computed once per topology change (via `register_sink`) and
-    /// cached; subsequent checkpoints clone the cached Vec rather than
-    /// re-sorting the sinks list.
+    /// Sorted sink names for the manifest; cached and rebuilt only when the sink list changes.
     fn sorted_sink_names(&mut self) -> Vec<String> {
         if self.cached_sorted_sink_names.is_none() {
             let mut names: Vec<String> = self.sinks.iter().map(|s| s.name.clone()).collect();
             names.sort();
             self.cached_sorted_sink_names = Some(names);
         }
-        // Invariant: set above.
         self.cached_sorted_sink_names.as_ref().unwrap().clone()
     }
 
-    /// Returns the current phase.
+    /// Current checkpoint phase.
     #[must_use]
     pub fn phase(&self) -> CheckpointPhase {
         self.phase
     }
 
-    /// Returns the next epoch to be allocated.
+    /// Next epoch to be allocated.
     #[must_use]
     pub fn epoch(&self) -> u64 {
         self.allocator.peek().0
     }
 
-    /// Returns the next checkpoint ID to be allocated.
+    /// Next checkpoint ID to be allocated.
     #[must_use]
     pub fn next_checkpoint_id(&self) -> u64 {
         self.allocator.peek().1
     }
 
-    /// Returns the checkpoint config.
+    /// Checkpoint configuration.
     #[must_use]
     pub fn config(&self) -> &CheckpointConfig {
         &self.config
     }
 
-    /// Returns checkpoint statistics.
+    /// Checkpoint performance statistics.
     #[must_use]
     pub fn stats(&self) -> CheckpointStats {
         let (p50, p95, p99) = self.duration_histogram.percentiles();
-        // Histogram stores microseconds; stats fields are milliseconds.
+        // Histogram is in microseconds; stats fields are milliseconds.
         CheckpointStats {
             completed: self.checkpoints_completed,
             failed: self.checkpoints_failed,
@@ -1708,22 +1466,18 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Returns a reference to the underlying store.
+    /// The underlying checkpoint store.
     #[must_use]
     pub fn store(&self) -> &dyn CheckpointStore {
         &*self.store
     }
 
-    /// Performs a full checkpoint with pre-captured source offsets.
+    /// Run a full checkpoint using pre-captured source offsets.
     ///
-    /// When [`CheckpointRequest::source_offset_overrides`] is non-empty,
-    /// those sources skip the live `snapshot_sources()` call and use the
-    /// provided offsets instead. This is essential for barrier-aligned
-    /// checkpoints where source positions must match the operator state
-    /// at the barrier point.
+    /// Non-empty `source_offset_overrides` bypass the live snapshot call — required for
+    /// barrier-aligned checkpoints where source positions must match operator state exactly.
     ///
     /// # Errors
-    ///
     /// Returns `DbError::Checkpoint` if any phase fails.
     pub async fn checkpoint_with_offsets(
         &mut self,
@@ -1733,9 +1487,8 @@ impl CheckpointCoordinator {
             .await
     }
 
-    /// Pipelined-barrier entry point: ids were allocated at admission
-    /// and the capture quorum already ran before the coordinator mutex
-    /// was taken (see `QuorumStage::Done`).
+    /// Checkpoint entry point for pipelined barriers where ids were pre-allocated and the
+    /// capture quorum already ran (`QuorumStage::Done`).
     ///
     /// # Errors
     /// Returns `DbError::Checkpoint` if any phase fails.
@@ -1750,9 +1503,8 @@ impl CheckpointCoordinator {
             .await
     }
 
-    /// Abandon a pre-allocated epoch whose pre-mutex stage (alignment
-    /// or capture quorum) failed: announce `Abort`, roll back, and
-    /// begin the next epoch's sink transactions.
+    /// Abandon a pre-allocated epoch that failed before the mutex: announce `Abort`, roll
+    /// back sinks, and begin the next epoch.
     #[cfg(feature = "cluster")]
     pub(crate) async fn abandon_epoch(
         &mut self,
@@ -1764,15 +1516,11 @@ impl CheckpointCoordinator {
             .await
     }
 
-    /// Follower half of a cluster checkpoint: ack the capture, run the
-    /// durable prepare (pre-commit + manifest + partial uploads), then
-    /// wait for the leader's commit/abort.
-    /// `Ok(true)` = committed, `Ok(false)` = aborted/timed out.
+    /// Follower checkpoint: ack the capture, run the durable prepare, then wait for the
+    /// leader's commit/abort. Returns `Ok(true)` = committed, `Ok(false)` = aborted.
     ///
-    /// The ack precedes the durable prepare — it means "aligned +
-    /// captured". The leader verifies prepare completion through the
-    /// restorable gate instead (partials are written last, so their
-    /// presence implies the whole prepare finished).
+    /// The ack means "aligned + captured"; the leader verifies prepare completion through
+    /// the restorable gate (partials written last imply the full prepare finished).
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1791,29 +1539,24 @@ impl CheckpointCoordinator {
             ));
         };
 
-        // Capture ack — state is already consistently captured by the
-        // caller; the leader needs nothing more to release pipelines.
+        // State is captured; ack so the leader can release the pipeline.
         cc.ack_barrier(&BarrierAck {
             epoch: ann.epoch,
             ok: true,
             error: None,
-            // Leader folds this into the cluster-wide min announced on
-            // Aligned/Commit. `None` is non-blocking.
             local_watermark_ms: self.local_watermark_ms,
         })
         .await
-        .ok(); // best effort; leader's quorum wait tolerates missed acks
+        .ok(); // best effort; leader's quorum tolerates missed acks
 
         self.follower_checkpoint_acked(request, ann, decision_timeout)
             .await
     }
 
-    /// [`follower_checkpoint`](Self::follower_checkpoint) minus the
-    /// capture ack: prepare, await the decision, then commit/rollback.
-    /// Pipelined tails call the three stages separately so the
-    /// decision wait does not hold the coordinator mutex (the next
-    /// epoch's uploads would queue behind it for up to
-    /// `decision_timeout`).
+    /// `follower_checkpoint` minus the capture ack: prepare, await the decision, commit/rollback.
+    ///
+    /// Pipelined tails call the three stages separately so the decision wait doesn't hold the
+    /// mutex while the next epoch's uploads queue.
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1843,10 +1586,9 @@ impl CheckpointCoordinator {
         Ok(self.follower_finish(epoch, checkpoint_id, committed).await)
     }
 
-    /// Stage 1 of the follower tail: durable prepare (sink pre-commit +
-    /// manifest + partial uploads), after the capture ack. On failure,
-    /// a best-effort `ok = false` ack overwrites the capture ack and
-    /// the epoch rolls back.
+    /// Follower stage 1: durable prepare (pre-commit + manifest + partial uploads).
+    ///
+    /// On failure a best-effort `ok = false` ack overwrites the capture ack.
     ///
     /// # Errors
     /// Propagates sink pre-commit, manifest save, or marker-write failures.
@@ -1859,9 +1601,7 @@ impl CheckpointCoordinator {
     ) -> Result<(), DbError> {
         use laminar_core::cluster::control::BarrierAck;
 
-        // Track the leader's ids so a later leader-mode call resumes
-        // correctly. Monotonic: a depth>1 tail finishing late must not
-        // walk the allocator backwards past a successor's ids.
+        // Monotonic: a late-finishing depth>1 tail must not walk ids back past a successor's.
         self.allocator
             .advance_to(epoch, checkpoint_id.saturating_add(1));
 
@@ -1878,21 +1618,17 @@ impl CheckpointCoordinator {
             }
             self.rollback_sinks(epoch).await.ok();
             self.phase = CheckpointPhase::Idle;
-            // The rollback aborted the sinks' open transaction; open
-            // the next epoch's so post-failure writes stay
-            // transactional (mirrors the leader's `fail_epoch`).
+            // Open the next epoch so post-failure writes stay transactional (mirrors fail_epoch).
             self.begin_next_epoch_bounded().await;
             return Err(e);
         }
         Ok(())
     }
 
-    /// Stage 2 of the follower tail: wait for the leader's decision —
-    /// `&self`-free so the wait never holds the coordinator mutex.
-    /// Only Commit/Abort (or epoch advancement) end the wait; a newer
-    /// epoch's announcement can supersede this epoch's Commit under
-    /// latest-wins observation, so the durable marker is the
-    /// tie-breaker. Returns the verdict.
+    /// Follower stage 2: wait for the leader's decision without holding the coordinator mutex.
+    ///
+    /// Only Commit/Abort (or a newer epoch) end the wait. A superseded announcement defers
+    /// to the durable marker. Returns the commit verdict.
     #[cfg(feature = "cluster")]
     pub(crate) async fn await_follower_decision(
         cc: &laminar_core::cluster::control::ClusterController,
@@ -1931,7 +1667,6 @@ impl CheckpointCoordinator {
             match decision {
                 Some(a) if a.epoch == epoch => return a.phase == Phase::Commit,
                 Some(a) => {
-                    // Newer epoch supersedes the decision announcement.
                     if is_marked().await {
                         info!(
                             epoch,
@@ -1941,13 +1676,11 @@ impl CheckpointCoordinator {
                         );
                         return true;
                     }
-                    // No marker yet — keep waiting. Each pass through
-                    // this (rare) state costs an object-store HEAD, so
-                    // pace the re-check well below the decision timeout.
+                    // No marker yet; each check costs an object-store HEAD so pace the re-check.
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
                 None => {
-                    // Deadline: one last durable-marker check.
+                    // Deadline: one final marker check.
                     if is_marked().await {
                         warn!(
                             epoch,
@@ -1966,8 +1699,7 @@ impl CheckpointCoordinator {
         }
     }
 
-    /// Stage 3 of the follower tail: act on the decision. Returns
-    /// `true` on a clean commit.
+    /// Follower stage 3: act on the decision. Returns `true` on a clean commit.
     #[cfg(feature = "cluster")]
     pub(crate) async fn follower_finish(
         &mut self,
@@ -1983,15 +1715,12 @@ impl CheckpointCoordinator {
             self.phase = CheckpointPhase::Idle;
             false
         };
-        // Commit and rollback both close the sinks' open transaction;
-        // open the next epoch's so subsequent writes are transactional
-        // (the leader's mirror lives in `checkpoint_inner`/`fail_epoch`).
+        // Both paths close the sinks' open transaction; open the next epoch (mirrors fail_epoch).
         self.begin_next_epoch_bounded().await;
         clean
     }
 
-    /// Durable commit-marker store handle, for the lock-free decision
-    /// wait in pipelined follower tails.
+    /// Commit-marker store handle for the lock-free decision wait in pipelined follower tails.
     #[cfg(feature = "cluster")]
     pub(crate) fn decision_store_handle(
         &self,
@@ -1999,8 +1728,7 @@ impl CheckpointCoordinator {
         self.decision_store.clone()
     }
 
-    /// Commit this follower's sinks for `epoch` and update its
-    /// manifest's Pending entries. Returns `true` on clean commit.
+    /// Commit this follower's sinks for `epoch` and overwrite the Pending manifest entries.
     #[cfg(feature = "cluster")]
     async fn drive_follower_commit(&mut self, epoch: u64, checkpoint_id: u64) -> bool {
         let statuses = self.commit_sinks_tracked(epoch).await;
@@ -2017,9 +1745,6 @@ impl CheckpointCoordinator {
             self.phase = CheckpointPhase::Idle;
             return false;
         }
-        // Overwrite the follower's own manifest so the Pending sink
-        // entries stamped during prepare get replaced with the
-        // Committed statuses we just produced.
         if let Err(e) = self
             .persist_recovered_statuses(checkpoint_id, statuses)
             .await
@@ -2096,12 +1821,7 @@ impl CheckpointCoordinator {
         Ok(())
     }
 
-    /// Shared checkpoint implementation for all checkpoint entry points.
-    ///
-    /// When [`CheckpointRequest::source_offset_overrides`] is non-empty,
-    /// those sources use the provided offsets instead of calling
-    /// `snapshot_sources()`. This ensures barrier-aligned and pre-captured
-    /// offsets are used atomically.
+    /// Shared checkpoint implementation for all entry points.
     #[allow(clippy::too_many_lines)]
     async fn checkpoint_inner(
         &mut self,
@@ -2119,27 +1839,18 @@ impl CheckpointCoordinator {
             source_offset_overrides,
         } = request;
         let start = Instant::now();
-        // Ids are allocated up front (Flink-style): a failed attempt is
-        // abandoned — never retried under the same ids — so a future
-        // epoch's identity never depends on this one's outcome, which
-        // is what allows epochs to overlap. Pipelined barrier paths
-        // allocate at admission and pass the ids in; forced/timer
-        // paths allocate here.
+        // Flink-style: ids allocated up front; a failed epoch is abandoned, never retried.
+        // Pipelined barrier paths allocate at admission; forced/timer paths allocate here.
         let (epoch, checkpoint_id) = ids.unwrap_or_else(|| self.allocator.allocate());
 
         info!(checkpoint_id, epoch, "starting checkpoint");
 
-        // Source offsets are provided by the caller (pre-captured at barrier
-        // alignment or pre-spawn). Table offsets come from extra_table_offsets.
         self.phase = CheckpointPhase::Snapshotting;
         let source_offsets = source_offset_overrides;
         let table_offsets = extra_table_offsets;
 
-        // Two-level completion, level 1: collect capture acks from
-        // every live follower, then announce `Aligned` (the pipeline
-        // resume gate); the restorable gate below verifies their
-        // durable prepares. Pipelined barrier tails run this stage
-        // pre-mutex and pass `Done` here.
+        // Level 1: collect capture acks, announce `Aligned` (pipeline resume gate).
+        // Pipelined tails run this pre-mutex and pass `Done`.
         #[cfg(feature = "cluster")]
         #[allow(unused_assignments)] // both match arms assign; init keeps non-cluster shape
         let mut quorum_participants: Vec<QuorumPeer> = Vec::new();
@@ -2191,13 +1902,10 @@ impl CheckpointCoordinator {
         manifest.source_offsets = source_offsets;
         manifest.table_offsets = table_offsets;
         manifest.sink_epochs = self.collect_sink_epochs(epoch);
-        // Mark all exactly-once sinks as Pending before commit phase.
         manifest.sink_commit_statuses = self.initial_sink_commit_statuses();
         manifest.watermark = watermark;
-        // Use caller-provided per-source watermarks if available. When empty,
-        // leave source_watermarks empty — recovery falls back to the global
-        // manifest.watermark. Do NOT fabricate per-source values from the
-        // global watermark, as that loses granularity on recovery.
+        // When empty, recovery falls back to manifest.watermark; do not fabricate per-source
+        // values from the global watermark as that loses granularity.
         manifest.source_watermarks = source_watermarks;
         manifest.table_store_checkpoint_path = table_store_checkpoint_path;
         manifest.source_names = {
@@ -2246,10 +1954,8 @@ impl CheckpointCoordinator {
         let checkpoint_bytes = sidecar_bytes as u64;
 
         self.phase = CheckpointPhase::Persisting;
-        // Arc-wrap so the save task gets a cheap refcount bump instead of
-        // a deep clone. After `save_manifest.await` the task drops its
-        // Arc and we're the sole owner; `Arc::make_mut` below gets us a
-        // free mutable reference for the post-commit sink-status update.
+        // Arc so `save_manifest` gets a refcount bump without a deep clone.
+        // After the await we're the sole owner; `Arc::make_mut` below is zero-copy.
         let mut manifest = Arc::new(manifest);
         if let Err(e) = self.save_manifest(Arc::clone(&manifest), state_data).await {
             error!(checkpoint_id, epoch, error = %e, "[LDB-6008] manifest persist failed");
@@ -2263,9 +1969,6 @@ impl CheckpointCoordinator {
                 .await);
         }
 
-        // Publish each owned vnode's partial (operator-state slice + commit
-        // marker in one blob) so the durability gate below has something to
-        // check and a future owner can rehydrate the vnode's state.
         if let Err(e) = self.write_vnode_partials(epoch, checkpoint_id).await {
             error!(checkpoint_id, epoch, error = %e, "[LDB-6025] vnode partial write failed");
             return Ok(self
@@ -2278,23 +1981,14 @@ impl CheckpointCoordinator {
                 .await);
         }
 
-        // Durability gate (level 2, "restorable"): confirm every
-        // participating vnode has its partial persisted before sinks
-        // commit. `gate_vnode_set` is the FULL registry in cluster mode —
-        // the leader verifies markers from every follower's
-        // shared-storage writes, not just its own. Single-instance
-        // defaults to `vnode_set` (the two match). Followers upload
-        // asynchronously after their capture ack, so this polls until
-        // `restorable_gate_timeout` rather than checking once.
+        // Level 2 ("restorable"): all vnodes persisted before sinks commit.
+        // Polls because followers upload asynchronously after their capture ack.
         #[cfg(not(feature = "cluster"))]
         let quorum_participants: Vec<QuorumPeer> = Vec::new();
         let gate_start = Instant::now();
         let gate_result = self
             .await_restorable_gate(epoch, &quorum_participants)
             .await;
-        // Observed on failure too — a burned gate timeout is the signal
-        // that decides when the push-driven completion-ack follow-up is
-        // worth building.
         if let Some(ref m) = self.prom {
             m.checkpoint_restorable_gate_wait
                 .observe(gate_start.elapsed().as_secs_f64());
@@ -2310,10 +2004,8 @@ impl CheckpointCoordinator {
             return Ok(self.fail_epoch(checkpoint_id, epoch, start, gate_err).await);
         }
 
-        // Record the commit marker before issuing sink commits — this
-        // is the durable record of the commit decision that recovery
-        // reads to distinguish "committed mid-flight" from "never
-        // committed". Cluster mode gates on leadership.
+        // Write the commit marker before sink commits; recovery uses this to distinguish a
+        // committed epoch from a crash mid-flight. Leader-gated in cluster mode.
         let is_decision_leader = {
             #[cfg(feature = "cluster")]
             {
@@ -2341,9 +2033,6 @@ impl CheckpointCoordinator {
         }
 
         #[cfg(feature = "cluster")]
-        // Fan out the cluster-wide min watermark computed during
-        // `await_prepare_quorum`. Followers consume this from
-        // `observe_barrier` and update their consumer-side view.
         self.announce_if_leader(
             epoch,
             checkpoint_id,
@@ -2359,9 +2048,7 @@ impl CheckpointCoordinator {
             .any(|s| matches!(s, SinkCommitStatus::Failed(_)));
 
         if !sink_statuses.is_empty() {
-            // `Arc::make_mut`: COW. Refcount is 1 here (spawn_blocking
-            // task in save_manifest has already returned and dropped its
-            // clone), so this is a zero-copy mutable borrow.
+            // Refcount is 1 here; `Arc::make_mut` is a zero-copy borrow.
             Arc::make_mut(&mut manifest).sink_commit_statuses = sink_statuses;
             if let Err(e) = self.update_manifest_only(Arc::clone(&manifest)).await {
                 warn!(
@@ -2374,11 +2061,8 @@ impl CheckpointCoordinator {
         }
 
         if has_failures {
-            // The commit decision is already durable (marker + Commit
-            // announcement), so the epoch is NOT rolled back: the failed
-            // sinks' statuses are recorded in the manifest and re-driven
-            // by `reconcile_prepared_on_init` on restart. Begin the next
-            // epoch so subsequent writes stay transactional.
+            // The commit decision is durable; don't roll back. Failed statuses are re-driven
+            // by `reconcile_prepared_on_init` on restart.
             self.checkpoints_failed += 1;
             error!(
                 checkpoint_id,
@@ -2408,19 +2092,12 @@ impl CheckpointCoordinator {
         self.duration_histogram.record(duration);
         self.emit_checkpoint_metrics(true, epoch, duration);
 
-        // Emit checkpoint size metrics.
         if let Some(ref m) = self.prom {
             #[allow(clippy::cast_possible_wrap)]
             m.checkpoint_size_bytes.set(checkpoint_bytes as i64);
         }
 
-        // Garbage-collect state-backend partials / commit markers for
-        // epochs no longer needed for recovery. Without this the
-        // in-process backend grows per-checkpoint forever and the
-        // object-store backend leaks `epoch=N/…` objects indefinitely.
-        // `max_retained` is in terms of checkpoints which map 1:1 to
-        // epochs here, so prune everything older than
-        // `epoch - max_retained`.
+        // Prune old partials/markers outside the retention window.
         if let Some(ref backend) = self.state_backend {
             let horizon = epoch.saturating_sub(self.config.max_retained as u64);
             if horizon > 0 {
@@ -2460,9 +2137,7 @@ impl CheckpointCoordinator {
             "checkpoint completed"
         );
 
-        // The checkpoint itself succeeded (state persisted, sinks committed).
-        // begin_epoch failure for the *next* epoch is reported as a warning
-        // but does not retroactively fail the completed checkpoint.
+        // A `begin_epoch` failure for the next epoch does not retroactively fail this one.
         self.pending_vnode_states.clear();
         Ok(CheckpointResult {
             success: true,
@@ -2473,32 +2148,23 @@ impl CheckpointCoordinator {
         })
     }
 
-    /// Attempts recovery from the latest checkpoint.
-    ///
-    /// Creates a [`RecoveryManager`](crate::recovery_manager::RecoveryManager)
-    /// using the coordinator's store and delegates recovery to it.
-    /// On success, advances `self.epoch` past the recovered epoch so the
-    /// next checkpoint gets a fresh epoch number.
+    /// Recover from the latest stored checkpoint.
     ///
     /// Returns `Ok(None)` for a fresh start (no checkpoint found).
     ///
     /// # Errors
-    ///
-    /// Returns `DbError::Checkpoint` if the store itself fails.
+    /// Returns `DbError::Checkpoint` if the store read fails.
     pub async fn recover(
         &mut self,
     ) -> Result<Option<crate::recovery_manager::RecoveredState>, DbError> {
         use crate::recovery_manager::RecoveryManager;
 
         let mgr = RecoveryManager::new(&*self.store);
-        // Sources and table sources are restored by the pipeline lifecycle
-        // (via SourceRegistration.restore_checkpoint), not by the coordinator.
-        // Pass empty slices — the coordinator only manages sink recovery here.
+        // Sources are restored by the pipeline lifecycle; pass empty slices here.
         let result = mgr.recover(&[], &self.sinks, &[]).await?;
 
         if let Some(ref recovered) = result {
-            // Monotonic: the recovered (committed) epoch may be older
-            // than a Pending manifest this node seeded its ids from.
+            // Monotonic: the committed epoch may predate a Pending manifest that seeded ids.
             self.allocator
                 .advance_to(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
             let (epoch, checkpoint_id) = self.allocator.peek();
@@ -2508,10 +2174,9 @@ impl CheckpointCoordinator {
         Ok(result)
     }
 
-    /// Loads the latest manifest from the store.
+    /// Load the latest manifest from the store.
     ///
     /// # Errors
-    ///
     /// Returns `DbError::Checkpoint` on store errors.
     pub async fn load_latest_manifest(&self) -> Result<Option<CheckpointManifest>, DbError> {
         self.store.load_latest().await.map_err(DbError::from)
@@ -2530,17 +2195,11 @@ impl std::fmt::Debug for CheckpointCoordinator {
     }
 }
 
-/// Fixed-size ring buffer for duration percentile tracking.
-///
-/// Stores the last `CAPACITY` durations in **microseconds** and computes
-/// p50/p95/p99 via sorted extraction. No heap allocation after construction.
+/// Fixed-size ring buffer for duration percentile tracking (microseconds, p50/p95/p99).
 #[derive(Clone)]
 pub struct DurationHistogram {
-    /// Ring buffer of durations in microseconds.
     samples: Box<[u64; Self::CAPACITY]>,
-    /// Write cursor (wraps at `CAPACITY`).
     cursor: usize,
-    /// Total samples written (may exceed `CAPACITY`).
     count: u64,
 }
 
@@ -2553,7 +2212,7 @@ impl Default for DurationHistogram {
 impl DurationHistogram {
     const CAPACITY: usize = 100;
 
-    /// Creates an empty histogram.
+    /// Empty histogram.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -2563,7 +2222,7 @@ impl DurationHistogram {
         }
     }
 
-    /// Records a duration sample (stored in microseconds).
+    /// Record a duration sample.
     pub fn record(&mut self, duration: Duration) {
         #[allow(clippy::cast_possible_truncation)]
         let us = duration.as_micros() as u64;
@@ -2572,29 +2231,26 @@ impl DurationHistogram {
         self.count += 1;
     }
 
-    /// Returns `true` if no samples have been recorded.
+    /// True if no samples have been recorded.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.count == 0
     }
 
-    /// Returns the number of recorded samples (up to `CAPACITY`).
+    /// Number of recorded samples, up to `CAPACITY`.
     #[must_use]
     pub fn len(&self) -> usize {
         if self.count >= Self::CAPACITY as u64 {
             Self::CAPACITY
         } else {
-            // SAFETY: count < CAPACITY (100), which always fits in usize.
-            #[allow(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_possible_truncation)] // count < 100, always fits usize
             {
                 self.count as usize
             }
         }
     }
 
-    /// Computes a percentile (0.0–1.0) from recorded samples.
-    ///
-    /// Returns 0 if no samples have been recorded.
+    /// Compute percentile `p` (0.0–1.0) over recorded samples. Returns 0 if empty.
     #[must_use]
     pub fn percentile(&self, p: f64) -> u64 {
         let n = self.len();
@@ -2612,7 +2268,7 @@ impl DurationHistogram {
         sorted[idx]
     }
 
-    /// Returns (p50, p95, p99) in microseconds. Sorts once.
+    /// Returns `(p50, p95, p99)` in microseconds, sorting once.
     #[must_use]
     pub fn percentiles(&self) -> (u64, u64, u64) {
         let n = self.len();
@@ -2651,27 +2307,27 @@ impl std::fmt::Debug for DurationHistogram {
 /// Checkpoint performance statistics.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CheckpointStats {
-    /// Total completed checkpoints.
+    /// Successful checkpoint count.
     pub completed: u64,
-    /// Total failed checkpoints.
+    /// Failed checkpoint count.
     pub failed: u64,
-    /// Duration of the last checkpoint.
+    /// Duration of the most recent checkpoint.
     pub last_duration: Option<Duration>,
-    /// p50 checkpoint duration in milliseconds.
+    /// p50 in milliseconds.
     pub duration_p50_ms: u64,
-    /// p95 checkpoint duration in milliseconds.
+    /// p95 in milliseconds.
     pub duration_p95_ms: u64,
-    /// p99 checkpoint duration in milliseconds.
+    /// p99 in milliseconds.
     pub duration_p99_ms: u64,
-    /// Total bytes written across all checkpoints.
+    /// Cumulative sidecar bytes written.
     pub total_bytes_written: u64,
-    /// Current checkpoint phase.
+    /// Current phase.
     pub current_phase: CheckpointPhase,
-    /// Current epoch number.
+    /// Current epoch.
     pub current_epoch: u64,
 }
 
-/// Converts a `SourceCheckpoint` to a `ConnectorCheckpoint`.
+/// Convert a `SourceCheckpoint` to a `ConnectorCheckpoint`.
 #[must_use]
 pub fn source_to_connector_checkpoint(cp: &SourceCheckpoint) -> ConnectorCheckpoint {
     ConnectorCheckpoint {
@@ -2681,7 +2337,7 @@ pub fn source_to_connector_checkpoint(cp: &SourceCheckpoint) -> ConnectorCheckpo
     }
 }
 
-/// Converts a `ConnectorCheckpoint` back to a `SourceCheckpoint`.
+/// Convert a `ConnectorCheckpoint` back to a `SourceCheckpoint`.
 #[must_use]
 pub fn connector_to_source_checkpoint(cp: &ConnectorCheckpoint) -> SourceCheckpoint {
     let mut source_cp = SourceCheckpoint::with_offsets(cp.epoch, cp.offsets.clone());

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -652,10 +652,22 @@ impl CheckpointCoordinator {
     /// after the tier write is confirmed and the operator dropped the
     /// groups). The reference-partial flow then keys off the cold marker.
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
+    #[allow(dead_code)] // exercised by tests; the trigger uses the per-op variant
     pub(crate) fn mark_vnode_demoted(&mut self, vnode: u32) {
         if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
             for s in slices.values_mut() {
+                *s = UploadedSlice::Cold;
+            }
+        }
+    }
+
+    /// Release one operator's byte pin for a demoted `(operator, vnode)`
+    /// slice. The trigger demotes per operator (a vnode may carry several),
+    /// so a refusal by one operator doesn't strand the others' records.
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn mark_slice_demoted(&mut self, vnode: u32, operator: &str) {
+        if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
+            if let Some(s) = slices.get_mut(operator) {
                 *s = UploadedSlice::Cold;
             }
         }

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -32,6 +32,49 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::DbError;
 
+/// One operator's staged slice for one vnode of the next checkpoint.
+#[derive(Debug, Clone)]
+pub(crate) enum StagedSlice {
+    /// Freshly serialized memory-resident state.
+    Bytes(bytes::Bytes),
+    /// Demoted to the cold tier and untouched since the upload recorded in
+    /// `last_vnode_uploads`: no bytes staged. The coordinator emits a
+    /// reference partial, or fetches the slice back from the tier when a
+    /// full re-upload is forced.
+    Cold,
+}
+
+/// Per-vnode staged slices, `vnode → operator → slice`.
+pub(crate) type StagedVnodeStates = HashMap<u32, HashMap<String, StagedSlice>>;
+
+/// What `last_vnode_uploads` records per operator slice of the last full
+/// upload: the exact bytes (the reference-partial comparison base, and the
+/// byte source for coordinator-driven demotion), or a cold marker once the
+/// slice was demoted — the bytes then live only in the tier, releasing the
+/// in-memory pin.
+#[derive(Debug, Clone)]
+pub(crate) enum UploadedSlice {
+    Bytes(bytes::Bytes),
+    Cold,
+}
+
+impl UploadedSlice {
+    /// Whether `staged` proves the slice unchanged since this upload.
+    ///
+    /// `Cold` staged ⇒ unchanged by the demotion contract (a demoted slice
+    /// is byte-identical to its recorded upload, and any row for it
+    /// promotes the slice back to memory before processing). Fresh bytes
+    /// against a cold record are conservatively "changed" — the cold bytes
+    /// aren't here to compare, so the slice re-uploads full once.
+    fn matches(&self, staged: &StagedSlice) -> bool {
+        match (staged, self) {
+            (StagedSlice::Cold, _) => true,
+            (StagedSlice::Bytes(b), UploadedSlice::Bytes(prev)) => b == prev,
+            (StagedSlice::Bytes(_), UploadedSlice::Cold) => false,
+        }
+    }
+}
+
 /// Unified checkpoint configuration.
 ///
 /// Timeouts prevent a stuck sink or hung filesystem from stalling the
@@ -329,15 +372,19 @@ pub struct CheckpointCoordinator {
     /// [`write_vnode_partials`](Self::write_vnode_partials). Empty in
     /// single-instance mode (the partial is then just a durability marker).
     #[allow(clippy::disallowed_types)] // matches the graph snapshot shape
-    pending_vnode_states:
-        std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+    pending_vnode_states: StagedVnodeStates,
     /// Per-vnode `(epoch, slices)` of the last *full* partial uploaded —
     /// the bases for unchanged-vnode reference partials. Bytes are
     /// refcounted, so this holds one serialized
-    /// snapshot's worth of memory, not a deep copy per epoch.
+    /// snapshot's worth of memory, not a deep copy per epoch; demoted
+    /// slices hold a cold marker instead (their bytes live in the tier).
     #[allow(clippy::disallowed_types)]
     last_vnode_uploads:
-        std::collections::HashMap<u32, (u64, std::collections::HashMap<String, bytes::Bytes>)>,
+        std::collections::HashMap<u32, (u64, std::collections::HashMap<String, UploadedSlice>)>,
+    /// Cold-tier request channel; lets a forced full re-upload of a
+    /// demoted slice fetch its bytes back from the tier.
+    #[cfg(feature = "state-tier")]
+    state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
     /// `Some` in cluster mode, `None` in single-instance / embedded.
     #[cfg(feature = "cluster")]
     cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
@@ -406,6 +453,8 @@ impl CheckpointCoordinator {
             rotation_epoch_floor: 0,
             pending_vnode_states: std::collections::HashMap::new(),
             last_vnode_uploads: std::collections::HashMap::new(),
+            #[cfg(feature = "state-tier")]
+            state_tier: None,
             #[cfg(feature = "cluster")]
             cluster_controller: None,
             cached_sorted_sink_names: None,
@@ -461,11 +510,19 @@ impl CheckpointCoordinator {
     /// Call once per checkpoint (even with an empty map) so a prior epoch's
     /// slices never leak forward.
     #[allow(clippy::disallowed_types)]
-    pub fn set_pending_vnode_states(
-        &mut self,
-        states: std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
-    ) {
+    pub(crate) fn set_pending_vnode_states(&mut self, states: StagedVnodeStates) {
         self.pending_vnode_states = states;
+    }
+
+    /// Wire the cold-tier request channel (forced full re-uploads of
+    /// demoted slices fetch their bytes through it).
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
+    pub(crate) fn set_state_tier(
+        &mut self,
+        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    ) {
+        self.state_tier = Some(tier);
     }
 
     /// Vnodes this instance owns; drives marker writes. Also the
@@ -486,6 +543,114 @@ impl CheckpointCoordinator {
     /// registry in cluster mode). Defaults to `vnode_set` when unset.
     pub fn set_gate_vnode_set(&mut self, vnodes: Vec<u32>) {
         self.gate_vnode_set = vnodes;
+    }
+
+    /// Fetch a demoted slice's bytes back from the cold tier for a forced
+    /// full re-upload.
+    #[cfg(feature = "state-tier")]
+    async fn fetch_cold_slice(&self, operator: &str, vnode: u32) -> Result<bytes::Bytes, DbError> {
+        let Some(ref tier) = self.state_tier else {
+            return Err(DbError::Checkpoint(format!(
+                "cold slice staged but no state tier is wired \
+                 (operator={operator}, vnode={vnode})"
+            )));
+        };
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        tier.send(crate::state_tier::TierRequest::Fetch {
+            operator: Arc::from(operator),
+            vnode,
+            reply,
+        })
+        .await
+        .map_err(|_| DbError::Checkpoint("state tier worker is gone".to_string()))?;
+        match rx
+            .await
+            .map_err(|_| DbError::Checkpoint("state tier worker dropped the reply".to_string()))??
+        {
+            Some(bytes) => Ok(bytes),
+            None => Err(DbError::Checkpoint(format!(
+                "demoted slice missing from the state tier \
+                 (operator={operator}, vnode={vnode}) — failing the epoch \
+                 rather than dropping it from recovery truth"
+            ))),
+        }
+    }
+
+    /// `state-tier` off: a `Cold` slice can never be staged, so reaching
+    /// this is a logic error reported as a failed epoch.
+    #[cfg(not(feature = "state-tier"))]
+    #[allow(clippy::unused_async)]
+    async fn fetch_cold_slice(&self, operator: &str, vnode: u32) -> Result<bytes::Bytes, DbError> {
+        Err(DbError::Checkpoint(format!(
+            "cold slice staged without state-tier support \
+             (operator={operator}, vnode={vnode})"
+        )))
+    }
+
+    /// Vnodes eligible for demotion: every recorded slice still
+    /// memory-resident, and the base epoch already durable at or below
+    /// `restorable_epoch` (the demoted bytes must be recoverable without
+    /// the tier). Returns `(vnode, base_epoch, total_bytes)`, largest
+    /// first — demoting big idle slices first frees the most memory.
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
+    pub(crate) fn demotion_candidates(&self, restorable_epoch: u64) -> Vec<(u32, u64, usize)> {
+        let mut out: Vec<(u32, u64, usize)> = self
+            .last_vnode_uploads
+            .iter()
+            .filter(|(_, (base, slices))| {
+                *base <= restorable_epoch
+                    && !slices.is_empty()
+                    && slices
+                        .values()
+                        .all(|s| matches!(s, UploadedSlice::Bytes(_)))
+            })
+            .map(|(v, (base, slices))| {
+                let total = slices
+                    .values()
+                    .map(|s| match s {
+                        UploadedSlice::Bytes(b) => b.len(),
+                        UploadedSlice::Cold => 0,
+                    })
+                    .sum();
+                (*v, *base, total)
+            })
+            .collect();
+        out.sort_by_key(|&(_, _, total)| std::cmp::Reverse(total));
+        out
+    }
+
+    /// The recorded upload bytes for `vnode`, to hand to the tier. These
+    /// are exactly the bytes of the slice's last durable full upload, so a
+    /// demotion writes truth-identical state by construction.
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
+    pub(crate) fn slices_for_demotion(&self, vnode: u32) -> Vec<(String, bytes::Bytes)> {
+        self.last_vnode_uploads
+            .get(&vnode)
+            .map(|(_, slices)| {
+                slices
+                    .iter()
+                    .filter_map(|(n, s)| match s {
+                        UploadedSlice::Bytes(b) => Some((n.clone(), b.clone())),
+                        UploadedSlice::Cold => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Release the in-memory byte pins for a demoted vnode (call only
+    /// after the tier write is confirmed and the operator dropped the
+    /// groups). The reference-partial flow then keys off the cold marker.
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
+    pub(crate) fn mark_vnode_demoted(&mut self, vnode: u32) {
+        if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
+            for s in slices.values_mut() {
+                *s = UploadedSlice::Cold;
+            }
+        }
     }
 
     /// Registers a sink connector for checkpoint coordination.
@@ -766,9 +931,15 @@ impl CheckpointCoordinator {
         let caller_version = self.assignment_version;
         let max_ref_age = (self.config.max_retained as u64).max(1);
 
-        // Step 1 (sync): classify each vnode as reference or full and
-        // encode its payload.
-        let mut full_uploads: Vec<(u32, std::collections::HashMap<String, bytes::Bytes>)> =
+        // Step 1: classify each vnode as reference or full and encode its
+        // payload. A staged `Cold` slice counts as unchanged (the demotion
+        // contract guarantees byte identity with the recorded upload); when
+        // a full upload is forced anyway — another operator's slice changed,
+        // or the reference base is aging out — the cold bytes are fetched
+        // back from the tier. A fetch failure fails the epoch: writing a
+        // partial without the demoted slice would silently drop it from the
+        // recovery truth.
+        let mut full_uploads: Vec<(u32, std::collections::HashMap<String, UploadedSlice>)> =
             Vec::new();
         let mut emptied: Vec<u32> = Vec::new();
         let mut reference_count: u64 = 0;
@@ -778,7 +949,13 @@ impl CheckpointCoordinator {
             let base = ops.filter(|ops| !ops.is_empty()).and_then(|ops| {
                 self.last_vnode_uploads
                     .get(&v)
-                    .filter(|(base, last)| epoch.saturating_sub(*base) < max_ref_age && last == ops)
+                    .filter(|(base, last)| {
+                        epoch.saturating_sub(*base) < max_ref_age
+                            && last.len() == ops.len()
+                            && ops
+                                .iter()
+                                .all(|(n, s)| last.get(n).is_some_and(|prev| prev.matches(s)))
+                    })
                     .map(|(base, _)| *base)
             });
             let partial = if let Some(base_epoch) = base {
@@ -789,15 +966,35 @@ impl CheckpointCoordinator {
                     base_epoch: Some(base_epoch),
                 }
             } else {
-                match ops {
-                    Some(ops) if !ops.is_empty() => full_uploads.push((v, ops.clone())),
-                    _ => emptied.push(v),
+                let mut resolved: Vec<(String, Vec<u8>)> = Vec::new();
+                let mut recorded: std::collections::HashMap<String, UploadedSlice> =
+                    std::collections::HashMap::new();
+                if let Some(ops) = ops {
+                    for (name, slice) in ops {
+                        let bytes = match slice {
+                            StagedSlice::Bytes(b) => b.clone(),
+                            StagedSlice::Cold => self.fetch_cold_slice(name, v).await?,
+                        };
+                        resolved.push((name.clone(), bytes.to_vec()));
+                        // Record cold slices as cold: their bytes go into
+                        // this upload but stay pinned only in the tier.
+                        recorded.insert(
+                            name.clone(),
+                            match slice {
+                                StagedSlice::Bytes(b) => UploadedSlice::Bytes(b.clone()),
+                                StagedSlice::Cold => UploadedSlice::Cold,
+                            },
+                        );
+                    }
+                }
+                if recorded.is_empty() {
+                    emptied.push(v);
+                } else {
+                    full_uploads.push((v, recorded));
                 }
                 crate::vnode_partial::VnodePartial {
                     checkpoint_id,
-                    operators: ops
-                        .map(|ops| ops.iter().map(|(n, b)| (n.clone(), b.to_vec())).collect())
-                        .unwrap_or_default(),
+                    operators: resolved,
                     base_epoch: None,
                 }
             };
@@ -3622,7 +3819,10 @@ mod tests {
 
         let slices = || {
             let mut ops = std::collections::HashMap::new();
-            ops.insert("agg".to_string(), bytes::Bytes::from_static(b"state-v1"));
+            ops.insert(
+                "agg".to_string(),
+                StagedSlice::Bytes(bytes::Bytes::from_static(b"state-v1")),
+            );
             std::collections::HashMap::from([(0u32, ops)])
         };
 
@@ -3678,7 +3878,10 @@ mod tests {
         // Changed slices always upload full.
         let mut changed = std::collections::HashMap::new();
         let mut ops = std::collections::HashMap::new();
-        ops.insert("agg".to_string(), bytes::Bytes::from_static(b"state-v2"));
+        ops.insert(
+            "agg".to_string(),
+            StagedSlice::Bytes(bytes::Bytes::from_static(b"state-v2")),
+        );
         changed.insert(0u32, ops);
         coord.set_pending_vnode_states(changed);
         let r4 = coord
@@ -3692,6 +3895,173 @@ mod tests {
         .unwrap();
         assert_eq!(p4.base_epoch, None);
         assert!(!p4.operators.is_empty());
+    }
+
+    /// A demoted (cold-staged) slice keeps emitting references while its
+    /// base is fresh, and a forced full re-upload (base hitting the age
+    /// cap) fetches the bytes back from the tier instead of dropping the
+    /// slice from recovery truth.
+    #[cfg(feature = "state-tier")]
+    #[tokio::test]
+    async fn cold_slice_references_then_tier_fetch_on_forced_full() {
+        use laminar_core::state::InProcessBackend;
+
+        let tier_dir = tempfile::tempdir().unwrap();
+        let tier = Arc::new(
+            crate::state_tier::StateTierStore::open(tier_dir.path().join("tier"), None).unwrap(),
+        );
+        tier.put("agg", 0, b"state-v1").unwrap();
+        let tier_tx = crate::state_tier::spawn_worker(&tokio::runtime::Handle::current(), tier, 16);
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = CheckpointConfig {
+            max_retained: 2, // reference age cap = 2 epochs
+            ..CheckpointConfig::default()
+        };
+        let store = Box::new(FileSystemCheckpointStore::new(dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(config, store).await.unwrap();
+        let backend = Arc::new(InProcessBackend::new(2));
+        coord.set_state_backend(Arc::clone(&backend) as Arc<dyn StateBackend>);
+        coord.set_vnode_set(vec![0]);
+        coord.set_state_tier(tier_tx);
+
+        // Epoch 1: full upload while the slice is still memory-resident.
+        let mut ops = std::collections::HashMap::new();
+        ops.insert(
+            "agg".to_string(),
+            StagedSlice::Bytes(bytes::Bytes::from_static(b"state-v1")),
+        );
+        coord.set_pending_vnode_states(std::collections::HashMap::from([(0u32, ops)]));
+        let r1 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r1.success);
+
+        // Demote: release the in-memory pin; subsequent captures stage Cold.
+        assert_eq!(
+            coord.demotion_candidates(r1.epoch),
+            vec![(0, r1.epoch, b"state-v1".len())]
+        );
+        assert!(
+            coord.demotion_candidates(r1.epoch - 1).is_empty(),
+            "a base newer than the restorable epoch must not be a candidate"
+        );
+        let slices = coord.slices_for_demotion(0);
+        assert_eq!(slices.len(), 1);
+        assert_eq!(slices[0].1.as_ref(), b"state-v1");
+        coord.mark_vnode_demoted(0);
+        assert!(coord.demotion_candidates(r1.epoch).is_empty());
+
+        // Epoch 2: Cold staged → reference to epoch 1, no bytes needed.
+        let cold = || {
+            let mut ops = std::collections::HashMap::new();
+            ops.insert("agg".to_string(), StagedSlice::Cold);
+            std::collections::HashMap::from([(0u32, ops)])
+        };
+        coord.set_pending_vnode_states(cold());
+        let r2 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r2.success);
+        let p2 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r2.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(p2.base_epoch, Some(r1.epoch), "cold slice must reference");
+
+        // Epoch 3: still cold, base ages out → full re-upload from the tier.
+        coord.set_pending_vnode_states(cold());
+        let r3 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(
+            r3.success,
+            "forced full must fetch from the tier: {:?}",
+            r3.error
+        );
+        let p3 = crate::vnode_partial::VnodePartial::decode(
+            &backend.read_partial(0, r3.epoch).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(p3.base_epoch, None);
+        assert_eq!(p3.operators.len(), 1);
+        assert_eq!(p3.operators[0].0, "agg");
+        assert_eq!(
+            p3.operators[0].1, b"state-v1",
+            "the re-uploaded slice must be the tier's bytes"
+        );
+    }
+
+    /// A forced full re-upload whose cold slice is missing from the tier
+    /// must fail the epoch — writing the partial without it would silently
+    /// drop the slice from recovery truth.
+    #[cfg(feature = "state-tier")]
+    #[tokio::test]
+    async fn cold_slice_missing_from_tier_fails_epoch() {
+        use laminar_core::state::InProcessBackend;
+
+        let tier_dir = tempfile::tempdir().unwrap();
+        let tier = Arc::new(
+            crate::state_tier::StateTierStore::open(tier_dir.path().join("tier"), None).unwrap(),
+        );
+        // Deliberately empty tier.
+        let tier_tx = crate::state_tier::spawn_worker(&tokio::runtime::Handle::current(), tier, 16);
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = CheckpointConfig {
+            max_retained: 2,
+            ..CheckpointConfig::default()
+        };
+        let store = Box::new(FileSystemCheckpointStore::new(dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(config, store).await.unwrap();
+        let backend = Arc::new(InProcessBackend::new(2));
+        coord.set_state_backend(Arc::clone(&backend) as Arc<dyn StateBackend>);
+        coord.set_vnode_set(vec![0]);
+        coord.set_state_tier(tier_tx);
+
+        let mut ops = std::collections::HashMap::new();
+        ops.insert(
+            "agg".to_string(),
+            StagedSlice::Bytes(bytes::Bytes::from_static(b"state-v1")),
+        );
+        coord.set_pending_vnode_states(std::collections::HashMap::from([(0u32, ops)]));
+        let r1 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r1.success);
+        coord.mark_vnode_demoted(0);
+
+        let cold = || {
+            let mut ops = std::collections::HashMap::new();
+            ops.insert("agg".to_string(), StagedSlice::Cold);
+            std::collections::HashMap::from([(0u32, ops)])
+        };
+        // Epoch 2 references; epoch 3 forces full → tier miss → failure.
+        coord.set_pending_vnode_states(cold());
+        assert!(
+            coord
+                .checkpoint(CheckpointRequest::default())
+                .await
+                .unwrap()
+                .success
+        );
+        coord.set_pending_vnode_states(cold());
+        let r3 = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(
+            !r3.success,
+            "a tier miss must fail the epoch, not drop state"
+        );
+        assert!(
+            r3.error.unwrap().contains("missing from the state tier"),
+            "failure must name the missing slice"
+        );
     }
 
     /// `InProcessBackend` wrapper with a per-write delay (forces epoch
@@ -3803,14 +4173,14 @@ mod tests {
                     0u32,
                     std::collections::HashMap::from([(
                         "agg".to_string(),
-                        bytes::Bytes::from_static(tag),
+                        StagedSlice::Bytes(bytes::Bytes::from_static(tag)),
                     )]),
                 ),
                 (
                     1u32,
                     std::collections::HashMap::from([(
                         "agg".to_string(),
-                        bytes::Bytes::from_static(tag),
+                        StagedSlice::Bytes(bytes::Bytes::from_static(tag)),
                     )]),
                 ),
             ]);

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -592,21 +592,18 @@ impl CheckpointCoordinator {
         )))
     }
 
-    /// Vnodes eligible for demotion: every recorded slice still
-    /// memory-resident (`Bytes`, not already `Cold`). Returns
-    /// `(vnode, total_bytes)`, largest first — demoting big idle slices
-    /// first frees the most memory. The caller only invokes this with no
-    /// checkpoint in flight, so every recorded upload is already durable.
+    /// Vnodes with at least one `Bytes` (memory-resident) slice, as
+    /// `(vnode, resident_bytes)` over those slices, largest first. Caller
+    /// invokes only with no checkpoint in flight, so every upload is durable.
     #[cfg(feature = "state-tier")]
     pub(crate) fn demotion_candidates(&self) -> Vec<(u32, usize)> {
         let mut out: Vec<(u32, usize)> = self
             .last_vnode_uploads
             .iter()
             .filter(|(_, (_, slices))| {
-                !slices.is_empty()
-                    && slices
-                        .values()
-                        .all(|s| matches!(s, UploadedSlice::Bytes(_)))
+                slices
+                    .values()
+                    .any(|s| matches!(s, UploadedSlice::Bytes(_)))
             })
             .map(|(v, (_, slices))| {
                 let total = slices

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -392,7 +392,7 @@ pub struct CheckpointCoordinator {
     /// Cold-tier request channel; lets a forced full re-upload of a
     /// demoted slice fetch its bytes back from the tier.
     #[cfg(feature = "state-tier")]
-    state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
+    state_tier: Option<crate::state_tier::TierTx>,
     /// `Some` in cluster mode, `None` in single-instance / embedded.
     #[cfg(feature = "cluster")]
     cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
@@ -526,10 +526,7 @@ impl CheckpointCoordinator {
     /// demoted slices fetch their bytes through it).
     #[cfg(feature = "state-tier")]
     #[allow(dead_code)] // wired once the demotion trigger lands with promotion
-    pub(crate) fn set_state_tier(
-        &mut self,
-        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    ) {
+    pub(crate) fn set_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         self.state_tier = Some(tier);
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -593,24 +593,22 @@ impl CheckpointCoordinator {
     }
 
     /// Vnodes eligible for demotion: every recorded slice still
-    /// memory-resident, and the base epoch already durable at or below
-    /// `restorable_epoch` (the demoted bytes must be recoverable without
-    /// the tier). Returns `(vnode, base_epoch, total_bytes)`, largest
-    /// first — demoting big idle slices first frees the most memory.
+    /// memory-resident (`Bytes`, not already `Cold`). Returns
+    /// `(vnode, total_bytes)`, largest first — demoting big idle slices
+    /// first frees the most memory. The caller only invokes this with no
+    /// checkpoint in flight, so every recorded upload is already durable.
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
-    pub(crate) fn demotion_candidates(&self, restorable_epoch: u64) -> Vec<(u32, u64, usize)> {
-        let mut out: Vec<(u32, u64, usize)> = self
+    pub(crate) fn demotion_candidates(&self) -> Vec<(u32, usize)> {
+        let mut out: Vec<(u32, usize)> = self
             .last_vnode_uploads
             .iter()
-            .filter(|(_, (base, slices))| {
-                *base <= restorable_epoch
-                    && !slices.is_empty()
+            .filter(|(_, (_, slices))| {
+                !slices.is_empty()
                     && slices
                         .values()
                         .all(|s| matches!(s, UploadedSlice::Bytes(_)))
             })
-            .map(|(v, (base, slices))| {
+            .map(|(v, (_, slices))| {
                 let total = slices
                     .values()
                     .map(|s| match s {
@@ -618,10 +616,10 @@ impl CheckpointCoordinator {
                         UploadedSlice::Cold => 0,
                     })
                     .sum();
-                (*v, *base, total)
+                (*v, total)
             })
             .collect();
-        out.sort_by_key(|&(_, _, total)| std::cmp::Reverse(total));
+        out.sort_by_key(|&(_, total)| std::cmp::Reverse(total));
         out
     }
 
@@ -629,7 +627,6 @@ impl CheckpointCoordinator {
     /// are exactly the bytes of the slice's last durable full upload, so a
     /// demotion writes truth-identical state by construction.
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // wired once the demotion trigger lands with promotion
     pub(crate) fn slices_for_demotion(&self, vnode: u32) -> Vec<(String, bytes::Bytes)> {
         self.last_vnode_uploads
             .get(&vnode)
@@ -645,22 +642,11 @@ impl CheckpointCoordinator {
             .unwrap_or_default()
     }
 
-    /// Release the in-memory byte pins for a demoted vnode (call only
-    /// after the tier write is confirmed and the operator dropped the
-    /// groups). The reference-partial flow then keys off the cold marker.
-    #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // exercised by tests; the trigger uses the per-op variant
-    pub(crate) fn mark_vnode_demoted(&mut self, vnode: u32) {
-        if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
-            for s in slices.values_mut() {
-                *s = UploadedSlice::Cold;
-            }
-        }
-    }
-
     /// Release one operator's byte pin for a demoted `(operator, vnode)`
-    /// slice. The trigger demotes per operator (a vnode may carry several),
-    /// so a refusal by one operator doesn't strand the others' records.
+    /// slice — call only after the tier write is confirmed and the operator
+    /// dropped the groups. The reference-partial flow then keys off the cold
+    /// marker. Per operator (a vnode may carry several) so a refusal by one
+    /// doesn't strand the others' records.
     #[cfg(feature = "state-tier")]
     pub(crate) fn mark_slice_demoted(&mut self, vnode: u32, operator: &str) {
         if let Some((_, slices)) = self.last_vnode_uploads.get_mut(&vnode) {
@@ -3956,19 +3942,12 @@ mod tests {
         assert!(r1.success);
 
         // Demote: release the in-memory pin; subsequent captures stage Cold.
-        assert_eq!(
-            coord.demotion_candidates(r1.epoch),
-            vec![(0, r1.epoch, b"state-v1".len())]
-        );
-        assert!(
-            coord.demotion_candidates(r1.epoch - 1).is_empty(),
-            "a base newer than the restorable epoch must not be a candidate"
-        );
+        assert_eq!(coord.demotion_candidates(), vec![(0, b"state-v1".len())]);
         let slices = coord.slices_for_demotion(0);
         assert_eq!(slices.len(), 1);
         assert_eq!(slices[0].1.as_ref(), b"state-v1");
-        coord.mark_vnode_demoted(0);
-        assert!(coord.demotion_candidates(r1.epoch).is_empty());
+        coord.mark_slice_demoted(0, "agg");
+        assert!(coord.demotion_candidates().is_empty());
 
         // Epoch 2: Cold staged → reference to epoch 1, no bytes needed.
         let cold = || {
@@ -4050,7 +4029,7 @@ mod tests {
             .await
             .unwrap();
         assert!(r1.success);
-        coord.mark_vnode_demoted(0);
+        coord.mark_slice_demoted(0, "agg");
 
         let cold = || {
             let mut ops = std::collections::HashMap::new();

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -33,6 +33,11 @@ use tracing::{debug, error, info, warn};
 use crate::error::DbError;
 
 /// One operator's staged slice for one vnode of the next checkpoint.
+///
+/// Both variants are only constructed on the per-vnode capture path
+/// (`cluster`); without it the coordinator still carries the type but never
+/// builds one.
+#[cfg_attr(not(feature = "cluster"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub(crate) enum StagedSlice {
     /// Freshly serialized memory-resident state.
@@ -52,6 +57,9 @@ pub(crate) type StagedVnodeStates = HashMap<u32, HashMap<String, StagedSlice>>;
 /// byte source for coordinator-driven demotion), or a cold marker once the
 /// slice was demoted — the bytes then live only in the tier, releasing the
 /// in-memory pin.
+/// `Cold` is only recorded when a demotion lands (`state-tier`); the plain
+/// `cluster` build records bytes but never a cold marker.
+#[cfg_attr(not(feature = "state-tier"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub(crate) enum UploadedSlice {
     Bytes(bytes::Bytes),

--- a/crates/laminar-db/src/config.rs
+++ b/crates/laminar-db/src/config.rs
@@ -65,6 +65,10 @@ pub struct LaminarConfig {
     pub delivery_guarantee: DeliveryGuarantee,
     /// Per-operator state limit. At 80% warns, at 100% errors. `None` = unlimited.
     pub max_state_bytes_per_operator: Option<usize>,
+    /// Node-level cap on total operator state held in memory. Crossing it
+    /// pauses source intake (backpressure, not failure) until state drains
+    /// below the budget. `None` = unlimited.
+    pub state_memory_budget_bytes: Option<usize>,
 
     /// Source-to-coordinator channel capacity. `None` = 64.
     pub pipeline_channel_capacity: Option<usize>,
@@ -94,6 +98,7 @@ impl Default for LaminarConfig {
             http_auth_token: None,
             delivery_guarantee: DeliveryGuarantee::default(),
             max_state_bytes_per_operator: None,
+            state_memory_budget_bytes: None,
             pipeline_channel_capacity: None,
             pipeline_batch_window: None,
             pipeline_drain_budget_ns: None,

--- a/crates/laminar-db/src/config.rs
+++ b/crates/laminar-db/src/config.rs
@@ -69,6 +69,11 @@ pub struct LaminarConfig {
     /// pauses source intake (backpressure, not failure) until state drains
     /// below the budget. `None` = unlimited.
     pub state_memory_budget_bytes: Option<usize>,
+    /// Local directory for the disk cold tier. When set together with
+    /// `state_memory_budget_bytes`, operator state approaching the budget is
+    /// demoted here (off-heap) instead of backpressuring. `None` = no tier.
+    /// Requires the `state-tier` build feature; ignored otherwise.
+    pub state_tier_dir: Option<PathBuf>,
 
     /// Source-to-coordinator channel capacity. `None` = 64.
     pub pipeline_channel_capacity: Option<usize>,
@@ -99,6 +104,7 @@ impl Default for LaminarConfig {
             delivery_guarantee: DeliveryGuarantee::default(),
             max_state_bytes_per_operator: None,
             state_memory_budget_bytes: None,
+            state_tier_dir: None,
             pipeline_channel_capacity: None,
             pipeline_batch_window: None,
             pipeline_drain_budget_ns: None,

--- a/crates/laminar-db/src/connector_manager.rs
+++ b/crates/laminar-db/src/connector_manager.rs
@@ -23,13 +23,11 @@ pub(crate) struct SourceRegistration {
 #[derive(Debug, Clone)]
 pub(crate) struct SinkRegistration {
     pub name: String,
-    /// Input source or stream name (schema lookup + routing).
     pub input: String,
     pub connector_type: Option<String>,
     pub connector_options: HashMap<String, String>,
     pub format: Option<String>,
     pub format_options: HashMap<String, String>,
-    /// WHERE filter expression as SQL text.
     pub filter_expr: Option<String>,
 }
 
@@ -40,9 +38,6 @@ pub(crate) struct StreamRegistration {
     pub emit_clause: Option<laminar_sql::parser::EmitClause>,
     pub window_config: Option<laminar_sql::translator::WindowOperatorConfig>,
     pub order_config: Option<laminar_sql::translator::OrderOperatorConfig>,
-    /// Per-step join configs from the planner (one entry per binary step,
-    /// left-deep). Lets the executor skip SQL re-parses when the query
-    /// has no streaming-specific join step.
     pub join_config: Option<Vec<laminar_sql::translator::JoinOperatorConfig>>,
 }
 
@@ -55,12 +50,7 @@ pub(crate) struct TableRegistration {
     pub format: Option<String>,
     pub format_options: HashMap<String, String>,
     pub refresh: Option<RefreshMode>,
-    /// Byte budget for the on-demand lookup `LookupMemoryCache` (partial mode).
-    /// `None` falls back to the cache's default.
     pub cache_max_bytes: Option<usize>,
-    /// Time-to-live for on-demand lookup cache entries (partial mode). After
-    /// this duration an entry is lazily re-fetched on the next probe. `None`
-    /// means entries live until byte-eviction / CDC invalidation.
     pub cache_ttl: Option<std::time::Duration>,
 }
 
@@ -165,16 +155,12 @@ pub struct ConnectorManager {
     sinks: HashMap<String, SinkRegistration>,
     streams: HashMap<String, StreamRegistration>,
     tables: HashMap<String, TableRegistration>,
-    /// Original DDL text for SHOW CREATE, keyed by object name.
     ddl_store: HashMap<String, String>,
-    /// Object names in creation order. Pairs with `ddl_store` to emit the
-    /// catalog manifest in a dependency-safe replay order (a view selecting
-    /// from another is created after it). Names are removed on DROP.
+    // Creation order for dependency-safe catalog manifest replay.
     ddl_order: Vec<String>,
 }
 
 impl ConnectorManager {
-    /// Create an empty manager.
     pub fn new() -> Self {
         Self {
             sources: HashMap::new(),
@@ -186,9 +172,7 @@ impl ConnectorManager {
         }
     }
 
-    /// Store DDL text for SHOW CREATE and the catalog manifest. Preserves
-    /// first-seen creation order; a re-`CREATE` (e.g. OR REPLACE) updates the
-    /// text in place without reordering.
+    /// Store DDL text for SHOW CREATE. OR REPLACE updates in place without reordering.
     pub fn store_ddl(&mut self, name: &str, ddl: &str) {
         if self
             .ddl_store
@@ -199,20 +183,17 @@ impl ConnectorManager {
         }
     }
 
-    /// Retrieve stored DDL text.
     pub fn get_ddl(&self, name: &str) -> Option<&str> {
         self.ddl_store.get(name).map(String::as_str)
     }
 
-    /// Forget an object's DDL (on DROP) so it leaves the catalog manifest.
     pub fn remove_ddl(&mut self, name: &str) {
         if self.ddl_store.remove(name).is_some() {
             self.ddl_order.retain(|n| n != name);
         }
     }
 
-    /// All stored DDL as `(name, ddl)` in creation order — the catalog
-    /// manifest's replay sequence.
+    /// Returns stored DDL in creation order for catalog manifest replay.
     #[cfg(feature = "cluster")]
     pub fn ordered_ddl(&self) -> Vec<(String, String)> {
         self.ddl_order
@@ -225,17 +206,14 @@ impl ConnectorManager {
             .collect()
     }
 
-    /// Register a source.
     pub fn register_source(&mut self, reg: SourceRegistration) {
         self.sources.insert(reg.name.clone(), reg);
     }
 
-    /// Register a sink.
     pub fn register_sink(&mut self, reg: SinkRegistration) {
         self.sinks.insert(reg.name.clone(), reg);
     }
 
-    /// Register a stream.
     pub fn register_stream(&mut self, reg: StreamRegistration) {
         self.streams.insert(reg.name.clone(), reg);
     }
@@ -258,7 +236,6 @@ impl ConnectorManager {
         self.streams.remove(name).is_some()
     }
 
-    /// Register a reference/dimension table.
     pub fn register_table(&mut self, reg: TableRegistration) {
         self.tables.insert(reg.name.clone(), reg);
     }
@@ -269,7 +246,6 @@ impl ConnectorManager {
         self.tables.remove(name).is_some()
     }
 
-    /// All table registrations.
     pub fn tables(&self) -> &HashMap<String, TableRegistration> {
         &self.tables
     }
@@ -281,17 +257,14 @@ impl ConnectorManager {
             || self.tables.values().any(|t| t.connector_type.is_some())
     }
 
-    /// All source registrations.
     pub fn sources(&self) -> &HashMap<String, SourceRegistration> {
         &self.sources
     }
 
-    /// All sink registrations.
     pub fn sinks(&self) -> &HashMap<String, SinkRegistration> {
         &self.sinks
     }
 
-    /// All stream registrations.
     pub fn streams(&self) -> &HashMap<String, StreamRegistration> {
         &self.streams
     }

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -28,7 +28,6 @@ use crate::aggregate_state::{
 use crate::eowc_state::{extract_i64_timestamps, NULL_TIMESTAMP};
 use crate::error::DbError;
 
-/// Which core window assigner variant is in use.
 enum CoreWindowAssigner {
     Tumbling(TumblingWindowAssigner),
     Hopping(SlidingWindowAssigner),
@@ -41,12 +40,10 @@ struct PostProjection {
     final_schema: SchemaRef,
 }
 
-/// A `WHERE` predicate calling `now()`: kept logical and re-resolved per
-/// cycle (a statically-compiled `now()` errors at `evaluate()` because
-/// `DataFusion` only folds it in the `SimplifyExpressions` pass we skip).
+/// A `WHERE` predicate calling `now()`: kept logical and re-resolved per cycle
+/// because a statically compiled `now()` errors at `evaluate()`.
 struct NowWhereFilter {
     predicate: datafusion_expr::Expr,
-    /// Schema the predicate was planned against (carries table qualifiers).
     df_schema: Arc<DFSchema>,
 }
 
@@ -54,7 +51,6 @@ fn is_wallclock_fn(name: &str) -> bool {
     name.eq_ignore_ascii_case("now") || name.eq_ignore_ascii_case("current_timestamp")
 }
 
-/// True if `expr` calls `now()`/`current_timestamp()`.
 fn expr_uses_wallclock(expr: &datafusion_expr::Expr) -> bool {
     let mut found = false;
     let _ = expr.apply(|e| {
@@ -69,10 +65,8 @@ fn expr_uses_wallclock(expr: &datafusion_expr::Expr) -> bool {
     found
 }
 
-/// Replace `now()`/`current_timestamp()` with a fixed `Timestamp(ns,
-/// "+00:00")` literal — matching `DataFusion`'s own return type so the
-/// analyzer's coercion casts stay valid — so the predicate lowers to a
-/// static `PhysicalExpr` for this cycle.
+/// Substitute `now()`/`current_timestamp()` with a fixed nanosecond literal
+/// matching `DataFusion`'s return type so coercion casts stay valid.
 fn substitute_wallclock(
     expr: datafusion_expr::Expr,
     now_ns: i64,
@@ -108,9 +102,6 @@ struct SessionGroupState {
 pub(crate) struct SessionCheckpoint {
     pub start: i64,
     pub end: i64,
-    /// One Arrow IPC blob per aggregate; each encodes that aggregate's
-    /// `Accumulator::state()` tuple as a one-row batch. See
-    /// [`crate::aggregate_state::scalars_to_ipc`].
     pub acc_states: Vec<Vec<u8>>,
 }
 
@@ -118,7 +109,6 @@ pub(crate) struct SessionCheckpoint {
     Clone, serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 pub(crate) struct SessionGroupCheckpoint {
-    /// Arrow IPC bytes for the group-key tuple.
     pub key: Vec<u8>,
     pub sessions: Vec<SessionCheckpoint>,
 }
@@ -128,30 +118,22 @@ pub(crate) struct SessionGroupCheckpoint {
 )]
 pub(crate) struct CoreWindowCheckpoint {
     pub fingerprint: u64,
-    /// Tumbling / hopping per-window state (reuses EOWC format).
     pub windows: Vec<WindowCheckpoint>,
-    /// Session-assigner per-group state.
     #[serde(default)]
     pub session_state: Vec<SessionGroupCheckpoint>,
-    /// Restore discriminant. No serde default — missing tag must fail
-    /// loud rather than silently routing into the wrong branch.
+    /// No serde default — missing tag must error rather than silently route wrong.
     pub window_type: String,
     pub high_watermark_ms: i64,
 }
 
-/// Core window state for windowed aggregate queries.
-///
-/// Uses the core engine's canonical window assigners for window assignment
-/// and `DataFusion` `Accumulator`s for per-group aggregation.
+/// Core window state for tumbling/hopping/session aggregate queries.
 pub(crate) struct CoreWindowState {
     assigner: CoreWindowAssigner,
-    /// Per-window aggregate state: `window_start` -> per-group accumulators.
     #[allow(clippy::type_complexity)]
     windows:
         BTreeMap<i64, AHashMap<arrow::row::OwnedRow, Vec<Box<dyn datafusion_expr::Accumulator>>>>,
-    /// Per-group session state. Only populated for session windows.
+    // Only populated for session windows.
     session_groups: AHashMap<arrow::row::OwnedRow, SessionGroupState>,
-    /// Persistent row converter for group key encoding/decoding.
     row_converter: arrow::row::RowConverter,
     agg_specs: Vec<AggFuncSpec>,
     num_group_cols: usize,
@@ -161,37 +143,30 @@ pub(crate) struct CoreWindowState {
     output_schema: SchemaRef,
     having_sql: Option<String>,
     compiled_projection: Option<CompiledProjection>,
-    /// Built once; `LiveSourceExec` leaves carry fresh data per execute.
+    // Built once; LiveSourceExec leaves carry fresh data per execute.
     cached_pre_agg_physical: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
-    /// Set when WHERE references `now()`; resolved per cycle.
+    // Set when WHERE references `now()`; resolved per cycle.
     now_where: Option<NowWhereFilter>,
-    /// Compiled `now()` predicate keyed by the second it was built for.
-    /// `Err` caches a compile failure so we don't re-run the analyzer
-    /// every cycle while it's broken; retries at the next second roll.
+    // Compiled `now()` predicate keyed by the second it was compiled for.
+    // Err caches a compile failure; retries at the next second roll.
     #[allow(clippy::type_complexity)]
     now_filter_cache: Option<(i64, Result<Arc<dyn PhysicalExpr>, String>)>,
     having_filter: Option<Arc<dyn PhysicalExpr>>,
     max_groups_per_window: usize,
-    /// Grace after window end; late events within this window are kept.
     allowed_lateness_ms: i64,
-    /// Highest watermark seen via `close_windows`; `i64::MIN` until first close.
     high_watermark_ms: i64,
     post_projection: Option<PostProjection>,
     prom: Option<Arc<crate::engine_metrics::EngineMetrics>>,
     having_sql_cache: Option<crate::operator::HavingSqlCache>,
     scratch_nogroup: AHashMap<i64, Vec<u32>>,
-    /// Bucket map keyed by `(window_start, group_id)`. Group ids come
-    /// from `scratch_group_keys` and are dense within a batch.
+    // Group ids are dense within a batch and index into scratch_group_keys.
     scratch_grouped: AHashMap<(i64, u32), Vec<u32>>,
-    /// Per-batch group-key set; the index is the group id used by
-    /// `scratch_grouped`.
     scratch_group_keys: indexmap::IndexSet<arrow::row::OwnedRow, ahash::RandomState>,
 }
 
 impl CoreWindowState {
-    /// Attempt to build a `CoreWindowState` by introspecting the logical
-    /// plan of the given SQL query. Returns `None` if the query is not a
-    /// windowed aggregate that can be routed through the core pipeline.
+    /// Build state from SQL; returns `None` if the query is not a windowed
+    /// aggregate that can be routed through the core pipeline.
     #[allow(clippy::too_many_lines)]
     pub async fn try_from_sql(
         ctx: &SessionContext,
@@ -280,8 +255,7 @@ impl CoreWindowState {
             return Ok(None);
         }
 
-        // Determine if we should attempt to compile pre-agg expressions.
-        // Use single_source_table (counts occurrences) to reject self-joins.
+        // single_source_table rejects self-joins before attempting expression compile.
         let compile_source = crate::sql_analysis::single_source_table(sql);
         let state_ref = ctx.state();
         let compile_props = state_ref.execution_props();
@@ -290,8 +264,7 @@ impl CoreWindowState {
         let mut proj_fields: Vec<Field> = Vec::new();
         let mut compile_ok = compile_source.is_some();
 
-        // Detect post-aggregate projection: top schema differs from Aggregate
-        // schema when a Projection sits above the Aggregate.
+        // A Projection above the Aggregate makes the top schema differ.
         let has_projection = {
             let same = top_schema.fields().len() == agg_schema.fields().len()
                 && top_schema
@@ -302,7 +275,6 @@ impl CoreWindowState {
             !same
         };
 
-        // Extract projection expressions + DFSchema (carries table qualifiers).
         let projection_info = if has_projection {
             fn find_projection(
                 plan: &datafusion_expr::LogicalPlan,
@@ -323,10 +295,8 @@ impl CoreWindowState {
             None
         };
 
-        // `now()` re-resolves per cycle only in WHERE; elsewhere
-        // (GROUP BY/SELECT/HAVING/aggregate args+FILTER) it would freeze
-        // at plan time. `Unsupported` (not `Pipeline`) so the EOWC
-        // operator re-propagates rather than falling back to raw.
+        // `now()` in GROUP BY/SELECT/HAVING/aggregate args would freeze at plan time.
+        // `Unsupported` (not `Pipeline`) lets the EOWC operator re-propagate.
         let nonwhere_now = group_exprs.iter().any(expr_uses_wallclock)
             || aggr_exprs.iter().any(expr_uses_wallclock)
             || having_predicate.as_ref().is_some_and(expr_uses_wallclock)
@@ -371,7 +341,6 @@ impl CoreWindowState {
                 pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
             }
 
-            // Compile group expression
             if compile_ok {
                 match create_physical_expr(group_expr, input_df_schema, compile_props) {
                     Ok(phys) => {
@@ -395,8 +364,6 @@ impl CoreWindowState {
         for (i, expr) in aggr_exprs.iter().enumerate() {
             let agg_schema_idx = num_group_cols + i;
             let agg_field = agg_schema.field(agg_schema_idx);
-            // When a projection is present, use the Aggregate output name
-            // so the intermediate batch columns match what PhysicalExpr expects.
             let output_name = if has_projection {
                 agg_field.name().clone()
             } else if agg_schema_idx < top_schema.fields().len() {
@@ -419,7 +386,6 @@ impl CoreWindowState {
                     input_col_indices.push(col_idx);
                     input_types.push(DataType::Boolean);
 
-                    // Compile literal TRUE
                     if compile_ok {
                         match create_physical_expr(
                             &datafusion_expr::lit(true),
@@ -449,7 +415,6 @@ impl CoreWindowState {
                                 "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
                             ));
 
-                            // Compile: CASE WHEN filter THEN arg ELSE NULL END
                             if compile_ok {
                                 let case_expr =
                                     datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
@@ -487,7 +452,6 @@ impl CoreWindowState {
                             pre_agg_select_items
                                 .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
 
-                            // Compile the arg expression directly
                             if compile_ok {
                                 match create_physical_expr(arg_expr, input_df_schema, compile_props)
                                 {
@@ -523,7 +487,6 @@ impl CoreWindowState {
                         "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
                     ));
 
-                    // Compile: CASE WHEN filter THEN TRUE ELSE FALSE END
                     if compile_ok {
                         let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
                             expr: None,
@@ -570,11 +533,9 @@ impl CoreWindowState {
             }
         }
 
-        // Add time column for window assignment
         let time_col_index = next_col_idx;
         pre_agg_select_items.push(format!("\"{}\" AS \"__cw_ts\"", window_config.time_column));
 
-        // Compile time column expression
         if compile_ok {
             let time_expr = datafusion_expr::Expr::Column(
                 datafusion_common::Column::new_unqualified(&window_config.time_column),
@@ -599,11 +560,8 @@ impl CoreWindowState {
             clauses.where_clause,
         );
 
-        // Build compiled projection for single-source queries.
         let compiled_projection = if compile_ok {
-            // Compile WHERE predicate. A `now()`/`current_timestamp()`
-            // predicate cannot be compiled once (it errors at evaluate),
-            // so leave the static filter empty and apply it per cycle.
+            // A `now()` predicate can't be compiled once; apply it per cycle instead.
             let filter = if where_uses_now {
                 None
             } else if let Some(where_pred) = &agg_info.where_predicate {
@@ -629,9 +587,7 @@ impl CoreWindowState {
             None
         };
 
-        // `now()` in WHERE re-resolves per cycle only on the compiled
-        // single-source path; the interpreted cached-plan fallback would
-        // freeze it at plan time. Fail loud at CREATE instead.
+        // The interpreted fallback would freeze `now()` at plan time; fail at CREATE.
         if where_uses_now && compiled_projection.is_none() {
             return Err(DbError::Unsupported(format!(
                 "[{}] now()/current_timestamp() in WHERE requires the single-source \
@@ -663,8 +619,7 @@ impl CoreWindowState {
         let output_schema = Arc::new(Schema::new(output_fields));
 
         let post_projection = if let Some((proj_exprs, agg_df_schema)) = projection_info {
-            // Coerce literal types — NULLIF/CASE accept `(any, any)` and
-            // skip DataFusion's normal cast insertion.
+            // NULLIF/CASE accept `(any, any)` and skip DataFusion's normal cast insertion.
             let mut rewriter = TypeCoercionRewriter::new(&agg_df_schema);
             let mut compiled = Vec::with_capacity(proj_exprs.len());
             for expr in proj_exprs {
@@ -691,7 +646,6 @@ impl CoreWindowState {
             None
         };
 
-        // Compile HAVING filter.
         let having_filter = compile_having_filter(ctx, having_predicate.as_ref(), &output_schema);
         let having_sql = if having_filter.is_none() {
             having_predicate.as_ref().map(expr_to_sql)
@@ -699,7 +653,6 @@ impl CoreWindowState {
             None
         };
 
-        // Plan once at init; `LiveSourceProvider` leaves carry fresh data.
         let cached_pre_agg_physical = if compiled_projection.is_none() {
             let df = ctx
                 .sql(&pre_agg_sql)
@@ -741,7 +694,7 @@ impl CoreWindowState {
             now_filter_cache: None,
             having_filter,
             max_groups_per_window: 1_000_000,
-            // EMIT FINAL drops late data, so force lateness=0 (Flink "drop late").
+            // EMIT FINAL drops late data; force lateness to 0.
             allowed_lateness_ms: if matches!(emit_clause, Some(EmitClause::Final)) {
                 0
             } else {
@@ -759,13 +712,7 @@ impl CoreWindowState {
 
     /// Update per-window accumulators with a new pre-aggregation batch.
     ///
-    /// Vectorized batch update: extracts timestamps and group keys at the
-    /// batch level using `RowConverter`, groups row indices by
-    /// `(window_start, group_key)`, then calls `update_group_accumulators`
-    /// once per group with a single `take()` per column.
-    ///
-    /// Session windows fall back to per-row processing because session
-    /// merging depends on insertion order.
+    /// Session windows use per-row processing because merge depends on insertion order.
     #[allow(clippy::too_many_lines)]
     pub fn update_batch(&mut self, batch: &RecordBatch) -> Result<(), DbError> {
         if batch.num_rows() == 0 {
@@ -774,12 +721,10 @@ impl CoreWindowState {
 
         let ts_array = extract_i64_timestamps(batch, self.time_col_index)?;
 
-        // Session windows require per-row processing (merge depends on order)
         if matches!(self.assigner, CoreWindowAssigner::Session { .. }) {
             return self.update_batch_session(batch, &ts_array);
         }
 
-        // Batch-level group key extraction via persistent RowConverter
         let rows = if self.num_group_cols > 0 {
             let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
                 .map(|i| Arc::clone(batch.column(i)))
@@ -793,18 +738,14 @@ impl CoreWindowState {
             None
         };
 
-        // Group row indices by (window_start, group_key).
-        // Same pattern as aggregate_state.rs: OwnedRow as HashMap key.
         let has_groups = self.num_group_cols > 0;
-
-        // For no-group case, just group by window_start
         if !has_groups {
             let empty_key = crate::aggregate_state::global_aggregate_key();
             let mut grouped = std::mem::take(&mut self.scratch_nogroup);
             grouped.clear();
             for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
                 if ts_ms == NULL_TIMESTAMP {
-                    continue; // skip rows with null timestamps
+                    continue;
                 }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
@@ -860,7 +801,6 @@ impl CoreWindowState {
             return Ok(());
         }
 
-        // Grouped path: dedup group keys per batch, bucket by integer id.
         let rows_ref = rows.as_ref().expect("rows set when has_groups");
         let mut grouped = std::mem::take(&mut self.scratch_grouped);
         let mut group_keys = std::mem::take(&mut self.scratch_group_keys);
@@ -956,13 +896,12 @@ impl CoreWindowState {
         };
         for (row, &ts_ms) in ts_array.iter().enumerate() {
             if ts_ms == NULL_TIMESTAMP {
-                continue; // skip rows with null timestamps
+                continue;
             }
             #[allow(clippy::cast_possible_truncation)]
             let index_array = arrow::array::UInt32Array::from_value(row as u32, 1);
             let key = self.extract_group_key_row(batch, &index_array)?;
-            // Drop new keys once `session_groups` hits the cap. Existing
-            // keys still aggregate so in-flight sessions aren't corrupted.
+            // Drop new keys past the cap; existing keys still accumulate.
             if !self.session_groups.contains_key(&key)
                 && self.session_groups.len() >= self.max_groups_per_window
             {
@@ -977,7 +916,6 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// Extract group key for a single row (scalar fallback for session windows).
     fn extract_group_key_row(
         &self,
         batch: &RecordBatch,
@@ -1012,11 +950,6 @@ impl CoreWindowState {
         let new_start = ts_ms;
         let new_end = ts_ms.saturating_add(gap_ms);
 
-        // BTreeMap range iteration yields unique keys, so `overlapping`
-        // is dedup-by-construction. The unwraps below rely on this and
-        // on the matching `session_groups.get_mut(key)` succeeding when
-        // we just observed `get(key).map(...)`. A debug_assert encodes
-        // the invariant for refactor safety.
         let overlapping: Vec<i64> = self
             .session_groups
             .get(key)
@@ -1135,7 +1068,6 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// Create fresh accumulators from agg specs.
     fn create_fresh_accumulators(
         &self,
     ) -> Result<Vec<Box<dyn datafusion_expr::Accumulator>>, DbError> {
@@ -1146,7 +1078,6 @@ impl CoreWindowState {
         Ok(accs)
     }
 
-    /// Feed a single row into the given accumulators.
     fn update_accumulators(
         accs: &mut [Box<dyn datafusion_expr::Accumulator>],
         agg_specs: &[AggFuncSpec],
@@ -1186,9 +1117,8 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// Per-window late-event predicate. Per-window (not per-event) so
-    /// hopping windows whose earlier slices have closed still admit
-    /// the event into their still-open later slices.
+    /// Per-window predicate so hopping windows whose earlier slices closed still
+    /// admit the event into still-open later slices.
     #[inline]
     fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
@@ -1205,7 +1135,7 @@ impl CoreWindowState {
             <= self.high_watermark_ms
     }
 
-    /// Close windows whose end <= watermark, returning emitted batches.
+    /// Close and emit all windows whose end (plus lateness grace) <= watermark.
     pub fn close_windows(&mut self, watermark_ms: i64) -> Result<Vec<RecordBatch>, DbError> {
         self.high_watermark_ms = self.high_watermark_ms.max(watermark_ms);
         let batches = match &self.assigner {
@@ -1216,13 +1146,11 @@ impl CoreWindowState {
         self.apply_post_projection(batches)
     }
 
-    /// Close fixed-size windows (tumbling/hopping) whose end <= watermark.
     fn close_fixed_windows(
         &mut self,
         watermark_ms: i64,
         size_ms: i64,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        // Fast check: if the earliest window hasn't expired, nothing to close.
         if let Some((&first_ws, _)) = self.windows.first_key_value() {
             if first_ws
                 .saturating_add(size_ms)
@@ -1263,9 +1191,7 @@ impl CoreWindowState {
         Ok(result_batches)
     }
 
-    /// Close session windows whose end <= watermark.
     fn close_session_windows(&mut self, watermark_ms: i64) -> Result<Vec<RecordBatch>, DbError> {
-        // Fast check: skip allocation if no sessions are closeable.
         let any_closeable = self.session_groups.values().any(|g| {
             g.sessions
                 .values()
@@ -1314,16 +1240,12 @@ impl CoreWindowState {
             return Ok(Vec::new());
         }
 
-        // Sort by (window_start, window_end) for deterministic output
         rows.sort_by_key(|(ws, we, _, _)| (*ws, *we));
 
         self.emit_session_rows(rows)
     }
 
-    /// Build a `RecordBatch` from closed session rows.
-    /// Output schema: `[group_cols..., agg_outputs...]`.
-    /// Sessions have data-dependent ends, so session boundaries are not
-    /// in the row output; project `MIN(ts)` / `MAX(ts)` upstream instead.
+    /// Emit closed session rows as a `RecordBatch`.
     #[allow(clippy::type_complexity)]
     fn emit_session_rows(
         &self,
@@ -1351,7 +1273,6 @@ impl CoreWindowState {
             }
         }
 
-        // Convert OwnedRow keys back to columnar arrays via RowConverter
         let group_arrays: Vec<ArrayRef> = if self.num_group_cols > 0 {
             let row_refs: Vec<arrow::row::Row<'_>> = row_keys.iter().map(|r| r.row()).collect();
             let cols = self
@@ -1396,7 +1317,6 @@ impl CoreWindowState {
         Ok(vec![batch])
     }
 
-    /// Emit a single window's accumulated state as a `RecordBatch`.
     fn emit_window(
         &self,
         groups: AHashMap<arrow::row::OwnedRow, Vec<Box<dyn datafusion_expr::Accumulator>>>,
@@ -1410,9 +1330,6 @@ impl CoreWindowState {
         )
     }
 
-    /// Apply compiled post-aggregate projection to emitted batches.
-    /// Input schema is `[group_cols..., agg_outputs...]`; output schema
-    /// is `final_schema` (the user's SELECT list).
     fn apply_post_projection(
         &self,
         batches: Vec<RecordBatch>,
@@ -1474,11 +1391,9 @@ impl CoreWindowState {
         &mut self.having_sql_cache
     }
 
-    /// Filter `inputs` by the `now()` `WHERE` clause, with `now()` bound
-    /// to the event-time watermark (not wall clock) so it is
-    /// replay-deterministic. `watermark_ms == i64::MIN` ⇒ `Ok(None)` (no
-    /// frontier yet — don't drop startup rows). Compiled predicate cached
-    /// per watermark-second.
+    /// Apply the `now()` WHERE predicate with `now()` bound to the watermark
+    /// for replay determinism. Returns `Ok(None)` when no filter is set or the
+    /// watermark is not yet established. Predicate is compiled once per second.
     pub(crate) fn apply_dynamic_now_filter(
         &mut self,
         ctx: &SessionContext,
@@ -1488,8 +1403,7 @@ impl CoreWindowState {
         if self.now_where.is_none() || watermark_ms == i64::MIN {
             return Ok(None);
         }
-        // Bind now() to the watermark, coarsened to whole seconds so the
-        // compiled predicate is reused until the frontier second rolls.
+        // Coarsen to seconds so the compiled predicate is reused within the same second.
         let secs = watermark_ms.div_euclid(1000);
         if self
             .now_filter_cache
@@ -1564,7 +1478,6 @@ impl CoreWindowState {
             f.name().hash(&mut h);
             f.data_type().to_string().hash(&mut h);
         }
-        // Window shape must invalidate the checkpoint on change.
         self.window_type_tag().hash(&mut h);
         match &self.assigner {
             CoreWindowAssigner::Tumbling(t) => t.size_ms().hash(&mut h),
@@ -1578,7 +1491,6 @@ impl CoreWindowState {
         h.finish()
     }
 
-    /// Returns a tag string for the current assigner type.
     fn window_type_tag(&self) -> &'static str {
         match &self.assigner {
             CoreWindowAssigner::Tumbling(_) => "tumbling",
@@ -1587,15 +1499,9 @@ impl CoreWindowState {
         }
     }
 
-    /// Estimated memory usage in bytes across all windows and groups.
-    ///
-    /// For tumbling/hopping windows, iterates over `windows` (`BTreeMap` of
-    /// window-start to per-group accumulators). For session windows, iterates
-    /// over `session_groups`. Uses `ScalarValue::size()` for keys and
-    /// `Accumulator::size()` for accumulator state.
+    /// Estimated memory usage in bytes across all open windows and groups.
     pub(crate) fn estimated_size_bytes(&self) -> usize {
         let mut total = 0;
-        // Tumbling/hopping windows
         for groups in self.windows.values() {
             for (key, accs) in groups {
                 total += key.as_ref().len();
@@ -1604,21 +1510,18 @@ impl CoreWindowState {
                 }
             }
         }
-        // Session windows
         for (key, group_state) in &self.session_groups {
             total += key.as_ref().len();
             for session in group_state.sessions.values() {
                 for acc in &session.accs {
                     total += acc.size();
                 }
-                // start/end timestamps: 2 × 8 bytes
-                total += 16;
+                total += 16; // start + end timestamps
             }
         }
         total
     }
 
-    /// Checkpoint all per-window group states into a serializable struct.
     pub(crate) fn checkpoint_windows(&mut self) -> Result<CoreWindowCheckpoint, DbError> {
         use crate::aggregate_state::scalars_to_ipc;
 
@@ -1705,7 +1608,6 @@ impl CoreWindowState {
         }
     }
 
-    /// Restore per-window group states from a checkpoint.
     pub(crate) fn restore_windows(
         &mut self,
         checkpoint: &CoreWindowCheckpoint,
@@ -1729,7 +1631,6 @@ impl CoreWindowState {
         }
     }
 
-    /// Restore fixed (tumbling/hopping) windows from checkpoint.
     fn restore_fixed_windows(
         &mut self,
         checkpoint: &CoreWindowCheckpoint,
@@ -1772,7 +1673,6 @@ impl CoreWindowState {
         Ok(total_groups)
     }
 
-    /// Restore session windows from checkpoint.
     fn restore_session_windows(
         &mut self,
         checkpoint: &CoreWindowCheckpoint,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -27,7 +27,7 @@ use crate::sql_utils;
 /// Cloneable async sender for the live-DDL control channel.
 pub(crate) type ControlMsgTx = crossfire::MAsyncTx<crossfire::mpsc::Array<ControlMsg>>;
 
-/// Lifecycle state of a [`LaminarDB`] instance, stored as `AtomicU8`.
+/// Lifecycle state of a [`LaminarDB`] instance.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DbState {
@@ -58,8 +58,7 @@ impl DbState {
         atomic.store(self as u8, std::sync::atomic::Ordering::Release);
     }
 
-    /// Atomically transition `current -> new`; returns the observed state on
-    /// failure so callers can claim an exclusive transition.
+    /// Atomically transition `current → new`; returns the observed state on failure.
     pub(crate) fn compare_exchange(
         current: Self,
         new: Self,
@@ -84,9 +83,7 @@ fn cache_entries_from_memory(mem: laminar_sql::parser::lookup_table::ByteSize) -
 
 /// The main `LaminarDB` database handle.
 ///
-/// Provides a unified interface for SQL execution, data ingestion,
-/// and result consumption. All streaming infrastructure (sources, sinks,
-/// channels, subscriptions) is managed internally.
+/// Unified interface for SQL execution, data ingestion, and result consumption.
 pub struct LaminarDB {
     pub(crate) catalog: Arc<SourceCatalog>,
     pub(crate) planner: parking_lot::Mutex<StreamingPlanner>,
@@ -94,7 +91,6 @@ pub struct LaminarDB {
     pub(crate) config: LaminarConfig,
     pub(crate) config_vars: Arc<HashMap<String, String>>,
     pub(crate) shutdown: std::sync::atomic::AtomicBool,
-    /// Populated by `start()`.
     pub(crate) coordinator:
         Arc<tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>>,
     pub(crate) connector_manager: parking_lot::Mutex<crate::connector_manager::ConnectorManager>,
@@ -111,36 +107,30 @@ pub struct LaminarDB {
     pub(crate) session_properties: parking_lot::Mutex<HashMap<String, String>>,
     /// Min of all source watermarks.
     pub(crate) pipeline_watermark: Arc<std::sync::atomic::AtomicI64>,
-    /// The registry of lookup table snapshots.
     pub(crate) lookup_registry: Arc<laminar_sql::datafusion::LookupTableRegistry>,
-    /// Assembled AI subsystem (registry + providers + cache + call log).
-    /// `None` unless `[ai]`/`[models]` are configured. Set once in the builder.
+    /// `None` unless `[ai]`/`[models]` are configured.
     pub(crate) ai_runtime: Option<Arc<crate::ai::AiRuntime>>,
-    /// Main runtime handle the AI inference workers spawn on. Set with `ai_runtime`.
+    /// Runtime the AI inference workers spawn on; set alongside `ai_runtime`.
     pub(crate) ai_handle: Option<tokio::runtime::Handle>,
-    /// Live-DDL channel to the running coordinator. `None` outside `start..shutdown`.
+    /// Live-DDL channel; `None` outside `start..shutdown`.
     pub(crate) control_tx: parking_lot::Mutex<Option<ControlMsgTx>>,
     pub(crate) mv_store: Arc<parking_lot::RwLock<crate::mv_store::MvStore>>,
-    /// Activates leader/follower checkpoint flow when set. `None` in embedded mode.
+    /// `None` in embedded mode.
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::ClusterController>>>,
-    /// Pair with `vnode_registry`; the coordinator writes per-vnode durability
-    /// markers each checkpoint and runs the gate when both are installed.
+    /// Paired with `vnode_registry`; the coordinator gates commits when both are installed.
     pub(crate) state_backend:
         parking_lot::Mutex<Option<Arc<dyn laminar_core::state::StateBackend>>>,
     pub(crate) vnode_registry: parking_lot::Mutex<Option<Arc<laminar_core::state::VnodeRegistry>>>,
-    /// Applied to both `self.ctx` and the pipeline-side `OperatorGraph` context.
     pub(crate) physical_optimizer_rules:
         Arc<[Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>]>,
     /// `target_partitions` override; cluster mode sets this to `vnode_count`.
     pub(crate) pipeline_target_partitions: Option<usize>,
-    /// Used by `SqlQueryOperator` to row-shuffle pre-aggregate batches to owners.
     #[cfg(feature = "cluster")]
     pub(crate) shuffle_sender:
         parking_lot::Mutex<Option<Arc<laminar_core::shuffle::ShuffleSender>>>,
-    /// `Arc`-wrapped so the subscription-router task can hold a weak handle and
-    /// read the receiver lazily (installed after the controller).
+    /// `Arc`-wrapped so the subscription-router task can hold a weak handle.
     #[cfg(feature = "cluster")]
     pub(crate) shuffle_receiver:
         Arc<parking_lot::Mutex<Option<Arc<laminar_core::shuffle::ShuffleReceiver>>>>,
@@ -150,33 +140,25 @@ pub struct LaminarDB {
     #[cfg(feature = "cluster")]
     pub(crate) assignment_snapshot_store:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::AssignmentSnapshotStore>>>,
-    /// Cluster-wide catalog manifest store (`catalog/manifest.json` on the
-    /// shared object store). Persisted on each successful checkpoint and
-    /// replayed at boot so a node rebuilds MVs/sources it lacks locally.
+    /// Cluster-wide catalog manifest; persisted on checkpoint, replayed at boot.
     #[cfg(feature = "cluster")]
     pub(crate) catalog_manifest_store:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::CatalogManifestStore>>>,
-    /// Committed per-vnode state staged by [`Self::adopt_assignment_snapshot`]
-    /// for vnodes this node newly acquired in a rebalance. Operators that
-    /// adopt the per-vnode state backend drain this on their next cycle to
-    /// resume from the last committed epoch instead of empty state.
-    ///
-    /// `Arc`-wrapped so the same handle is shared with the `OperatorGraph`
-    /// (via [`ClusterShuffleConfig`](crate::operator::sql_query::ClusterShuffleConfig)),
-    /// which drains and applies the staged slices into live operators each cycle.
+    /// Committed vnode state staged during rebalance adoption; operators drain
+    /// this each cycle to resume from the last committed epoch. Shared with
+    /// `OperatorGraph` via `ClusterShuffleConfig`.
     #[cfg(feature = "cluster")]
     pub(crate) rehydrated_vnode_state: Arc<parking_lot::Mutex<HashMap<u32, RehydratedVnode>>>,
-    /// Hands `db.checkpoint()` requests to the pipeline callback so it can capture
-    /// operator state before the manifest is packed. When `None`, falls back to
-    /// the direct coordinator path — only valid for stateless engines.
+    /// Routes `db.checkpoint()` requests to the pipeline callback so operator
+    /// state is captured. When `None`, the coordinator is driven directly
+    /// (stateless / pre-start path).
     pub(crate) force_ckpt_tx: parking_lot::Mutex<Option<ForceCheckpointTx>>,
     pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
-    /// Cluster mode: stream/MV name → subscribing node ids, refreshed from
-    /// gossip by the router task and read each cycle by producers.
+    /// stream/MV name → subscribing node ids; refreshed from gossip by the router task.
     #[cfg(feature = "cluster")]
     pub(crate) active_subs:
         Arc<parking_lot::RwLock<std::collections::HashMap<String, std::collections::HashSet<u64>>>>,
-    /// Stream output schemas resolved at `start()`; consulted by SUBSCRIBE WHERE.
+    /// Resolved at `start()`; consulted by SUBSCRIBE WHERE.
     pub(crate) stream_schemas:
         parking_lot::RwLock<std::collections::HashMap<String, arrow_schema::SchemaRef>>,
 }
@@ -185,8 +167,6 @@ pub struct LaminarDB {
 pub(crate) type ForceCheckpointReply =
     crossfire::oneshot::TxOneshot<Result<crate::checkpoint_coordinator::CheckpointResult, DbError>>;
 
-/// `db.checkpoint()` → pipeline callback request channel. Cold path; the cap
-/// is generous enough that callers never wait.
 pub(crate) type ForceCheckpointTx =
     crossfire::MAsyncTx<crossfire::mpsc::Array<ForceCheckpointReply>>;
 
@@ -195,14 +175,13 @@ pub(crate) type ForceCheckpointRx =
 
 pub(crate) const FORCE_CHECKPOINT_CHANNEL_CAPACITY: usize = 64;
 
-/// Subscription-router timer period. Drains run every tick, so this bounds
-/// cross-node SUBSCRIBE delivery latency.
+/// Subscription-router drain period; bounds cross-node SUBSCRIBE delivery latency.
 #[cfg(feature = "cluster")]
 const SUB_ROUTER_TICK: std::time::Duration = std::time::Duration::from_millis(10);
-/// Refresh the gossip interest cache ~every 500ms while subscriptions exist.
+/// Gossip interest refresh cadence (~500ms) while subscriptions are active.
 #[cfg(feature = "cluster")]
 const SUB_REFRESH_ACTIVE_TICKS: u64 = 50;
-/// Back off to ~5s when there is no subscription activity anywhere.
+/// Idle refresh cadence (~5s) when no subscriptions are active.
 #[cfg(feature = "cluster")]
 const SUB_REFRESH_IDLE_TICKS: u64 = 500;
 
@@ -229,31 +208,25 @@ pub(crate) fn filter_late_rows(
 
 pub(crate) use laminar_core::time::parse_duration_str;
 
-/// Committed state for a single vnode, staged during rebalance adoption
-/// so newly-acquired vnodes resume from the last committed epoch.
+/// Committed vnode state staged during rebalance adoption for deferred apply.
 #[cfg(feature = "cluster")]
 #[derive(Debug, Clone)]
 pub struct RehydratedVnode {
     /// Committed epoch the partial was read from.
     pub epoch: u64,
-    /// The vnode's `partial.bin` bytes at `epoch`.
+    /// `partial.bin` bytes at `epoch`.
     pub bytes: bytes::Bytes,
 }
 
 /// Summary of a single [`LaminarDB::adopt_assignment_snapshot`] call.
-///
-/// Returned so the rebalance control plane can log and meter what each
-/// adoption moved — in particular the vnodes this node gained and how
-/// much of their committed state it rehydrated from durable storage.
 #[cfg(feature = "cluster")]
 #[derive(Debug, Default)]
 pub struct SnapshotAdoption {
-    /// `false` when the snapshot was stale (≤ the current registry
-    /// version) or no registry was installed — nothing changed.
+    /// `false` when the snapshot was stale or no registry was installed.
     pub adopted: bool,
-    /// The snapshot version this call considered.
+    /// The snapshot version considered.
     pub version: u64,
-    /// Vnodes this node owns now but did not before this rotation.
+    /// Vnodes this node gained in this rotation.
     pub newly_acquired: Vec<u32>,
     /// How many of `newly_acquired` had committed state read back.
     pub rehydrated: usize,
@@ -415,17 +388,14 @@ impl LaminarDB {
         })
     }
 
-    /// Install the AI subsystem and the runtime handle its inference workers
-    /// spawn on. Called by the builder before the engine is shared; the handle
-    /// must be the main multi-threaded runtime.
+    /// Install the AI subsystem. Called by the builder; `handle` must be the
+    /// main multi-threaded runtime.
     pub(crate) fn set_ai_runtime(
         &mut self,
         runtime: Arc<crate::ai::AiRuntime>,
         handle: tokio::runtime::Handle,
     ) {
-        // Register the laminar.models / laminar.ai_calls catalog views. A
-        // failure here is non-fatal — inference still works, the views just
-        // aren't queryable.
+        // Non-fatal: inference still works if catalog view registration fails.
         if let Err(e) = crate::ai_catalog::register_ai_catalog(&self.ctx, &runtime) {
             tracing::warn!(error = %e, "failed to register laminar.* AI catalog views");
         }
@@ -487,8 +457,7 @@ impl LaminarDB {
         *self.assignment_snapshot_store.lock() = Some(store);
     }
 
-    /// Install the shared catalog manifest store. Enables catalog-manifest
-    /// persistence (on checkpoint) and boot-time replay.
+    /// Install the shared catalog manifest store.
     #[cfg(feature = "cluster")]
     pub(crate) fn set_catalog_manifest_store(
         &self,
@@ -497,10 +466,8 @@ impl LaminarDB {
         *self.catalog_manifest_store.lock() = Some(store);
     }
 
-    /// Publish this node's current catalog DDL to the shared
-    /// `catalog/manifest.json`. Best-effort and cluster-only — a failure is
-    /// logged, never propagated, since the manifest is an availability aid,
-    /// not a correctness gate. Called after each successful checkpoint.
+    /// Publish this node's catalog DDL to `catalog/manifest.json`. Best-effort;
+    /// failures are logged and never propagated.
     #[cfg(feature = "cluster")]
     pub(crate) async fn persist_catalog_manifest(&self) {
         let Some(store) = self.catalog_manifest_store.lock().clone() else {
@@ -518,8 +485,7 @@ impl LaminarDB {
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_millis() as i64);
         let manifest = laminar_core::cluster::control::CatalogManifest {
-            // Wall-clock as a monotonic-in-practice diagnostic version; the
-            // object is overwritten in place, so the value is informational.
+            // Wall-clock as a diagnostic version; the object is overwritten in place.
             version: now_ms.unsigned_abs(),
             updated_at_ms: now_ms,
             entries,
@@ -529,11 +495,8 @@ impl LaminarDB {
         }
     }
 
-    /// Replay catalog DDL from the shared `catalog/manifest.json`, recreating
-    /// any object this node doesn't already have locally. Best-effort and
-    /// cluster-only; runs at boot before the pipeline starts so the operator
-    /// graph for rebalanced-in MVs exists. A per-entry replay failure is
-    /// logged and skipped — the node still serves the objects that did rebuild.
+    /// Replay catalog DDL from the shared manifest, recreating objects this node
+    /// lacks. Runs at boot; per-entry failures are logged and skipped.
     #[cfg(feature = "cluster")]
     pub(crate) async fn restore_catalog_from_manifest(&self) {
         let Some(store) = self.catalog_manifest_store.lock().clone() else {
@@ -547,9 +510,8 @@ impl LaminarDB {
                 return;
             }
         };
-        // Detach the manifest store during replay: `execute` otherwise
-        // re-persists this node's still-partial catalog after every DDL, so a
-        // mid-replay failure would truncate the shared manifest. Reinstalled below.
+        // Detach during replay: execute() would re-persist a still-partial catalog
+        // after each DDL, potentially truncating the shared manifest on failure.
         let detached = self.catalog_manifest_store.lock().take();
         for entry in &manifest.entries {
             if self.catalog_object_exists(&entry.name) {
@@ -566,8 +528,7 @@ impl LaminarDB {
         *self.catalog_manifest_store.lock() = detached;
     }
 
-    /// Whether a catalog object with `name` is already registered locally
-    /// (any of source/sink/stream/table). Drives idempotent manifest replay.
+    /// Returns `true` if any catalog type (source/sink/stream/table) is registered under `name`.
     #[cfg(feature = "cluster")]
     fn catalog_object_exists(&self, name: &str) -> bool {
         let mgr = self.connector_manager.lock();
@@ -577,15 +538,12 @@ impl LaminarDB {
             || mgr.tables().contains_key(name)
     }
 
-    /// Adopt a new vnode assignment snapshot atomically across the registry,
-    /// state-backend fence, and coordinator, then rehydrate committed state
-    /// for any vnodes this node newly acquired. Idempotent for versions ≤ the
-    /// current registry version.
+    /// Atomically adopt a new vnode assignment across the registry, state-backend
+    /// fence, and coordinator, then rehydrate committed state for newly-acquired
+    /// vnodes. Idempotent for versions ≤ the current registry version.
     ///
-    /// Rehydration (the durable read of newly-acquired vnodes' partials) runs
-    /// *after* the coordinator lock is released so a slow object store can't
-    /// stall the checkpoint cadence; the recovered bytes are staged in
-    /// [`Self::rehydrated_vnode_state`] for operators to drain.
+    /// Rehydration runs after the coordinator lock is released so a slow
+    /// object-store read can't stall the checkpoint cadence.
     #[cfg(feature = "cluster")]
     pub async fn adopt_assignment_snapshot(
         &self,
@@ -613,9 +571,7 @@ impl LaminarDB {
                 laminar_core::state::NodeId(c.instance_id().0)
             });
 
-        // Hold the coord mutex so registry + fence updates land between
-        // epochs. Snapshot the owned set on both sides of the swap to
-        // derive exactly which vnodes this node gained.
+        // Hold the coord mutex so registry + fence updates land between epochs.
         let mut guard = self.coordinator.lock().await;
         let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
         registry.set_assignment_and_version(new_assignment, snapshot.version);
@@ -630,19 +586,16 @@ impl LaminarDB {
         }
         drop(guard);
 
-        // Newly-acquired vnodes = new \ old.
         let old_set: std::collections::HashSet<u32> = old_owned.into_iter().collect();
         let newly_acquired: Vec<u32> = new_owned
             .into_iter()
             .filter(|v| !old_set.contains(v))
             .collect();
 
-        // Mark every newly-acquired vnode `Restoring` up front — before the
-        // (possibly slow) durable read below — so the operator suppresses
-        // emission for their keys from the moment the shuffle starts routing
-        // their rows here. Vnodes with no durable state are flipped back to
-        // `Active` immediately after the read; the ones we stage stay
-        // `Restoring` until the graph merges their state in.
+        // Mark Restoring before the (slow) durable read so the operator suppresses
+        // emission from the moment the shuffle starts routing rows here. Vnodes
+        // with no durable state flip back to Active immediately; staged ones stay
+        // Restoring until the graph applies their state.
         if !newly_acquired.is_empty() {
             registry.mark_restoring(&newly_acquired);
         }
@@ -655,10 +608,7 @@ impl LaminarDB {
             rehydration_epoch: None,
         };
 
-        // Pull the last committed state for the gained vnodes off the
-        // shared durable backend so they don't resume from empty state.
-        // Clone the Arc out first so the (non-Send) lock guard is dropped
-        // before the rehydration await.
+        // Clone the Arc before the await so the lock guard drops first.
         let backend = self.state_backend.lock().clone();
         if let (false, Some(backend)) = (newly_acquired.is_empty(), backend) {
             let report = crate::recovery_manager::VnodeRehydrator::new(backend.as_ref())
@@ -666,9 +616,7 @@ impl LaminarDB {
                 .await;
             adoption.rehydrated = report.restored.len();
             adoption.rehydration_epoch = report.epoch;
-            // Vnodes with no durable state to apply serve immediately — flip
-            // them back to `Active` so their emission isn't gated forever. The
-            // graph flips the staged ones once it merges their state in.
+            // No durable state → serve immediately; don't gate emission forever.
             let no_state: Vec<u32> = newly_acquired
                 .iter()
                 .copied()
@@ -684,8 +632,7 @@ impl LaminarDB {
                 }
             }
         } else if !newly_acquired.is_empty() {
-            // No backend / nothing to rehydrate — clear the Restoring marks we
-            // optimistically set so emission isn't gated with no state coming.
+            // No backend — clear the optimistic Restoring marks.
             registry.mark_active(&newly_acquired);
         }
 
@@ -699,10 +646,7 @@ impl LaminarDB {
         adoption
     }
 
-    /// Snapshot of committed per-vnode state staged for newly-acquired
-    /// vnodes during the most recent rebalance adoptions. Keyed by vnode.
-    /// Drained by operators that adopt the per-vnode state backend; exposed
-    /// for inspection and tests.
+    /// Staged vnode state from the most recent rebalance adoptions, keyed by vnode.
     #[cfg(feature = "cluster")]
     #[must_use]
     pub fn rehydrated_vnode_state(&self) -> HashMap<u32, RehydratedVnode> {
@@ -714,8 +658,7 @@ impl LaminarDB {
         &self,
         controller: Arc<laminar_core::cluster::control::ClusterController>,
     ) {
-        // Serve this node's local MV/table rows to peers. Weak store handles
-        // (not `self`) avoid a reference cycle.
+        // Weak store handles avoid a reference cycle with the DB.
         controller.register_query_handler(Arc::new(DbQueryHandler {
             mv_store: Arc::downgrade(&self.mv_store),
             table_store: Arc::downgrade(&self.table_store),
@@ -728,9 +671,8 @@ impl LaminarDB {
         self.update_sql_cluster_context();
     }
 
-    /// Router task: refreshes the gossip interest cache (cadence backs off when
-    /// idle) and drains remote `__sub::` batches to local subscribers. Weak
-    /// handles, so it exits once the `LaminarDB` is dropped.
+    /// Refresh the gossip interest cache and drain remote `__sub::` batches.
+    /// Weak handles so the task exits when the `LaminarDB` is dropped.
     #[cfg(feature = "cluster")]
     fn spawn_subscription_router(
         &self,
@@ -738,16 +680,14 @@ impl LaminarDB {
     ) {
         use std::collections::{HashMap, HashSet};
 
-        // Needs a running runtime; some unit tests install a controller without
-        // one. Skip — distributed routing is server-mode only.
+        // Some unit tests install a controller without a runtime; server-mode only.
         if tokio::runtime::Handle::try_current().is_err() {
             return;
         }
 
         let kv = Arc::clone(controller.kv());
 
-        // Skip entirely on backends that can't discover subscription interest
-        // (e.g. object store), rather than advertising interest nothing reads.
+        // Object-store backends have no subscription-interest discovery.
         if !kv.supports_subscription_routing() {
             tracing::info!(
                 "distributed SUBSCRIBE routing disabled: coordination backend has \
@@ -779,7 +719,6 @@ impl LaminarDB {
 
                 let local_names = registry.active_subscription_names();
 
-                // Refresh the producer-side interest cache when due.
                 if until_refresh == 0 {
                     let mut map: HashMap<String, HashSet<u64>> = HashMap::new();
                     for (node_id, key, value) in kv.scan_prefix("sub:").await {
@@ -799,8 +738,6 @@ impl LaminarDB {
                 }
                 until_refresh = until_refresh.saturating_sub(1);
 
-                // Advertise newly-added / clear newly-removed local interests
-                // (rare; only on subscription lifecycle changes).
                 for name in &local_names {
                     if advertised.insert(name.clone()) {
                         kv.write(&format!("sub:{name}"), "active".to_string()).await;
@@ -816,9 +753,7 @@ impl LaminarDB {
                     advertised.remove(&name);
                 }
 
-                // Publish remote batches for locally-subscribed streams; one lock
-                // cycle drains every `__sub::` stage (dropped subs fall through
-                // `send_batch` as a no-op rather than piling up in `staged`).
+                // Drain every `__sub::` stage; dropped subs fall through send_batch as a no-op.
                 if !local_names.is_empty() {
                     let receiver = receiver_slot.lock().clone();
                     if let Some(receiver) = receiver {
@@ -849,7 +784,7 @@ impl LaminarDB {
         self.update_sql_cluster_context();
     }
 
-    /// The underlying `DataFusion` `SessionContext`.
+    /// The underlying `DataFusion` session context.
     #[must_use]
     pub fn session_context(&self) -> &SessionContext {
         &self.ctx
@@ -861,11 +796,8 @@ impl LaminarDB {
         LaminarDbBuilder::new()
     }
 
-    /// Register built-in connectors based on enabled features.
     #[allow(unused_variables)]
     fn register_builtin_connectors(registry: &laminar_connectors::registry::ConnectorRegistry) {
-        // Infra-free synthetic source; always available (used by demos
-        // and the cluster soak harness).
         laminar_connectors::generator::register_generator_source(registry);
         #[cfg(feature = "kafka")]
         {
@@ -920,9 +852,6 @@ impl LaminarDB {
         }
     }
 
-    /// Handle `CREATE LOOKUP TABLE` by registering the table in the
-    /// `TableStore`, `ConnectorManager`, `DataFusion` catalog, and lookup
-    /// registry.
     fn handle_register_lookup_table(
         &self,
         info: laminar_sql::planner::LookupTableInfo,
@@ -936,7 +865,6 @@ impl LaminarDB {
         }
         let pk = info.primary_key[0].clone();
 
-        // Register in TableStore for PK-based upsert
         let cache_mode = info.properties.cache_memory.map(|mem| {
             let max_entries = cache_entries_from_memory(mem);
             crate::table_cache_mode::TableCacheMode::Partial { max_entries }
@@ -954,13 +882,10 @@ impl LaminarDB {
                 .create_table(&info.name, info.arrow_schema.clone(), &pk)?;
         }
 
-        // For external connectors: register in ConnectorManager so
-        // start_connector_pipeline() handles snapshot + CDC loading
         if !matches!(info.properties.connector, ConnectorType::Static) {
             self.register_lookup_connector(&info, &pk)?;
         }
 
-        // Register in DataFusion for SELECT/JOIN queries
         {
             let provider = crate::table_provider::ReferenceTableProvider::new(
                 info.name.clone(),
@@ -975,8 +900,6 @@ impl LaminarDB {
                 })?;
         }
 
-        // Register snapshot in the lookup registry so the physical
-        // planner can build LookupJoinExec nodes for JOIN queries.
         if let Some(batch) = self.table_store.read().to_record_batch(&info.name) {
             self.lookup_registry.register(
                 &info.name,
@@ -984,8 +907,6 @@ impl LaminarDB {
             );
         }
 
-        // Register the logical optimizer rule so JOINs referencing
-        // this table are rewritten to LookupJoinNode.
         self.refresh_lookup_optimizer_rule();
 
         Ok(ExecuteResult::Ddl(DdlInfo {
@@ -994,8 +915,6 @@ impl LaminarDB {
         }))
     }
 
-    /// Register an external connector for a lookup table in the
-    /// `ConnectorManager` and `TableStore`.
     #[allow(clippy::unnecessary_wraps)]
     fn register_lookup_connector(
         &self,
@@ -1022,7 +941,7 @@ impl LaminarDB {
         let refresh = match info.properties.strategy {
             laminar_sql::parser::lookup_table::LookupStrategy::Replicated
             | laminar_sql::parser::lookup_table::LookupStrategy::Partitioned => {
-                // Standalone postgres uses snapshot-only (no CDC slot needed).
+                // Postgres has no CDC slot; snapshot-only is sufficient.
                 if matches!(info.properties.connector, ConnectorType::Postgres) {
                     Some(laminar_connectors::reference::RefreshMode::SnapshotOnly)
                 } else {
@@ -1034,9 +953,8 @@ impl LaminarDB {
             }
         };
 
-        // Build connector options and format options from raw WITH clause.
-        // Keys consumed by LookupTableProperties are excluded; keys starting
-        // with "format." are routed to format_options (prefix stripped).
+        // Keys consumed by LookupTableProperties are excluded; "format.*" keys
+        // go to format_options with the prefix stripped.
         let consumed = [
             "connector",
             "strategy",
@@ -1060,15 +978,12 @@ impl LaminarDB {
             }
         }
 
-        // The on-demand lookup cache is byte-weighted; carry the user's
-        // cache_memory budget through as bytes (no lossy entry-count conversion).
+        // Carry as bytes; the partial lookup cache is byte-weighted, not entry-counted.
         let cache_max_bytes = info
             .properties
             .cache_memory
             .map(|m| usize::try_from(m.as_bytes()).unwrap_or(usize::MAX));
 
-        // cache_ttl is specified in seconds; carry it as a Duration so the
-        // partial lookup cache expires stale entries lazily on read.
         let cache_ttl = info
             .properties
             .cache_ttl
@@ -1091,8 +1006,7 @@ impl LaminarDB {
         Ok(())
     }
 
-    /// Replaces the `LookupJoinRewriteRule` on the `DataFusion` context
-    /// with one that knows the current set of registered lookup tables.
+    /// Rebuild the lookup optimizer rules for the current set of registered tables.
     fn refresh_lookup_optimizer_rule(&self) {
         use laminar_sql::planner::lookup_join::{LookupColumnPruningRule, LookupJoinRewriteRule};
         use laminar_sql::planner::predicate_split::{
@@ -1100,7 +1014,6 @@ impl LaminarDB {
             SourceCapabilitiesRegistry,
         };
 
-        // Remove old rules if present
         self.ctx.remove_optimizer_rule("lookup_join_rewrite");
         self.ctx.remove_optimizer_rule("predicate_splitter");
         self.ctx.remove_optimizer_rule("lookup_column_pruning");
@@ -1110,7 +1023,6 @@ impl LaminarDB {
             return;
         }
 
-        // Build capabilities registry from table properties
         let mut caps_registry = SourceCapabilitiesRegistry::default();
         for (name, info) in &tables {
             let mode = match info.properties.pushdown_mode {
@@ -1132,7 +1044,6 @@ impl LaminarDB {
             );
         }
 
-        // Register rules in order: rewrite → predicate split → column pruning
         self.ctx
             .add_optimizer_rule(Arc::new(LookupJoinRewriteRule::new(tables)));
         self.ctx
@@ -1141,41 +1052,23 @@ impl LaminarDB {
             .add_optimizer_rule(Arc::new(LookupColumnPruningRule));
     }
 
-    /// Returns the connector registry for registering custom connectors.
-    ///
-    /// Use this to register user-defined source/sink connectors before
-    /// calling `start()`.
+    /// Returns the connector registry for registering custom connectors before `start()`.
     #[must_use]
     pub fn connector_registry(&self) -> &laminar_connectors::registry::ConnectorRegistry {
         &self.connector_registry
     }
 
-    /// Register a custom scalar UDF on the `SessionContext`.
-    ///
-    /// Called by `LaminarDbBuilder::build()` after construction.
+    /// Register a custom scalar UDF. Called by the builder after construction.
     pub(crate) fn register_custom_udf(&self, udf: datafusion_expr::ScalarUDF) {
         self.ctx.register_udf(udf);
     }
 
-    /// Register a custom aggregate UDF (UDAF) on the `SessionContext`.
-    ///
-    /// Called by `LaminarDbBuilder::build()` after construction.
+    /// Register a custom aggregate UDF. Called by the builder after construction.
     pub(crate) fn register_custom_udaf(&self, udaf: datafusion_expr::AggregateUDF) {
         self.ctx.register_udaf(udaf);
     }
 
-    /// Registers a Delta Lake table as a `DataFusion` `TableProvider`.
-    ///
-    /// After registration, the table can be queried via SQL:
-    /// ```sql
-    /// SELECT * FROM my_delta_table WHERE id > 100
-    /// ```
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - SQL table name (e.g., `"trades"`)
-    /// * `table_uri` - Path to the Delta Lake table (local, `s3://`, `az://`, `gs://`)
-    /// * `storage_options` - Storage credentials and configuration
+    /// Register a Delta Lake table as a `DataFusion` table provider.
     ///
     /// # Errors
     ///
@@ -1199,16 +1092,6 @@ impl LaminarDB {
 
     /// Execute a SQL statement.
     ///
-    /// Supports:
-    /// - `CREATE SOURCE` / `CREATE SINK` — registers sources and sinks
-    /// - `DROP SOURCE` / `DROP SINK` — removes sources and sinks
-    /// - `SHOW SOURCES` / `SHOW SINKS` / `SHOW QUERIES` — list registered objects
-    /// - `DESCRIBE source_name` — show source schema
-    /// - `SELECT ...` — execute a streaming query
-    /// - `INSERT INTO source_name VALUES (...)` — insert data
-    /// - `CREATE MATERIALIZED VIEW` — create a streaming materialized view
-    /// - `EXPLAIN SELECT ...` — show query plan
-    ///
     /// # Errors
     ///
     /// Returns `DbError` if SQL parsing, planning, or execution fails.
@@ -1217,20 +1100,17 @@ impl LaminarDB {
             return Err(DbError::Shutdown);
         }
 
-        // Apply config variable substitution
         let resolved = if self.config_vars.is_empty() {
             sql.to_string()
         } else {
             sql_utils::resolve_config_vars(sql, &self.config_vars, true)?
         };
 
-        // Split into multiple statements
         let stmts = sql_utils::split_statements(&resolved);
         if stmts.is_empty() {
             return Err(DbError::InvalidOperation("Empty SQL statement".into()));
         }
 
-        // Execute each statement, return the last result (or first error)
         let mut last_result = None;
         for stmt_sql in &stmts {
             last_result = Some(self.execute_single(stmt_sql).await?);
@@ -1239,7 +1119,6 @@ impl LaminarDB {
         last_result.ok_or_else(|| DbError::InvalidOperation("Empty SQL statement".into()))
     }
 
-    /// Execute a single SQL statement.
     #[allow(clippy::too_many_lines)]
     async fn execute_single(&self, sql: &str) -> Result<ExecuteResult, DbError> {
         let statements = parse_streaming_sql(sql)?;
@@ -1435,10 +1314,6 @@ impl LaminarDB {
         result
     }
 
-    /// Handle INSERT INTO statement.
-    ///
-    /// Inserts SQL VALUES into a registered source, a `TableStore`-managed
-    /// table (with PK upsert), or a plain `DataFusion` `MemTable`.
     async fn handle_insert_into(
         &self,
         table_name: &sqlparser::ast::ObjectName,
@@ -1447,7 +1322,6 @@ impl LaminarDB {
     ) -> Result<ExecuteResult, DbError> {
         let name = table_name.to_string();
 
-        // Try inserting into a registered source
         if let Some(entry) = self.catalog.get_source(&name) {
             let batch = sql_utils::sql_values_to_record_batch(&entry.schema, values)?;
             entry
@@ -1456,8 +1330,7 @@ impl LaminarDB {
             return Ok(ExecuteResult::RowsAffected(values.len() as u64));
         }
 
-        // Try inserting into a TableStore-managed table (with PK upsert).
-        // Single lock scope avoids TOCTOU race between has_table/schema/upsert.
+        // Single lock scope avoids TOCTOU between has_table/schema/upsert.
         {
             let mut ts = self.table_store.write();
             if ts.has_table(&name) {
@@ -1473,8 +1346,6 @@ impl LaminarDB {
             }
         }
 
-        // Otherwise, insert into a DataFusion MemTable
-        // Look up the table provider
         let table = self
             .ctx
             .table_provider(&name)
@@ -1484,7 +1355,6 @@ impl LaminarDB {
         let schema = table.schema();
         let batch = sql_utils::sql_values_to_record_batch(&schema, values)?;
 
-        // Deregister the old table, then re-register with the new data
         self.ctx
             .deregister_table(&name)
             .map_err(|e| DbError::InsertError(format!("Failed to deregister table: {e}")))?;
@@ -1500,11 +1370,7 @@ impl LaminarDB {
         Ok(ExecuteResult::RowsAffected(values.len() as u64))
     }
 
-    /// Handle RESTORE FROM CHECKPOINT statement (not yet implemented).
-    ///
-    /// Will eventually stop the pipeline, reload state from the checkpoint
-    /// manifest, seek source offsets, and restart the pipeline.
-    #[allow(clippy::unused_self)] // will use self when restore is implemented
+    #[allow(clippy::unused_self)] // will use self when implemented
     fn handle_restore_checkpoint(&self, _checkpoint_id: u64) -> Result<ExecuteResult, DbError> {
         Err(DbError::Unsupported(
             "RESTORE FROM CHECKPOINT is not yet implemented — \
@@ -1514,7 +1380,7 @@ impl LaminarDB {
         ))
     }
 
-    /// Get a session property value.
+    /// Return a session property value.
     #[must_use]
     pub fn get_session_property(&self, key: &str) -> Option<String> {
         self.session_properties
@@ -1523,13 +1389,13 @@ impl LaminarDB {
             .cloned()
     }
 
-    /// Get all session properties.
+    /// Return all session properties.
     #[must_use]
     pub fn session_properties(&self) -> HashMap<String, String> {
         self.session_properties.lock().clone()
     }
 
-    /// Set a session property. Keys are lowercased.
+    /// Set a session property (keys are lowercased).
     pub fn set_session_property(&self, key: &str, value: &str) {
         self.session_properties
             .lock()
@@ -1567,16 +1433,12 @@ impl LaminarDB {
             .ok_or_else(|| DbError::StreamNotFound(name.to_string()))
     }
 
-    /// Schema a `SUBSCRIBE` against `name` would emit, plus a `filterable`
-    /// flag that's `false` only when the schema came from a `StreamEntry`
-    /// sink placeholder (`Schema::empty`) — a `WHERE` clause can't compile
-    /// against that and must be rejected.
+    /// Schema a `SUBSCRIBE` against `name` would emit, plus `filterable`.
     ///
-    /// Lookup order: MV registry → `start()`-resolved stream output →
-    /// `StreamEntry` sink (placeholder). A bare SOURCE is intentionally not
-    /// resolved: only streams/MVs defined over it publish to the registry, so
-    /// subscribing to the source directly would block forever — it falls
-    /// through to `None`, which the caller surfaces as `StreamNotFound`.
+    /// `filterable` is `false` only when the schema comes from a `StreamEntry`
+    /// sink placeholder — a `WHERE` clause can't compile against it.
+    /// Order: MV registry → resolved stream output → `StreamEntry` sink.
+    /// A bare source is not resolved (subscribing to it would block forever).
     #[must_use]
     pub fn lookup_subscription_schema(
         &self,
@@ -1653,11 +1515,8 @@ impl LaminarDB {
         })
     }
 
-    /// Handle EXPLAIN statement — show the streaming query plan.
     fn handle_explain(&self, statement: &StreamingStatement) -> Result<ExecuteResult, DbError> {
         let mut planner = self.planner.lock();
-
-        // Plan the inner statement to extract streaming info
         let plan_result = planner.plan(statement);
 
         let mut rows: Vec<(String, String)> = Vec::new();
@@ -1728,7 +1587,6 @@ impl LaminarDB {
                 }
             }
             Err(e) => {
-                // Even if planning fails, show what we know
                 rows.push(("error".into(), format!("{e}")));
                 rows.push((
                     "statement".into(),
@@ -1757,13 +1615,11 @@ impl LaminarDB {
         Ok(ExecuteResult::Metadata(batch))
     }
 
-    /// Handle EXPLAIN ANALYZE: run the plan and collect execution metrics.
     async fn handle_explain_analyze(
         &self,
         statement: &StreamingStatement,
         original_sql: &str,
     ) -> Result<ExecuteResult, DbError> {
-        // First get the normal EXPLAIN output
         let explain_result = self.handle_explain(statement)?;
         let mut rows: Vec<(String, String)> = Vec::new();
 
@@ -1783,12 +1639,10 @@ impl LaminarDB {
             }
         }
 
-        // Extract the inner SQL from the original EXPLAIN ANALYZE statement
         let upper = original_sql.to_uppercase();
         let inner_start = upper.find("ANALYZE").map_or(0, |pos| pos + "ANALYZE".len());
         let inner_sql = original_sql[inner_start..].trim();
 
-        // Try to execute the inner query via DataFusion and collect metrics
         let start = std::time::Instant::now();
         match self.ctx.sql(inner_sql).await {
             Ok(df) => match df.collect().await {
@@ -1830,10 +1684,8 @@ impl LaminarDB {
         Ok(ExecuteResult::Metadata(batch))
     }
 
-    /// Handle a streaming or standard SQL query.
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn handle_query(&self, sql: &str) -> Result<ExecuteResult, DbError> {
-        // Synchronous planning under the lock — released before any await
         let plan = {
             let statements = parse_streaming_sql(sql)?;
             if statements.is_empty() {
@@ -1859,22 +1711,18 @@ impl LaminarDB {
                 }))
             }
             laminar_sql::planner::StreamingPlan::Query(query_plan) => {
-                // Check for ASOF join — DataFusion can't parse ASOF syntax
                 if let Some(asof_config) = Self::extract_asof_config(&query_plan) {
                     return self.execute_asof_query(&asof_config, sql).await;
                 }
 
                 let plan_sql = query_plan.statement.to_string();
                 let logical_plan = self.ctx.state().create_logical_plan(&plan_sql).await?;
-
-                // DataFusion interpreted execution.
                 let df = self.ctx.execute_logical_plan(logical_plan).await?;
                 let stream = df.execute_stream().await?;
 
                 Ok(self.bridge_query_stream(sql, stream))
             }
             laminar_sql::planner::StreamingPlan::Standard(stmt) => {
-                // Async execution without the lock
                 let sql_str = stmt.to_string();
                 let df = self.ctx.sql(&sql_str).await?;
                 let stream = df.execute_stream().await?;
@@ -1898,8 +1746,6 @@ impl LaminarDB {
         }
     }
 
-    /// Bridge a `DataFusion` `SendableRecordBatchStream` into the streaming
-    /// subscription infrastructure and return a `QueryHandle`.
     fn bridge_query_stream(
         &self,
         sql: &str,
@@ -1954,7 +1800,6 @@ impl LaminarDB {
         })
     }
 
-    /// Extract an ASOF join config from a query plan, if present.
     fn extract_asof_config(
         plan: &laminar_sql::planner::QueryPlan,
     ) -> Option<AsofJoinTranslatorConfig> {
@@ -1967,9 +1812,6 @@ impl LaminarDB {
         })
     }
 
-    /// Execute an ASOF join query by fetching left/right tables separately
-    /// and performing the join in-process (bypasses `DataFusion`'s SQL parser
-    /// which doesn't understand ASOF syntax).
     async fn execute_asof_query(
         &self,
         asof_config: &AsofJoinTranslatorConfig,
@@ -2037,15 +1879,12 @@ impl LaminarDB {
         Ok(self.bridge_query_stream(original_sql, stream))
     }
 
-    /// Get a typed source handle for pushing data.
-    ///
-    /// The source must have been created via `CREATE SOURCE`.
+    /// Get a typed handle for pushing data to a registered source.
     ///
     /// # Errors
     ///
     /// Returns `DbError::SourceNotFound` if the source is not registered.
-    /// Returns `DbError::SchemaMismatch` if the Rust type's schema does not
-    /// match the source's SQL schema.
+    /// Returns `DbError::SchemaMismatch` if the Rust type's schema doesn't match.
     pub fn source<T: laminar_core::streaming::Record>(
         &self,
         name: &str,
@@ -2070,7 +1909,7 @@ impl LaminarDB {
         Ok(UntypedSourceHandle::new(entry))
     }
 
-    /// List all registered sources.
+    /// List registered sources.
     pub fn sources(&self) -> Vec<SourceInfo> {
         let names = self.catalog.list_sources();
         names
@@ -2085,7 +1924,7 @@ impl LaminarDB {
             .collect()
     }
 
-    /// List all registered sinks.
+    /// List registered sinks.
     pub fn sinks(&self) -> Vec<SinkInfo> {
         self.catalog
             .list_sinks()
@@ -2094,7 +1933,7 @@ impl LaminarDB {
             .collect()
     }
 
-    /// List all registered materialized views with their SQL and state.
+    /// List registered materialized views.
     pub fn materialized_views(&self) -> Vec<crate::handle::MaterializedViewInfo> {
         let registry = self.mv_registry.lock();
         registry
@@ -2103,7 +1942,7 @@ impl LaminarDB {
             .collect()
     }
 
-    /// List all registered streams with their SQL definitions.
+    /// List registered streams.
     pub fn streams(&self) -> Vec<crate::handle::StreamInfo> {
         let mgr = self.connector_manager.lock();
         mgr.streams()
@@ -2115,22 +1954,15 @@ impl LaminarDB {
             .collect()
     }
 
-    /// Build the pipeline topology graph from registered sources, streams,
-    /// and sinks.
-    ///
-    /// Returns a `PipelineTopology` with nodes for every source, stream,
-    /// and sink, plus edges derived from stream SQL `FROM` references and
-    /// sink `input` fields.
+    /// Build the pipeline topology graph (nodes + edges) from registered sources, streams, and sinks.
     pub fn pipeline_topology(&self) -> crate::handle::PipelineTopology {
         use crate::handle::{PipelineEdge, PipelineNode, PipelineNodeType};
 
         let mut nodes = Vec::new();
         let mut edges = Vec::new();
 
-        // Collect source names for FROM matching
         let source_names = self.catalog.list_sources();
 
-        // Source nodes
         for name in &source_names {
             let schema = self.catalog.get_source(name).map(|e| e.schema.clone());
             nodes.push(PipelineNode {
@@ -2141,7 +1973,6 @@ impl LaminarDB {
             });
         }
 
-        // Stream nodes + edges from SQL FROM references
         let mgr = self.connector_manager.lock();
         let stream_names: Vec<String> = mgr.streams().keys().cloned().collect();
         for (name, reg) in mgr.streams() {
@@ -2152,9 +1983,7 @@ impl LaminarDB {
                 sql: Some(reg.query_sql.clone()),
             });
 
-            // Extract FROM references by checking which known sources/streams
-            // appear in the query SQL. This is a lightweight heuristic that
-            // avoids a full SQL parse.
+            // Lightweight heuristic: substring match instead of a full parse.
             let sql_upper = reg.query_sql.to_uppercase();
             for src in &source_names {
                 if sql_upper.contains(&src.to_uppercase()) {
@@ -2164,7 +1993,6 @@ impl LaminarDB {
                     });
                 }
             }
-            // Also check for stream-to-stream references (cascading)
             for other in &stream_names {
                 if other != name && sql_upper.contains(&other.to_uppercase()) {
                     edges.push(PipelineEdge {
@@ -2175,7 +2003,6 @@ impl LaminarDB {
             }
         }
 
-        // Sink nodes + edges from input field
         for (name, reg) in mgr.sinks() {
             nodes.push(PipelineNode {
                 name: name.clone(),
@@ -2184,7 +2011,6 @@ impl LaminarDB {
                 sql: None,
             });
 
-            // Sinks read from their `input` field
             if !reg.input.is_empty() {
                 edges.push(PipelineEdge {
                     from: reg.input.clone(),
@@ -2193,12 +2019,9 @@ impl LaminarDB {
             }
         }
 
-        // Also add catalog-only sinks (no connector type) that aren't
-        // already in the connector manager
         let cm_sink_names: std::collections::HashSet<&String> = mgr.sinks().keys().collect();
         for name in self.catalog.list_sinks() {
             if !cm_sink_names.contains(&name) {
-                // Check if there's a sink entry in the catalog with input info
                 if let Some(input) = self.catalog.get_sink_input(&name) {
                     nodes.push(PipelineNode {
                         name: name.clone(),
@@ -2221,7 +2044,7 @@ impl LaminarDB {
         crate::handle::PipelineTopology { nodes, edges }
     }
 
-    /// List all active queries.
+    /// List active queries.
     pub fn queries(&self) -> Vec<QueryInfo> {
         self.catalog
             .list_queries()
@@ -2236,23 +2059,16 @@ impl LaminarDB {
         self.config.checkpoint.is_some()
     }
 
-    /// Returns a checkpoint store instance, if checkpointing is configured.
-    ///
-    /// Returns an [`ObjectStoreCheckpointStore`](laminar_core::storage::ObjectStoreCheckpointStore)
-    /// when `object_store_url` is set, otherwise a
-    /// [`FileSystemCheckpointStore`](laminar_core::storage::FileSystemCheckpointStore).
+    /// Return a checkpoint store for the current configuration, if any.
     pub fn checkpoint_store(&self) -> Option<Box<dyn laminar_core::storage::CheckpointStore>> {
         let cp_config = self.config.checkpoint.as_ref()?;
         let max_retained = cp_config.max_retained.unwrap_or(3);
-        // Pass the runtime vnode count through so manifest validation
-        // checks against the real invariant, not a hardcoded default.
         let vnode_count = self.vnode_registry.lock().as_ref().map_or(
             laminar_core::storage::checkpoint_manifest::DEFAULT_VNODE_COUNT,
             |r| u16::try_from(r.vnode_count()).unwrap_or(u16::MAX),
         );
 
         if let Some(ref url) = self.config.object_store_url {
-            // The builder roots the store at the URL's path prefix.
             let obj_store = laminar_core::storage::object_store_builder::build_object_store(
                 url,
                 &self.config.object_store_options,
@@ -2282,18 +2098,12 @@ impl LaminarDB {
         }
     }
 
-    /// Triggers a streaming checkpoint that persists source offsets, sink
-    /// positions, and operator state to disk via the
-    /// [`CheckpointCoordinator`](crate::checkpoint_coordinator::CheckpointCoordinator).
-    ///
-    /// Returns the checkpoint result on success, including the checkpoint ID,
-    /// epoch, and duration.
+    /// Trigger a checkpoint that persists source offsets, sink positions, and operator state.
     ///
     /// # Errors
     ///
-    /// Returns `DbError::Checkpoint` if checkpointing is not enabled, the
-    /// coordinator has not been initialized (call `start()` first), or the
-    /// checkpoint operation fails.
+    /// Returns `DbError::Checkpoint` if checkpointing is disabled, the
+    /// coordinator is not initialized, or the checkpoint fails.
     pub async fn checkpoint(
         &self,
     ) -> Result<crate::checkpoint_coordinator::CheckpointResult, DbError> {
@@ -2331,11 +2141,9 @@ impl LaminarDB {
             }
         }
 
-        // When the streaming pipeline is live, route through the
-        // pipeline callback so it captures operator state (via the same
-        // path that the periodic checkpoint timer uses). Without this,
-        // the manifest has an empty `operator_states` map and restart
-        // loses everything the `IncrementalAggState` accumulators held.
+        // Route through the callback so it captures operator state the same way
+        // the periodic timer does; direct coordinator calls produce an empty
+        // operator_states map and lose accumulator state on restart.
         let tx = self.force_ckpt_tx.lock().clone();
         let result = if let Some(tx) = tx {
             let (reply_tx, reply_rx) = crossfire::oneshot::oneshot();
@@ -2348,10 +2156,8 @@ impl LaminarDB {
                 DbError::Checkpoint("pipeline callback dropped oneshot before replying".into())
             })?
         } else {
-            // Fallback: no running pipeline (e.g., engine built but not yet
-            // started). Drive the coordinator directly. Operator state will
-            // be empty, but restart from this manifest is still well-defined
-            // because there's nothing to restore anyway.
+            // No running pipeline; drive the coordinator directly. Operator state
+            // will be empty — safe when there is nothing to restore yet.
             let mut guard = self.coordinator.lock().await;
             let coord = guard.as_mut().ok_or_else(|| {
                 DbError::Checkpoint("coordinator not initialized — call start() first".to_string())
@@ -2361,8 +2167,6 @@ impl LaminarDB {
                 .await
         };
 
-        // Refresh the shared catalog manifest on every successful checkpoint so
-        // a node joining later can rebuild this node's MVs/sources. Best-effort.
         #[cfg(feature = "cluster")]
         if matches!(&result, Ok(r) if r.success) {
             self.persist_catalog_manifest().await;
@@ -2421,9 +2225,7 @@ impl LaminarDB {
         }
     }
 
-    /// Returns checkpoint performance statistics.
-    ///
-    /// Returns `None` if the checkpoint coordinator has not been initialized.
+    /// Returns checkpoint performance statistics, or `None` if the coordinator is not initialized.
     pub async fn checkpoint_stats(&self) -> Option<crate::checkpoint_coordinator::CheckpointStats> {
         let guard = self.coordinator.lock().await;
         guard
@@ -2444,7 +2246,7 @@ impl std::fmt::Debug for LaminarDB {
     }
 }
 
-/// Wraps `DefaultPhysicalPlanner` with lookup join extension support.
+/// `DefaultPhysicalPlanner` with lookup-join extension support.
 struct LookupQueryPlanner {
     extension_planner: Arc<dyn datafusion::physical_planner::ExtensionPlanner + Send + Sync>,
 }
@@ -2473,14 +2275,14 @@ impl datafusion::execution::context::QueryPlanner for LookupQueryPlanner {
     }
 }
 
-/// Serves a node's local MV / reference-table rows to peers (pull path). Weak
-/// store handles, so it never keeps the database alive.
+/// Serves local MV / reference-table rows to peers. Weak store handles so
+/// it never keeps the database alive.
 #[cfg(feature = "cluster")]
 struct DbQueryHandler {
     mv_store: std::sync::Weak<parking_lot::RwLock<crate::mv_store::MvStore>>,
     table_store: std::sync::Weak<parking_lot::RwLock<crate::table_store::TableStore>>,
-    /// Isolated context for compiling a pushed `filter_sql` (only the temp table
-    /// is visible), so a crafted predicate can't reference other tables.
+    /// Isolated context: only the temp table is visible, so a pushed predicate
+    /// can't reference other registered tables.
     filter_ctx: SessionContext,
 }
 
@@ -2504,8 +2306,8 @@ impl laminar_core::cluster::control::RemoteQueryHandler for DbQueryHandler {
             })
             .ok_or_else(|| format!("table '{table_name}' not found"))?;
 
-        // Apply the pushed predicate before projecting (it may reference dropped
-        // columns); on any failure skip it — the coordinator re-applies it.
+        // Apply before projecting (predicate may reference dropped columns);
+        // on any failure skip — the coordinator re-applies it.
         let batch = match filter_sql {
             Some(sql) => {
                 let schema = batch.schema();

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -1,6 +1,4 @@
-//! DDL (Data Definition Language) handlers for `LaminarDB`.
-//!
-//! Reopens `impl LaminarDB` to keep the main `db.rs` focused on dispatch.
+//! DDL handlers — reopens `impl LaminarDB` to keep `db.rs` focused on dispatch.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -28,14 +26,12 @@ fn reject_reserved_namespace(name: &str) -> Result<(), DbError> {
 }
 
 impl LaminarDB {
-    /// Handle CREATE SOURCE statement.
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn handle_create_source(
         &self,
         create: &laminar_sql::parser::CreateSourceStatement,
     ) -> Result<ExecuteResult, DbError> {
-        // Reject connector-bearing CREATE SOURCE when pipeline is already running.
-        // Connectors are instantiated in start() which is a one-shot operation.
+        // Connectors are instantiated in start() — reject mid-run DDL.
         let has_connector =
             create.connector_type.is_some() || create.with_options.contains_key("connector");
         if has_connector && self.is_pipeline_running() {
@@ -46,7 +42,6 @@ impl LaminarDB {
             )));
         }
 
-        // IF NOT EXISTS: short-circuit before discovery runs any network I/O.
         let source_name = create.name.to_string();
         reject_reserved_namespace(&source_name)?;
         if create.if_not_exists && self.catalog.get_source(&source_name).is_some() {
@@ -56,8 +51,6 @@ impl LaminarDB {
             }));
         }
 
-        // Discover columns from the connector before translating, so
-        // `WATERMARK FOR col` can validate against real columns.
         let source_def = if create.columns.is_empty() && has_connector {
             let resolved = resolve_connector_info(
                 create.connector_type.as_ref(),
@@ -72,8 +65,7 @@ impl LaminarDB {
             })?;
             let normalized = normalize_connector_type(connector_type);
 
-            // Surface unknown-connector errors before discovery so a typo
-            // doesn't get reported as a schema-discovery failure.
+            // Fail on unknown connector before discovery so a typo isn't reported as a schema failure.
             if self.connector_registry.source_info(&normalized).is_none() {
                 return Err(DbError::Config(format!(
                     "source '{source_name}': unknown connector type '{normalized}'"
@@ -132,7 +124,6 @@ impl LaminarDB {
             .as_ref()
             .map(|w| w.max_out_of_orderness);
 
-        // Extract config from source definition
         let buffer_size = if source_def.config.buffer_size > 0 {
             Some(source_def.config.buffer_size)
         } else {
@@ -172,7 +163,6 @@ impl LaminarDB {
             )?)
         };
 
-        // Mark processing-time sources
         if let Some(ref wm) = source_def.watermark {
             if wm.is_processing_time {
                 if let Some(ref entry) = entry {
@@ -183,8 +173,6 @@ impl LaminarDB {
             }
         }
 
-        // Register source as a DataFusion table for ad-hoc SELECT queries.
-        // For OR REPLACE, deregister the old table first.
         if let Some(ref entry) = entry {
             if create.or_replace {
                 let _ = self.ctx.deregister_table(name);
@@ -199,10 +187,8 @@ impl LaminarDB {
             }
         }
 
-        // Register as a base table in the MV registry for dependency tracking
         self.mv_registry.lock().register_base_table(name);
 
-        // Also register in the planner
         {
             let mut planner = self.planner.lock();
             let stmt = StreamingStatement::CreateSource(Box::new(create.clone()));
@@ -211,7 +197,6 @@ impl LaminarDB {
             }
         }
 
-        // Register connector info in ConnectorManager if external connector specified.
         let resolved = resolve_connector_info(
             create.connector_type.as_ref(),
             &create.connector_options,
@@ -275,7 +260,6 @@ impl LaminarDB {
             self.catalog.register_sink(&name, &input)?;
         }
 
-        // Register in planner
         {
             let mut planner = self.planner.lock();
             let stmt = StreamingStatement::CreateSink(Box::new(create.clone()));
@@ -284,7 +268,6 @@ impl LaminarDB {
             }
         }
 
-        // Register connector info in ConnectorManager if external connector specified.
         let resolved = resolve_connector_info(
             create.connector_type.as_ref(),
             &create.connector_options,
@@ -329,7 +312,6 @@ impl LaminarDB {
         let name = create.name.to_string();
         reject_reserved_namespace(&name)?;
 
-        // Build Arrow schema from column definitions
         let fields: Vec<arrow::datatypes::Field> = create
             .columns
             .iter()
@@ -354,10 +336,8 @@ impl LaminarDB {
 
         let schema = Arc::new(arrow::datatypes::Schema::new(fields));
 
-        // Extract primary key from column constraints or table constraints
         let mut primary_key: Option<String> = None;
 
-        // Check column-level PRIMARY KEY
         for col in &create.columns {
             for opt in &col.options {
                 if matches!(
@@ -376,7 +356,6 @@ impl LaminarDB {
             }
         }
 
-        // Check table-level PRIMARY KEY constraint
         if primary_key.is_none() {
             for constraint in &create.constraints {
                 if let sqlparser::ast::TableConstraint::PrimaryKey { columns, .. } = constraint {
@@ -390,7 +369,6 @@ impl LaminarDB {
             }
         }
 
-        // Extract connector options from WITH (...)
         let mut connector_type: Option<String> = None;
         let mut connector_options: HashMap<String, String> = HashMap::with_capacity(8);
         let mut format: Option<String> = None;
@@ -464,7 +442,6 @@ impl LaminarDB {
             }
         }
 
-        // Resolve cache mode: if Partial and cache_max_entries overrides, apply it
         let resolved_cache_mode = match (&cache_mode, cache_max_entries) {
             (Some(crate::table_cache_mode::TableCacheMode::Partial { .. }), Some(max)) => {
                 Some(crate::table_cache_mode::TableCacheMode::Partial { max_entries: max })
@@ -472,10 +449,8 @@ impl LaminarDB {
             _ => cache_mode.clone(),
         };
 
-        // Determine whether this is a persistent table
         let is_persistent = storage.as_deref() == Some("persistent");
 
-        // Register in TableStore if PK found
         if let Some(ref pk) = primary_key {
             let cache = resolved_cache_mode
                 .clone()
@@ -494,7 +469,6 @@ impl LaminarDB {
             }
         }
 
-        // Register connector-backed table in ConnectorManager
         if connector_type.is_some() || !connector_options.is_empty() {
             if let Some(ref pk) = primary_key {
                 if let Some(ref ct) = connector_type {
@@ -517,8 +491,7 @@ impl LaminarDB {
             }
         }
 
-        // Live ReferenceTableProvider: scan() reads current TableStore rows, so
-        // SELECTs need no re-register after INSERTs (lookup joins use the snapshot).
+        // scan() reads current TableStore rows; no re-register needed after INSERTs.
         {
             let provider = crate::table_provider::ReferenceTableProvider::new(
                 name.clone(),
@@ -544,8 +517,6 @@ impl LaminarDB {
     ) -> Result<ExecuteResult, DbError> {
         let name_str = name.to_string();
 
-        // Reject DROP SOURCE while pipeline is running — the running source
-        // task cannot be stopped without dynamic task cancellation support.
         if self.is_pipeline_running() {
             return Err(DbError::Pipeline(format!(
                 "Cannot drop source '{name_str}' while pipeline is running. \
@@ -553,7 +524,6 @@ impl LaminarDB {
             )));
         }
 
-        // Check for dependents: streams and MVs that reference this source
         if cascade {
             self.cascade_drop_dependents(&name_str);
         } else {
@@ -571,7 +541,6 @@ impl LaminarDB {
         if !dropped && !if_exists {
             return Err(DbError::SourceNotFound(name_str));
         }
-        // Deregister from DataFusion so SELECT no longer resolves.
         let _ = self.ctx.deregister_table(&name_str);
         self.connector_manager.lock().unregister_source(&name_str);
         Ok(ExecuteResult::Ddl(DdlInfo {
@@ -588,7 +557,6 @@ impl LaminarDB {
         use laminar_sql::parser::AlterSourceOperation;
         let name_str = name.to_string();
 
-        // Verify source exists
         let existing_schema = self
             .catalog
             .describe_source(&name_str)
@@ -602,13 +570,11 @@ impl LaminarDB {
                 )
                 .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)))?;
 
-                // Build new schema with the added column
                 let mut fields: Vec<arrow::datatypes::FieldRef> =
                     existing_schema.fields().iter().cloned().collect();
                 fields.push(Arc::new(Field::new(&col_name, arrow_type, true)));
                 let new_schema = Arc::new(arrow::datatypes::Schema::new(fields));
 
-                // Re-register the source with the new schema
                 let entry = self.catalog.get_source(&name_str);
                 let (wm_col, max_ooo) = entry.as_ref().map_or((None, None), |e| {
                     (e.watermark_column.clone(), e.max_out_of_orderness)
@@ -623,7 +589,6 @@ impl LaminarDB {
                     None,
                 );
 
-                // Update DataFusion registration
                 let _ = self.ctx.deregister_table(&name_str);
                 let provider = datafusion::datasource::MemTable::try_new(new_schema, vec![vec![]])
                     .map_err(|e| {
@@ -641,7 +606,6 @@ impl LaminarDB {
                 }))
             }
             AlterSourceOperation::SetProperties { properties } => {
-                // Store properties in session config for this source
                 let mut props = self.session_properties.lock();
                 for (key, value) in properties {
                     props.insert(format!("{name_str}.{key}"), value.clone());
@@ -662,8 +626,6 @@ impl LaminarDB {
     ) -> Result<ExecuteResult, DbError> {
         let name_str = name.to_string();
 
-        // Reject DROP SINK while pipeline is running — the running sink
-        // task cannot be stopped without dynamic task cancellation support.
         if self.is_pipeline_running() {
             return Err(DbError::Pipeline(format!(
                 "Cannot drop sink '{name_str}' while pipeline is running. \
@@ -701,11 +663,7 @@ impl LaminarDB {
 
         let query_sql = query_sql.to_string();
 
-        // Plan the statement to extract emit_clause, window_config, order_config,
-        // and the multi-step join_config (one entry per binary join step).
-        // Planning errors (e.g. unbounded multi-way stream-stream rejection)
-        // surface to the caller — DDL must not silently fall back when the
-        // planner has rejected the query.
+        // Planning errors surface to the caller — DDL must not silently fall back.
         let (plan_emit, plan_window, plan_order, plan_joins) = {
             let mut planner = self.planner.lock();
             let stmt = StreamingStatement::CreateStream {
@@ -729,7 +687,6 @@ impl LaminarDB {
             }
         };
 
-        // Store the query SQL for stream execution at start()
         {
             let mut mgr = self.connector_manager.lock();
             mgr.register_stream(crate::connector_manager::StreamRegistration {
@@ -742,12 +699,8 @@ impl LaminarDB {
             });
         }
 
-        // Register the stream's output schema as a planning placeholder so MVs and
-        // streams created later resolve `FROM <this stream>`. The running pipeline
-        // reads stream output through the operator graph, not this provider — it
-        // exists only for plan-time name resolution (start() also seeds these for
-        // any not yet present). Best-effort: a stream whose schema can't yet be
-        // planned still registers in the catalog and runs.
+        // Register as a DataFusion placeholder for plan-time name resolution by downstream MVs.
+        // Best-effort: if planning fails, the stream still runs.
         if let Some(schema) =
             crate::pipeline_lifecycle::plan_output_schema(&self.ctx, &query_sql).await
         {
@@ -768,11 +721,7 @@ impl LaminarDB {
             }
         }
 
-        // If the pipeline is already running, send via control channel so
-        // the coordinator picks up the new query on the next cycle. The
-        // catalog is already updated; if the channel is saturated we have
-        // to surface that to the caller — silently dropping the message
-        // would leave the new stream registered but never running.
+        // Hot-add the query while running; a saturated channel is a retryable error.
         if let Some(ref tx) = *self.control_tx.lock() {
             tx.try_send(crate::pipeline::ControlMsg::AddStream {
                 name: name_str.clone(),
@@ -806,7 +755,6 @@ impl LaminarDB {
     ) -> Result<ExecuteResult, DbError> {
         let name_str = name.to_string();
 
-        // Check for dependents: MVs that reference this stream
         if cascade {
             self.cascade_drop_dependents(&name_str);
         } else {
@@ -828,10 +776,7 @@ impl LaminarDB {
 
         self.subscription_registry.drop_name(&name_str);
 
-        // Notify the running coordinator to remove the query. If the
-        // channel is saturated, surface a transient error so the caller
-        // can retry rather than seeing a successful DROP that leaves the
-        // coordinator still running the query.
+        // A saturated channel surfaces as a retryable error rather than a silent no-op.
         if let Some(ref tx) = *self.control_tx.lock() {
             tx.try_send(crate::pipeline::ControlMsg::DropStream {
                 name: name_str.clone(),
@@ -869,7 +814,6 @@ impl LaminarDB {
                         .join(", ")
                 };
 
-                // Intercept checkpoint_interval for runtime reconfiguration.
                 if key == "checkpoint_interval" {
                     return self.handle_set_checkpoint_interval(&value);
                 }
@@ -917,7 +861,6 @@ impl LaminarDB {
     pub(crate) fn find_dependents(&self, name: &str) -> Vec<String> {
         let mut dependents = Vec::new();
 
-        // Check streams: scan registered streams for SQL references to `name`
         {
             let mgr = self.connector_manager.lock();
             for (stream_name, reg) in mgr.streams() {
@@ -928,7 +871,6 @@ impl LaminarDB {
             }
         }
 
-        // Check MVs via the dependency graph
         {
             let registry = self.mv_registry.lock();
             for dep in registry.get_dependents(name) {
@@ -943,12 +885,10 @@ impl LaminarDB {
     pub(crate) fn cascade_drop_dependents(&self, name: &str) {
         let dependents = self.find_dependents(name);
         for dep in &dependents {
-            // Try dropping as stream first
             if self.catalog.drop_stream(dep) {
                 self.connector_manager.lock().unregister_stream(dep);
                 self.subscription_registry.drop_name(dep);
             }
-            // Try dropping as MV (cascade further)
             {
                 let mut registry = self.mv_registry.lock();
                 if let Ok(views) = registry.unregister_cascade(dep) {
@@ -963,11 +903,7 @@ impl LaminarDB {
         }
     }
 
-    /// Handle CREATE MATERIALIZED VIEW statement.
-    ///
-    /// Registers the view in the MV registry with dependency tracking,
-    /// then executes the backing query through `DataFusion` to obtain the
-    /// output schema.
+    /// Register a materialized view and wire it into the running pipeline.
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_create_materialized_view(
@@ -983,7 +919,6 @@ impl LaminarDB {
         let name_str = name.to_string();
         reject_reserved_namespace(&name_str)?;
 
-        // Check if the MV already exists
         {
             let registry = self.mv_registry.lock();
             if registry.get(&name_str).is_some() {
@@ -1003,10 +938,7 @@ impl LaminarDB {
 
         let query_sql = query_sql.to_string();
 
-        // Resolve the output schema by planning. Executing the query just to
-        // read its schema is wasteful and yields an empty schema for joins
-        // DataFusion can't lower (ASOF); fall back to execution only if
-        // planning fails.
+        // Planning is cheaper than execution; fall back for ASOF and other joins DataFusion can't lower.
         let schema =
             match crate::pipeline_lifecycle::plan_output_schema(&self.ctx, &query_sql).await {
                 Some(s) => s,
@@ -1020,7 +952,6 @@ impl LaminarDB {
                 },
             };
 
-        // Discover source references via AST-based extraction (not substring matching)
         let table_refs = crate::sql_analysis::extract_table_references(&query_sql);
         let catalog_sources = self.catalog.list_sources();
         let mut sources: Vec<String> = catalog_sources
@@ -1028,7 +959,6 @@ impl LaminarDB {
             .filter(|s| table_refs.contains(s.as_str()))
             .collect();
 
-        // Also check existing MVs as potential sources (cascading MVs)
         {
             let registry = self.mv_registry.lock();
             for view in registry.views() {
@@ -1038,7 +968,6 @@ impl LaminarDB {
             }
         }
 
-        // Register in the MV registry
         {
             let mv =
                 laminar_core::mv::MaterializedView::new(&name_str, sql, sources, schema.clone());
@@ -1046,7 +975,6 @@ impl LaminarDB {
             let mut registry = self.mv_registry.lock();
 
             if or_replace {
-                // Drop existing view (and dependents) before re-registering
                 let _ = registry.unregister_cascade(&name_str);
             }
 
@@ -1055,10 +983,7 @@ impl LaminarDB {
                 .map_err(|e| DbError::MaterializedView(e.to_string()))?;
         }
 
-        // Reuse the planner by wrapping as a CreateStream. The MV's EMIT
-        // clause must be passed through — OperatorGraph routes
-        // EMIT ON WINDOW CLOSE to EowcQueryOperator (close-only emit),
-        // anything else to SqlQueryOperator (per-cycle emit).
+        // EMIT ON WINDOW CLOSE routes to EowcQueryOperator; other emit modes use SqlQueryOperator.
         let (plan_emit, plan_window, plan_order, plan_joins) = {
             let mut planner = self.planner.lock();
             let stmt = StreamingStatement::CreateStream {
@@ -1081,7 +1006,6 @@ impl LaminarDB {
             }
         };
 
-        // Register the MV as a stream so start() picks it up for execution
         {
             let mut mgr = self.connector_manager.lock();
             mgr.register_stream(crate::connector_manager::StreamRegistration {
@@ -1094,14 +1018,11 @@ impl LaminarDB {
             });
         }
 
-        // Register MV result store + DataFusion table provider.
         {
             use crate::mv_store::MvStorageMode;
 
-            // Non-windowed aggregates (IncrementalAggState) emit ALL groups
-            // every cycle → replace-all is correct.
-            // Windowed aggregates (CoreWindowState) only emit closing windows
-            // → must append to keep previous windows' results.
+            // Non-windowed aggs emit all groups every cycle (replace-all); windowed aggs emit
+            // only closing windows (append) so previous windows aren't overwritten.
             let has_aggregate = self.ctx.sql(&query_sql).await.ok().is_some_and(|df| {
                 crate::aggregate_state::find_aggregate(df.logical_plan()).is_some()
             });
@@ -1121,8 +1042,7 @@ impl LaminarDB {
                 self.mv_store.clone(),
             );
 
-            // In cluster mode each node holds only its vnode-owned slice of the
-            // result; wrap the local provider so reads union every peer's slice.
+            // In cluster mode each node owns a vnode slice; wrap to union peers on read.
             #[cfg(feature = "cluster")]
             let provider: Arc<dyn datafusion::datasource::TableProvider> =
                 if let Some(controller) = self.cluster_controller.lock().clone() {
@@ -1146,9 +1066,7 @@ impl LaminarDB {
             })?;
         }
 
-        // If the pipeline is already running, hot-add the query. On a
-        // saturated control channel surface a transient error rather than
-        // leaving the MV catalog-registered but not actually running.
+        // Hot-add to running pipeline; roll back on a saturated channel so retry is clean.
         if let Some(ref tx) = *self.control_tx.lock() {
             tx.try_send(crate::pipeline::ControlMsg::AddStream {
                 name: name_str.clone(),
@@ -1159,8 +1077,6 @@ impl LaminarDB {
                 join_config: plan_joins,
             })
             .map_err(|e| {
-                // Roll back every piece of state this DDL wrote so a
-                // retry starts from a clean slate.
                 let _ = self.ctx.deregister_table(&name_str);
                 let _ = self.mv_registry.lock().unregister(&name_str);
                 self.connector_manager.lock().unregister_stream(&name_str);
@@ -1186,7 +1102,6 @@ impl LaminarDB {
     ) -> Result<ExecuteResult, DbError> {
         let name_str = name.to_string();
 
-        // Collect names to unregister from connector manager
         let dropped_names;
         {
             let mut registry = self.mv_registry.lock();
@@ -1211,11 +1126,7 @@ impl LaminarDB {
             }
         }
 
-        // Notify the coordinator BEFORE the destructive local teardown
-        // so a saturated channel surfaces as a retryable error with
-        // local state still intact. mv_registry was already mutated
-        // above; the coordinator path treats a missing entry as
-        // "already dropped" on retry.
+        // Notify before local teardown so a saturated channel stays retryable.
         if let Some(ref tx) = *self.control_tx.lock() {
             for dropped in &dropped_names {
                 tx.try_send(crate::pipeline::ControlMsg::DropStream {
@@ -1229,7 +1140,6 @@ impl LaminarDB {
             }
         }
 
-        // Coordinator notified; now reap local state.
         {
             let mut mgr = self.connector_manager.lock();
             let mut mv_store = self.mv_store.write();
@@ -1239,7 +1149,6 @@ impl LaminarDB {
                 let _ = self.ctx.deregister_table(dropped);
             }
         }
-        // Drop subscription channels outside the locks (registry never nests in mv_store).
         for dropped in &dropped_names {
             self.subscription_registry.drop_name(dropped);
         }
@@ -1259,13 +1168,8 @@ impl LaminarDB {
         for obj_name in names {
             let name_str = obj_name.to_string();
 
-            // Remove from TableStore
             self.table_store.write().drop_table(&name_str);
-
-            // Remove from ConnectorManager
             self.connector_manager.lock().unregister_table(&name_str);
-
-            // Deregister from DataFusion context
             match self.ctx.deregister_table(&name_str) {
                 Ok(None) if !if_exists => {
                     return Err(DbError::TableNotFound(name_str));
@@ -1320,11 +1224,7 @@ const STREAMING_OPTION_KEYS: &[&str] = &[
     "watermark_delay",
 ];
 
-/// Resolved connector metadata extracted from a CREATE SOURCE/SINK statement.
-///
-/// Both `handle_create_source` and `handle_create_sink` support two syntax
-/// forms (`FROM KAFKA (...)` vs `WITH ('connector' = ...)`). This struct
-/// captures the resolved result so the resolution logic lives in one place.
+/// Normalised connector info after merging the two CREATE SOURCE/SINK syntax forms.
 pub(crate) struct ResolvedConnector {
     pub connector_type: Option<String>,
     pub connector_options: HashMap<String, String>,
@@ -1332,12 +1232,7 @@ pub(crate) struct ResolvedConnector {
     pub format_options: HashMap<String, String>,
 }
 
-/// Resolve connector info from a DDL statement that has `connector_type`,
-/// `connector_options`, `format`, and `with_options` fields.
-///
-/// Supports:
-///   1. `FROM KAFKA ('topic' = 'events', ...)` — `connector_type` is set
-///   2. `WITH ('connector' = 'kafka', ...)` — extracted from `with_options`
+/// Merge the `FROM <TYPE> (...)` and `WITH ('connector' = ...)` syntax into one result.
 pub(crate) fn resolve_connector_info(
     connector_type: Option<&String>,
     connector_options: &HashMap<String, String>,
@@ -1382,15 +1277,7 @@ pub(crate) fn validate_format(format: Option<&String>) -> Result<(), DbError> {
     Ok(())
 }
 
-/// Extracts connector-specific options from a `WITH (...)` clause map.
-///
-/// When a source or sink is created with the `WITH ('connector' = '...', ...)`
-/// syntax (as opposed to `FROM KAFKA (...)`), the `connector` key selects the
-/// connector type and the `format` key selects the serialisation format.
-/// All remaining entries that are **not** known streaming-engine options are
-/// forwarded as connector options.
-///
-/// Returns `(connector_options, format, format_options)`.
+/// Extract `(connector_options, format, format_options)` from a `WITH (...)` clause.
 pub(crate) fn extract_connector_from_with_options(
     with_options: &HashMap<String, String>,
 ) -> (
@@ -1405,14 +1292,12 @@ pub(crate) fn extract_connector_from_with_options(
     for (key, value) in with_options {
         let lower = key.to_lowercase();
         if lower == "connector" {
-            // Already handled by the caller.
             continue;
         }
         if lower == "format" {
             format = Some(value.clone());
             continue;
         }
-        // Keys starting with "format." are format-specific sub-options.
         if let Some(suffix) = lower.strip_prefix("format.") {
             format_options.insert(suffix.to_string(), value.clone());
             continue;

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -51,9 +51,6 @@ pub struct EngineMetrics {
     pub state_tier_fetch_total: IntCounter,
     /// Cold-tier fetch latency (the promotion path's disk read).
     pub state_tier_fetch_duration: Histogram,
-    /// Cold-tier directories wiped at open (unclean shutdown, version
-    /// mismatch, corrupt marker) — each one implies a rehydration.
-    pub state_tier_wipes_total: IntCounter,
     /// Global pipeline watermark.
     pub pipeline_watermark: IntGauge,
     /// Per-source watermark (epoch-ms). Label: `source`.
@@ -244,11 +241,6 @@ impl EngineMetrics {
                     "Cold-tier slice fetch latency"
                 )
                 .buckets(prometheus::exponential_buckets(0.0005, 2.0, 18).unwrap()),
-            )
-            .unwrap()),
-            state_tier_wipes_total: reg!(IntCounter::new(
-                "state_tier_wipes_total",
-                "Cold-tier directories wiped at open"
             )
             .unwrap()),
             pipeline_watermark: reg!(IntGauge::new(

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -30,6 +30,17 @@ pub struct EngineMetrics {
     pub mv_updates: IntCounter,
     /// Approximate MV bytes stored.
     pub mv_bytes_stored: IntGauge,
+    /// Estimated operator state bytes held in memory, summed across all
+    /// operators. Refreshed by the memory-budget probe.
+    pub state_bytes: IntGauge,
+    /// Estimated state bytes per operator. Label: `operator`.
+    pub operator_state_bytes: IntGaugeVec,
+    /// Configured node-level state memory budget; `0` = unlimited.
+    pub state_memory_budget_bytes: IntGauge,
+    /// `1` while operator state exceeds the memory budget (ingest paused), else `0`.
+    pub state_over_budget: IntGauge,
+    /// Cycles whose source intake was paused by the state memory budget.
+    pub state_budget_paused_cycles: IntCounter,
     /// Global pipeline watermark.
     pub pipeline_watermark: IntGauge,
     /// Per-source watermark (epoch-ms). Label: `source`.
@@ -163,6 +174,35 @@ impl EngineMetrics {
             mv_bytes_stored: reg!(
                 IntGauge::new("mv_bytes_stored", "Approximate MV bytes stored").unwrap()
             ),
+            state_bytes: reg!(IntGauge::new(
+                "state_bytes",
+                "Estimated operator state bytes held in memory (all operators)"
+            )
+            .unwrap()),
+            // Labels are catalog-bound (one per registered query/operator).
+            operator_state_bytes: reg!(IntGaugeVec::new(
+                Opts::new(
+                    "operator_state_bytes",
+                    "Estimated state bytes per operator"
+                ),
+                &["operator"],
+            )
+            .unwrap()),
+            state_memory_budget_bytes: reg!(IntGauge::new(
+                "state_memory_budget_bytes",
+                "Configured node-level state memory budget (0 = unlimited)"
+            )
+            .unwrap()),
+            state_over_budget: reg!(IntGauge::new(
+                "state_over_budget",
+                "1 while operator state exceeds the memory budget (ingest paused)"
+            )
+            .unwrap()),
+            state_budget_paused_cycles: reg!(IntCounter::new(
+                "state_budget_paused_cycles_total",
+                "Cycles whose source intake was paused by the state memory budget"
+            )
+            .unwrap()),
             pipeline_watermark: reg!(IntGauge::new(
                 "pipeline_watermark",
                 "Global pipeline watermark"

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -41,6 +41,19 @@ pub struct EngineMetrics {
     pub state_over_budget: IntGauge,
     /// Cycles whose source intake was paused by the state memory budget.
     pub state_budget_paused_cycles: IntCounter,
+    /// Logical bytes held by the disk cold tier for demoted operator state.
+    pub state_tier_bytes: IntGauge,
+    /// Slices (operator, vnode) currently resident in the cold tier.
+    pub state_tier_slices: IntGauge,
+    /// Slices written to the cold tier (demotions).
+    pub state_tier_demote_total: IntCounter,
+    /// Slice reads from the cold tier (promotion fetches).
+    pub state_tier_fetch_total: IntCounter,
+    /// Cold-tier fetch latency (the promotion path's disk read).
+    pub state_tier_fetch_duration: Histogram,
+    /// Cold-tier directories wiped at open (unclean shutdown, version
+    /// mismatch, corrupt marker) — each one implies a rehydration.
+    pub state_tier_wipes_total: IntCounter,
     /// Global pipeline watermark.
     pub pipeline_watermark: IntGauge,
     /// Per-source watermark (epoch-ms). Label: `source`.
@@ -201,6 +214,41 @@ impl EngineMetrics {
             state_budget_paused_cycles: reg!(IntCounter::new(
                 "state_budget_paused_cycles_total",
                 "Cycles whose source intake was paused by the state memory budget"
+            )
+            .unwrap()),
+            state_tier_bytes: reg!(IntGauge::new(
+                "state_tier_bytes",
+                "Logical bytes held by the disk cold tier"
+            )
+            .unwrap()),
+            state_tier_slices: reg!(IntGauge::new(
+                "state_tier_slices",
+                "Slices (operator, vnode) resident in the cold tier"
+            )
+            .unwrap()),
+            state_tier_demote_total: reg!(IntCounter::new(
+                "state_tier_demote_total",
+                "Slices written to the cold tier"
+            )
+            .unwrap()),
+            state_tier_fetch_total: reg!(IntCounter::new(
+                "state_tier_fetch_total",
+                "Slice reads from the cold tier"
+            )
+            .unwrap()),
+            // Dev-box bench: cold 4 MiB slice fetch p99 ~18ms; cover to ~80s
+            // so a degraded disk is visible rather than clipped.
+            state_tier_fetch_duration: reg!(Histogram::with_opts(
+                HistogramOpts::new(
+                    "state_tier_fetch_duration_seconds",
+                    "Cold-tier slice fetch latency"
+                )
+                .buckets(prometheus::exponential_buckets(0.0005, 2.0, 18).unwrap()),
+            )
+            .unwrap()),
+            state_tier_wipes_total: reg!(IntCounter::new(
+                "state_tier_wipes_total",
+                "Cold-tier directories wiped at open"
             )
             .unwrap()),
             pipeline_watermark: reg!(IntGauge::new(

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -89,11 +89,7 @@ fn assign_windows(ts_ms: i64, window_type: &EowcWindowType) -> WindowStarts {
             windows
         }
         EowcWindowType::Session { .. } => {
-            // Session windows MUST be routed through CoreWindowState (Ring 0
-            // operators) which implements proper gap-based merge.  The guard
-            // at stream_executor.rs:973-980 prevents session queries from
-            // reaching IncrementalEowcState.  If we get here, the routing
-            // logic has a bug — crash rather than produce wrong results.
+            // Session queries must be routed to CoreWindowState; reaching here is a bug.
             unreachable!(
                 "session window reached EOWC assign_windows — \
                  this is a routing bug; session queries must use CoreWindowState"
@@ -102,10 +98,7 @@ fn assign_windows(ts_ms: i64, window_type: &EowcWindowType) -> WindowStarts {
     }
 }
 
-/// Per-window accumulator state for EOWC aggregate queries.
-///
-/// Keyed by window start timestamp (ms since epoch). Each window contains
-/// per-group accumulators that are updated incrementally as batches arrive.
+/// Incremental per-window accumulator state for EOWC aggregate queries.
 pub(crate) struct IncrementalEowcState {
     window_type: EowcWindowType,
     #[allow(clippy::type_complexity)]
@@ -119,25 +112,19 @@ pub(crate) struct IncrementalEowcState {
     output_schema: SchemaRef,
     time_col_index: usize,
     compiled_projection: Option<CompiledProjection>,
-    /// See [`CoreWindowState::cached_pre_agg_physical`].
     cached_pre_agg_physical: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
     having_filter: Option<Arc<dyn PhysicalExpr>>,
     having_sql: Option<String>,
     max_groups_per_window: usize,
-    /// Grace period (ms) after window end before closing. Late events
-    /// arriving within this window are included instead of dropped.
-    /// Must match `CoreWindowState::allowed_lateness_ms` behavior.
     allowed_lateness_ms: i64,
-    /// See [`CoreWindowState::high_watermark_ms`].
     high_watermark_ms: i64,
     prom: Option<Arc<crate::engine_metrics::EngineMetrics>>,
     having_sql_cache: Option<crate::operator::HavingSqlCache>,
 }
 
 impl IncrementalEowcState {
-    /// Attempt to build an `IncrementalEowcState` by introspecting the logical
-    /// plan of the given SQL query. Returns `None` if the query does not
-    /// contain an `Aggregate` node (not an aggregation query).
+    /// Build state from SQL; returns `None` if the query has no `Aggregate` node
+    /// or uses a plan shape that requires the interpreted fallback.
     #[allow(clippy::too_many_lines)]
     pub async fn try_from_sql(
         ctx: &SessionContext,
@@ -167,8 +154,7 @@ impl IncrementalEowcState {
             return Ok(None);
         }
 
-        // Determine if we should attempt to compile pre-agg expressions.
-        // Use single_source_table (counts occurrences) to reject self-joins.
+        // single_source_table rejects self-joins before attempting expression compile.
         let compile_source = crate::sql_analysis::single_source_table(sql);
         let state = ctx.state();
         let props = state.execution_props();
@@ -177,13 +163,8 @@ impl IncrementalEowcState {
         let mut proj_fields: Vec<Field> = Vec::new();
         let mut compile_ok = compile_source.is_some();
 
-        // Bail out if the top-level plan has a non-trivial projection above
-        // the Aggregate (e.g., SUM(a)/SUM(b) AS ratio, CASE WHEN ... END).
-        // The incremental accumulator emits raw aggregate outputs and cannot
-        // apply post-aggregate projections.  Fall through to EOWC raw-batch.
-        //
-        // Check both field count AND types — a coincidental count match can
-        // mask a projection that remaps group columns to computed aggregates.
+        // Bail if there's a post-aggregate projection (e.g. SUM(a)/SUM(b)); fall through
+        // to raw-batch EOWC. Check types too — count match alone can hide remaps.
         if top_schema.fields().len() != agg_schema.fields().len() {
             return Ok(None);
         }
@@ -195,7 +176,6 @@ impl IncrementalEowcState {
 
         let num_group_cols = group_exprs.len();
 
-        // Resolve group-by column names and types
         let mut group_col_names = Vec::new();
         let mut group_types = Vec::new();
         for i in 0..num_group_cols {
@@ -216,7 +196,6 @@ impl IncrementalEowcState {
                 pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
             }
 
-            // Compile group expression
             if compile_ok {
                 match create_physical_expr(group_expr, input_df_schema, props) {
                     Ok(phys) => {
@@ -260,7 +239,6 @@ impl IncrementalEowcState {
                     input_col_indices.push(col_idx);
                     input_types.push(DataType::Boolean);
 
-                    // Compile literal TRUE
                     if compile_ok {
                         match create_physical_expr(
                             &datafusion_expr::lit(true),
@@ -290,7 +268,6 @@ impl IncrementalEowcState {
                                 "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
                             ));
 
-                            // Compile: CASE WHEN filter THEN arg ELSE NULL END
                             if compile_ok {
                                 let case_expr =
                                     datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
@@ -324,7 +301,6 @@ impl IncrementalEowcState {
                             pre_agg_select_items
                                 .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
 
-                            // Compile the arg expression directly
                             if compile_ok {
                                 match create_physical_expr(arg_expr, input_df_schema, props) {
                                     Ok(phys) => {
@@ -359,7 +335,6 @@ impl IncrementalEowcState {
                             "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
                         ));
 
-                    // Compile: CASE WHEN filter THEN TRUE ELSE FALSE END
                     if compile_ok {
                         let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
                             expr: None,
@@ -406,14 +381,12 @@ impl IncrementalEowcState {
             }
         }
 
-        // Add time column for window assignment
         let time_col_index = next_col_idx;
         pre_agg_select_items.push(format!(
             "\"{}\" AS \"__eowc_ts\"",
             window_config.time_column
         ));
 
-        // Compile time column expression
         if compile_ok {
             let time_expr = datafusion_expr::Expr::Column(
                 datafusion_common::Column::new_unqualified(&window_config.time_column),
@@ -438,9 +411,7 @@ impl IncrementalEowcState {
             clauses.where_clause,
         );
 
-        // Build compiled projection for single-source queries.
         let compiled_projection = if compile_ok {
-            // Compile WHERE predicate
             let filter = if let Some(where_pred) = &agg_info.where_predicate {
                 if let Ok(phys) = create_physical_expr(where_pred, input_df_schema, props) {
                     Some(phys)
@@ -477,7 +448,6 @@ impl IncrementalEowcState {
         }
         let output_schema = Arc::new(Schema::new(output_fields));
 
-        // Compile HAVING filter.
         let having_filter = compile_having_filter(ctx, having_predicate.as_ref(), &output_schema);
         let having_sql = if having_filter.is_none() {
             having_predicate.as_ref().map(expr_to_sql)
@@ -487,9 +457,7 @@ impl IncrementalEowcState {
 
         let window_type = EowcWindowType::from_config(window_config);
 
-        // Plan once at init; `LiveSourceExec` leaves carry fresh data.
-        // No compiled fast-path ⇒ the cached plan is the only path, so
-        // propagate any planning error rather than failing at process time.
+        // Without the compiled path the cached plan is the only path; fail early.
         let cached_pre_agg_physical = if compiled_projection.is_none() {
             let logical = ctx
                 .sql(&pre_agg_sql)
@@ -529,7 +497,7 @@ impl IncrementalEowcState {
             having_filter,
             having_sql,
             max_groups_per_window: 1_000_000,
-            // EMIT FINAL drops late data; see CoreWindowState.
+            // EMIT FINAL drops late data; force lateness to 0.
             allowed_lateness_ms: if matches!(emit_clause, Some(EmitClause::Final)) {
                 0
             } else {
@@ -541,7 +509,6 @@ impl IncrementalEowcState {
         }))
     }
 
-    /// See [`CoreWindowState::is_window_closed`].
     #[inline]
     fn is_window_closed(&self, window_start: i64) -> bool {
         if self.high_watermark_ms == i64::MIN {
@@ -557,10 +524,7 @@ impl IncrementalEowcState {
             <= self.high_watermark_ms
     }
 
-    /// Vectorized batch update: extracts timestamps and group keys at the
-    /// batch level using `RowConverter`, groups row indices by
-    /// `(window_start, group_key)`, then calls `update_group_accumulators`
-    /// once per group with a single `take()` per column.
+    /// Update per-window accumulators with a new pre-aggregation batch.
     #[allow(clippy::too_many_lines)]
     pub fn update_batch(&mut self, batch: &RecordBatch) -> Result<(), DbError> {
         if batch.num_rows() == 0 {
@@ -570,7 +534,6 @@ impl IncrementalEowcState {
         let ts_array = extract_i64_timestamps(batch, self.time_col_index)?;
         let has_groups = self.num_group_cols > 0;
 
-        // Batch-level group key extraction via persistent RowConverter
         let rows = if has_groups {
             let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
                 .map(|i| Arc::clone(batch.column(i)))
@@ -584,13 +547,12 @@ impl IncrementalEowcState {
             None
         };
 
-        // Group row indices by (window_start, group_key).
         if !has_groups {
             let empty_key = crate::aggregate_state::global_aggregate_key();
             let mut grouped: AHashMap<i64, Vec<u32>> = AHashMap::new();
             for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
                 if ts_ms == NULL_TIMESTAMP {
-                    continue; // skip rows with null timestamps
+                    continue;
                 }
                 #[allow(clippy::cast_possible_truncation)]
                 let idx = row_idx as u32;
@@ -635,9 +597,8 @@ impl IncrementalEowcState {
             return Ok(());
         }
 
-        // Grouped path. Dedup group keys per batch and bucket by
-        // (window, group_id) so per-window assignment doesn't clone the
-        // OwnedRow for each overlapping window.
+        // Dedup group keys per batch; bucket by (window, group_id) to avoid cloning OwnedRow
+        // for each overlapping window (hopping).
         let rows_ref = rows.as_ref().expect("rows set when has_groups");
         let mut group_keys: indexmap::IndexSet<arrow::row::OwnedRow, ahash::RandomState> =
             indexmap::IndexSet::default();
@@ -709,11 +670,7 @@ impl IncrementalEowcState {
         Ok(())
     }
 
-    /// Close windows whose end <= watermark, returning emitted batches.
-    ///
-    /// Iterates the `BTreeMap` from earliest window and closes all windows
-    /// where `window_start + window_size <= watermark_ms`. Closed windows
-    /// are removed from state.
+    /// Close and emit all windows whose end (plus lateness grace) <= watermark.
     pub fn close_windows(&mut self, watermark_ms: i64) -> Result<Vec<RecordBatch>, DbError> {
         self.high_watermark_ms = self.high_watermark_ms.max(watermark_ms);
         let size_ms = self.window_type.size_ms();
@@ -820,7 +777,6 @@ impl IncrementalEowcState {
             f.name().hash(&mut h);
             f.data_type().to_string().hash(&mut h);
         }
-        // Window shape: see CoreWindowState::query_fingerprint.
         match &self.window_type {
             EowcWindowType::Tumbling { size_ms } => {
                 "tumbling".hash(&mut h);
@@ -840,10 +796,7 @@ impl IncrementalEowcState {
         h.finish()
     }
 
-    /// Estimated memory usage in bytes across all windows and groups.
-    ///
-    /// Iterates over every open window and its per-group accumulators, summing
-    /// `ScalarValue::size()` for keys and `Accumulator::size()` for state.
+    /// Estimated memory usage in bytes across all open windows and groups.
     pub(crate) fn estimated_size_bytes(&self) -> usize {
         let mut total = 0;
         for groups in self.windows.values() {
@@ -857,7 +810,6 @@ impl IncrementalEowcState {
         total
     }
 
-    /// Checkpoint all per-window group states into a serializable struct.
     pub(crate) fn checkpoint_windows(&mut self) -> Result<EowcStateCheckpoint, DbError> {
         use crate::aggregate_state::{scalars_to_ipc, GroupCheckpoint, WindowCheckpoint};
 
@@ -898,7 +850,6 @@ impl IncrementalEowcState {
         })
     }
 
-    /// Restore per-window group states from a checkpoint.
     pub(crate) fn restore_windows(
         &mut self,
         checkpoint: &EowcStateCheckpoint,
@@ -950,17 +901,12 @@ impl IncrementalEowcState {
     }
 }
 
-/// Sentinel value for null timestamps. Callers must skip rows with this value
-/// instead of assigning them to the epoch-0 window.
+/// Sentinel for null timestamps; callers must skip rows with this value
+/// rather than assigning them to the epoch-0 window.
 pub(crate) const NULL_TIMESTAMP: i64 = i64::MIN;
 
-/// Extract i64 timestamp values from a batch column.
-///
-/// Handles Int64 columns directly and Arrow Timestamp columns by extracting
-/// the underlying i64 values (already in the native time unit).
-///
-/// Null values are mapped to [`NULL_TIMESTAMP`] (`i64::MIN`). Callers must
-/// check for this sentinel and skip the corresponding rows.
+/// Extract millisecond timestamps from a batch column as `i64`.
+/// Nulls become [`NULL_TIMESTAMP`]; callers must skip those rows.
 pub(crate) fn extract_i64_timestamps(
     batch: &RecordBatch,
     col_index: usize,

--- a/crates/laminar-db/src/ffi/arrow_ffi.rs
+++ b/crates/laminar-db/src/ffi/arrow_ffi.rs
@@ -12,24 +12,10 @@ use crate::api::ApiError;
 
 /// Export a `RecordBatch` to the Arrow C Data Interface.
 ///
-/// The batch is exported as a struct array (Arrow convention for record batches).
-/// The caller must allocate the `ArrowArray` and `ArrowSchema` structs before calling.
-///
-/// # Arguments
-///
-/// * `batch` - Record batch to export
-/// * `out_array` - Pointer to caller-allocated `ArrowArray` struct
-/// * `out_schema` - Pointer to caller-allocated `ArrowSchema` struct
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `batch` must be a valid batch handle
-/// * `out_array` and `out_schema` must be valid pointers to uninitialized structs
-/// * Caller must eventually call the release callbacks on both structs
+/// `batch`, `out_array`, and `out_schema` must be valid non-null pointers;
+/// caller must call the release callbacks on both output structs.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_export(
     batch: *mut LaminarRecordBatch,
@@ -42,17 +28,14 @@ pub unsafe extern "C" fn laminar_batch_export(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: batch is non-null (checked above)
     let batch_ref = unsafe { &(*batch) };
     let record_batch = batch_ref.inner();
 
-    // Convert RecordBatch to StructArray for export (Arrow convention)
     let struct_array: StructArray = record_batch.clone().into();
     let data = struct_array.into_data();
 
     match to_ffi(&data) {
         Ok((array, schema)) => {
-            // SAFETY: out_array and out_schema are non-null (checked above)
             unsafe {
                 std::ptr::write(out_array, array);
                 std::ptr::write(out_schema, schema);
@@ -68,22 +51,9 @@ pub unsafe extern "C" fn laminar_batch_export(
 
 /// Export just the schema to the Arrow C Data Interface.
 ///
-/// Useful when consumers need the schema before receiving data.
-///
-/// # Arguments
-///
-/// * `schema` - Schema to export
-/// * `out_schema` - Pointer to caller-allocated `ArrowSchema` struct
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `schema` must be a valid schema handle
-/// * `out_schema` must be a valid pointer to an uninitialized struct
-/// * Caller must eventually call the release callback
+/// `schema` and `out_schema` must be valid non-null pointers; caller must call the release callback.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_schema_export(
     schema: *mut LaminarSchema,
@@ -95,12 +65,10 @@ pub unsafe extern "C" fn laminar_schema_export(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: schema is non-null (checked above)
     let schema_ref = unsafe { (*schema).schema() };
 
     match FFI_ArrowSchema::try_from(schema_ref.as_ref()) {
         Ok(ffi_schema) => {
-            // SAFETY: out_schema is non-null (checked above)
             unsafe {
                 std::ptr::write(out_schema, ffi_schema);
             }
@@ -117,23 +85,10 @@ pub unsafe extern "C" fn laminar_schema_export(
 
 /// Export a single column from a `RecordBatch` to the Arrow C Data Interface.
 ///
-/// # Arguments
-///
-/// * `batch` - Record batch containing the column
-/// * `column_index` - Zero-based index of the column to export
-/// * `out_array` - Pointer to caller-allocated `ArrowArray` struct
-/// * `out_schema` - Pointer to caller-allocated `ArrowSchema` struct
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `batch` must be a valid batch handle
-/// * `column_index` must be less than the number of columns
-/// * `out_array` and `out_schema` must be valid pointers
-/// * Caller must eventually call the release callbacks
+/// `batch`, `out_array`, and `out_schema` must be valid non-null pointers;
+/// `column_index` must be in range; caller must call the release callbacks.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_export_column(
     batch: *mut LaminarRecordBatch,
@@ -147,7 +102,6 @@ pub unsafe extern "C" fn laminar_batch_export_column(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: batch is non-null (checked above)
     let batch_ref = unsafe { &(*batch) };
     let record_batch = batch_ref.inner();
 
@@ -164,7 +118,6 @@ pub unsafe extern "C" fn laminar_batch_export_column(
 
     match to_ffi(&data) {
         Ok((array, schema)) => {
-            // SAFETY: out_array and out_schema are non-null (checked above)
             unsafe {
                 std::ptr::write(out_array, array);
                 std::ptr::write(out_schema, schema);
@@ -180,26 +133,12 @@ pub unsafe extern "C" fn laminar_batch_export_column(
     }
 }
 
-/// Import a `RecordBatch` from the Arrow C Data Interface.
-///
-/// Takes ownership of the `ArrowArray` and `ArrowSchema` structs.
-/// The release callbacks will be called automatically.
-///
-/// # Arguments
-///
-/// * `array` - Pointer to `ArrowArray` struct (ownership transferred)
-/// * `schema` - Pointer to `ArrowSchema` struct (ownership transferred)
-/// * `out` - Pointer to receive the new batch handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Import a `RecordBatch` from the Arrow C Data Interface, taking ownership of both structs.
 ///
 /// # Safety
 ///
-/// * `array` and `schema` must be valid Arrow C Data Interface structs
-/// * Ownership is transferred - the structs will be released by this function
-/// * `out` must be a valid pointer
+/// `array`, `schema`, and `out` must be valid non-null pointers;
+/// ownership of `array` and `schema` is transferred and they are released by this function.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_import(
     array: *mut FFI_ArrowArray,
@@ -212,13 +151,10 @@ pub unsafe extern "C" fn laminar_batch_import(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: array and schema are non-null (checked above)
-    // Take ownership by reading the structs
     let ffi_array = unsafe { std::ptr::read(array) };
     let ffi_schema = unsafe { std::ptr::read(schema) };
 
-    // Clear the original pointers to prevent double-free
-    // (The consumer should not use these after calling import)
+    // Zero the originals to prevent double-free; callers must not use them after this.
     unsafe {
         std::ptr::write_bytes(array, 0, 1);
         std::ptr::write_bytes(schema, 0, 1);
@@ -226,12 +162,10 @@ pub unsafe extern "C" fn laminar_batch_import(
 
     match from_ffi(ffi_array, &ffi_schema) {
         Ok(data) => {
-            // Convert ArrayData to StructArray then to RecordBatch
             let struct_array = StructArray::from(data);
             let batch = RecordBatch::from(struct_array);
 
             let handle = Box::new(LaminarRecordBatch::new(batch));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -242,14 +176,11 @@ pub unsafe extern "C" fn laminar_batch_import(
     }
 }
 
-/// Create a `RecordBatch` from Arrow C Data Interface for writing.
-///
-/// This is an alias for `laminar_batch_import` for clarity when the
-/// intent is to create data for writing rather than receiving query results.
+/// Alias for [`laminar_batch_import`] for use when creating data for writing.
 ///
 /// # Safety
 ///
-/// Same requirements as `laminar_batch_import`.
+/// Same requirements as [`laminar_batch_import`].
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_create(
     array: *mut FFI_ArrowArray,

--- a/crates/laminar-db/src/ffi/callback.rs
+++ b/crates/laminar-db/src/ffi/callback.rs
@@ -12,74 +12,46 @@ use super::error::{
 };
 use super::query::LaminarRecordBatch;
 
-// ============================================================================
-// Event Type Constants
-// ============================================================================
-
 /// Event type: insert (+1 weight).
 pub const LAMINAR_EVENT_INSERT: i32 = 0;
 /// Event type: delete (-1 weight).
 pub const LAMINAR_EVENT_DELETE: i32 = 1;
-/// Event type: update (decomposed to delete + insert).
+/// Event type: update (delete + insert pair).
 pub const LAMINAR_EVENT_UPDATE: i32 = 2;
-/// Event type: watermark progress (no data).
+/// Event type: watermark progress.
 pub const LAMINAR_EVENT_WATERMARK: i32 = 3;
-/// Event type: snapshot (initial state load).
+/// Event type: initial-state snapshot.
 pub const LAMINAR_EVENT_SNAPSHOT: i32 = 4;
 
-// ============================================================================
-// Callback Function Types
-// ============================================================================
-
-/// Callback function type for subscription data.
-///
-/// # Arguments
-///
-/// * `user_data` - Opaque pointer passed to `laminar_subscribe_callback`
-/// * `batch` - Record batch (ownership transferred to callback, must free)
-/// * `event_type` - One of `LAMINAR_EVENT_*` constants
+/// Callback invoked from the subscription thread with each batch.
 ///
 /// # Safety
 ///
-/// The callback must free the batch with `laminar_batch_free`.
+/// The callback receives ownership of `batch` and must free it with `laminar_batch_free`.
 pub type LaminarSubscriptionCallback = Option<
     unsafe extern "C" fn(user_data: *mut c_void, batch: *mut LaminarRecordBatch, event_type: i32),
 >;
 
-/// Callback function type for errors.
-///
-/// # Arguments
-///
-/// * `user_data` - Opaque pointer passed to `laminar_subscribe_callback`
-/// * `error_code` - One of `LAMINAR_ERR_*` constants
-/// * `error_message` - Error message (valid only during callback)
+/// Callback invoked when a subscription error occurs.
 pub type LaminarErrorCallback = Option<
     unsafe extern "C" fn(user_data: *mut c_void, error_code: i32, error_message: *const c_char),
 >;
-
-// ============================================================================
-// Subscription Handle
-// ============================================================================
 
 /// Opaque handle for a callback-based subscription.
 ///
 /// Created by `laminar_subscribe_callback`, freed by `laminar_subscription_free`.
 #[repr(C)]
 pub struct LaminarSubscriptionHandle {
-    /// Flag to signal cancellation to the background thread.
     cancelled: Arc<AtomicBool>,
-    /// Background thread handle (if still running).
     thread_handle: Option<JoinHandle<()>>,
-    /// User data pointer (stored for reference, not owned).
+    // Not owned; caller is responsible for lifetime.
     user_data: *mut c_void,
 }
 
-// SAFETY: The handle can be sent between threads. The user_data pointer
-// is the caller's responsibility to ensure thread safety.
+// SAFETY: user_data thread-safety is the caller's responsibility.
 unsafe impl Send for LaminarSubscriptionHandle {}
 
 impl LaminarSubscriptionHandle {
-    /// Create a new subscription handle.
     fn new(
         cancelled: Arc<AtomicBool>,
         thread_handle: JoinHandle<()>,
@@ -92,96 +64,51 @@ impl LaminarSubscriptionHandle {
         }
     }
 
-    /// Cancel the subscription and wait for the thread to stop.
     fn cancel(&mut self) {
-        // Signal cancellation
         self.cancelled.store(true, Ordering::SeqCst);
-
-        // Wait for thread to finish
         if let Some(handle) = self.thread_handle.take() {
             let _ = handle.join();
         }
     }
 }
 
-// ============================================================================
-// Callback Context
-// ============================================================================
-
-/// Internal context passed to the background subscription thread.
 struct CallbackContext {
-    /// User data pointer.
     user_data: *mut c_void,
-    /// Data callback.
     on_data: LaminarSubscriptionCallback,
-    /// Error callback.
     on_error: LaminarErrorCallback,
-    /// Cancellation flag.
     cancelled: Arc<AtomicBool>,
 }
 
-// SAFETY: CallbackContext is only accessed from the subscription thread.
-// The user_data pointer is the caller's responsibility.
+// SAFETY: only accessed from the subscription thread; user_data is caller's responsibility.
 unsafe impl Send for CallbackContext {}
 
 impl CallbackContext {
-    /// Invoke the data callback if set.
     fn call_on_data(&self, batch: LaminarRecordBatch, event_type: i32) {
         if let Some(callback) = self.on_data {
             let batch_ptr = Box::into_raw(Box::new(batch));
-            // SAFETY: Callback is provided by FFI caller, we pass valid pointers.
-            unsafe {
-                callback(self.user_data, batch_ptr, event_type);
-            }
+            unsafe { callback(self.user_data, batch_ptr, event_type) };
         }
     }
 
-    /// Invoke the error callback if set.
     fn call_on_error(&self, error_code: i32, message: &str) {
         if let Some(callback) = self.on_error {
             let c_message = CString::new(message)
                 .unwrap_or_else(|_| CString::new("Error message contained null byte").unwrap());
-            // SAFETY: Callback is provided by FFI caller, we pass valid pointers.
-            unsafe {
-                callback(self.user_data, error_code, c_message.as_ptr());
-            }
+            unsafe { callback(self.user_data, error_code, c_message.as_ptr()) };
         }
     }
 
-    /// Check if cancellation has been requested.
     fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
     }
 }
 
-// ============================================================================
-// FFI Functions
-// ============================================================================
-
-/// Create a callback-based subscription.
-///
-/// The `on_data` callback is invoked from a background thread when new data
-/// arrives. The callback receives ownership of the batch and must free it.
-///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `query` - SQL query string (null-terminated)
-/// * `on_data` - Callback for data batches (may be NULL to ignore data)
-/// * `on_error` - Callback for errors (may be NULL to ignore errors)
-/// * `user_data` - Opaque pointer passed to callbacks
-/// * `out` - Pointer to receive subscription handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Create a callback-based subscription; `on_data` is called from a background thread.
 ///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `query` must be a valid null-terminated UTF-8 string
-/// * `out` must be a valid pointer
-/// * Callbacks must be thread-safe if `user_data` is shared
+/// `conn`, `query`, and `out` must be valid non-null pointers; `query` must be a
+/// null-terminated UTF-8 string; callbacks must be thread-safe if `user_data` is shared.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_subscribe_callback(
     conn: *mut LaminarConnection,
@@ -197,15 +124,12 @@ pub unsafe extern "C" fn laminar_subscribe_callback(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // Parse query string
     let Ok(query_str) = (unsafe { CStr::from_ptr(query) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
-    // Create the subscription (using query_stream for streaming results)
     let stream = match conn_ref.query_stream(query_str) {
         Ok(s) => s,
         Err(e) => {
@@ -215,11 +139,9 @@ pub unsafe extern "C" fn laminar_subscribe_callback(
         }
     };
 
-    // Set up cancellation flag
     let cancelled = Arc::new(AtomicBool::new(false));
     let cancelled_clone = Arc::clone(&cancelled);
 
-    // Create callback context
     let ctx = CallbackContext {
         user_data,
         on_data,
@@ -227,51 +149,41 @@ pub unsafe extern "C" fn laminar_subscribe_callback(
         cancelled: cancelled_clone,
     };
 
-    // Spawn background thread to drive the subscription
     let thread_handle = thread::spawn(move || {
         subscription_thread(stream, ctx);
     });
 
-    // Create handle
     let handle = Box::new(LaminarSubscriptionHandle::new(
         cancelled,
         thread_handle,
         user_data,
     ));
 
-    // SAFETY: out is non-null (checked above)
     unsafe { *out = Box::into_raw(handle) };
 
     LAMINAR_OK
 }
 
-/// Background thread function that drives the subscription.
-#[allow(clippy::needless_pass_by_value)] // ctx is owned by the thread
+#[allow(clippy::needless_pass_by_value)]
 fn subscription_thread(mut stream: crate::api::QueryStream, ctx: CallbackContext) {
     loop {
-        // Check for cancellation
         if ctx.is_cancelled() {
             break;
         }
 
-        // Try to get next batch (non-blocking to allow cancellation checks)
         match stream.try_next() {
             Ok(Some(batch)) => {
-                // Determine event type (default to insert for query results)
-                let event_type = LAMINAR_EVENT_INSERT;
-                ctx.call_on_data(LaminarRecordBatch::new(batch), event_type);
+                ctx.call_on_data(LaminarRecordBatch::new(batch), LAMINAR_EVENT_INSERT);
             }
             Ok(None) => {
-                // No data available, check if stream is exhausted
                 if !stream.is_active() {
                     break;
                 }
-                // Brief sleep to avoid busy-waiting
+                // Poll interval — avoid busy spin.
                 std::thread::sleep(std::time::Duration::from_millis(1));
             }
             Err(e) => {
                 ctx.call_on_error(e.code(), e.message());
-                // Continue unless fatal
                 if !stream.is_active() {
                     break;
                 }
@@ -280,18 +192,7 @@ fn subscription_thread(mut stream: crate::api::QueryStream, ctx: CallbackContext
     }
 }
 
-/// Cancel a callback-based subscription.
-///
-/// After this function returns, no more callbacks will be invoked.
-/// It is safe to free resources referenced by `user_data` after this returns.
-///
-/// # Arguments
-///
-/// * `handle` - Subscription handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Cancel a callback-based subscription; no callbacks will fire after this returns.
 ///
 /// # Safety
 ///
@@ -306,7 +207,6 @@ pub unsafe extern "C" fn laminar_subscription_cancel(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: handle is non-null (checked above)
     let handle_ref = unsafe { &mut *handle };
     handle_ref.cancel();
 
@@ -315,19 +215,9 @@ pub unsafe extern "C" fn laminar_subscription_cancel(
 
 /// Check if a subscription is still active.
 ///
-/// # Arguments
-///
-/// * `handle` - Subscription handle
-/// * `out` - Pointer to receive result (true if active)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `handle` must be a valid subscription handle
-/// * `out` must be a valid pointer
+/// `handle` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_subscription_is_active(
     handle: *mut LaminarSubscriptionHandle,
@@ -339,7 +229,6 @@ pub unsafe extern "C" fn laminar_subscription_is_active(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: handle and out are non-null (checked above)
     let handle_ref = unsafe { &*handle };
     let active = !handle_ref.cancelled.load(Ordering::SeqCst) && handle_ref.thread_handle.is_some();
 
@@ -348,15 +237,7 @@ pub unsafe extern "C" fn laminar_subscription_is_active(
     LAMINAR_OK
 }
 
-/// Get the user data pointer from a subscription handle.
-///
-/// # Arguments
-///
-/// * `handle` - Subscription handle
-///
-/// # Returns
-///
-/// The user data pointer passed to `laminar_subscribe_callback`, or NULL.
+/// Return the user data pointer from a subscription handle, or NULL.
 ///
 /// # Safety
 ///
@@ -369,17 +250,10 @@ pub unsafe extern "C" fn laminar_subscription_user_data(
         return std::ptr::null_mut();
     }
 
-    // SAFETY: handle is non-null (checked above)
     unsafe { (*handle).user_data }
 }
 
-/// Free a subscription handle.
-///
-/// If the subscription is still active, it will be cancelled first.
-///
-/// # Arguments
-///
-/// * `handle` - Subscription handle to free
+/// Free a subscription handle, cancelling it first if still active.
 ///
 /// # Safety
 ///
@@ -387,18 +261,11 @@ pub unsafe extern "C" fn laminar_subscription_user_data(
 #[no_mangle]
 pub unsafe extern "C" fn laminar_subscription_free(handle: *mut LaminarSubscriptionHandle) {
     if !handle.is_null() {
-        // SAFETY: handle is non-null and was allocated by Box
         let mut boxed = unsafe { Box::from_raw(handle) };
-        // Cancel if still active
         boxed.cancel();
         drop(boxed);
     }
 }
-
-// Note: Async write operations (laminar_writer_write_async) are deferred to a
-// future release. They require careful synchronization (Arc<Mutex<Writer>>)
-// that is beyond the scope of this initial callback implementation.
-// For now, use the synchronous laminar_writer_write() API.
 
 #[cfg(test)]
 #[allow(

--- a/crates/laminar-db/src/ffi/connection.rs
+++ b/crates/laminar-db/src/ffi/connection.rs
@@ -1,6 +1,4 @@
 //! FFI connection functions.
-//!
-//! Provides `extern "C"` wrappers for database connection operations.
 
 use std::ffi::{c_char, CStr};
 use std::ptr;
@@ -13,25 +11,13 @@ use super::error::{
 };
 use super::query::{LaminarQueryResult, LaminarQueryStream};
 
-/// Opaque connection handle for FFI.
-///
-/// This wraps a `Connection` for C callers. Create with `laminar_open()`,
-/// free with `laminar_close()`.
+/// Opaque connection handle. Create with `laminar_open`, free with `laminar_close`.
 #[repr(C)]
 pub struct LaminarConnection {
     pub(crate) inner: Connection,
 }
 
 /// Open a new database connection.
-///
-/// # Arguments
-///
-/// * `out` - Pointer to receive the connection handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code. On error, call `laminar_last_error()`
-/// for details.
 ///
 /// # Safety
 ///
@@ -47,7 +33,6 @@ pub unsafe extern "C" fn laminar_open(out: *mut *mut LaminarConnection) -> i32 {
     match Connection::open() {
         Ok(conn) => {
             let handle = Box::new(LaminarConnection { inner: conn });
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -59,22 +44,11 @@ pub unsafe extern "C" fn laminar_open(out: *mut *mut LaminarConnection) -> i32 {
     }
 }
 
-/// Close a database connection.
-///
-/// This frees the connection and all associated resources. The connection
-/// handle becomes invalid after this call.
-///
-/// # Arguments
-///
-/// * `conn` - Connection handle to close
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Close a database connection and free all associated resources.
 ///
 /// # Safety
 ///
-/// `conn` must be a valid handle from `laminar_open()` that has not been closed.
+/// `conn` must be a valid handle from `laminar_open` that has not been closed.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_close(conn: *mut LaminarConnection) -> i32 {
     clear_last_error();
@@ -83,7 +57,6 @@ pub unsafe extern "C" fn laminar_close(conn: *mut LaminarConnection) -> i32 {
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: conn is non-null and was created by laminar_open
     let handle = unsafe { Box::from_raw(conn) };
     match handle.inner.close() {
         Ok(()) => LAMINAR_OK,
@@ -95,26 +68,12 @@ pub unsafe extern "C" fn laminar_close(conn: *mut LaminarConnection) -> i32 {
     }
 }
 
-/// Execute a SQL statement.
-///
-/// For DDL statements (CREATE, DROP), `out` may be NULL. For queries,
-/// `out` receives a `LaminarQueryResult` handle.
-///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `sql` - Null-terminated SQL string
-/// * `out` - Optional pointer to receive query result (may be NULL for DDL)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Execute a SQL statement. For DDL, `out` may be NULL.
 ///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `sql` must be a valid null-terminated UTF-8 string
-/// * If `out` is non-null, it must be a valid pointer
+/// `conn` and `sql` must be valid non-null pointers; `sql` must be null-terminated UTF-8;
+/// if `out` is non-null it must be a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_execute(
     conn: *mut LaminarConnection,
@@ -127,49 +86,40 @@ pub unsafe extern "C" fn laminar_execute(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: sql is non-null (checked above)
     let Ok(sql_str) = (unsafe { CStr::from_ptr(sql) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.execute(sql_str) {
         Ok(result) => {
             use crate::api::ExecuteResult;
             match result {
-                ExecuteResult::Query(stream) => {
-                    // Collect to materialized result
-                    match stream.collect() {
-                        Ok(query_result) => {
-                            if !out.is_null() {
-                                let handle = Box::new(LaminarQueryResult::new(query_result));
-                                // SAFETY: out is non-null (checked)
-                                unsafe { *out = Box::into_raw(handle) };
-                            }
-                            LAMINAR_OK
+                ExecuteResult::Query(stream) => match stream.collect() {
+                    Ok(query_result) => {
+                        if !out.is_null() {
+                            let handle = Box::new(LaminarQueryResult::new(query_result));
+                            unsafe { *out = Box::into_raw(handle) };
                         }
-                        Err(e) => {
-                            let code = e.code();
-                            set_last_error(e);
-                            code
-                        }
+                        LAMINAR_OK
                     }
-                }
+                    Err(e) => {
+                        let code = e.code();
+                        set_last_error(e);
+                        code
+                    }
+                },
                 ExecuteResult::Metadata(batch) => {
                     if !out.is_null() {
                         let query_result = crate::api::QueryResult::from_batch(batch);
                         let handle = Box::new(LaminarQueryResult::new(query_result));
-                        // SAFETY: out is non-null (checked)
                         unsafe { *out = Box::into_raw(handle) };
                     }
                     LAMINAR_OK
                 }
                 ExecuteResult::Ddl(_) | ExecuteResult::RowsAffected(_) => {
-                    // DDL or DML - no result to return
                     if !out.is_null() {
-                        // SAFETY: out is non-null
                         unsafe { *out = ptr::null_mut() };
                     }
                     LAMINAR_OK
@@ -184,25 +134,11 @@ pub unsafe extern "C" fn laminar_execute(
     }
 }
 
-/// Execute a query and get materialized results.
-///
-/// This executes the SQL and waits for all results before returning.
-///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `sql` - Null-terminated SQL string
-/// * `out` - Pointer to receive query result
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Execute a query and collect all results into memory.
 ///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `sql` must be a valid null-terminated UTF-8 string
-/// * `out` must be a valid pointer
+/// `conn`, `sql`, and `out` must be valid non-null pointers; `sql` must be null-terminated UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_query(
     conn: *mut LaminarConnection,
@@ -215,18 +151,15 @@ pub unsafe extern "C" fn laminar_query(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: sql is non-null (checked above)
     let Ok(sql_str) = (unsafe { CStr::from_ptr(sql) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.query(sql_str) {
         Ok(result) => {
             let handle = Box::new(LaminarQueryResult::new(result));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -240,23 +173,9 @@ pub unsafe extern "C" fn laminar_query(
 
 /// Execute a query with streaming results.
 ///
-/// Returns a stream handle for incremental result retrieval.
-///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `sql` - Null-terminated SQL string
-/// * `out` - Pointer to receive query stream
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `sql` must be a valid null-terminated UTF-8 string
-/// * `out` must be a valid pointer
+/// `conn`, `sql`, and `out` must be valid non-null pointers; `sql` must be null-terminated UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_query_stream(
     conn: *mut LaminarConnection,
@@ -269,18 +188,15 @@ pub unsafe extern "C" fn laminar_query_stream(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: sql is non-null (checked above)
     let Ok(sql_str) = (unsafe { CStr::from_ptr(sql) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.query_stream(sql_str) {
         Ok(stream) => {
             let handle = Box::new(LaminarQueryStream::new(stream));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -294,14 +210,6 @@ pub unsafe extern "C" fn laminar_query_stream(
 
 /// Start the streaming pipeline.
 ///
-/// # Arguments
-///
-/// * `conn` - Database connection
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
 /// `conn` must be a valid connection handle.
@@ -313,7 +221,6 @@ pub unsafe extern "C" fn laminar_start(conn: *mut LaminarConnection) -> i32 {
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.start() {
@@ -328,19 +235,9 @@ pub unsafe extern "C" fn laminar_start(conn: *mut LaminarConnection) -> i32 {
 
 /// Check if the connection is closed.
 ///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `out` - Pointer to receive result (true if closed)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `out` must be a valid pointer
+/// `conn` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_is_closed(conn: *mut LaminarConnection, out: *mut bool) -> i32 {
     clear_last_error();
@@ -349,7 +246,6 @@ pub unsafe extern "C" fn laminar_is_closed(conn: *mut LaminarConnection, out: *m
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: conn and out are non-null (checked above)
     unsafe {
         *out = (*conn).inner.is_closed();
     }

--- a/crates/laminar-db/src/ffi/error.rs
+++ b/crates/laminar-db/src/ffi/error.rs
@@ -1,15 +1,10 @@
-//! Thread-local error storage for FFI.
-//!
-//! C functions return error codes; this module stores the last error message
-//! so callers can retrieve it via `laminar_last_error()`.
+//! Thread-local error storage for FFI; callers retrieve the last message via `laminar_last_error`.
 
 use std::cell::RefCell;
 use std::ffi::{c_char, CString};
 use std::ptr;
 
 use crate::api::ApiError;
-
-// Error code constants
 
 /// Success return code.
 pub const LAMINAR_OK: i32 = 0;
@@ -36,18 +31,15 @@ pub const LAMINAR_ERR_INTERNAL: i32 = 900;
 /// Database is shutting down.
 pub const LAMINAR_ERR_SHUTDOWN: i32 = 901;
 
-// Thread-local storage for the last error.
 thread_local! {
     static LAST_ERROR: RefCell<Option<StoredError>> = const { RefCell::new(None) };
 }
 
-/// Stored error with pre-allocated C string.
 struct StoredError {
     error: ApiError,
     c_message: CString,
 }
 
-/// Store an error for later retrieval.
 pub(crate) fn set_last_error(err: ApiError) {
     let c_message = CString::new(err.message())
         .unwrap_or_else(|_| CString::new("Error message contained null byte").unwrap());
@@ -59,12 +51,10 @@ pub(crate) fn set_last_error(err: ApiError) {
     });
 }
 
-/// Clear the last error.
 pub(crate) fn clear_last_error() {
     LAST_ERROR.with(|e| *e.borrow_mut() = None);
 }
 
-/// Get the last error code, or 0 if none.
 #[must_use]
 pub(crate) fn last_error_code() -> i32 {
     LAST_ERROR.with(|e| {
@@ -74,7 +64,6 @@ pub(crate) fn last_error_code() -> i32 {
     })
 }
 
-/// Convert `ApiError` to FFI error code.
 fn api_error_to_ffi_code(err: &ApiError) -> i32 {
     use crate::api::codes;
     let code = err.code();
@@ -89,15 +78,11 @@ fn api_error_to_ffi_code(err: &ApiError) -> i32 {
             LAMINAR_ERR_SUBSCRIPTION
         }
         codes::SHUTDOWN => LAMINAR_ERR_SHUTDOWN,
-        // All other codes (including INTERNAL_ERROR) map to INTERNAL
         _ => LAMINAR_ERR_INTERNAL,
     }
 }
 
-/// Get the last error message.
-///
-/// Returns a pointer to a null-terminated string, or null if no error.
-/// The pointer is valid until the next FFI call on the same thread.
+/// Get the last error message as a null-terminated string, or null if no error.
 ///
 /// # Safety
 ///
@@ -110,17 +95,13 @@ pub extern "C" fn laminar_last_error() -> *const c_char {
     })
 }
 
-/// Get the last error code.
-///
-/// Returns 0 (`LAMINAR_OK`) if no error has occurred.
+/// Get the last error code, or `LAMINAR_OK` if none.
 #[no_mangle]
 pub extern "C" fn laminar_last_error_code() -> i32 {
     last_error_code()
 }
 
 /// Clear the last error.
-///
-/// Call this to reset error state before a sequence of operations.
 #[no_mangle]
 pub extern "C" fn laminar_clear_error() {
     clear_last_error();

--- a/crates/laminar-db/src/ffi/memory.rs
+++ b/crates/laminar-db/src/ffi/memory.rs
@@ -1,47 +1,31 @@
 //! FFI memory management functions.
-//!
-//! Provides `extern "C"` functions for freeing memory allocated by `LaminarDB`.
 
 use std::ffi::{c_char, CString};
 
-/// Transfer ownership of a `CString` to a raw pointer.
-///
-/// The caller is responsible for freeing this with `laminar_string_free`.
+/// Transfer ownership of a `CString` to a raw pointer; free with `laminar_string_free`.
 pub(crate) fn take_ownership_string(s: CString) -> *mut c_char {
     s.into_raw()
 }
 
-/// Free a string allocated by `LaminarDB`.
-///
-/// # Arguments
-///
-/// * `s` - String pointer to free, or NULL
+/// Free a string allocated by a laminar function.
 ///
 /// # Safety
 ///
 /// `s` must be a pointer returned by a laminar function, or NULL.
-/// After calling this function, the pointer is invalid.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_string_free(s: *mut c_char) {
     if !s.is_null() {
-        // SAFETY: s is non-null and was allocated by CString::into_raw
         drop(unsafe { CString::from_raw(s) });
     }
 }
 
-/// Get the `LaminarDB` library version.
-///
-/// # Returns
-///
-/// A pointer to a null-terminated version string. This is a static string
-/// and should NOT be freed.
+/// Return the library version as a static null-terminated string (do not free).
 ///
 /// # Safety
 ///
 /// The returned pointer is valid for the lifetime of the process.
 #[no_mangle]
 pub extern "C" fn laminar_version() -> *const c_char {
-    // Static string, never freed
     static VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
     VERSION.as_ptr().cast()
 }

--- a/crates/laminar-db/src/ffi/mod.rs
+++ b/crates/laminar-db/src/ffi/mod.rs
@@ -9,7 +9,6 @@ mod query;
 mod schema;
 mod writer;
 
-// Re-export all FFI functions
 pub use arrow_ffi::{
     laminar_batch_create, laminar_batch_export, laminar_batch_export_column, laminar_batch_import,
     laminar_schema_export,

--- a/crates/laminar-db/src/ffi/query.rs
+++ b/crates/laminar-db/src/ffi/query.rs
@@ -1,6 +1,4 @@
 //! FFI query result functions.
-//!
-//! Provides `extern "C"` wrappers for query result operations.
 
 use std::ptr;
 
@@ -11,80 +9,55 @@ use crate::api::{QueryResult, QueryStream};
 use super::error::{clear_last_error, set_last_error, LAMINAR_ERR_NULL_POINTER, LAMINAR_OK};
 use super::schema::LaminarSchema;
 
-/// Opaque query result handle for FFI.
-///
-/// Contains materialized query results (all batches in memory).
+/// Opaque handle for materialized query results.
 #[repr(C)]
 pub struct LaminarQueryResult {
     inner: QueryResult,
 }
 
 impl LaminarQueryResult {
-    /// Create from `QueryResult`.
     pub(crate) fn new(result: QueryResult) -> Self {
         Self { inner: result }
     }
 }
 
-/// Opaque query stream handle for FFI.
-///
-/// Provides streaming access to query results.
+/// Opaque handle for streaming query results.
 #[repr(C)]
 pub struct LaminarQueryStream {
     inner: QueryStream,
 }
 
 impl LaminarQueryStream {
-    /// Create from `QueryStream`.
     pub(crate) fn new(stream: QueryStream) -> Self {
         Self { inner: stream }
     }
 }
 
-/// Opaque record batch handle for FFI.
-///
-/// Wraps an Arrow `RecordBatch`. Create from query results, free with `laminar_batch_free`.
+/// Opaque Arrow `RecordBatch` handle. Free with `laminar_batch_free`.
 #[repr(C)]
 pub struct LaminarRecordBatch {
     inner: RecordBatch,
 }
 
 impl LaminarRecordBatch {
-    /// Create from `RecordBatch`.
     pub(crate) fn new(batch: RecordBatch) -> Self {
         Self { inner: batch }
     }
 
-    /// Consume and return inner `RecordBatch`.
     pub(crate) fn into_inner(self) -> RecordBatch {
         self.inner
     }
 
-    /// Get reference to inner `RecordBatch`.
     pub(crate) fn inner(&self) -> &RecordBatch {
         &self.inner
     }
 }
 
-// ============================================================================
-// Query Result Functions
-// ============================================================================
-
 /// Get the schema from a query result.
-///
-/// # Arguments
-///
-/// * `result` - Query result handle
-/// * `out` - Pointer to receive schema handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
 ///
 /// # Safety
 ///
-/// * `result` must be a valid query result handle
-/// * `out` must be a valid pointer
+/// `result` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_result_schema(
     result: *mut LaminarQueryResult,
@@ -96,30 +69,18 @@ pub unsafe extern "C" fn laminar_result_schema(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: result is non-null (checked above)
     let schema = unsafe { (*result).inner.schema() };
     let handle = Box::new(LaminarSchema::new(schema));
 
-    // SAFETY: out is non-null (checked above)
     unsafe { *out = Box::into_raw(handle) };
     LAMINAR_OK
 }
 
 /// Get the total row count from a query result.
 ///
-/// # Arguments
-///
-/// * `result` - Query result handle
-/// * `out` - Pointer to receive row count
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `result` must be a valid query result handle
-/// * `out` must be a valid pointer
+/// `result` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_result_num_rows(
     result: *mut LaminarQueryResult,
@@ -131,7 +92,6 @@ pub unsafe extern "C" fn laminar_result_num_rows(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: result and out are non-null (checked above)
     unsafe {
         *out = (*result).inner.num_rows();
     }
@@ -140,19 +100,9 @@ pub unsafe extern "C" fn laminar_result_num_rows(
 
 /// Get the number of batches in a query result.
 ///
-/// # Arguments
-///
-/// * `result` - Query result handle
-/// * `out` - Pointer to receive batch count
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `result` must be a valid query result handle
-/// * `out` must be a valid pointer
+/// `result` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_result_num_batches(
     result: *mut LaminarQueryResult,
@@ -164,7 +114,6 @@ pub unsafe extern "C" fn laminar_result_num_batches(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: result and out are non-null (checked above)
     unsafe {
         *out = (*result).inner.num_batches();
     }
@@ -173,21 +122,9 @@ pub unsafe extern "C" fn laminar_result_num_batches(
 
 /// Get a batch by index from a query result.
 ///
-/// # Arguments
-///
-/// * `result` - Query result handle
-/// * `index` - Batch index (0-based)
-/// * `out` - Pointer to receive batch handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `result` must be a valid query result handle
-/// * `index` must be less than the batch count
-/// * `out` must be a valid pointer
+/// `result` and `out` must be valid non-null pointers; `index` must be in range.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_result_get_batch(
     result: *mut LaminarQueryResult,
@@ -200,17 +137,13 @@ pub unsafe extern "C" fn laminar_result_get_batch(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: result is non-null (checked above)
     let result_ref = unsafe { &(*result).inner };
 
     if let Some(batch) = result_ref.batch(index) {
         let handle = Box::new(LaminarRecordBatch::new(batch.clone()));
-        // SAFETY: out is non-null (checked above)
         unsafe { *out = Box::into_raw(handle) };
         LAMINAR_OK
     } else {
-        // Index out of bounds
-        // SAFETY: out is non-null
         unsafe { *out = ptr::null_mut() };
         LAMINAR_ERR_NULL_POINTER
     }
@@ -218,40 +151,21 @@ pub unsafe extern "C" fn laminar_result_get_batch(
 
 /// Free a query result handle.
 ///
-/// # Arguments
-///
-/// * `result` - Query result handle to free
-///
 /// # Safety
 ///
 /// `result` must be a valid handle from a laminar function, or NULL.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_result_free(result: *mut LaminarQueryResult) {
     if !result.is_null() {
-        // SAFETY: result is non-null and was allocated by Box
         drop(unsafe { Box::from_raw(result) });
     }
 }
 
-// ============================================================================
-// Query Stream Functions
-// ============================================================================
-
 /// Get the schema from a query stream.
-///
-/// # Arguments
-///
-/// * `stream` - Query stream handle
-/// * `out` - Pointer to receive schema handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
 ///
 /// # Safety
 ///
-/// * `stream` must be a valid query stream handle
-/// * `out` must be a valid pointer
+/// `stream` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_stream_schema(
     stream: *mut LaminarQueryStream,
@@ -263,30 +177,18 @@ pub unsafe extern "C" fn laminar_stream_schema(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: stream is non-null (checked above)
     let schema = unsafe { (*stream).inner.schema() };
     let handle = Box::new(LaminarSchema::new(schema));
 
-    // SAFETY: out is non-null (checked above)
     unsafe { *out = Box::into_raw(handle) };
     LAMINAR_OK
 }
 
-/// Get the next batch from a query stream (blocking).
-///
-/// # Arguments
-///
-/// * `stream` - Query stream handle
-/// * `out` - Pointer to receive batch handle (NULL when stream exhausted)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Get the next batch from a query stream (blocking). Sets `*out` to NULL when exhausted.
 ///
 /// # Safety
 ///
-/// * `stream` must be a valid query stream handle
-/// * `out` must be a valid pointer
+/// `stream` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_stream_next(
     stream: *mut LaminarQueryStream,
@@ -298,24 +200,19 @@ pub unsafe extern "C" fn laminar_stream_next(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: stream is non-null (checked above)
     let stream_ref = unsafe { &mut (*stream).inner };
 
     match stream_ref.next() {
         Ok(Some(batch)) => {
             let handle = Box::new(LaminarRecordBatch::new(batch));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
         Ok(None) => {
-            // Stream exhausted
-            // SAFETY: out is non-null
             unsafe { *out = ptr::null_mut() };
             LAMINAR_OK
         }
         Err(e) => {
-            // SAFETY: out is non-null
             unsafe { *out = ptr::null_mut() };
             let code = e.code();
             set_last_error(e);
@@ -324,21 +221,11 @@ pub unsafe extern "C" fn laminar_stream_next(
     }
 }
 
-/// Try to get the next batch from a query stream (non-blocking).
-///
-/// # Arguments
-///
-/// * `stream` - Query stream handle
-/// * `out` - Pointer to receive batch handle (NULL if none available)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Try to get the next batch from a query stream (non-blocking). Sets `*out` to NULL if none available.
 ///
 /// # Safety
 ///
-/// * `stream` must be a valid query stream handle
-/// * `out` must be a valid pointer
+/// `stream` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_stream_try_next(
     stream: *mut LaminarQueryStream,
@@ -350,24 +237,19 @@ pub unsafe extern "C" fn laminar_stream_try_next(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: stream is non-null (checked above)
     let stream_ref = unsafe { &mut (*stream).inner };
 
     match stream_ref.try_next() {
         Ok(Some(batch)) => {
             let handle = Box::new(LaminarRecordBatch::new(batch));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
         Ok(None) => {
-            // No batch available
-            // SAFETY: out is non-null
             unsafe { *out = ptr::null_mut() };
             LAMINAR_OK
         }
         Err(e) => {
-            // SAFETY: out is non-null
             unsafe { *out = ptr::null_mut() };
             let code = e.code();
             set_last_error(e);
@@ -378,19 +260,9 @@ pub unsafe extern "C" fn laminar_stream_try_next(
 
 /// Check if a query stream is still active.
 ///
-/// # Arguments
-///
-/// * `stream` - Query stream handle
-/// * `out` - Pointer to receive result (true if active)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `stream` must be a valid query stream handle
-/// * `out` must be a valid pointer
+/// `stream` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_stream_is_active(
     stream: *mut LaminarQueryStream,
@@ -402,7 +274,6 @@ pub unsafe extern "C" fn laminar_stream_is_active(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: stream and out are non-null (checked above)
     unsafe {
         *out = (*stream).inner.is_active();
     }
@@ -410,14 +281,6 @@ pub unsafe extern "C" fn laminar_stream_is_active(
 }
 
 /// Cancel a query stream.
-///
-/// # Arguments
-///
-/// * `stream` - Query stream handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
 ///
 /// # Safety
 ///
@@ -430,7 +293,6 @@ pub unsafe extern "C" fn laminar_stream_cancel(stream: *mut LaminarQueryStream) 
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: stream is non-null (checked above)
     unsafe {
         (*stream).inner.cancel();
     }
@@ -439,40 +301,21 @@ pub unsafe extern "C" fn laminar_stream_cancel(stream: *mut LaminarQueryStream) 
 
 /// Free a query stream handle.
 ///
-/// # Arguments
-///
-/// * `stream` - Query stream handle to free
-///
 /// # Safety
 ///
 /// `stream` must be a valid handle from a laminar function, or NULL.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_stream_free(stream: *mut LaminarQueryStream) {
     if !stream.is_null() {
-        // SAFETY: stream is non-null and was allocated by Box
         drop(unsafe { Box::from_raw(stream) });
     }
 }
 
-// ============================================================================
-// Record Batch Functions
-// ============================================================================
-
 /// Get the number of rows in a record batch.
-///
-/// # Arguments
-///
-/// * `batch` - Record batch handle
-/// * `out` - Pointer to receive row count
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
 ///
 /// # Safety
 ///
-/// * `batch` must be a valid record batch handle
-/// * `out` must be a valid pointer
+/// `batch` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_num_rows(
     batch: *mut LaminarRecordBatch,
@@ -484,7 +327,6 @@ pub unsafe extern "C" fn laminar_batch_num_rows(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: batch and out are non-null (checked above)
     unsafe {
         *out = (*batch).inner.num_rows();
     }
@@ -493,19 +335,9 @@ pub unsafe extern "C" fn laminar_batch_num_rows(
 
 /// Get the number of columns in a record batch.
 ///
-/// # Arguments
-///
-/// * `batch` - Record batch handle
-/// * `out` - Pointer to receive column count
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `batch` must be a valid record batch handle
-/// * `out` must be a valid pointer
+/// `batch` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_num_columns(
     batch: *mut LaminarRecordBatch,
@@ -517,7 +349,6 @@ pub unsafe extern "C" fn laminar_batch_num_columns(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: batch and out are non-null (checked above)
     unsafe {
         *out = (*batch).inner.num_columns();
     }
@@ -526,17 +357,12 @@ pub unsafe extern "C" fn laminar_batch_num_columns(
 
 /// Free a record batch handle.
 ///
-/// # Arguments
-///
-/// * `batch` - Record batch handle to free
-///
 /// # Safety
 ///
 /// `batch` must be a valid handle from a laminar function, or NULL.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_batch_free(batch: *mut LaminarRecordBatch) {
     if !batch.is_null() {
-        // SAFETY: batch is non-null and was allocated by Box
         drop(unsafe { Box::from_raw(batch) });
     }
 }

--- a/crates/laminar-db/src/ffi/schema.rs
+++ b/crates/laminar-db/src/ffi/schema.rs
@@ -1,6 +1,4 @@
 //! FFI schema inspection functions.
-//!
-//! Provides `extern "C"` wrappers for schema inspection operations.
 
 use std::ffi::{c_char, CStr, CString};
 
@@ -20,13 +18,11 @@ pub struct LaminarSchema {
 }
 
 impl LaminarSchema {
-    /// Create from Arrow schema.
     pub(crate) fn new(schema: SchemaRef) -> Self {
         Self { inner: schema }
     }
 
-    /// Get inner schema reference.
-    #[allow(dead_code)] // Used for Arrow C Data Interface export
+    #[allow(dead_code)] // used in arrow_ffi
     pub(crate) fn schema(&self) -> &SchemaRef {
         &self.inner
     }
@@ -34,21 +30,9 @@ impl LaminarSchema {
 
 /// Get schema for a source.
 ///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `name` - Null-terminated source name
-/// * `out` - Pointer to receive schema handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `name` must be a valid null-terminated UTF-8 string
-/// * `out` must be a valid pointer
+/// `conn`, `name`, and `out` must be valid non-null pointers; `name` must be null-terminated UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_get_schema(
     conn: *mut LaminarConnection,
@@ -61,18 +45,15 @@ pub unsafe extern "C" fn laminar_get_schema(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: name is non-null (checked above)
     let Ok(name_str) = (unsafe { CStr::from_ptr(name) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.get_schema(name_str) {
         Ok(schema) => {
             let handle = Box::new(LaminarSchema::new(schema));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -84,23 +65,11 @@ pub unsafe extern "C" fn laminar_get_schema(
     }
 }
 
-/// List all sources as JSON array.
-///
-/// Returns a JSON array like `["source1", "source2"]`.
-///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `out` - Pointer to receive JSON string (caller frees with `laminar_string_free`)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// List all sources as a JSON array (e.g., `["src1","src2"]`). Caller frees with `laminar_string_free`.
 ///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `out` must be a valid pointer
+/// `conn` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_list_sources(
     conn: *mut LaminarConnection,
@@ -112,7 +81,6 @@ pub unsafe extern "C" fn laminar_list_sources(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     let sources = conn_ref.list_sources();
@@ -127,7 +95,6 @@ pub unsafe extern "C" fn laminar_list_sources(
 
     match CString::new(json) {
         Ok(c_str) => {
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = take_ownership_string(c_str) };
             LAMINAR_OK
         }
@@ -137,19 +104,9 @@ pub unsafe extern "C" fn laminar_list_sources(
 
 /// Get the number of fields in a schema.
 ///
-/// # Arguments
-///
-/// * `schema` - Schema handle
-/// * `out` - Pointer to receive field count
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `schema` must be a valid schema handle
-/// * `out` must be a valid pointer
+/// `schema` and `out` must be valid non-null pointers.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_schema_num_fields(
     schema: *mut LaminarSchema,
@@ -161,30 +118,17 @@ pub unsafe extern "C" fn laminar_schema_num_fields(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: schema and out are non-null (checked above)
     unsafe {
         *out = (*schema).inner.fields().len();
     }
     LAMINAR_OK
 }
 
-/// Get the name of a field by index.
-///
-/// # Arguments
-///
-/// * `schema` - Schema handle
-/// * `index` - Field index (0-based)
-/// * `out` - Pointer to receive field name (caller frees with `laminar_string_free`)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Get the name of a field by index. Caller frees the result with `laminar_string_free`.
 ///
 /// # Safety
 ///
-/// * `schema` must be a valid schema handle
-/// * `index` must be less than the number of fields
-/// * `out` must be a valid pointer
+/// `schema` and `out` must be valid non-null pointers; `index` must be in range.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_schema_field_name(
     schema: *mut LaminarSchema,
@@ -197,17 +141,15 @@ pub unsafe extern "C" fn laminar_schema_field_name(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: schema is non-null (checked above)
     let schema_ref = unsafe { &(*schema).inner };
 
     if index >= schema_ref.fields().len() {
-        return LAMINAR_ERR_NULL_POINTER; // Index out of bounds
+        return LAMINAR_ERR_NULL_POINTER;
     }
 
     let name = schema_ref.field(index).name();
     match CString::new(name.as_str()) {
         Ok(c_str) => {
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = take_ownership_string(c_str) };
             LAMINAR_OK
         }
@@ -215,25 +157,11 @@ pub unsafe extern "C" fn laminar_schema_field_name(
     }
 }
 
-/// Get the type of a field by index.
-///
-/// Returns the Arrow data type as a string (e.g., "Int64", "Utf8", "Float64").
-///
-/// # Arguments
-///
-/// * `schema` - Schema handle
-/// * `index` - Field index (0-based)
-/// * `out` - Pointer to receive type name (caller frees with `laminar_string_free`)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Get the Arrow data type of a field by index as a string. Caller frees with `laminar_string_free`.
 ///
 /// # Safety
 ///
-/// * `schema` must be a valid schema handle
-/// * `index` must be less than the number of fields
-/// * `out` must be a valid pointer
+/// `schema` and `out` must be valid non-null pointers; `index` must be in range.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_schema_field_type(
     schema: *mut LaminarSchema,
@@ -246,18 +174,16 @@ pub unsafe extern "C" fn laminar_schema_field_type(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: schema is non-null (checked above)
     let schema_ref = unsafe { &(*schema).inner };
 
     if index >= schema_ref.fields().len() {
-        return LAMINAR_ERR_NULL_POINTER; // Index out of bounds
+        return LAMINAR_ERR_NULL_POINTER;
     }
 
     let data_type = schema_ref.field(index).data_type();
     let type_str = format!("{data_type:?}");
     match CString::new(type_str) {
         Ok(c_str) => {
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = take_ownership_string(c_str) };
             LAMINAR_OK
         }
@@ -267,17 +193,12 @@ pub unsafe extern "C" fn laminar_schema_field_type(
 
 /// Free a schema handle.
 ///
-/// # Arguments
-///
-/// * `schema` - Schema handle to free
-///
 /// # Safety
 ///
 /// `schema` must be a valid handle from a laminar function, or NULL.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_schema_free(schema: *mut LaminarSchema) {
     if !schema.is_null() {
-        // SAFETY: schema is non-null and was allocated by Box
         drop(unsafe { Box::from_raw(schema) });
     }
 }

--- a/crates/laminar-db/src/ffi/writer.rs
+++ b/crates/laminar-db/src/ffi/writer.rs
@@ -1,6 +1,4 @@
 //! FFI writer functions.
-//!
-//! Provides `extern "C"` wrappers for data ingestion operations.
 
 use std::ffi::{c_char, CStr};
 
@@ -20,7 +18,6 @@ pub struct LaminarWriter {
 }
 
 impl LaminarWriter {
-    /// Create from Writer.
     fn new(writer: Writer) -> Self {
         Self {
             inner: Some(writer),
@@ -30,21 +27,10 @@ impl LaminarWriter {
 
 /// Create a writer for a source.
 ///
-/// # Arguments
-///
-/// * `conn` - Database connection
-/// * `source_name` - Null-terminated source name
-/// * `out` - Pointer to receive writer handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
-/// * `conn` must be a valid connection handle
-/// * `source_name` must be a valid null-terminated UTF-8 string
-/// * `out` must be a valid pointer
+/// `conn`, `source_name`, and `out` must be valid non-null pointers;
+/// `source_name` must be null-terminated UTF-8.
 #[no_mangle]
 pub unsafe extern "C" fn laminar_writer_create(
     conn: *mut LaminarConnection,
@@ -57,18 +43,15 @@ pub unsafe extern "C" fn laminar_writer_create(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: source_name is non-null (checked above)
     let Ok(name_str) = (unsafe { CStr::from_ptr(source_name) }).to_str() else {
         return LAMINAR_ERR_INVALID_UTF8;
     };
 
-    // SAFETY: conn is non-null (checked above)
     let conn_ref = unsafe { &(*conn).inner };
 
     match conn_ref.writer(name_str) {
         Ok(writer) => {
             let handle = Box::new(LaminarWriter::new(writer));
-            // SAFETY: out is non-null (checked above)
             unsafe { *out = Box::into_raw(handle) };
             LAMINAR_OK
         }
@@ -80,21 +63,11 @@ pub unsafe extern "C" fn laminar_writer_create(
     }
 }
 
-/// Write a record batch to the source.
-///
-/// # Arguments
-///
-/// * `writer` - Writer handle
-/// * `batch` - Record batch to write (ownership is transferred)
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Write a record batch to the source. Ownership of `batch` is transferred.
 ///
 /// # Safety
 ///
-/// * `writer` must be a valid writer handle
-/// * `batch` must be a valid record batch handle (will be consumed)
+/// `writer` must be a valid writer handle; `batch` must be a valid non-null handle (consumed).
 #[no_mangle]
 pub unsafe extern "C" fn laminar_writer_write(
     writer: *mut LaminarWriter,
@@ -106,11 +79,9 @@ pub unsafe extern "C" fn laminar_writer_write(
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: batch is non-null (checked above), take ownership
     let batch_box = unsafe { Box::from_raw(batch) };
     let record_batch = batch_box.into_inner();
 
-    // SAFETY: writer is non-null (checked above)
     let writer_ref = unsafe { &mut (*writer).inner };
 
     if let Some(w) = writer_ref.as_mut() {
@@ -130,14 +101,6 @@ pub unsafe extern "C" fn laminar_writer_write(
 
 /// Flush buffered data.
 ///
-/// # Arguments
-///
-/// * `writer` - Writer handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
-///
 /// # Safety
 ///
 /// `writer` must be a valid writer handle.
@@ -149,7 +112,6 @@ pub unsafe extern "C" fn laminar_writer_flush(writer: *mut LaminarWriter) -> i32
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: writer is non-null (checked above)
     let writer_ref = unsafe { &mut (*writer).inner };
 
     if let Some(w) = writer_ref.as_mut() {
@@ -167,18 +129,7 @@ pub unsafe extern "C" fn laminar_writer_flush(writer: *mut LaminarWriter) -> i32
     }
 }
 
-/// Close the writer and release resources.
-///
-/// After calling this, the writer handle can still be freed with `laminar_writer_free`,
-/// but no more writes are allowed.
-///
-/// # Arguments
-///
-/// * `writer` - Writer handle
-///
-/// # Returns
-///
-/// `LAMINAR_OK` on success, or an error code.
+/// Close the writer. The handle may still be freed with `laminar_writer_free` afterward.
 ///
 /// # Safety
 ///
@@ -191,7 +142,6 @@ pub unsafe extern "C" fn laminar_writer_close(writer: *mut LaminarWriter) -> i32
         return LAMINAR_ERR_NULL_POINTER;
     }
 
-    // SAFETY: writer is non-null (checked above)
     let writer_ref = unsafe { &mut (*writer).inner };
 
     match writer_ref.take() {
@@ -203,18 +153,11 @@ pub unsafe extern "C" fn laminar_writer_close(writer: *mut LaminarWriter) -> i32
                 code
             }
         },
-        None => {
-            // Already closed, that's fine
-            LAMINAR_OK
-        }
+        None => LAMINAR_OK,
     }
 }
 
 /// Free a writer handle.
-///
-/// # Arguments
-///
-/// * `writer` - Writer handle to free
 ///
 /// # Safety
 ///
@@ -222,7 +165,6 @@ pub unsafe extern "C" fn laminar_writer_close(writer: *mut LaminarWriter) -> i32
 #[no_mangle]
 pub unsafe extern "C" fn laminar_writer_free(writer: *mut LaminarWriter) {
     if !writer.is_null() {
-        // SAFETY: writer is non-null and was allocated by Box
         drop(unsafe { Box::from_raw(writer) });
     }
 }

--- a/crates/laminar-db/src/filter_compile.rs
+++ b/crates/laminar-db/src/filter_compile.rs
@@ -14,9 +14,7 @@ use crate::error::DbError;
 
 static COMPILE_SEQ: AtomicU64 = AtomicU64::new(0);
 
-/// Registers a temporary table on construction and deregisters on drop, so a
-/// concurrent compile or an early return can never leak the registration onto
-/// the shared `SessionContext`.
+/// RAII guard that registers a temp table and deregisters it on drop.
 struct ScopedTable<'a> {
     ctx: &'a SessionContext,
     name: String,
@@ -42,9 +40,7 @@ impl Drop for ScopedTable<'_> {
     }
 }
 
-/// Compile `filter_sql` into a `PhysicalExpr` against `schema`. Each failure
-/// (planner, predicate extraction, physical lowering) is reported with enough
-/// context that the caller can surface a meaningful message to the user.
+/// Compile `filter_sql` into a `PhysicalExpr` against `schema`.
 pub(crate) async fn compile(
     ctx: &SessionContext,
     filter_sql: &str,
@@ -58,8 +54,7 @@ pub(crate) async fn compile(
         .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}': {e}")))?
         .logical_plan()
         .clone();
-    // The predicate columns are qualified by the temp table name; capture
-    // that qualifier into the DFSchema before dropping `scoped`.
+    // Capture the temp-table qualifier into the DFSchema before dropping `scoped`.
     let df_schema = DFSchema::try_from_qualified_schema(scoped.name.as_str(), schema.as_ref())
         .map_err(|e| DbError::Pipeline(format!("filter '{filter_sql}' (df_schema): {e}")))?;
     drop(scoped);
@@ -83,7 +78,7 @@ fn find_predicate(plan: &LogicalPlan) -> Option<Expr> {
     }
 }
 
-/// Apply a compiled boolean predicate. `Ok(None)` if every row is filtered out.
+/// Apply a compiled boolean predicate; `Ok(None)` if every row is filtered out.
 pub(crate) fn apply(
     batch: &RecordBatch,
     expr: &dyn PhysicalExpr,

--- a/crates/laminar-db/src/interval_join.rs
+++ b/crates/laminar-db/src/interval_join.rs
@@ -1,13 +1,7 @@
 #![deny(clippy::disallowed_types)]
 
-//! Stream-stream interval join execution.
-//!
-//! Implements a stateful interval join that buffers rows from both sides
-//! across execution cycles, matching any pair where
-//! `|left_ts - right_ts| <= time_bound_ms`. Expired rows are evicted
-//! when the watermark advances beyond `time_bound_ms`.
-//!
-//! The join state is checkpointed via Arrow IPC serialization.
+//! Stream-stream interval join: buffers both sides and matches pairs where
+//! `|left_ts - right_ts| <= time_bound_ms`. Evicts expired rows on watermark advance.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -23,23 +17,16 @@ use crate::aggregate_state::JoinStateCheckpoint;
 use crate::error::DbError;
 use crate::key_column::{extract_column_as_timestamps, extract_key_column, KeyColumn};
 
-/// Compact when accumulated batch count exceeds this threshold.
 const COMPACTION_THRESHOLD: usize = 32;
 
-/// Flush partial output once the match buffer reaches this many pairs.
-/// Bounds memory on cross-product shapes.
+/// Caps memory on cross-product shapes.
 const EMIT_THRESHOLD: usize = 65_536;
 
-/// Index type: `key_hash` → sorted `timestamp` → list of `(batch_idx, row_idx)`.
 type SideIndex = FxHashMap<u64, BTreeMap<i64, Vec<(usize, usize)>>>;
 
-/// Per-side state for interval join, persisted across cycles.
 pub(crate) struct SideState {
-    /// Accumulated batches from previous cycles, compacted periodically.
     batches: Vec<RecordBatch>,
-    /// Index: `key_hash` → `BTreeMap<timestamp, Vec<(batch_idx, row_idx)>>`
     index: SideIndex,
-    /// Total buffered rows.
     row_count: usize,
 }
 
@@ -52,7 +39,6 @@ impl SideState {
         }
     }
 
-    /// Add a batch and index its rows.
     pub(crate) fn add_batch(
         &mut self,
         batch: &RecordBatch,
@@ -77,14 +63,13 @@ impl SideState {
                     .push((batch_idx, row_idx));
                 indexed_rows += 1;
             }
-            // Null keys are skipped per SQL three-valued logic
+            // null keys never match (SQL three-valued logic)
         }
         self.row_count += indexed_rows;
         self.batches.push(batch.clone());
         Ok(())
     }
 
-    /// Remove entries matching `(key_hash, timestamp)` with verified key equality.
     pub(crate) fn remove_by_key_ts(
         &mut self,
         key_hash: u64,
@@ -100,7 +85,7 @@ impl SideState {
             return Ok(());
         };
 
-        // `Vec::retain` can't surface errors, so do it by hand.
+        // Vec::retain can't surface errors.
         let mut kept: Vec<(usize, usize)> = Vec::with_capacity(entries.len());
         for &(batch_idx, row_idx) in entries.iter() {
             let stored_key = extract_key_column(&self.batches[batch_idx], key_col_name)?;
@@ -120,31 +105,23 @@ impl SideState {
         Ok(())
     }
 
-    /// Evict all rows with `ts < cutoff`, then compact if batch count exceeds threshold.
     fn evict_before(&mut self, cutoff: i64, key_col: &str, time_col: &str) -> Result<(), DbError> {
-        // Collect entries to remove from each btree
         for btree in self.index.values_mut() {
-            // BTreeMap::split_off returns entries >= cutoff; we keep those.
             let keep = btree.split_off(&cutoff);
-            // Count evicted rows
             for entries in btree.values() {
                 self.row_count = self.row_count.saturating_sub(entries.len());
             }
             *btree = keep;
         }
-        // Remove empty btrees
         self.index.retain(|_, btree| !btree.is_empty());
 
-        // Compact when too many batches have accumulated (dead rows waste memory)
         if self.batches.len() > COMPACTION_THRESHOLD {
             self.compact(key_col, time_col)?;
         }
         Ok(())
     }
 
-    /// Compact all live rows into a single batch, freeing dead batch memory.
     fn compact(&mut self, key_col: &str, time_col: &str) -> Result<(), DbError> {
-        // Collect all live (batch_idx, row_idx) from the index
         let mut live_rows: Vec<(usize, usize)> = Vec::with_capacity(self.row_count);
         for btree in self.index.values() {
             for entries in btree.values() {
@@ -157,10 +134,8 @@ impl SideState {
             return Ok(());
         }
 
-        // Sort by (batch_idx, row_idx) for sequential access
         live_rows.sort_unstable();
 
-        // One `take` per source batch over the contiguous run of live rows.
         let mut taken: Vec<RecordBatch> = Vec::new();
         let mut i = 0;
         while i < live_rows.len() {
@@ -193,7 +168,6 @@ impl SideState {
         let compacted = concat_batches(&schema, &taken)
             .map_err(|e| DbError::query_pipeline_arrow("interval join (compact)", &e))?;
 
-        // Replace batches and rebuild index
         self.batches = vec![compacted];
         self.index.clear();
 
@@ -214,20 +188,16 @@ impl SideState {
     }
 }
 
-/// Complete interval join state for one query.
+/// Per-query interval join state.
 pub(crate) struct IntervalJoinState {
     pub(crate) left: SideState,
     pub(crate) right: SideState,
-    /// Last cutoff used for left-side eviction (derived from right watermark).
     left_evicted_cutoff: i64,
-    /// Last cutoff used for right-side eviction (derived from left watermark).
     right_evicted_cutoff: i64,
-    /// Output schema (left cols + right cols).
     output_schema: Option<SchemaRef>,
 }
 
 impl IntervalJoinState {
-    /// Create empty state.
     pub(crate) fn new() -> Self {
         Self {
             left: SideState::new(),
@@ -238,7 +208,6 @@ impl IntervalJoinState {
         }
     }
 
-    /// Estimated total memory usage in bytes.
     pub(crate) fn estimated_size_bytes(&self) -> usize {
         let mut size = 0usize;
         for b in &self.left.batches {
@@ -247,15 +216,13 @@ impl IntervalJoinState {
         for b in &self.right.batches {
             size += b.get_array_memory_size();
         }
-        // Rough estimate: index overhead ~64 bytes per entry
         let index_entries: usize = self.left.index.values().map(BTreeMap::len).sum::<usize>()
             + self.right.index.values().map(BTreeMap::len).sum::<usize>();
         size += index_entries * 64;
         size
     }
 
-    /// Serialize to checkpoint. Compacts both sides first so that only live
-    /// rows are serialized (dead/evicted rows in old batches are discarded).
+    /// Compacts both sides before serialization to avoid checkpointing dead rows.
     pub(crate) fn snapshot_checkpoint(
         &mut self,
         left_key: &str,
@@ -263,7 +230,6 @@ impl IntervalJoinState {
         right_key: &str,
         right_time: &str,
     ) -> Result<JoinStateCheckpoint, DbError> {
-        // Compact before serialization to avoid checkpointing dead rows
         if !self.left.batches.is_empty() {
             self.left.compact(left_key, left_time)?;
         }
@@ -303,8 +269,7 @@ impl IntervalJoinState {
         })
     }
 
-    /// Restore from a checkpoint. The index is rebuilt from the deserialized
-    /// batches using the provided key/time column names.
+    /// Restores from a checkpoint, rebuilding the index from deserialized batches.
     pub(crate) fn from_checkpoint(
         cp: &JoinStateCheckpoint,
         left_key_col: &str,
@@ -338,11 +303,8 @@ impl IntervalJoinState {
     }
 }
 
-/// Build the merged output schema from left and right schemas.
-/// The joined output schema: left fields, then right fields suffixed with
-/// `_{right_table}`. Shared with the processing-time join so both produce the
-/// column names the residual projection (built by `build_stream_join_projection_sql`)
-/// expects.
+/// Left fields then right fields suffixed with `_{right_table}`.
+/// Shared with the processing-time join to match the residual projection column names.
 pub(crate) fn build_output_schema(
     left_schema: &SchemaRef,
     right_schema: &SchemaRef,
@@ -388,9 +350,7 @@ pub(crate) fn build_output_schema(
     Arc::new(Schema::new(fields))
 }
 
-/// Probe one side's index for matches against a single row from the other side.
-///
-/// Returns all `(batch_idx, row_idx)` where `|probe_ts - candidate_ts| <= bound_ms`.
+/// All `(batch_idx, row_idx)` where `|probe_ts - candidate_ts| <= bound_ms`.
 fn probe_index(
     index: &SideIndex,
     key_hash: u64,
@@ -409,8 +369,6 @@ fn probe_index(
     results
 }
 
-/// Drain `match_pairs` into one output batch via `arrow::compute::interleave` —
-/// one call per column, no per-row slice + concat.
 fn flush_match_pairs(
     match_pairs: &mut Vec<(usize, usize, usize, usize)>,
     output_schema: &SchemaRef,
@@ -470,12 +428,7 @@ fn flush_match_pairs(
     Ok(())
 }
 
-/// Execute one cycle of an interval join.
-///
-/// Bounds are inclusive: `|left_ts - right_ts| <= bound_ms`. NULL keys are
-/// skipped. New left rows probe all right; new right rows probe only old left
-/// (avoids double-emit). State is compacted on eviction when batch count
-/// exceeds `COMPACTION_THRESHOLD`.
+/// One cycle: new left rows probe all right; new right rows probe only old left (avoids double-emit).
 #[allow(clippy::too_many_lines)]
 pub(crate) fn execute_interval_join_cycle(
     state: &mut IntervalJoinState,
@@ -523,7 +476,7 @@ pub(crate) fn execute_interval_join_cycle(
         }
     }
 
-    // A pure-delete CDC batch yields zero positive rows; treat it as None
+    // A pure-delete CDC batch has zero positive rows; treat it as None
     // so new_*_batch_idx never points past the end of state.
     let concat_nonempty =
         |slices: &[RecordBatch], side: &str| -> Result<Option<RecordBatch>, DbError> {
@@ -538,9 +491,8 @@ pub(crate) fn execute_interval_join_cycle(
     let new_left = concat_nonempty(&left_pos, "interval join (left concat)")?;
     let new_right = concat_nonempty(&right_pos, "interval join (right concat)")?;
 
-    // Buffer before probing so every (batch_idx, row_idx) we produce already
-    // points into state.batches — lets flush_match_pairs run mid-probe
-    // without juggling in-flight batch references.
+    // Buffer first so every (batch_idx, row_idx) already points into state.batches,
+    // letting flush_match_pairs run mid-probe without juggling in-flight references.
     let left_old_count = state.left.batches.len();
     let right_old_count = state.right.batches.len();
     if let Some(ref rb) = new_right {
@@ -561,7 +513,6 @@ pub(crate) fn execute_interval_join_cycle(
         StreamJoinType::LeftSemi | StreamJoinType::LeftAnti
     );
 
-    // Refresh the output schema once both sides have been seen.
     {
         let left_schema = state.left.batches.first().map(RecordBatch::schema);
         let right_schema = state.right.batches.first().map(RecordBatch::schema);
@@ -587,11 +538,8 @@ pub(crate) fn execute_interval_join_cycle(
     let is_anti = config.join_type == StreamJoinType::LeftAnti;
     let mut result: Vec<RecordBatch> = Vec::new();
 
-    // Borrow batches immutably for the probe; eviction below needs &mut so
-    // the cached key columns must drop first.
     {
-        // One KeyColumn per buffered batch — saves a schema lookup +
-        // downcast per candidate inside the inner probe loops.
+        // One KeyColumn per buffered batch — avoids a schema lookup + downcast per candidate.
         let left_key_cols: Vec<KeyColumn<'_>> = state
             .left
             .batches
@@ -605,7 +553,6 @@ pub(crate) fn execute_interval_join_cycle(
             .map(|b| extract_key_column(b, &config.right_key))
             .collect::<Result<_, _>>()?;
 
-        // Anti emits only at eviction; don't bother accumulating pairs we'll discard.
         let collect_pairs = !is_anti;
         let mut match_pairs: Vec<(usize, usize, usize, usize)> = Vec::new();
         let mut semi_matched: FxHashSet<usize> = FxHashSet::default();
@@ -627,7 +574,7 @@ pub(crate) fn execute_interval_join_cycle(
             )
         };
 
-        // Step 1: probe new left rows against all right (old + new).
+        // Probe new left against all right (old + new).
         if new_left.is_some() {
             let lb_kc = &left_key_cols[new_left_batch_idx];
             let lb_ts = extract_column_as_timestamps(
@@ -662,8 +609,7 @@ pub(crate) fn execute_interval_join_cycle(
             }
         }
 
-        // Step 2: probe new right rows against OLD left rows only — new_left ×
-        // new_right pairs were already produced in step 1.
+        // Probe new right against OLD left only — new_left × new_right already covered above.
         if new_right.is_some() {
             let rb_kc = &right_key_cols[new_right_batch_idx];
             let rb_ts = extract_column_as_timestamps(
@@ -694,8 +640,7 @@ pub(crate) fn execute_interval_join_cycle(
 
         flush(&mut match_pairs, &mut result)?;
 
-        // Step 3: emit unmatched rows about to be evicted (LEFT/RIGHT/FULL/ANTI).
-        // Runs before eviction so the opposite side's state is still complete.
+        // Emit unmatched rows about to be evicted — must run before eviction.
         if matches!(
             config.join_type,
             StreamJoinType::Left | StreamJoinType::Full | StreamJoinType::LeftAnti
@@ -731,9 +676,7 @@ pub(crate) fn execute_interval_join_cycle(
         }
     }
 
-    // Step 4: evict. A left row at ts can only still match right rows with
-    // ts in [left_ts - bound, left_ts + bound], so once the right watermark
-    // passes left_ts + bound it's safe to drop. Symmetric for right.
+    // A left row at ts is evictable once the right watermark passes ts + bound. Symmetric for right.
     let left_cutoff = right_watermark.saturating_sub(bound_ms);
     if left_cutoff > state.left_evicted_cutoff {
         state
@@ -752,8 +695,7 @@ pub(crate) fn execute_interval_join_cycle(
     Ok(result)
 }
 
-/// LEFT/ANTI: emit pre-eviction left rows with no match in current right state.
-/// Output is chunked at `EMIT_THRESHOLD` rows.
+/// LEFT/ANTI: emit pre-eviction left rows with no match in right state.
 fn emit_unmatched_left_rows(
     state: &IntervalJoinState,
     left_key_cols: &[KeyColumn<'_>],
@@ -841,7 +783,6 @@ fn emit_unmatched_left_rows(
     Ok(())
 }
 
-/// RIGHT/FULL: symmetric to `emit_unmatched_left_rows`.
 fn emit_unmatched_right_rows(
     state: &IntervalJoinState,
     left_key_cols: &[KeyColumn<'_>],

--- a/crates/laminar-db/src/key_column.rs
+++ b/crates/laminar-db/src/key_column.rs
@@ -63,7 +63,7 @@ impl KeyColumn<'_> {
             (KeyColumn::Utf8(a), KeyColumn::Utf8(b)) => a.value(i) == b.value(j),
             (KeyColumn::Int64(a), KeyColumn::Int64(b)) => a.value(i) == b.value(j),
             (KeyColumn::Timestamp(a), KeyColumn::Timestamp(b)) => a.value(i) == b.value(j),
-            // Cross-type: Int64 epoch-ms ↔ Timestamp(ms) match by value.
+            // Int64 epoch-ms and Timestamp(ms) compare equal by value.
             (KeyColumn::Int64(a), KeyColumn::Timestamp(b)) => a.value(i) == b.value(j),
             (KeyColumn::Timestamp(a), KeyColumn::Int64(b)) => a.value(i) == b.value(j),
             _ => false,
@@ -93,9 +93,7 @@ pub(crate) fn extract_key_column<'a>(
                 .downcast_ref::<Int64Array>()
                 .ok_or_else(|| DbError::Pipeline(format!("Column '{col_name}' is not Int64")))?,
         )),
-        // Any Timestamp time-unit and timezone — normalised to ms via the
-        // shared cast helper. Cross-type Int64↔Timestamp equality is
-        // handled in `eq_at`.
+        // Any Timestamp variant — normalised to ms; cross-type equality handled in `eq_at`.
         DataType::Timestamp(_, _) => {
             let normalised = cast_to_millis_array(array.as_ref()).map_err(|e| {
                 DbError::Pipeline(format!("Column '{col_name}' timestamp cast: {e}"))

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -129,6 +129,8 @@ pub use handle::{
     PipelineNodeType, PipelineTopology, QueryHandle, QueryInfo, SinkInfo, SourceHandle, SourceInfo,
     StreamInfo, TypedSubscription, UntypedSourceHandle,
 };
+#[cfg(feature = "state-tier")]
+pub use metrics::TierMetrics;
 pub use metrics::{PipelineMetrics, PipelineState, SourceMetrics, StreamMetrics};
 pub use profile::{Profile, ProfileError};
 pub use recovery_manager::{RecoveredState, RecoveryManager, VnodeRehydration, VnodeRehydrator};

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -84,6 +84,9 @@ mod show_commands;
 mod sink_task;
 mod sql_analysis;
 mod sql_utils;
+/// Disk cold tier for demoted operator state.
+#[cfg(feature = "state-tier")]
+mod state_tier;
 /// External `SUBSCRIBE` substrate: per-name broadcast channel and the
 /// per-portal pump task.
 pub mod subscription;

--- a/crates/laminar-db/src/metrics.rs
+++ b/crates/laminar-db/src/metrics.rs
@@ -60,6 +60,22 @@ pub struct PipelineMetrics {
     pub mv_bytes_stored: u64,
 }
 
+/// Cold-tier (demoted operator state) metrics. Embedded mode has no
+/// `/metrics` endpoint, so this is the way to observe demotion/promotion on a
+/// single node.
+#[cfg(feature = "state-tier")]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TierMetrics {
+    /// Effective demotions — slices that actually left memory for the tier.
+    pub demote_total: u64,
+    /// Promotion fetches — cold slices read back into memory.
+    pub fetch_total: u64,
+    /// Logical bytes currently resident in the tier.
+    pub resident_bytes: i64,
+    /// Slices currently resident in the tier.
+    pub resident_slices: i64,
+}
+
 /// Metrics for a single registered source.
 #[derive(Debug, Clone)]
 pub struct SourceMetrics {

--- a/crates/laminar-db/src/metrics_api.rs
+++ b/crates/laminar-db/src/metrics_api.rs
@@ -84,6 +84,25 @@ impl LaminarDB {
         }
     }
 
+    /// Cold-tier demotion/promotion metrics — the embedded equivalent of the
+    /// server's `laminardb_state_tier_*` gauges. All zero until the tier is
+    /// active.
+    #[cfg(feature = "state-tier")]
+    #[must_use]
+    pub fn tier_metrics(&self) -> crate::metrics::TierMetrics {
+        let guard = self.engine_metrics.lock();
+        guard
+            .as_ref()
+            .map_or_else(crate::metrics::TierMetrics::default, |m| {
+                crate::metrics::TierMetrics {
+                    demote_total: m.state_tier_demote_total.get(),
+                    fetch_total: m.state_tier_fetch_total.get(),
+                    resident_bytes: m.state_tier_bytes.get(),
+                    resident_slices: m.state_tier_slices.get(),
+                }
+            })
+    }
+
     /// Get metrics for a single source by name.
     #[must_use]
     pub fn source_metrics(&self, name: &str) -> Option<crate::metrics::SourceMetrics> {

--- a/crates/laminar-db/src/mv_store.rs
+++ b/crates/laminar-db/src/mv_store.rs
@@ -1,7 +1,4 @@
-//! Materialized view result storage.
-//!
-//! Stores the latest results for each materialized view so they can be
-//! queried via `SELECT * FROM mv_name`.
+//! Materialized view result storage, queryable via `SELECT * FROM mv_name`.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::{HashMap, VecDeque};
@@ -24,7 +21,7 @@ const DEFAULT_MAX_BYTES: usize = 256 * 1024 * 1024;
 /// How a materialized view accumulates results.
 #[derive(Debug, Clone)]
 pub(crate) enum MvStorageMode {
-    /// GROUP BY queries: replace entire result set per cycle.
+    /// GROUP BY queries: replace the result set each cycle.
     Aggregate,
     /// Non-aggregate queries: append with bounded retention.
     Append { max_batches: usize },
@@ -91,13 +88,10 @@ impl MvEntry {
     }
 }
 
-/// Store for all materialized view results.
-///
-/// Shared between the compute thread (writes) and query threads (reads)
-/// via `Arc<parking_lot::RwLock<MvStore>>`.
+/// Store for all materialized view results; shared via `Arc<RwLock<MvStore>>`.
 pub(crate) struct MvStore {
     entries: HashMap<String, MvEntry>,
-    /// Mirrors `!entries.is_empty()`; lets the hot path skip the write lock.
+    /// Lets the hot path skip the write lock when no MVs exist.
     has_any: Arc<AtomicBool>,
 }
 
@@ -145,8 +139,7 @@ impl MvStore {
         self.entries.values().map(|e| e.approx_bytes).sum()
     }
 
-    /// Returns per-MV IPC-serialized bytes for checkpoint.
-    /// Each entry is keyed `"mv:{name}"` for use in the `operator_states` map.
+    /// Serialize all MV results for checkpoint; keys are `"mv:{name}"`.
     pub fn checkpoint_states(&self) -> Result<HashMap<String, bytes::Bytes>, DbError> {
         let mut out = HashMap::new();
         for (name, entry) in &self.entries {
@@ -159,16 +152,14 @@ impl MvStore {
         Ok(out)
     }
 
-    /// Restore a single MV from checkpoint IPC bytes.
-    /// Returns `Ok(true)` if restored, `Ok(false)` if the MV is no longer registered.
+    /// Restore a single MV from checkpoint IPC bytes; `Ok(false)` if not registered.
     pub fn restore_from_ipc(&mut self, name: &str, bytes: &[u8]) -> Result<bool, DbError> {
         let Some(entry) = self.entries.get_mut(name) else {
             return Ok(false);
         };
         let batches = ipc_to_batches(bytes)
             .map_err(|e| DbError::Storage(format!("MV restore '{name}': {e}")))?;
-        // Validate schema compatibility — reject stale checkpoints from
-        // before a schema change rather than panicking in concat_batches.
+        // Reject stale checkpoints from before a schema change rather than panicking later.
         if let Some(first) = batches.first() {
             if first.schema() != entry.schema {
                 return Err(DbError::Storage(format!(

--- a/crates/laminar-db/src/operator/ai_inference.rs
+++ b/crates/laminar-db/src/operator/ai_inference.rs
@@ -1,27 +1,9 @@
 //! Async-decoupled AI inference operator.
 //!
-//! This is the one operator that does not do its work inside `process`.
-//! `GraphOperator::process` runs on the `laminar-compute` thread (Ring 0), where
-//! network and blocking calls are forbidden, so the model call cannot happen
-//! there. Instead `process` is **decoupled across cycles**:
-//!
-//! - serve cache hits inline (a memory lookup);
-//! - hand cache misses to the Ring 1 worker over a bounded channel and return;
-//! - drain whatever results the worker has completed since the last cycle and
-//!   emit those batches.
-//!
-//! Crucially, `process` contains no `await` on the inference path — it only does
-//! synchronous channel and Arrow work — so it provably cannot block on a model
-//! call. Enriched rows are therefore emitted in a later cycle than they arrived
-//! (see the checkpoint handling for how in-flight rows survive recovery).
-//!
-//! Backpressure: once in-flight misses exceed a cap, `wants_input` returns
-//! false, so the graph stops draining this node's input buffer and the source
-//! is throttled through the existing input-buffer gate (effective when
-//! input-buffer caps are configured). The output watermark is held behind the
-//! oldest in-flight batch (`watermark_hold`) so async-enriched rows aren't
-//! dropped as late by a downstream window. `estimated_state_bytes` reports
-//! retained input batches plus queued miss text.
+//! Cache hits serve inline; misses go to a Ring 1 worker over a bounded channel
+//! and emit in a later cycle. `process` never awaits on the inference path.
+//! Backpressure via `wants_input`; output watermark held behind oldest in-flight
+//! batch so enriched rows aren't dropped late by a downstream window.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -48,44 +30,31 @@ use crate::error::DbError;
 use crate::operator::ProjectingJoinState;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 
-/// Temp table the enriched batch is registered under for the residual
-/// projection. Must match `sql_analysis`'s `AI_TMP_TABLE` (the generated
-/// `projection_sql` reads from this name).
+/// Must match `sql_analysis::AI_TMP_TABLE` — `projection_sql` reads from this name.
 const AI_TMP_TABLE: &str = "__ai_tmp";
 
 const SUBMIT_CAPACITY: usize = 256;
 const RESULT_CAPACITY: usize = 256;
-/// In-flight miss rows above which the operator refuses new input, so its input
-/// buffer fills and the graph backpressures the source (when input-buffer caps
-/// are configured).
 const MAX_IN_FLIGHT_ROWS: usize = 8192;
 
 /// Static configuration for an [`AiInferenceOperator`].
 pub(crate) struct AiOperatorConfig {
-    /// The task this operator performs.
     pub task: Task,
-    /// The backend kind (selects the worker's adapter path).
     pub kind: BackendKind,
-    /// Stable per-model integer for the cache key.
     pub model_id: u32,
-    /// Provider/runtime model identifier.
     pub model: String,
-    /// Name of the input column to read text from.
     pub input_column: String,
-    /// Name of the output column to append.
     pub output_column: String,
-    /// Effective labels (local classification + cache versioning).
     pub labels: Option<Vec<String>>,
 }
 
-/// A batch awaiting enrichment: the original rows plus per-row outputs that fill
-/// in as the worker resolves them. `pending` counts rows still in flight.
+/// A batch awaiting enrichment: original rows plus per-row outputs that fill in as
+/// the worker resolves them. `pending` counts rows still in flight.
 struct PendingBatch {
     batch: RecordBatch,
     outputs: Vec<Option<CachedOutput>>,
     pending: usize,
-    /// Input watermark when this batch was ingested. Holds the operator's output
-    /// watermark until the batch emits, so its rows aren't late downstream.
+    // Held until the batch emits so its rows aren't dropped late downstream.
     ingest_watermark: i64,
 }
 
@@ -100,19 +69,13 @@ pub(crate) struct AiInferenceOperator {
     submit_tx: crate::ai_worker::SubmitTx,
     result_rx: mpsc::Receiver<WorkResult>,
     pending: FxHashMap<u64, PendingBatch>,
-    /// Work items the worker was too busy to accept; retried next cycle.
+    // Rejected by a saturated worker; retried next cycle in order.
     unsubmitted: VecDeque<WorkItem>,
-    /// Input batches awaiting (re-)ingestion, each with the watermark it was
-    /// originally ingested under — filled on restore so recovered rows re-ingest
-    /// at their original watermark, not a newer one (else they'd be dropped as
-    /// late downstream).
+    // Recovered batches queued with their original ingest watermark so they
+    // don't re-ingest under a newer watermark and get dropped late downstream.
     replay: VecDeque<(i64, RecordBatch)>,
     next_batch_id: u64,
-    /// In-flight cap; above this, [`wants_input`](Self::wants_input) is false.
     max_in_flight: usize,
-    /// Residual projection applied to enriched batches (the user's SELECT with
-    /// the `ai_*` call rewritten to its alias column). Bounded local work — not
-    /// the inference path.
     projection: ProjectingJoinState,
     _worker: tokio::task::JoinHandle<()>,
 }
@@ -120,11 +83,8 @@ pub(crate) struct AiInferenceOperator {
 impl AiInferenceOperator {
     /// Build the operator and spawn its Ring 1 worker on `runtime`.
     ///
-    /// `runtime` MUST be the engine's main (multi-threaded) runtime handle, not
-    /// the `laminar-compute` runtime — the worker must run off the compute
-    /// thread. When wiring construction during a dynamic DDL hot-add (which
-    /// itself runs on the compute thread), pass the main handle captured at
-    /// start, never `Handle::current()`.
+    /// `runtime` must be the main (multi-threaded) runtime handle, not the
+    /// `laminar-compute` one. Never pass `Handle::current()` from a compute thread.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         name: &str,
@@ -175,7 +135,6 @@ impl AiInferenceOperator {
         }
     }
 
-    /// Total miss rows currently in flight (submitted-but-unresolved + queued).
     fn in_flight_rows(&self) -> usize {
         let pending: usize = self.pending.values().map(|pb| pb.pending).sum();
         let queued: usize = self.unsubmitted.iter().map(|item| item.rows.len()).sum();
@@ -187,9 +146,6 @@ impl AiInferenceOperator {
         self.max_in_flight = cap;
     }
 
-    /// Resolve a row against the cache, or queue it as a miss. `watermark` is the
-    /// input watermark at ingest, used to hold the output watermark while the
-    /// batch is in flight.
     fn ingest(
         &mut self,
         batch: RecordBatch,
@@ -245,14 +201,13 @@ impl AiInferenceOperator {
         Ok(())
     }
 
-    /// Apply a worker result, emitting the batch if it is now fully resolved.
     fn apply_result(
         &mut self,
         result: &WorkResult,
         out: &mut Vec<RecordBatch>,
     ) -> Result<(), DbError> {
         let Some(pb) = self.pending.get_mut(&result.batch_id) else {
-            return Ok(()); // batch no longer tracked (e.g. cleared on restore)
+            return Ok(()); // cleared on restore
         };
         for (position, &row_index) in result.row_indices.iter().enumerate() {
             if pb.outputs[row_index].is_some() {
@@ -274,7 +229,6 @@ impl AiInferenceOperator {
         Ok(())
     }
 
-    /// Retry work items the worker rejected while saturated, preserving order.
     fn flush_unsubmitted(&mut self) {
         while let Some(item) = self.unsubmitted.pop_front() {
             match self.submit_tx.try_send(item) {
@@ -282,13 +236,11 @@ impl AiInferenceOperator {
                     self.unsubmitted.push_front(item);
                     break;
                 }
-                // Delivered, or the worker is gone (shutdown) — nothing to retry.
                 Ok(()) | Err(crossfire::TrySendError::Disconnected(_)) => {}
             }
         }
     }
 
-    /// Submit a work item, queueing it if the worker is saturated.
     fn submit(&mut self, item: WorkItem) {
         if !self.unsubmitted.is_empty() {
             self.unsubmitted.push_back(item);
@@ -296,12 +248,10 @@ impl AiInferenceOperator {
         }
         match self.submit_tx.try_send(item) {
             Err(crossfire::TrySendError::Full(item)) => self.unsubmitted.push_back(item),
-            // Delivered, or the worker is gone (shutdown) — nothing to queue.
             Ok(()) | Err(crossfire::TrySendError::Disconnected(_)) => {}
         }
     }
 
-    /// Extract the input column as per-row optional text.
     fn input_texts<'a>(&self, batch: &'a RecordBatch) -> Result<Vec<Option<&'a str>>, DbError> {
         let column = batch.column_by_name(&self.input_column).ok_or_else(|| {
             DbError::InvalidOperation(format!(
@@ -323,7 +273,6 @@ impl AiInferenceOperator {
             .collect())
     }
 
-    /// Append the AI output column to a batch.
     fn build_output(
         &self,
         batch: &RecordBatch,
@@ -361,11 +310,6 @@ impl AiInferenceOperator {
 
 #[async_trait]
 impl GraphOperator for AiInferenceOperator {
-    // The only `await` is the residual projection — bounded local DataFusion
-    // work over the just-enriched batches, the same step every join operator
-    // runs. The model call never happens here: misses go to the Ring 1 worker
-    // and results are drained on a later cycle, so this cannot block on
-    // inference (R1).
     async fn process(
         &mut self,
         inputs: &[Vec<RecordBatch>],
@@ -389,18 +333,13 @@ impl GraphOperator for AiInferenceOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        // Capture every not-yet-emitted input batch: in-flight pending batches
-        // plus any queued for replay. In-flight requests are not treated as
-        // complete; on restore they are re-ingested and re-run (local is
-        // deterministic, remote dedups via the content-hash cache).
+        // In-flight requests are re-run on restore; local is deterministic,
+        // remote dedups via the content-hash cache.
         let serialize = |b: &RecordBatch| {
             serialize_batch_stream(b).map_err(|e| {
                 DbError::Pipeline(format!("ai operator: checkpoint serialization: {e}"))
             })
         };
-        // Each entry keeps the watermark its batch was ingested under, so on
-        // restore the rows re-ingest at the same watermark and aren't dropped as
-        // late by a downstream window.
         let mut blobs: Vec<(i64, Vec<u8>)> =
             Vec::with_capacity(self.pending.len() + self.replay.len());
         for pb in self.pending.values() {
@@ -452,15 +391,10 @@ impl GraphOperator for AiInferenceOperator {
         pending + replay + unsubmitted
     }
 
-    /// Hold the output watermark behind the oldest in-flight batch so async
-    /// enrichment isn't dropped as late by a downstream window.
     fn watermark_hold(&self) -> Option<i64> {
         self.pending.values().map(|pb| pb.ingest_watermark).min()
     }
 
-    /// Refuse new input once the in-flight cap is reached. The graph then leaves
-    /// this node's input buffered (backpressuring the source) while still
-    /// stepping the operator with empty input so it drains and emits.
     fn wants_input(&self) -> bool {
         self.in_flight_rows() < self.max_in_flight
     }
@@ -486,8 +420,6 @@ fn build_text_array(outputs: &[Option<CachedOutput>]) -> Result<ArrayRef, DbErro
     Ok(Arc::new(builder.finish()))
 }
 
-/// Build the `Float64` score column for `ai_sentiment`. A null input or a
-/// failed inference yields a null score.
 fn build_score_array(outputs: &[Option<CachedOutput>]) -> Result<ArrayRef, DbError> {
     let mut builder = Float64Builder::new();
     for output in outputs {

--- a/crates/laminar-db/src/operator/ai_inference.rs
+++ b/crates/laminar-db/src/operator/ai_inference.rs
@@ -97,7 +97,7 @@ pub(crate) struct AiInferenceOperator {
     output_column: String,
     params_version: u64,
     cache: Arc<AiResultCache>,
-    submit_tx: mpsc::Sender<WorkItem>,
+    submit_tx: crate::ai_worker::SubmitTx,
     result_rx: mpsc::Receiver<WorkResult>,
     pending: FxHashMap<u64, PendingBatch>,
     /// Work items the worker was too busy to accept; retried next cycle.
@@ -141,7 +141,7 @@ impl AiInferenceOperator {
         };
         let params_version = params_version(&params);
 
-        let (submit_tx, submit_rx) = mpsc::channel(SUBMIT_CAPACITY);
+        let (submit_tx, submit_rx) = crossfire::mpsc::bounded_async(SUBMIT_CAPACITY);
         let (result_tx, result_rx) = mpsc::channel(RESULT_CAPACITY);
 
         let worker_ctx = WorkerContext {
@@ -278,12 +278,12 @@ impl AiInferenceOperator {
     fn flush_unsubmitted(&mut self) {
         while let Some(item) = self.unsubmitted.pop_front() {
             match self.submit_tx.try_send(item) {
-                Err(mpsc::error::TrySendError::Full(item)) => {
+                Err(crossfire::TrySendError::Full(item)) => {
                     self.unsubmitted.push_front(item);
                     break;
                 }
                 // Delivered, or the worker is gone (shutdown) — nothing to retry.
-                Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+                Ok(()) | Err(crossfire::TrySendError::Disconnected(_)) => {}
             }
         }
     }
@@ -295,9 +295,9 @@ impl AiInferenceOperator {
             return;
         }
         match self.submit_tx.try_send(item) {
-            Err(mpsc::error::TrySendError::Full(item)) => self.unsubmitted.push_back(item),
+            Err(crossfire::TrySendError::Full(item)) => self.unsubmitted.push_back(item),
             // Delivered, or the worker is gone (shutdown) — nothing to queue.
-            Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+            Ok(()) | Err(crossfire::TrySendError::Disconnected(_)) => {}
         }
     }
 

--- a/crates/laminar-db/src/operator/asof_join.rs
+++ b/crates/laminar-db/src/operator/asof_join.rs
@@ -18,9 +18,7 @@ use crate::error::DbError;
 use crate::operator::ProjectingJoinState;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 
-/// Version byte prefixed to the rkyv payload so bad/old checkpoints fail
-/// loudly instead of corrupting state. Bump on any wire-format change to
-/// `AsofBufferCheckpoint`.
+/// Bump on any wire-format change to `AsofBufferCheckpoint`.
 const ASOF_CHECKPOINT_VERSION: u8 = 1;
 
 pub(crate) struct AsofJoinOperator {
@@ -28,10 +26,8 @@ pub(crate) struct AsofJoinOperator {
     projection: ProjectingJoinState,
     right_buffer: AsofRightBuffer,
     last_evicted_watermark: i64,
-    /// Right input schema, captured from the first non-empty right batch. Lets
-    /// a later cycle whose right buffer is empty still emit left rows with null
-    /// right columns, so a downstream projection over a right column keeps
-    /// resolving. `None` until the right side has emitted anything.
+    // Captured from the first non-empty right batch so a later cycle with an
+    // empty right buffer can still emit left rows with null right columns.
     right_schema: Option<SchemaRef>,
 }
 
@@ -68,18 +64,14 @@ impl GraphOperator for AsofJoinOperator {
             &self.config.right_time_column,
         )?;
 
-        // Capture the right schema from the first batch we see, so a later
-        // cycle with an empty right buffer can still emit left rows with null
-        // right columns instead of dropping them.
         if self.right_schema.is_none() {
             if let Some(b) = right_batches.first() {
                 self.right_schema = Some(b.schema());
             }
         }
 
-        // Join before evicting: a batch can carry rows below its own watermark
-        // (they set it) whose backward/nearest match still needs older right
-        // rows. Eviction (below) only constrains future cycles.
+        // Join before evicting: a batch's rows can still backward-match right
+        // rows whose timestamps they themselves set the watermark past.
         let output = if left_batches.is_empty() {
             Vec::new()
         } else {
@@ -96,12 +88,10 @@ impl GraphOperator for AsofJoinOperator {
             }
         };
 
-        // Prune the right buffer to what a future left (ts >= left_wm) can still
-        // match. Backward/Nearest keep the latest right <= left_wm per key; a
-        // bounded tolerance also drops rows below left_wm - tolerance. Forward
-        // drops everything below left_wm. Driving this off the watermark (not a
-        // tolerance-derived cutoff) is what bounds memory with no tolerance,
-        // where the old `left_wm - i64::MAX` cutoff was always i64::MIN.
+        // Prune: Backward/Nearest keep the latest right <= left_wm per key;
+        // bounded tolerance also evicts rows below left_wm - tol. Forward drops
+        // everything below left_wm. Driving off the watermark (not tolerance)
+        // bounds memory even when tolerance is None.
         let left_wm = watermarks.first().copied().unwrap_or(i64::MIN);
         if left_wm > self.last_evicted_watermark {
             match self.config.direction {
@@ -138,8 +128,7 @@ impl GraphOperator for AsofJoinOperator {
             ))
         })?;
 
-        // Version goes in the trailer so rkyv body stays at offset 0
-        // (preserves the alignment invariant `from_bytes` requires).
+        // Version in the trailer so the rkyv body stays at offset 0.
         let mut data = Vec::with_capacity(body.len() + 1);
         data.extend_from_slice(&body);
         data.push(ASOF_CHECKPOINT_VERSION);

--- a/crates/laminar-db/src/operator/eowc_query.rs
+++ b/crates/laminar-db/src/operator/eowc_query.rs
@@ -1,6 +1,5 @@
-//! EOWC (Emit On Window Close) operator. First `process()` picks one of
-//! three paths — `CoreWindowState`, `IncrementalEowcState`, or raw-batch
-//! accumulation — then commits to it.
+//! EOWC (Emit On Window Close) operator: routes to `CoreWindowState`,
+//! `IncrementalEowcState`, or raw-batch accumulation on first `process()`.
 
 use std::sync::Arc;
 
@@ -18,27 +17,19 @@ use crate::sql_analysis::compute_closed_boundary;
 use laminar_sql::parser::EmitClause;
 use laminar_sql::translator::WindowOperatorConfig;
 
-/// Maximum rows an EOWC raw-batch accumulator may hold before coalescing.
-/// Prevents unbounded memory growth when windows fail to close or late
-/// data keeps arriving.
+/// Row cap for the raw-batch accumulator; triggers coalescing to bound memory.
 const MAX_EOWC_ACCUMULATED_ROWS: usize = 1_000_000;
 
-/// Wrapper for checkpoint data that discriminates between state variants.
 #[derive(
     serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 enum EowcCheckpointEnvelope {
-    /// Checkpoint from `CoreWindowState`.
     CoreWindow(CoreWindowCheckpoint),
-    /// Checkpoint from `IncrementalEowcState`.
     EowcAgg(EowcStateCheckpoint),
-    /// Non-aggregate path: accumulated batches + boundary. Empty
-    /// `ipc` means no rows were buffered.
+    /// Non-aggregate path; empty `ipc` means no rows were buffered.
     Raw(RawCheckpoint),
 }
 
-/// Snapshot of the raw-EOWC accumulator. Source replay alone may not
-/// cover the window on recovery, so we ship the buffered batches.
 #[derive(
     serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
@@ -47,28 +38,22 @@ struct RawCheckpoint {
     last_closed_boundary: i64,
 }
 
-/// Lazy-initialized EOWC state. The variant is chosen on the first
-/// `process()` call by probing the SQL plan.
+/// Lazy-initialized EOWC state, variant chosen on the first `process()` call.
 enum EowcInnerState {
     Uninit,
     CoreWindow(Box<CoreWindowState>),
     EowcAgg(Box<IncrementalEowcState>),
-    /// Non-aggregate EOWC: accumulate batches and replay via SQL when
-    /// windows close.
+    /// Non-aggregate path: accumulate batches, replay SQL when windows close.
     Raw {
         accumulated: Vec<RecordBatch>,
         last_closed_boundary: i64,
         accumulated_rows: usize,
-        /// Lazy cache: `LiveSourceProvider` registered under a private
-        /// table name + the user SQL rewritten to reference it + cached
-        /// physical plan. Built on the first close-cycle, when the
-        /// source schema is known.
+        // Built on first close-cycle; cached thereafter to avoid re-planning.
         sql_cache: Option<RawSqlCache>,
     },
 }
 
-/// Raw-EOWC close-cycle cache: the user's SQL with its single source
-/// AST-rewritten to a private table backed by [`LiveSqlCache`].
+/// User SQL with its source AST-rewritten to a private table; cached physical plan.
 struct RawSqlCache(super::LiveSqlCache);
 
 impl RawSqlCache {
@@ -78,8 +63,6 @@ impl RawSqlCache {
         original_sql: &str,
         source_schema: arrow::datatypes::SchemaRef,
     ) -> Result<Self, DbError> {
-        // Single source only — multi-source raw EOWC can't be safely
-        // rewritten (which side do we swap?). Fail loud.
         let source = crate::sql_analysis::single_source_table(original_sql).ok_or_else(|| {
             DbError::Unsupported(format!(
                 "[LDB-1001] non-aggregate EMIT ON WINDOW CLOSE on multi-source \
@@ -125,16 +108,12 @@ fn restore_raw(cp: &RawCheckpoint) -> Result<Vec<RecordBatch>, DbError> {
         .map_err(|e| DbError::Pipeline(format!("EOWC raw restore: {e}")))
 }
 
-/// Walk a parsed SQL statement, replacing every `TableFactor::Table` whose
-/// unqualified name equals `source` with `temp`. AST-based so qualified
-/// names / aliases / nested joins / subqueries all preserve their structure.
+/// Replace every unqualified `source` table reference in SQL with `temp`.
 fn rewrite_source(sql: &str, source: &str, temp: &str) -> Result<String, DbError> {
     use sqlparser::ast::{Ident, ObjectName, SetExpr, Statement, TableFactor};
     use sqlparser::dialect::GenericDialect;
     use sqlparser::parser::Parser;
 
-    // Compare on the unqualified tail of both sides so `db.events` and
-    // bare `events` match when either form names the registered source.
     fn unqualify(s: &str) -> &str {
         s.rsplit('.').next().unwrap_or(s)
     }
@@ -224,8 +203,6 @@ impl EowcQueryOperator {
         }
     }
 
-    /// Lazy initialization: probe `CoreWindowState`, then
-    /// `IncrementalEowcState`, then fall back to `Raw`.
     async fn initialize(&mut self) -> Result<(), DbError> {
         if let Some(ref cfg) = self.window_config {
             let emit_ref = self.emit_clause.as_ref();
@@ -242,8 +219,7 @@ impl EowcQueryOperator {
                     return Ok(());
                 }
                 Ok(None) => {}
-                // Propagate wallclock misuse; let other feature gaps
-                // (CUMULATE, hop cap, ...) fall through.
+                // Propagate wallclock misuse; other gaps fall through.
                 Err(e @ DbError::Unsupported(_))
                     if {
                         let s = e.to_string();
@@ -261,8 +237,8 @@ impl EowcQueryOperator {
                 }
             }
 
-            // Guard: session windows MUST route through CoreWindowState.
-            // If it rejected, skip incremental EOWC (its session path panics).
+            // Session windows must go through CoreWindowState; the incremental
+            // path would panic on a session query.
             if matches!(
                 cfg.window_type,
                 laminar_sql::translator::WindowType::Session
@@ -307,12 +283,10 @@ impl EowcQueryOperator {
             accumulated_rows: 0,
             sql_cache: None,
         };
-        // Apply any pending Raw checkpoint that landed before init.
         self.apply_pending_restore()?;
         Ok(())
     }
 
-    /// Apply a deferred checkpoint after `initialize()` has set the state.
     fn apply_pending_restore(&mut self) -> Result<(), DbError> {
         let Some(envelope) = self.pending_restore.take() else {
             return Ok(());
@@ -365,11 +339,8 @@ impl EowcQueryOperator {
                     EowcCheckpointEnvelope::EowcAgg(_) => "EowcAgg",
                     EowcCheckpointEnvelope::Raw(_) => "Raw",
                 };
-                // Fail loud rather than silently dropping state and
-                // re-emitting freshly-zeroed windows after restart —
-                // a benign-looking edit (WHERE clause change re-routes
-                // the operator path) would otherwise produce duplicate
-                // window output, breaking exactly-once on the sink.
+                // Fail loud: silently discarding state here re-emits zeroed windows
+                // on restart, breaking exactly-once on the sink.
                 return Err(DbError::Pipeline(format!(
                     "EOWC checkpoint variant mismatch for '{}': state={} checkpoint={}; \
                      refusing to silently discard partial state. Drop the checkpoint or \
@@ -381,7 +352,6 @@ impl EowcQueryOperator {
         Ok(())
     }
 
-    /// Execute the `CoreWindowState` path: pre-agg, update, close.
     async fn process_core_window(
         cw: &mut CoreWindowState,
         inputs: &[RecordBatch],
@@ -389,9 +359,6 @@ impl EowcQueryOperator {
         op_name: &str,
         ctx: &SessionContext,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        // Resolve a `now()` WHERE clause against the event-time watermark
-        // (replay-deterministic) and pre-filter the inputs. No-op for
-        // predicates without `now()`.
         let now_filtered = cw.apply_dynamic_now_filter(ctx, inputs, watermark)?;
         let inputs: &[RecordBatch] = now_filtered.as_deref().unwrap_or(inputs);
 
@@ -421,12 +388,10 @@ impl EowcQueryOperator {
             )));
         };
 
-        // Update windowed state
         for batch in &pre_agg_batches {
             cw.update_batch(batch)?;
         }
 
-        // Close windows and apply HAVING filter
         let having_filter = cw.having_filter().cloned();
         let having_sql = cw.having_sql().map(String::from);
         let mut batches = cw.close_windows(watermark)?;
@@ -441,7 +406,6 @@ impl EowcQueryOperator {
         Ok(batches)
     }
 
-    /// Execute the `IncrementalEowcState` path: pre-agg, update, close.
     async fn process_eowc_agg(
         eowc: &mut IncrementalEowcState,
         inputs: &[RecordBatch],
@@ -475,12 +439,10 @@ impl EowcQueryOperator {
             )));
         };
 
-        // Update windowed state
         for batch in &pre_agg_batches {
             eowc.update_batch(batch)?;
         }
 
-        // Close windows and apply HAVING filter
         let having_filter = eowc.having_filter().cloned();
         let having_sql = eowc.having_sql().map(String::from);
         let mut batches = eowc.close_windows(watermark)?;
@@ -496,8 +458,6 @@ impl EowcQueryOperator {
         Ok(batches)
     }
 
-    /// Execute the raw accumulation path: accumulate batches, replay SQL
-    /// when windows close.
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     async fn process_raw(
         accumulated: &mut Vec<RecordBatch>,
@@ -511,7 +471,6 @@ impl EowcQueryOperator {
         op_name: &str,
         ctx: &SessionContext,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        // Accumulate new input batches
         for batch in inputs {
             if batch.num_rows() > 0 {
                 *accumulated_rows += batch.num_rows();
@@ -519,7 +478,6 @@ impl EowcQueryOperator {
             }
         }
 
-        // Memory pressure guard: coalesce when over the row limit
         if *accumulated_rows > MAX_EOWC_ACCUMULATED_ROWS && accumulated.len() > 1 {
             tracing::warn!(
                 query = op_name,
@@ -538,12 +496,10 @@ impl EowcQueryOperator {
             }
         }
 
-        // Compute closed-window boundary
         let closed_cut =
             window_config.map_or(watermark, |cfg| compute_closed_boundary(watermark, cfg));
 
         if closed_cut <= *last_closed_boundary {
-            // No new windows closed
             return Ok(Vec::new());
         }
 
@@ -552,16 +508,12 @@ impl EowcQueryOperator {
             return Ok(Vec::new());
         }
 
-        // Split accumulated data: closed-window rows for query, retained for
-        // the next cycle. If we have a time column, filter by timestamp.
         let (query_batches, retained_batches) = if let Some(cfg) = window_config {
             split_by_timestamp(accumulated, &cfg.time_column, closed_cut)
         } else {
-            // No window config means all data is emitted
             (std::mem::take(accumulated), Vec::new())
         };
 
-        // Replace accumulated state with retained batches
         *accumulated = retained_batches;
         *accumulated_rows = accumulated.iter().map(RecordBatch::num_rows).sum();
         *last_closed_boundary = closed_cut;
@@ -570,9 +522,6 @@ impl EowcQueryOperator {
             return Ok(Vec::new());
         }
 
-        // Lazy-init the per-operator LiveSourceProvider + cached physical
-        // plan. The user SQL is AST-rewritten once to reference the temp
-        // table; subsequent closes just swap data and re-collect.
         if sql_cache.is_none() {
             *sql_cache =
                 Some(RawSqlCache::build(ctx, op_name, sql, query_batches[0].schema()).await?);
@@ -596,7 +545,6 @@ impl GraphOperator for EowcQueryOperator {
         // Flatten inputs from port 0
         let input_batches: Vec<RecordBatch> = inputs.first().cloned().unwrap_or_default();
 
-        // Lazy initialization on first call
         if matches!(self.state, EowcInnerState::Uninit) {
             self.initialize().await?;
         }
@@ -641,8 +589,8 @@ impl GraphOperator for EowcQueryOperator {
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
         let envelope = match &mut self.state {
             EowcInnerState::Uninit => {
-                // If we have a pending restore, re-serialize it so a
-                // restore->checkpoint cycle before first process() preserves data.
+                // Re-serialize a pending restore so a restore→checkpoint before
+                // the first process() doesn't silently drop buffered state.
                 if let Some(ref env) = self.pending_restore {
                     let data = rkyv::to_bytes::<rkyv::rancor::Error>(env)
                         .map(|v| v.to_vec())
@@ -733,21 +681,15 @@ impl GraphOperator for EowcQueryOperator {
             EowcInnerState::Uninit => 0,
             EowcInnerState::CoreWindow(cw) => cw.estimated_size_bytes(),
             EowcInnerState::EowcAgg(eowc) => eowc.estimated_size_bytes(),
-            EowcInnerState::Raw { accumulated, .. } => {
-                // Rough estimate: sum of batch memory sizes
-                accumulated
-                    .iter()
-                    .map(RecordBatch::get_array_memory_size)
-                    .sum()
-            }
+            EowcInnerState::Raw { accumulated, .. } => accumulated
+                .iter()
+                .map(RecordBatch::get_array_memory_size)
+                .sum(),
         }
     }
 }
 
-/// Apply a HAVING filter expressed as SQL against the candidate batches.
-/// First call builds a `LiveSourceProvider`-backed cache; subsequent calls
-/// swap batches into the handle and re-run the cached physical plan — no
-/// per-cycle SQL parse/plan/optimize.
+/// Apply a HAVING predicate via SQL using a cached physical plan.
 async fn apply_having_via_sql(
     ctx: &SessionContext,
     query_name: &str,
@@ -771,10 +713,7 @@ async fn apply_having_via_sql(
         .await
 }
 
-/// Split accumulated batches into closed-window rows (ts < boundary) and
-/// retained rows (ts >= boundary). When the time column is missing or the
-/// wrong type the whole batch goes to `closed` — there is no way to split
-/// it by time, and leaking it into both buckets would double-emit.
+/// Split batches at `boundary` into closed (ts < boundary) and retained rows.
 fn split_by_timestamp(
     batches: &[RecordBatch],
     time_column: &str,

--- a/crates/laminar-db/src/operator/interval_join.rs
+++ b/crates/laminar-db/src/operator/interval_join.rs
@@ -1,10 +1,7 @@
 //! Interval join operator for the `OperatorGraph`.
 //!
-//! Wraps `crate::interval_join::IntervalJoinState` and the standalone
-//! `execute_interval_join_cycle` function. The operator is **stateful**
-//! across cycles: it buffers left/right rows and matches pairs where
-//! `|left_ts - right_ts| <= time_bound_ms`. Expired rows are evicted
-//! when the watermark advances.
+//! Buffers left/right rows across cycles and matches pairs where
+//! `|left_ts - right_ts| <= time_bound_ms`; evicts expired rows on watermark advance.
 
 use std::sync::Arc;
 

--- a/crates/laminar-db/src/operator/lookup_enrich.rs
+++ b/crates/laminar-db/src/operator/lookup_enrich.rs
@@ -1,12 +1,7 @@
-//! Async-decoupled on-demand lookup-enrich join.
+//! Async-decoupled lookup-enrich join for `partial`/`none` lookup tables.
 //!
-//! `partial`/`none` lookup joins run here instead of inside a `DataFusion` plan so
-//! a cache-miss source fetch never blocks the `laminar-compute` thread. Like
-//! [`AiInferenceOperator`](super::ai_inference), `process` is decoupled across
-//! cycles: cache hits are served inline, misses go to a Ring 1 worker over a
-//! bounded channel, and resolved batches emit in a later cycle. The output
-//! watermark is held behind the oldest in-flight batch so enriched rows are not
-//! dropped as late downstream.
+//! Cache hits serve inline; misses go to a Ring 1 worker and emit in a later cycle.
+//! Output watermark held behind the oldest in-flight batch.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -42,44 +37,33 @@ use laminar_core::shuffle::ShuffleMessage;
 const SUBMIT_CAPACITY: usize = 256;
 const RESULT_CAPACITY: usize = 256;
 const MAX_IN_FLIGHT_ROWS: usize = 8192;
-/// Deadline for one worker fetch; on timeout the item is retried next cycle.
+// On timeout the item is retried next cycle.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 const LOOKUP_TMP_TABLE: &str = "__lookup_enrich_tmp";
 
-/// Static config produced by the planner detector and routed by `create_operator`.
+/// Config produced by the planner detector.
 pub(crate) struct LookupEnrichConfig {
-    /// Name of the registered (partial/none) lookup table.
     pub table_name: String,
-    /// Stream-side join-key column names, in lookup primary-key order.
+    /// Stream-side join-key columns in lookup primary-key order.
     pub key_columns: Vec<String>,
-    /// `Inner` (drop non-matches) or `LeftOuter` (NULL non-matches).
     pub join_type: LookupJoinType,
 }
 
-// ── Ring 1 worker ────────────────────────────────────────────────
-
-/// Submit (request) channel to the worker. Crossfire — like the engine's
-/// other compute-thread/runtime channels; the `MAsyncTx` is `Send + Sync` so
-/// the operator stores it in `Resolved`. The result channel stays tokio mpsc
-/// because the operator stores its *receiver* (which must be `Sync`, and
-/// crossfire's `AsyncRx` is `!Sync`).
+// `MAsyncTx` is `Send+Sync`; result channel uses tokio mpsc because `AsyncRx` is `!Sync`.
 type SubmitTx = crossfire::MAsyncTx<crossfire::mpsc::Array<WorkItem>>;
 type SubmitRx = crossfire::AsyncRx<crossfire::mpsc::Array<WorkItem>>;
 
-/// A batch of cache-miss keys submitted to the worker.
 struct WorkItem {
     batch_id: u64,
     row_indices: Vec<usize>,
     keys: Vec<Vec<u8>>,
 }
 
-/// The worker's reply. `keys` echo back so the operator can populate the cache
-/// (positive and negative) keyed by the same bytes it submitted.
+/// `keys` echo back so the operator can populate the cache with the same bytes.
 struct WorkResult {
     batch_id: u64,
     row_indices: Vec<usize>,
     keys: Vec<Vec<u8>>,
-    /// Per-key lookup rows aligned to `row_indices`, or a batch-level error.
     outputs: Result<Vec<Option<RecordBatch>>, String>,
 }
 
@@ -89,7 +73,6 @@ async fn run_worker(
     submit_rx: SubmitRx,
     result_tx: mpsc::Sender<WorkResult>,
 ) {
-    // `recv` errors once the operator drops its submit sender.
     while let Ok(item) = submit_rx.recv().await {
         let key_refs: Vec<&[u8]> = item.keys.iter().map(Vec::as_slice).collect();
         let outputs = match tokio::time::timeout(
@@ -116,16 +99,11 @@ async fn run_worker(
     }
 }
 
-// ── Operator ─────────────────────────────────────────────────────
-
-/// One row's lookup result: `Pending` (in flight) or `Resolved` (hit = `Some`,
-/// miss = `None`).
 enum Slot {
     Pending,
     Resolved(Option<RecordBatch>),
 }
 
-/// A held batch whose `Pending` slots fill in as the worker resolves them.
 struct PendingBatch {
     batch: RecordBatch,
     slots: Vec<Slot>,
@@ -133,18 +111,15 @@ struct PendingBatch {
     ingest_watermark: i64,
 }
 
-/// Registry-resolved state, materialised on the first `process` (the
-/// `PartialLookupState` is only registered at pipeline start).
+/// Registry-resolved state, populated on the first `process` call.
 struct Resolved {
     cache: Arc<LookupMemoryCache>,
     converter: RowConverter,
     key_indices: Vec<usize>,
-    /// `(lookup key column, expected type)` per key, used to fail fast with a
-    /// clear message if the input join-key type differs from the lookup
-    /// primary-key type (otherwise the row-encoder errors cryptically later).
+    // (lookup key, expected type) for fast type-mismatch errors before encoding.
     key_checks: Vec<(String, DataType)>,
     lookup_schema: SchemaRef,
-    /// `None` = cache-only mode (no source); misses resolve to not-found.
+    // None = cache-only mode; misses resolve to not-found.
     submit_tx: Option<SubmitTx>,
     result_rx: Option<mpsc::Receiver<WorkResult>>,
     _worker: Option<JoinHandle<()>>,
@@ -152,8 +127,7 @@ struct Resolved {
 
 pub(crate) struct LookupEnrichOperator {
     table_name: String,
-    /// This operator's output (MV) name; used as the shuffle stage tag in
-    /// cluster mode so peers route this join's rows back to this operator.
+    // Shuffle stage tag in cluster mode so peers route rows back here.
     #[cfg(feature = "cluster")]
     op_name: Arc<str>,
     key_columns: Vec<String>,
@@ -164,16 +138,11 @@ pub(crate) struct LookupEnrichOperator {
     resolved: Option<Resolved>,
     pending: FxHashMap<u64, PendingBatch>,
     unsubmitted: VecDeque<WorkItem>,
-    /// Input batches awaiting (re-)ingestion, with their original watermark.
     replay: VecDeque<(i64, RecordBatch)>,
     next_batch_id: u64,
     max_in_flight: usize,
-    /// Per-table cache/source/in-flight metrics, when the engine has a registry.
     metrics: Option<Arc<EngineMetrics>>,
-    /// Cluster key-shuffle config; `None` outside cluster mode (the operator
-    /// then runs purely per-node). When set, `process` key-shards incoming
-    /// stream rows across the cluster by lookup key before probing the cache,
-    /// so each node caches only the key range it owns (cache affinity).
+    // When set, process key-shards by lookup key for cache affinity.
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<ClusterShuffleConfig>,
 }
@@ -209,16 +178,11 @@ impl LookupEnrichOperator {
         }
     }
 
-    /// Install the cluster key-shuffle config. When present, `process`
-    /// key-shards incoming stream rows by lookup key across the cluster
-    /// (shipping rows whose key-vnode this node does not own to the owner,
-    /// and ingesting rows peers ship here) before probing the cache.
     #[cfg(feature = "cluster")]
     pub(crate) fn attach_cluster_shuffle(&mut self, config: ClusterShuffleConfig) {
         self.cluster_shuffle = Some(config);
     }
 
-    /// Record per-batch cache effectiveness, if metrics are wired.
     fn record_cache(&self, hits: u64, misses: u64) {
         if let Some(m) = &self.metrics {
             if hits > 0 {
@@ -234,7 +198,6 @@ impl LookupEnrichOperator {
         }
     }
 
-    /// Publish the current in-flight row count to the gauge, if metrics are wired.
     fn publish_in_flight(&self) {
         if let Some(m) = &self.metrics {
             let rows = i64::try_from(self.in_flight_rows()).unwrap_or(i64::MAX);
@@ -244,8 +207,7 @@ impl LookupEnrichOperator {
         }
     }
 
-    /// Resolve the `PartialLookupState` from the registry and spawn the worker.
-    /// Idempotent: a no-op once resolved.
+    /// Resolve the `PartialLookupState` from the registry and spawn the worker. Idempotent.
     fn ensure_resolved(&mut self) -> Result<(), DbError> {
         if self.resolved.is_some() {
             return Ok(());
@@ -270,7 +232,6 @@ impl LookupEnrichOperator {
         let converter = RowConverter::new(key_sort_fields.clone())
             .map_err(|e| DbError::Pipeline(format!("lookup-enrich: row converter: {e}")))?;
 
-        // Expected input join-key types = the lookup table's primary-key types.
         let key_checks: Vec<(String, DataType)> = key_columns
             .iter()
             .map(|name| {
@@ -281,8 +242,7 @@ impl LookupEnrichOperator {
             })
             .collect();
 
-        // The worker fetches only the projected columns, so the joined-in lookup
-        // rows carry the projected schema. Empty projection = the full schema.
+        // Empty projection = the full schema (worker fetches all columns).
         let lookup_schema: SchemaRef = if projection.is_empty() {
             Arc::clone(schema)
         } else {
@@ -326,11 +286,7 @@ impl LookupEnrichOperator {
         pending + queued
     }
 
-    /// Resolve the stream-side key-column indices against the input schema
-    /// once, failing fast if a join-key type differs from the lookup
-    /// primary-key type (the row encoder would otherwise error cryptically
-    /// deep in the hot path). Idempotent once the indices are populated.
-    /// Shared by [`Self::ingest`] and the cluster key-shuffle.
+    // Resolves key-column indices on the first call; fails fast on type mismatch.
     fn ensure_key_indices(&mut self, batch: &RecordBatch) -> Result<(), DbError> {
         let resolved = self.resolved.as_mut().expect("resolved before ingest");
         if !resolved.key_indices.is_empty() {
@@ -362,8 +318,6 @@ impl LookupEnrichOperator {
         Ok(())
     }
 
-    /// Probe the cache for every row; serve a fully-resolved batch immediately,
-    /// else hold it and submit the misses to the worker.
     fn ingest(
         &mut self,
         batch: RecordBatch,
@@ -446,9 +400,6 @@ impl LookupEnrichOperator {
         Ok(())
     }
 
-    /// Apply a worker reply: populate the cache, fill slots, and emit when the
-    /// batch is fully resolved. On fetch error, re-queue for retry next cycle so
-    /// a transient source failure backpressures rather than NULL-fills.
     fn apply_result(
         &mut self,
         result: WorkResult,
@@ -503,8 +454,6 @@ impl LookupEnrichOperator {
         Ok(())
     }
 
-    /// Assemble stream columns + lookup columns. Inner drops non-matches;
-    /// `LeftOuter` keeps all rows with NULL lookup columns for misses.
     fn build_output(&self, stream: &RecordBatch, slots: &[Slot]) -> Result<RecordBatch, DbError> {
         let resolved = self.resolved.as_ref().expect("resolved");
         let lookup_schema = &resolved.lookup_schema;
@@ -585,7 +534,6 @@ impl LookupEnrichOperator {
         }
     }
 
-    /// Drain whatever the worker has resolved since the last cycle.
     fn drain_results(&mut self, out: &mut Vec<RecordBatch>) -> Result<(), DbError> {
         loop {
             let Some(rx) = self.resolved.as_mut().and_then(|r| r.result_rx.as_mut()) else {
@@ -598,10 +546,6 @@ impl LookupEnrichOperator {
         }
     }
 
-    /// In cluster mode, route each input row to the node owning its lookup-key
-    /// vnode: ship rows this node doesn't own, drain rows peers shipped here,
-    /// and return the local set to enrich. Forward-only — any node can look up
-    /// any key. `None` config (single node) is a pass-through.
     #[cfg(feature = "cluster")]
     async fn shuffle_input(
         &mut self,
@@ -619,8 +563,7 @@ impl LookupEnrichOperator {
                 continue;
             }
             self.ensure_key_indices(batch)?;
-            // Hash the same key columns the cache uses, so a key's vnode and its
-            // cache slot agree — the owner is the node that caches it.
+            // Hash by the same key columns the cache uses so vnode ownership and cache slot agree.
             let key_indices = &self.resolved.as_ref().expect("resolved").key_indices;
             let vnodes = laminar_core::shuffle::row_vnodes(batch, key_indices, vnode_count);
             for &v in &vnodes {
@@ -651,18 +594,13 @@ impl LookupEnrichOperator {
             }
         }
 
-        // Ship remote slices; fail the cycle on send error so offsets don't
-        // advance past undelivered rows. The await is a socket write bounded by
-        // TCP backpressure (same as the aggregate shuffle).
+        // Fail on send error so offsets don't advance past undelivered rows.
         for (peer, msg) in outbound {
             cfg.sender.send_to(peer, &msg).await.map_err(|e| {
                 DbError::Pipeline(format!("lookup-enrich: shuffle send to peer {peer}: {e}"))
             })?;
         }
 
-        // Drain rows peers shipped here, but only with in-flight headroom so a
-        // backpressured node lets them queue (TCP backpressure) instead of
-        // overrunning the cap.
         if self.wants_input() {
             for batch in cfg.receiver.drain_vnode_data_for(&self.op_name) {
                 if batch.num_rows() > 0 {
@@ -675,10 +613,8 @@ impl LookupEnrichOperator {
     }
 }
 
-/// Disambiguated name for a lookup column in the flattened join output: a
-/// lookup column whose name also exists on the stream side is suffixed with the
-/// lookup table name. The plan-time projection rewriter applies the identical
-/// rule, so its column references match this schema.
+/// Suffix a lookup column with the table name when it collides with a stream column.
+/// The plan-time projection rewriter uses the same rule.
 pub(crate) fn disambiguated_lookup_name(
     lookup_col: &str,
     stream_cols: &[String],
@@ -691,8 +627,6 @@ pub(crate) fn disambiguated_lookup_name(
     }
 }
 
-/// Output schema: stream fields followed by lookup fields (collision-suffixed
-/// per [`disambiguated_lookup_name`]; lookup fields forced nullable for `LeftOuter`).
 fn output_schema(
     stream: &arrow_schema::Schema,
     lookup: &SchemaRef,
@@ -727,10 +661,6 @@ impl GraphOperator for LookupEnrichOperator {
             self.ingest(batch, wm, &mut enriched)?;
         }
 
-        // New input: in cluster mode, key-shard across the cluster first (ship
-        // rows whose key-vnode we don't own to the owner, receive ours), then
-        // ingest the local + inbound set. Replayed batches above bypass the
-        // shuffle — they are already local. Single-node: a straight passthrough.
         let new_input = inputs.first().map_or(&[][..], Vec::as_slice);
         #[cfg(feature = "cluster")]
         let to_ingest = self.shuffle_input(new_input).await?;
@@ -747,9 +677,7 @@ impl GraphOperator for LookupEnrichOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        // Capture every not-yet-emitted input batch (in-flight + replay) with its
-        // ingest watermark. On restore they re-ingest and re-fetch; source reads
-        // are idempotent, so replay is safe.
+        // In-flight batches re-ingest and re-fetch on restore; source reads are idempotent.
         let mut blobs: Vec<(i64, Vec<u8>)> =
             Vec::with_capacity(self.pending.len() + self.replay.len());
         for pb in self.pending.values() {
@@ -816,9 +744,7 @@ impl GraphOperator for LookupEnrichOperator {
         batch: RecordBatch,
         watermark: i64,
     ) -> Result<(), DbError> {
-        // Peer-shipped rows are already owned by this node. Queue them on the
-        // replay path — which bypasses the shuffle and is itself checkpointed —
-        // so they enter this snapshot and re-ingest idempotently on restore.
+        // Replay path is checkpointed and bypasses the shuffle, so restore is idempotent.
         self.replay.push_back((watermark, batch));
         Ok(())
     }

--- a/crates/laminar-db/src/operator/lookup_enrich.rs
+++ b/crates/laminar-db/src/operator/lookup_enrich.rs
@@ -58,6 +58,14 @@ pub(crate) struct LookupEnrichConfig {
 
 // ── Ring 1 worker ────────────────────────────────────────────────
 
+/// Submit (request) channel to the worker. Crossfire — like the engine's
+/// other compute-thread/runtime channels; the `MAsyncTx` is `Send + Sync` so
+/// the operator stores it in `Resolved`. The result channel stays tokio mpsc
+/// because the operator stores its *receiver* (which must be `Sync`, and
+/// crossfire's `AsyncRx` is `!Sync`).
+type SubmitTx = crossfire::MAsyncTx<crossfire::mpsc::Array<WorkItem>>;
+type SubmitRx = crossfire::AsyncRx<crossfire::mpsc::Array<WorkItem>>;
+
 /// A batch of cache-miss keys submitted to the worker.
 struct WorkItem {
     batch_id: u64,
@@ -78,10 +86,11 @@ struct WorkResult {
 async fn run_worker(
     source: Arc<dyn LookupSourceDyn>,
     projection: Vec<ColumnId>,
-    mut submit_rx: mpsc::Receiver<WorkItem>,
+    submit_rx: SubmitRx,
     result_tx: mpsc::Sender<WorkResult>,
 ) {
-    while let Some(item) = submit_rx.recv().await {
+    // `recv` errors once the operator drops its submit sender.
+    while let Ok(item) = submit_rx.recv().await {
         let key_refs: Vec<&[u8]> = item.keys.iter().map(Vec::as_slice).collect();
         let outputs = match tokio::time::timeout(
             FETCH_TIMEOUT,
@@ -136,7 +145,7 @@ struct Resolved {
     key_checks: Vec<(String, DataType)>,
     lookup_schema: SchemaRef,
     /// `None` = cache-only mode (no source); misses resolve to not-found.
-    submit_tx: Option<mpsc::Sender<WorkItem>>,
+    submit_tx: Option<SubmitTx>,
     result_rx: Option<mpsc::Receiver<WorkResult>>,
     _worker: Option<JoinHandle<()>>,
 }
@@ -285,7 +294,7 @@ impl LookupEnrichOperator {
 
         let (submit_tx, result_rx, worker) = match source {
             Some(src) => {
-                let (submit_tx, submit_rx) = mpsc::channel(SUBMIT_CAPACITY);
+                let (submit_tx, submit_rx) = crossfire::mpsc::bounded_async(SUBMIT_CAPACITY);
                 let (result_tx, result_rx) = mpsc::channel(RESULT_CAPACITY);
                 let handle = self.runtime.spawn(run_worker(
                     Arc::clone(src),
@@ -554,11 +563,11 @@ impl LookupEnrichOperator {
         };
         while let Some(item) = self.unsubmitted.pop_front() {
             match tx.try_send(item) {
-                Err(mpsc::error::TrySendError::Full(item)) => {
+                Err(crossfire::TrySendError::Full(item)) => {
                     self.unsubmitted.push_front(item);
                     break;
                 }
-                Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+                Ok(()) | Err(crossfire::TrySendError::Disconnected(_)) => {}
             }
         }
     }
@@ -571,7 +580,7 @@ impl LookupEnrichOperator {
             self.unsubmitted.push_back(item);
             return;
         }
-        if let Err(mpsc::error::TrySendError::Full(item)) = tx.try_send(item) {
+        if let Err(crossfire::TrySendError::Full(item)) = tx.try_send(item) {
             self.unsubmitted.push_back(item);
         }
     }

--- a/crates/laminar-db/src/operator/lookup_enrich.rs
+++ b/crates/laminar-db/src/operator/lookup_enrich.rs
@@ -1246,12 +1246,15 @@ mod tests {
         .await;
 
         // node1 sees every key, keeps its own, ships node2's; pump both until
-        // all keys surface (the worker + loopback are async).
+        // all keys surface (the worker + loopback are async). The budget is
+        // generous (breaks early on delivery): under a fully parallel test
+        // run with CPU-heavy neighbors, 500ms of pumping was not enough on
+        // an 8-core box.
         let customers: Vec<Option<i64>> = all.iter().map(|&k| Some(k)).collect();
         let input = stream_batch(&vec![0; all.len()], &customers);
         let mut a = node1.process(&[vec![input]], &[0]).await.unwrap();
         let mut b = node2.process(&[vec![]], &[0]).await.unwrap();
-        for _ in 0..100 {
+        for _ in 0..600 {
             if a.iter().chain(&b).map(RecordBatch::num_rows).sum::<usize>() >= all.len() {
                 break;
             }

--- a/crates/laminar-db/src/operator/mod.rs
+++ b/crates/laminar-db/src/operator/mod.rs
@@ -1,7 +1,4 @@
-//! Operator implementations for the `OperatorGraph`.
-//!
-//! Each module contains a `GraphOperator` implementation that wraps an existing
-//! state type from `StreamExecutor`'s decomposed state maps.
+//! `GraphOperator` implementations for each streaming operator type.
 
 use std::sync::Arc;
 
@@ -12,10 +9,7 @@ use datafusion::prelude::SessionContext;
 use crate::error::DbError;
 use crate::sql_analysis::{extract_projection_exprs, CompiledPostProjection};
 
-/// Execute a pre-built physical plan. The plan's source leaves are
-/// `LiveSourceExec` (registered once at startup), so re-executing reads
-/// fresh per-cycle data without re-running the analyzer/optimizer/physical
-/// planner. All EOWC and multi-source operator paths go through this.
+/// Re-execute a cached physical plan without re-planning; source leaves are swapped per cycle.
 pub(crate) async fn execute_cached_physical(
     ctx: &SessionContext,
     op_name: &str,
@@ -27,19 +21,13 @@ pub(crate) async fn execute_cached_physical(
         .map_err(|e| DbError::query_pipeline(op_name, &e))
 }
 
-/// Pre-built physical plan whose only source leaf is a
-/// `LiveSourceProvider` — callers swap fresh batches in via the handle
-/// and re-execute without re-planning. Underpins HAVING-SQL fallback
-/// (see [`HavingSqlCache`]) and raw-EOWC close-cycle execution.
+/// Cached physical plan over a `LiveSourceProvider`; callers swap fresh batches in each cycle.
 pub(crate) struct LiveSqlCache {
     handle: laminar_sql::datafusion::LiveSourceHandle,
     physical: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
 }
 
 impl LiveSqlCache {
-    /// Register a `LiveSourceProvider` under `table_name`, plan `sql`
-    /// against it, and cache the physical plan. `what` is used in error
-    /// messages to identify the caller (`"HAVING"`, `"raw EOWC"`, ...).
     pub(crate) async fn build(
         ctx: &SessionContext,
         table_name: &str,
@@ -78,10 +66,7 @@ impl LiveSqlCache {
     }
 }
 
-/// HAVING-SQL fallback: a [`LiveSqlCache`] over `SELECT cols FROM
-/// table WHERE having_sql`. Used by both `EowcQueryOperator` and
-/// `SqlQueryOperator` when the HAVING predicate can't compile to a
-/// `PhysicalExpr`.
+/// `LiveSqlCache` wrapping HAVING SQL; used when the predicate can't compile to a `PhysicalExpr`.
 pub(crate) struct HavingSqlCache(LiveSqlCache);
 
 impl HavingSqlCache {
@@ -167,9 +152,7 @@ fn apply_compiled_post_projection(
         .map_err(|e| DbError::Pipeline(format!("post-projection batch: {e}")))
 }
 
-/// Lazily populated caches for the post-projection step. The compiled
-/// `PhysicalExpr` path is preferred; if it can't be built we fall back to a
-/// [`LiveSqlCache`] (built once, re-used every cycle) rather than re-planning.
+/// Compiled-expr or `LiveSqlCache` fallback for post-projection; populated on first use.
 #[derive(Default)]
 pub(crate) struct PostProjectionCache {
     compiled: Option<CompiledPostProjection>,
@@ -177,7 +160,7 @@ pub(crate) struct PostProjectionCache {
     sql_cache: Option<LiveSqlCache>,
 }
 
-/// Post-projection state shared by the four join operators.
+/// Post-projection state shared by join operators.
 pub(crate) struct ProjectingJoinState {
     pub(crate) op_name: Arc<str>,
     ctx: SessionContext,
@@ -234,7 +217,6 @@ pub(crate) async fn apply_post_projection(
         return Ok(Vec::new());
     }
 
-    // Try compiled path
     if cache.compiled.is_none() && !cache.compile_failed {
         let schema = batches[0].schema();
         match try_compile_post_projection(ctx, proj_sql, tmp_table_name, &schema).await {
@@ -254,11 +236,6 @@ pub(crate) async fn apply_post_projection(
         return Ok(result);
     }
 
-    // SQL fallback: build a `LiveSqlCache` once (registers a
-    // `LiveSourceProvider` under `tmp_table_name`, plans `proj_sql`, and
-    // caches the physical plan), then re-use it every cycle by swapping in
-    // fresh batches — avoids re-registering a `MemTable` and re-planning on
-    // each call.
     if cache.sql_cache.is_none() {
         let schema = batches[0].schema();
         cache.sql_cache =

--- a/crates/laminar-db/src/operator/process_time_join.rs
+++ b/crates/laminar-db/src/operator/process_time_join.rs
@@ -1,21 +1,8 @@
-//! Processing-time equi-join: a bounded stateful inner join between two windowed
-//! views, joined on their equi-key (e.g. `bucket_start`).
+//! Processing-time equi-join for two windowed views joined on a shared key.
 //!
-//! The two sides do **not** close a bucket in the same cycle — an upstream AI
-//! operator's watermark hold delays one side by its scoring latency — so a
-//! stateless per-cycle join would drop buckets. Each side keeps its unmatched
-//! rows and matches whenever the second side arrives, via the symmetric hash-join
-//! rule (new×buffered, buffered×new, new×new; buffered×buffered already emitted).
-//!
-//! Retention is **watermark-driven**: a side's buffered rows are evicted once the
-//! *opposite* side's watermark has passed them — the partner can no longer arrive
-//! — so state is bounded by the real cross-side skew, not a fixed count, and an
-//! unmatched row ages out (correct for an inner join). Eviction runs **after** the
-//! join, so a row still matches a partner arriving in the same cycle it would age
-//! out. `MAX_BUFFERED_ROWS` is a hard memory backstop for when watermarks don't
-//! advance (e.g. an idle or watermark-less source). The cached `DataFusion`
-//! `HashJoin` can't serve this: it memoizes its build side across cycles
-//! (`OnceAsync`).
+//! Symmetric hash-join across cycles: each side buffers unmatched rows and
+//! matches when the partner arrives. Eviction is watermark-driven (opposite-side
+//! progress), with `MAX_BUFFERED_ROWS` as a memory backstop.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -35,14 +22,9 @@ use crate::key_column::extract_key_column;
 use crate::operator::ProjectingJoinState;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 
-/// Hard memory backstop per side: when watermarks don't advance, retention falls
-/// back to keeping at most this many newest rows. With watermarks it is rarely
-/// reached — the cross-side skew is a handful of windows.
+// Backstop for when watermarks don't advance; normally the cross-side skew stays small.
 const MAX_BUFFERED_ROWS: usize = 4096;
 
-/// One join side's unmatched rows. Each cycle's arrivals are a chunk tagged with
-/// the input watermark at which they arrived; eviction drops whole chunks the
-/// opposite side has advanced past, oldest first.
 #[derive(Default)]
 struct SideBuffer {
     chunks: VecDeque<(i64, RecordBatch)>,
@@ -55,7 +37,6 @@ impl SideBuffer {
         }
     }
 
-    /// All buffered rows as one batch to probe against, or `None` when empty.
     fn concat(&self) -> Result<Option<RecordBatch>, DbError> {
         let Some((_, first)) = self.chunks.front() else {
             return Ok(None);
@@ -65,8 +46,6 @@ impl SideBuffer {
             .map_err(|e| DbError::Pipeline(format!("process-time join: concat buffer: {e}")))
     }
 
-    /// Evict rows the opposite side has passed (`tag < opposite_watermark`), then
-    /// enforce the memory backstop oldest-first.
     fn evict(&mut self, opposite_watermark: i64) {
         while self
             .chunks
@@ -75,8 +54,6 @@ impl SideBuffer {
         {
             self.chunks.pop_front();
         }
-        // Memory backstop: keep the newest MAX_BUFFERED_ROWS, slicing the oldest
-        // chunk rather than dropping a whole (possibly large) batch wholesale.
         let mut rows: usize = self.chunks.iter().map(|(_, b)| b.num_rows()).sum();
         while rows > MAX_BUFFERED_ROWS {
             let overage = rows - MAX_BUFFERED_ROWS;
@@ -88,7 +65,7 @@ impl SideBuffer {
                 self.chunks.pop_front();
                 rows -= front_rows;
             } else if let Some((_, front)) = self.chunks.front_mut() {
-                *front = front.slice(overage, front_rows - overage); // drop oldest `overage`
+                *front = front.slice(overage, front_rows - overage);
                 rows -= overage;
             }
         }
@@ -109,7 +86,6 @@ pub(crate) struct ProcessTimeJoinOperator {
     config: StreamJoinConfig,
     left: SideBuffer,
     right: SideBuffer,
-    /// The user's SELECT with the join's columns rewritten over the temp table.
     projection: ProjectingJoinState,
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<ClusterShuffleConfig>,
@@ -126,8 +102,6 @@ impl ProcessTimeJoinOperator {
             config,
             left: SideBuffer::default(),
             right: SideBuffer::default(),
-            // The `FROM` name `build_stream_join_projection_sql` emits (shared
-            // with the interval join; registered transiently per `apply`).
             projection: ProjectingJoinState::new(name, ctx, projection_sql, "__interval_tmp"),
             #[cfg(feature = "cluster")]
             cluster_shuffle: None,
@@ -214,8 +188,6 @@ impl ProcessTimeJoinOperator {
         Ok(local)
     }
 
-    /// Inner-join two batches on the equi-key. `None` when either is empty or
-    /// nothing matches.
     fn join_pair(
         &self,
         left: &RecordBatch,
@@ -227,8 +199,6 @@ impl ProcessTimeJoinOperator {
         let left_keys = extract_key_column(left, &self.config.left_key)?;
         let right_keys = extract_key_column(right, &self.config.right_key)?;
 
-        // Hash-index the right side, probe with the left; collisions are resolved
-        // by `keys_equal`.
         let mut index: FxHashMap<u64, Vec<u32>> = FxHashMap::default();
         for j in 0..right.num_rows() {
             if let Some(h) = right_keys.hash_at(j) {
@@ -272,7 +242,6 @@ impl ProcessTimeJoinOperator {
             .map_err(|e| DbError::Pipeline(format!("process-time join: build output: {e}")))
     }
 
-    /// Concat this cycle's batches for one side into one (or `None` if empty).
     fn concat_new(batches: &[RecordBatch]) -> Result<Option<RecordBatch>, DbError> {
         let Some(schema) = batches
             .iter()
@@ -339,10 +308,7 @@ impl GraphOperator for ProcessTimeJoinOperator {
         let wm_left = watermarks.first().copied().unwrap_or(i64::MIN);
         let wm_right = watermarks.get(1).copied().unwrap_or(i64::MIN);
 
-        // Emit against the OLD buffers first, then fold the new rows in — so each
-        // pair emits exactly once (when its later side arrives) and old×old is
-        // never re-emitted. Only concat a buffer when there are new rows to probe
-        // it with.
+        // Emit old×new, new×old, new×new in order so each pair emits once (on its later side).
         let right_buf = if new_left.is_some() {
             self.right.concat()?
         } else {
@@ -371,8 +337,7 @@ impl GraphOperator for ProcessTimeJoinOperator {
             self.right.push(wm_right, nr);
         }
 
-        // Evict AFTER joining (a row can match a partner arriving the same cycle it
-        // ages out): each side is bounded by the OPPOSITE side's progress.
+        // Evict after joining so a row can match a partner arriving the same cycle it ages out.
         self.left.evict(wm_right);
         self.right.evict(wm_left);
 
@@ -399,8 +364,7 @@ impl GraphOperator for ProcessTimeJoinOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        // (side, watermark, batch-blob); side 0 = left, 1 = right.
-        let mut blobs: Vec<(u8, i64, Vec<u8>)> = Vec::new();
+        let mut blobs: Vec<(u8, i64, Vec<u8>)> = Vec::new(); // (side 0=left/1=right, watermark, blob)
         let mut serialize =
             |side: u8, chunks: &VecDeque<(i64, RecordBatch)>| -> Result<(), DbError> {
                 for (tag, batch) in chunks {

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -186,9 +186,16 @@ impl AggPromotion {
 /// operator can carry them across a restart.
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 struct AggOpCheckpoint {
+    /// In-memory group state — only the resident (hot) vnodes; demoted
+    /// vnodes are listed in `cold_vnodes` and recovered from their durable
+    /// partials on restart.
     agg: Option<AggStateCheckpoint>,
     /// `(ingest watermark, IPC-serialized pre-aggregate batch)`.
     deferred: Vec<(i64, Vec<u8>)>,
+    /// Vnodes demoted to the cold tier at capture time. Their groups are
+    /// absent from `agg`; restart recovery replays each from its vnode
+    /// partial (the tier itself is wiped on restart). Empty without tiering.
+    cold_vnodes: Vec<u32>,
 }
 
 pub(crate) struct SqlQueryOperator {
@@ -216,6 +223,11 @@ pub(crate) struct SqlQueryOperator {
     /// promotion buffer once `lazy_init` builds it.
     #[cfg(feature = "state-tier")]
     pending_deferred: Vec<(i64, RecordBatch)>,
+    /// Vnodes that were demoted at the restored checkpoint; the restart path
+    /// drains this (`take_tier_cold_vnodes`) to know which durable partials
+    /// to replay back into `pending_restore` before `lazy_init`.
+    #[cfg(feature = "state-tier")]
+    pending_cold_rehydrate: Vec<u32>,
 }
 
 impl SqlQueryOperator {
@@ -246,6 +258,8 @@ impl SqlQueryOperator {
             tier_sender: None,
             #[cfg(feature = "state-tier")]
             pending_deferred: Vec::new(),
+            #[cfg(feature = "state-tier")]
+            pending_cold_rehydrate: Vec::new(),
         }
     }
 
@@ -945,10 +959,24 @@ impl GraphOperator for SqlQueryOperator {
         #[cfg(not(feature = "state-tier"))]
         let deferred: Vec<(i64, Vec<u8>)> = Vec::new();
 
-        if agg.is_none() && deferred.is_empty() {
+        // Demoted vnodes are absent from `agg` (their groups are not in
+        // memory); list them so restart recovery replays them from partials.
+        #[cfg(feature = "state-tier")]
+        let cold_vnodes: Vec<u32> = match self.state {
+            QueryState::Agg(ref agg_state) => agg_state.cold_vnodes().iter().copied().collect(),
+            _ => Vec::new(),
+        };
+        #[cfg(not(feature = "state-tier"))]
+        let cold_vnodes: Vec<u32> = Vec::new();
+
+        if agg.is_none() && deferred.is_empty() && cold_vnodes.is_empty() {
             return Ok(None);
         }
-        let cp = AggOpCheckpoint { agg, deferred };
+        let cp = AggOpCheckpoint {
+            agg,
+            deferred,
+            cold_vnodes,
+        };
         let data = rkyv::to_bytes::<rkyv::rancor::Error>(&cp)
             .map(|v| v.to_vec())
             .map_err(|e| {
@@ -990,6 +1018,13 @@ impl GraphOperator for SqlQueryOperator {
                 "dropping checkpointed promotion-deferred batches — \
                  this binary has no state-tier support"
             );
+        }
+
+        // Remember which vnodes were demoted so the restart path can replay
+        // their durable partials into `pending_restore` before `lazy_init`.
+        #[cfg(feature = "state-tier")]
+        if !cp.cold_vnodes.is_empty() {
+            self.pending_cold_rehydrate = cp.cold_vnodes;
         }
 
         let Some(agg_cp) = cp.agg else {
@@ -1117,6 +1152,11 @@ impl GraphOperator for SqlQueryOperator {
         } else {
             self.tier_sender = Some(tier);
         }
+    }
+
+    #[cfg(feature = "state-tier")]
+    fn take_tier_cold_vnodes(&mut self) -> Vec<u32> {
+        std::mem::take(&mut self.pending_cold_rehydrate)
     }
 
     #[cfg(feature = "cluster")]
@@ -1408,6 +1448,85 @@ mod promotion_tests {
             final_a,
             Some(5),
             "the restored deferred row replays, not dropped"
+        );
+    }
+
+    /// Simulates a restart: a tier operator demotes every vnode, checkpoints
+    /// (the manifest blob then holds no groups, only the cold-vnode list),
+    /// and a fresh operator restores from it and rehydrates each demoted
+    /// vnode from its saved partial slice — exactly what the restart path
+    /// does with `VnodeRehydrator`. Recovered state must be complete: a new
+    /// row sees the rehydrated prior contribution.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restart_rehydrates_demoted_vnodes_from_partials() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            crate::state_tier::StateTierStore::open(tmp.path().join("tier"), None).unwrap(),
+        );
+        let tier_tx = crate::state_tier::spawn_worker(
+            &tokio::runtime::Handle::current(),
+            Arc::clone(&store),
+            64,
+        );
+        let mut op = build_op(tier_tx.clone()).await;
+
+        op.process(&[vec![events_batch(&["a", "b", "c"], &[1, 2, 3])]], &[10])
+            .await
+            .unwrap();
+
+        // Capture every vnode's slice (the bytes a partial would carry), then
+        // demote every vnode.
+        let staged = op.checkpoint_by_vnode(VNODES).unwrap().unwrap();
+        let mut saved: FxHashMap<u32, bytes::Bytes> = FxHashMap::default();
+        for (v, slice) in &staged {
+            if let crate::checkpoint_coordinator::StagedSlice::Bytes(bytes) = slice {
+                saved.insert(*v, bytes.clone());
+            }
+        }
+        for &v in staged.keys() {
+            assert!(op.demote_vnode(v, VNODES));
+        }
+
+        // The manifest blob now omits the demoted groups but lists them.
+        let manifest = op.checkpoint().unwrap().expect("non-empty manifest");
+        let decoded: AggOpCheckpoint =
+            rkyv::from_bytes::<AggOpCheckpoint, rkyv::rancor::Error>(&manifest.data).unwrap();
+        assert!(
+            decoded.agg.as_ref().is_some_and(|a| a.groups.is_empty()),
+            "all vnodes demoted → manifest carries no groups"
+        );
+        let mut cold_listed: Vec<u32> = decoded.cold_vnodes.clone();
+        cold_listed.sort_unstable();
+        let mut cold_expected: Vec<u32> = staged.keys().copied().collect();
+        cold_expected.sort_unstable();
+        assert_eq!(
+            cold_listed, cold_expected,
+            "manifest lists the demoted vnodes"
+        );
+
+        // Fresh operator restores from the manifest, then the restart path
+        // replays each demoted vnode from its partial slice.
+        let mut op2 = build_op(tier_tx).await;
+        op2.restore(manifest).unwrap();
+        let cold = op2.take_tier_cold_vnodes();
+        assert_eq!(cold.len(), cold_expected.len());
+        for v in cold {
+            let slice = saved
+                .get(&v)
+                .expect("a slice was saved for every demoted vnode");
+            op2.apply_vnode_state(v, slice).unwrap();
+        }
+
+        // A new row for 'a' must reflect the rehydrated prior value (1 + 5),
+        // proving the demoted state survived the simulated restart.
+        let out = op2
+            .process(&[vec![events_batch(&["a"], &[5])]], &[30])
+            .await
+            .unwrap();
+        assert_eq!(
+            inserts(&out).get("a"),
+            Some(&6),
+            "rehydrated demoted state: original 1 + new 5"
         );
     }
 }

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -22,6 +22,15 @@ use crate::error::DbError;
 use crate::operator_graph::{try_evaluate_compiled, GraphOperator, OperatorCheckpoint};
 use crate::sql_analysis::{extract_projection_filter, single_source_table};
 
+#[cfg(feature = "state-tier")]
+use bytes::Bytes;
+#[cfg(feature = "state-tier")]
+use rustc_hash::{FxHashMap, FxHashSet};
+#[cfg(feature = "state-tier")]
+use std::collections::VecDeque;
+#[cfg(feature = "state-tier")]
+use tokio::sync::{mpsc, oneshot};
+
 /// Internal state for the query operator (lazy initialization).
 enum QueryState {
     /// Not yet initialized -- need to introspect SQL on first call.
@@ -67,6 +76,121 @@ impl std::fmt::Debug for ClusterShuffleConfig {
     }
 }
 
+/// Async-decoupled promotion of demoted (cold-tier) aggregate state.
+///
+/// When a pre-aggregate row's group hashes to a vnode that was demoted to
+/// the cold tier, the row cannot process inline — the group's accumulators
+/// are not in memory. Mirroring the lookup-enrich / AI-operator pattern,
+/// the row is deferred, a Ring-1 fetch of the vnode's slice runs off the
+/// compute thread (the cold read never stalls the pipeline), and the row
+/// replays a later cycle once the slice is merged back in. The output
+/// watermark is held behind the oldest deferred row so its eventual
+/// contribution is not treated as late downstream.
+#[cfg(feature = "state-tier")]
+struct AggPromotion {
+    op_name: Arc<str>,
+    tier: mpsc::Sender<crate::state_tier::TierRequest>,
+    /// Pre-aggregate batches deferred because they touch a cold vnode, each
+    /// with the watermark it was first ingested at (replayed at that
+    /// watermark, like lookup-enrich, so a late replay is not mis-aged).
+    deferred: VecDeque<(i64, RecordBatch)>,
+    /// Vnodes with a fetch in flight → its reply channel.
+    inflight: FxHashMap<u32, oneshot::Receiver<Result<Option<Bytes>, DbError>>>,
+    /// Backpressure cap: stop accepting input past this many deferred rows.
+    max_deferred_rows: usize,
+}
+
+#[cfg(feature = "state-tier")]
+const MAX_DEFERRED_PROMOTION_ROWS: usize = 8192;
+
+#[cfg(feature = "state-tier")]
+impl AggPromotion {
+    fn new(op_name: Arc<str>, tier: mpsc::Sender<crate::state_tier::TierRequest>) -> Self {
+        Self {
+            op_name,
+            tier,
+            deferred: VecDeque::new(),
+            inflight: FxHashMap::default(),
+            max_deferred_rows: MAX_DEFERRED_PROMOTION_ROWS,
+        }
+    }
+
+    /// Poll every in-flight fetch; return the slices that resolved this
+    /// cycle as `(vnode, slice_bytes)` (a `None` slice = the tier no longer
+    /// has it, surfaced so the caller can re-fetch). Errored or worker-gone
+    /// fetches are dropped so the still-cold deferred batch re-issues them.
+    fn drain_ready(&mut self) -> Vec<(u32, Option<Bytes>)> {
+        let mut ready = Vec::new();
+        let mut still: FxHashMap<u32, oneshot::Receiver<Result<Option<Bytes>, DbError>>> =
+            FxHashMap::default();
+        for (vnode, mut rx) in self.inflight.drain() {
+            match rx.try_recv() {
+                Ok(Ok(slice)) => ready.push((vnode, slice)),
+                Ok(Err(e)) => tracing::warn!(
+                    operator = %self.op_name, vnode, error = %e,
+                    "cold-tier promotion fetch failed — will retry"
+                ),
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    still.insert(vnode, rx);
+                }
+                Err(oneshot::error::TryRecvError::Closed) => tracing::warn!(
+                    operator = %self.op_name, vnode,
+                    "cold-tier worker dropped a promotion fetch"
+                ),
+            }
+        }
+        self.inflight = still;
+        ready
+    }
+
+    /// Start a fetch for `vnode` unless one is already in flight. A full or
+    /// closed channel is treated as backpressure: the deferred batch retries
+    /// the fetch next cycle.
+    fn issue_fetch(&mut self, vnode: u32) {
+        if self.inflight.contains_key(&vnode) {
+            return;
+        }
+        let (reply, rx) = oneshot::channel();
+        let req = crate::state_tier::TierRequest::Fetch {
+            operator: Arc::clone(&self.op_name),
+            vnode,
+            reply,
+        };
+        if self.tier.try_send(req).is_ok() {
+            self.inflight.insert(vnode, rx);
+        }
+    }
+
+    fn defer(&mut self, watermark: i64, batch: RecordBatch) {
+        self.deferred.push_back((watermark, batch));
+    }
+
+    fn take_deferred(&mut self) -> Vec<(i64, RecordBatch)> {
+        self.deferred.drain(..).collect()
+    }
+
+    fn deferred_rows(&self) -> usize {
+        self.deferred.iter().map(|(_, b)| b.num_rows()).sum()
+    }
+
+    fn min_deferred_watermark(&self) -> Option<i64> {
+        self.deferred.iter().map(|(wm, _)| *wm).min()
+    }
+}
+
+/// Whole-operator checkpoint for the aggregate path: the group state plus
+/// any pre-aggregate batches the cold-tier promotion buffer has deferred
+/// (empty unless the state tier is active). Replaces the bare
+/// `AggStateCheckpoint` blob so a checkpoint taken mid-promotion does not
+/// lose deferred rows — the source counts them consumed, so only the
+/// operator can carry them across a restart.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+struct AggOpCheckpoint {
+    agg: Option<AggStateCheckpoint>,
+    /// `(ingest watermark, IPC-serialized pre-aggregate batch)`.
+    deferred: Vec<(i64, Vec<u8>)>,
+}
+
 pub(crate) struct SqlQueryOperator {
     op_name: Arc<str>,
     sql: String,
@@ -80,6 +204,18 @@ pub(crate) struct SqlQueryOperator {
     idle_ttl_ms: Option<u64>,
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<ClusterShuffleConfig>,
+    /// Cold-tier promotion buffer, attached when the engine wires a state
+    /// tier and this operator runs the vnode-sharded aggregate path.
+    #[cfg(feature = "state-tier")]
+    promotion: Option<AggPromotion>,
+    /// Cold-tier sender held until `lazy_init` builds the aggregate state;
+    /// then moved into `promotion`. `None` = no tier wired.
+    #[cfg(feature = "state-tier")]
+    tier_sender: Option<mpsc::Sender<crate::state_tier::TierRequest>>,
+    /// Deferred batches restored from a checkpoint, replayed into the
+    /// promotion buffer once `lazy_init` builds it.
+    #[cfg(feature = "state-tier")]
+    pending_deferred: Vec<(i64, RecordBatch)>,
 }
 
 impl SqlQueryOperator {
@@ -104,6 +240,12 @@ impl SqlQueryOperator {
             idle_ttl_ms,
             #[cfg(feature = "cluster")]
             cluster_shuffle: None,
+            #[cfg(feature = "state-tier")]
+            promotion: None,
+            #[cfg(feature = "state-tier")]
+            tier_sender: None,
+            #[cfg(feature = "state-tier")]
+            pending_deferred: Vec::new(),
         }
     }
 
@@ -135,6 +277,17 @@ impl SqlQueryOperator {
                 }
                 self.log_tier(agg_state.compiled_projection().is_some());
                 self.state = QueryState::Agg(Box::new(agg_state));
+                // Activate cold-tier promotion now the aggregate path is
+                // live: move the held sender into a promotion buffer and
+                // re-queue any deferred batches restored from a checkpoint.
+                #[cfg(feature = "state-tier")]
+                if let Some(tier) = self.tier_sender.take() {
+                    let mut promo = AggPromotion::new(Arc::clone(&self.op_name), tier);
+                    for (wm, batch) in self.pending_deferred.drain(..) {
+                        promo.defer(wm, batch);
+                    }
+                    self.promotion = Some(promo);
+                }
                 return Ok(());
             }
             Ok(None) => {}
@@ -339,9 +492,97 @@ impl SqlQueryOperator {
             .await?
         };
 
-        // Step 2: Feed pre-agg batches to incremental accumulators.
+        // Step 2: Feed pre-agg batches to incremental accumulators. When a
+        // cold tier is wired, rows hitting a demoted vnode route through the
+        // promotion buffer instead (fetched back off-thread, replayed later).
+        #[cfg(feature = "state-tier")]
+        if self.promotion.is_some() {
+            return self
+                .process_with_promotion(pre_agg_batches, watermark)
+                .await;
+        }
         for batch in &pre_agg_batches {
             agg_state.process_batch(batch, watermark)?;
+        }
+
+        self.emit_agg_output(watermark).await
+    }
+
+    /// Aggregate ingest with cold-tier promotion. Drains resolved fetches
+    /// into memory, splits new + previously-deferred rows into those whose
+    /// groups are resident (processed now) and those still demoted
+    /// (re-deferred, fetch issued), then emits — the output watermark is
+    /// held behind the oldest deferred row by [`Self::watermark_hold`].
+    #[cfg(feature = "state-tier")]
+    async fn process_with_promotion(
+        &mut self,
+        pre_agg_batches: Vec<RecordBatch>,
+        watermark: i64,
+    ) -> Result<Vec<RecordBatch>, DbError> {
+        // 1. Apply slices whose fetch resolved this cycle.
+        let ready = self
+            .promotion
+            .as_mut()
+            .map(AggPromotion::drain_ready)
+            .unwrap_or_default();
+        for (vnode, slice) in ready {
+            match slice {
+                Some(bytes) => self.apply_vnode_state(vnode, &bytes)?,
+                None => {
+                    // The tier no longer has the slice (should not happen
+                    // mid-run). Re-issue; the deferred batch keeps waiting.
+                    if let Some(p) = self.promotion.as_mut() {
+                        p.issue_fetch(vnode);
+                    }
+                }
+            }
+        }
+
+        // 2. Candidate set = previously-deferred batches + this cycle's input.
+        let mut candidates = self
+            .promotion
+            .as_mut()
+            .map(AggPromotion::take_deferred)
+            .unwrap_or_default();
+        for batch in pre_agg_batches {
+            candidates.push((watermark, batch));
+        }
+
+        // 3. Split by whether every touched vnode is now resident.
+        let num_group_cols = match self.state {
+            QueryState::Agg(ref agg) => agg.num_group_cols(),
+            _ => unreachable!("process_with_promotion on non-agg state"),
+        };
+        let vnode_count = self
+            .cluster_shuffle
+            .as_ref()
+            .map_or(1, |c| c.registry.vnode_count());
+        let cold: FxHashSet<u32> = match self.state {
+            QueryState::Agg(ref agg) => agg.cold_vnodes().clone(),
+            _ => FxHashSet::default(),
+        };
+
+        let mut to_process: Vec<(i64, RecordBatch)> = Vec::new();
+        for (wm, batch) in candidates {
+            let touched = cold_vnodes_touched(&batch, num_group_cols, vnode_count, &cold);
+            if touched.is_empty() {
+                to_process.push((wm, batch));
+            } else if let Some(p) = self.promotion.as_mut() {
+                for v in touched {
+                    p.issue_fetch(v);
+                }
+                p.defer(wm, batch);
+            }
+        }
+
+        // 4. Fold the resident rows in, each at its own ingest watermark.
+        {
+            let QueryState::Agg(ref mut agg_state) = self.state else {
+                unreachable!();
+            };
+            for (wm, batch) in &to_process {
+                agg_state.process_batch(batch, *wm)?;
+            }
         }
 
         self.emit_agg_output(watermark).await
@@ -572,6 +813,29 @@ fn hash_rows_to_vnodes(batch: &RecordBatch, num_group_cols: usize, vnode_count: 
     laminar_core::shuffle::row_vnodes(batch, &columns, vnode_count)
 }
 
+/// The demoted vnodes a pre-aggregate batch's rows hash to. Uses the same
+/// `row_vnodes` hashing as the cluster shuffle and the per-vnode capture, so
+/// a row's vnode here is exactly the one its group's slice was demoted under.
+/// Empty `cold` (the common case) short-circuits before any row hashing.
+#[cfg(feature = "state-tier")]
+fn cold_vnodes_touched(
+    batch: &RecordBatch,
+    num_group_cols: usize,
+    vnode_count: u32,
+    cold: &FxHashSet<u32>,
+) -> Vec<u32> {
+    if cold.is_empty() || batch.num_rows() == 0 {
+        return Vec::new();
+    }
+    let mut touched: FxHashSet<u32> = FxHashSet::default();
+    for v in hash_rows_to_vnodes(batch, num_group_cols, vnode_count) {
+        if cold.contains(&v) {
+            touched.insert(v);
+        }
+    }
+    touched.into_iter().collect()
+}
+
 #[async_trait]
 impl GraphOperator for SqlQueryOperator {
     async fn process(
@@ -651,26 +915,40 @@ impl GraphOperator for SqlQueryOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        if matches!(self.state, QueryState::Uninit) {
-            if let Some(ref cp) = self.pending_restore {
-                let data = rkyv::to_bytes::<rkyv::rancor::Error>(cp)
-                    .map(|v| v.to_vec())
-                    .map_err(|e| {
-                        DbError::Pipeline(format!(
-                            "checkpoint serialization of pending restore for '{}': {e}",
-                            self.op_name
-                        ))
-                    })?;
-                return Ok(Some(OperatorCheckpoint { data }));
+        let agg: Option<AggStateCheckpoint> = match self.state {
+            QueryState::Uninit => self.pending_restore.clone(),
+            QueryState::Agg(ref mut agg_state) => Some(agg_state.checkpoint_groups()?),
+            QueryState::Compiled(_) | QueryState::CachedPlan(_) | QueryState::CachedPhysical(_) => {
+                None
             }
+        };
+        // Carry cold-tier promotion-deferred batches (the source counts them
+        // consumed, so only the operator can restore them). Always empty
+        // without the state tier.
+        #[cfg(feature = "state-tier")]
+        let deferred: Vec<(i64, Vec<u8>)> = {
+            let mut out = Vec::new();
+            let batches = self
+                .promotion
+                .as_ref()
+                .map(|p| p.deferred.iter())
+                .into_iter()
+                .flatten()
+                .chain(self.pending_deferred.iter());
+            for (wm, batch) in batches {
+                let blob = laminar_core::serialization::serialize_batch_stream(batch)
+                    .map_err(|e| DbError::Pipeline(format!("promotion checkpoint: {e}")))?;
+                out.push((*wm, blob));
+            }
+            out
+        };
+        #[cfg(not(feature = "state-tier"))]
+        let deferred: Vec<(i64, Vec<u8>)> = Vec::new();
+
+        if agg.is_none() && deferred.is_empty() {
             return Ok(None);
         }
-
-        let QueryState::Agg(ref mut agg_state) = self.state else {
-            return Ok(None);
-        };
-
-        let cp = agg_state.checkpoint_groups()?;
+        let cp = AggOpCheckpoint { agg, deferred };
         let data = rkyv::to_bytes::<rkyv::rancor::Error>(&cp)
             .map(|v| v.to_vec())
             .map_err(|e| {
@@ -683,7 +961,7 @@ impl GraphOperator for SqlQueryOperator {
     }
 
     fn restore(&mut self, checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
-        let cp: AggStateCheckpoint = rkyv::from_bytes::<AggStateCheckpoint, rkyv::rancor::Error>(
+        let cp: AggOpCheckpoint = rkyv::from_bytes::<AggOpCheckpoint, rkyv::rancor::Error>(
             &checkpoint.data,
         )
         .map_err(|e| {
@@ -693,12 +971,36 @@ impl GraphOperator for SqlQueryOperator {
             ))
         })?;
 
+        // Re-queue cold-tier promotion-deferred batches. Before `lazy_init`
+        // they wait in `pending_deferred`; after, straight into the buffer.
+        #[cfg(feature = "state-tier")]
+        for (wm, blob) in cp.deferred {
+            let batch = laminar_core::serialization::deserialize_batch_stream(&blob)
+                .map_err(|e| DbError::Pipeline(format!("promotion restore: {e}")))?;
+            match self.promotion.as_mut() {
+                Some(p) => p.defer(wm, batch),
+                None => self.pending_deferred.push((wm, batch)),
+            }
+        }
+        #[cfg(not(feature = "state-tier"))]
+        if !cp.deferred.is_empty() {
+            tracing::warn!(
+                query = %self.op_name,
+                count = cp.deferred.len(),
+                "dropping checkpointed promotion-deferred batches — \
+                 this binary has no state-tier support"
+            );
+        }
+
+        let Some(agg_cp) = cp.agg else {
+            return Ok(());
+        };
         match self.state {
             QueryState::Agg(ref mut agg_state) => {
-                agg_state.restore_groups(&cp)?;
+                agg_state.restore_groups(&agg_cp)?;
             }
             QueryState::Uninit => {
-                self.pending_restore = Some(cp);
+                self.pending_restore = Some(agg_cp);
             }
             QueryState::Compiled(_) | QueryState::CachedPlan(_) | QueryState::CachedPhysical(_) => {
                 tracing::warn!(
@@ -715,6 +1017,26 @@ impl GraphOperator for SqlQueryOperator {
             QueryState::Agg(ref agg_state) => agg_state.estimated_size_bytes(),
             _ => 0,
         }
+    }
+
+    /// Hold the output watermark behind the oldest pre-aggregate row deferred
+    /// for cold-tier promotion, so its eventual contribution is not dropped as
+    /// late by a downstream window. `None` when nothing is deferred.
+    #[cfg(feature = "state-tier")]
+    fn watermark_hold(&self) -> Option<i64> {
+        self.promotion
+            .as_ref()
+            .and_then(AggPromotion::min_deferred_watermark)
+    }
+
+    /// Backpressure the source once too many rows are parked waiting on
+    /// promotion, so a storm of cold-vnode hits can't grow the buffer
+    /// unbounded.
+    #[cfg(feature = "state-tier")]
+    fn wants_input(&self) -> bool {
+        self.promotion
+            .as_ref()
+            .is_none_or(|p| p.deferred_rows() < p.max_deferred_rows)
     }
 
     #[cfg(feature = "cluster")]
@@ -785,6 +1107,18 @@ impl GraphOperator for SqlQueryOperator {
         }
     }
 
+    #[cfg(feature = "state-tier")]
+    fn attach_state_tier(&mut self, tier: mpsc::Sender<crate::state_tier::TierRequest>) {
+        // Promotion only runs on the aggregate path. If the state is already
+        // resolved to aggregate, build the buffer now; otherwise hold the
+        // sender until `lazy_init` builds it.
+        if matches!(self.state, QueryState::Agg(_)) {
+            self.promotion = Some(AggPromotion::new(Arc::clone(&self.op_name), tier));
+        } else {
+            self.tier_sender = Some(tier);
+        }
+    }
+
     #[cfg(feature = "cluster")]
     fn apply_vnode_state(&mut self, vnode: u32, bytes: &[u8]) -> Result<(), DbError> {
         let cp: AggStateCheckpoint =
@@ -828,5 +1162,252 @@ impl GraphOperator for SqlQueryOperator {
             ),
         }
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "state-tier"))]
+mod promotion_tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use laminar_core::state::{NodeId, VnodeRegistry};
+    use rustc_hash::FxHashMap;
+    use std::time::Duration;
+
+    const VNODES: u32 = 8;
+
+    fn events_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("val", DataType::Int64, false),
+        ]))
+    }
+
+    fn events_batch(keys: &[&str], vals: &[i64]) -> RecordBatch {
+        RecordBatch::try_new(
+            events_schema(),
+            vec![
+                Arc::new(StringArray::from(keys.to_vec())),
+                Arc::new(Int64Array::from(vals.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// `key -> total` for the changelog inserts (weight > 0) in the output.
+    fn inserts(batches: &[RecordBatch]) -> FxHashMap<String, i64> {
+        let mut out = FxHashMap::default();
+        for b in batches {
+            if b.num_rows() == 0 {
+                continue;
+            }
+            let key = b
+                .column(b.schema().index_of("key").unwrap())
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let total = b
+                .column(b.schema().index_of("total").unwrap())
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            // The Z-set weight is the trailing column in changelog output.
+            let weight = b
+                .column(b.num_columns() - 1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                if weight.value(i) > 0 {
+                    out.insert(key.value(i).to_string(), total.value(i));
+                }
+            }
+        }
+        out
+    }
+
+    async fn single_node_shuffle() -> ClusterShuffleConfig {
+        let registry = Arc::new(VnodeRegistry::new(VNODES));
+        let assignment: Arc<[NodeId]> = (0..VNODES).map(|_| NodeId(1)).collect::<Vec<_>>().into();
+        registry.set_assignment(assignment);
+        let sender = laminar_core::shuffle::ShuffleSender::new(1);
+        let receiver = Arc::new(
+            laminar_core::shuffle::ShuffleReceiver::bind(1, "127.0.0.1:0".parse().unwrap())
+                .await
+                .unwrap(),
+        );
+        ClusterShuffleConfig {
+            registry,
+            sender: Arc::new(sender),
+            receiver,
+            self_id: NodeId(1),
+        }
+    }
+
+    async fn build_op(
+        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    ) -> SqlQueryOperator {
+        let ctx = laminar_sql::create_session_context();
+        let mem = datafusion::datasource::MemTable::try_new(
+            events_schema(),
+            vec![vec![events_batch(&["seed"], &[0])]],
+        )
+        .unwrap();
+        ctx.register_table("events", Arc::new(mem)).unwrap();
+        let mut op = SqlQueryOperator::new(
+            "out",
+            "SELECT key, SUM(val) AS total FROM events GROUP BY key",
+            ctx,
+            None,
+            true, // emit_changelog — required for demotion
+            None,
+        );
+        op.attach_cluster_shuffle(single_node_shuffle().await);
+        op.attach_state_tier(tier);
+        op
+    }
+
+    /// Establish groups, demote every vnode to the tier, then feed a new row
+    /// for an existing key: it must defer (hold the watermark), promote its
+    /// vnode off-thread, and replay so the aggregate reflects both the
+    /// restored and the new contribution.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn promotes_demoted_vnode_on_incoming_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            crate::state_tier::StateTierStore::open(tmp.path().join("tier"), None).unwrap(),
+        );
+        let tier_tx = crate::state_tier::spawn_worker(
+            &tokio::runtime::Handle::current(),
+            Arc::clone(&store),
+            64,
+        );
+        let mut op = build_op(tier_tx).await;
+
+        // Cycle 1: a=1, b=2, c=3.
+        let out1 = op
+            .process(&[vec![events_batch(&["a", "b", "c"], &[1, 2, 3])]], &[10])
+            .await
+            .unwrap();
+        assert_eq!(inserts(&out1).get("a"), Some(&1));
+
+        // Capture the clean baseline, persist every vnode's slice, demote all.
+        let staged = op.checkpoint_by_vnode(VNODES).unwrap().unwrap();
+        for (v, slice) in &staged {
+            if let crate::checkpoint_coordinator::StagedSlice::Bytes(bytes) = slice {
+                store.put("out", *v, bytes.as_ref()).unwrap();
+            }
+        }
+        for &v in staged.keys() {
+            assert!(op.demote_vnode(v, VNODES), "clean vnode must demote");
+        }
+        assert_eq!(op.estimated_state_bytes(), 0, "all groups demoted");
+
+        // Cycle 2: a new row for 'a' hits a cold vnode → deferred, not emitted.
+        let out2 = op
+            .process(&[vec![events_batch(&["a"], &[5])]], &[20])
+            .await
+            .unwrap();
+        assert!(
+            !inserts(&out2).contains_key("a"),
+            "a row for a demoted vnode must defer, not emit a partial aggregate"
+        );
+        assert_eq!(
+            op.watermark_hold(),
+            Some(20),
+            "the deferred row must hold the output watermark"
+        );
+
+        // Idle cycles drive the promotion fetch + replay to completion.
+        let mut final_a = None;
+        for _ in 0..200 {
+            let out = op.process(&[vec![]], &[30]).await.unwrap();
+            if let Some(&t) = inserts(&out).get("a") {
+                final_a = Some(t);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert_eq!(
+            final_a,
+            Some(6),
+            "promoted slice merged: original 1 + new 5"
+        );
+        assert_eq!(
+            op.watermark_hold(),
+            None,
+            "nothing deferred after promotion"
+        );
+    }
+
+    /// A checkpoint taken while a row is deferred for promotion must carry
+    /// that row across operator restore (the source counts it consumed).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deferred_row_survives_checkpoint_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            crate::state_tier::StateTierStore::open(tmp.path().join("tier"), None).unwrap(),
+        );
+        let tier_tx = crate::state_tier::spawn_worker(
+            &tokio::runtime::Handle::current(),
+            Arc::clone(&store),
+            64,
+        );
+        let mut op = build_op(tier_tx.clone()).await;
+
+        op.process(&[vec![events_batch(&["a"], &[1])]], &[10])
+            .await
+            .unwrap();
+        let staged = op.checkpoint_by_vnode(VNODES).unwrap().unwrap();
+        for (v, slice) in &staged {
+            if let crate::checkpoint_coordinator::StagedSlice::Bytes(bytes) = slice {
+                store.put("out", *v, bytes.as_ref()).unwrap();
+            }
+        }
+        for &v in staged.keys() {
+            assert!(op.demote_vnode(v, VNODES));
+        }
+
+        // Defer a row, then checkpoint mid-promotion.
+        op.process(&[vec![events_batch(&["a"], &[5])]], &[20])
+            .await
+            .unwrap();
+        assert_eq!(op.watermark_hold(), Some(20));
+        let cp = op
+            .checkpoint()
+            .unwrap()
+            .expect("deferred row → non-empty checkpoint");
+
+        // The blob must carry the deferred row at its ingest watermark.
+        let decoded: AggOpCheckpoint =
+            rkyv::from_bytes::<AggOpCheckpoint, rkyv::rancor::Error>(&cp.data).unwrap();
+        assert_eq!(
+            decoded.deferred.len(),
+            1,
+            "deferred row must be checkpointed"
+        );
+        assert_eq!(decoded.deferred[0].0, 20, "carried at its ingest watermark");
+
+        // Restoring into a fresh operator replays the row rather than dropping
+        // it. The merge of the demoted slice's prior contribution (+1) is
+        // restored only once restart recovery rehydrates cold vnodes from the
+        // partials (Phase 4a); a fresh operator holds no demoted state, so the
+        // replayed row stands alone — what matters here is that it is not lost.
+        let mut op2 = build_op(tier_tx).await;
+        op2.restore(cp).unwrap();
+        let mut final_a = None;
+        for _ in 0..200 {
+            let out = op2.process(&[vec![]], &[30]).await.unwrap();
+            if let Some(&t) = inserts(&out).get("a") {
+                final_a = Some(t);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert_eq!(
+            final_a,
+            Some(5),
+            "the restored deferred row replays, not dropped"
+        );
     }
 }

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -79,16 +79,11 @@ impl std::fmt::Debug for ClusterShuffleConfig {
     }
 }
 
-/// Async-decoupled promotion of demoted (cold-tier) aggregate state.
-///
-/// When a pre-aggregate row's group hashes to a vnode that was demoted to
-/// the cold tier, the row cannot process inline — the group's accumulators
-/// are not in memory. Mirroring the lookup-enrich / AI-operator pattern,
-/// the row is deferred, a Ring-1 fetch of the vnode's slice runs off the
-/// compute thread (the cold read never stalls the pipeline), and the row
-/// replays a later cycle once the slice is merged back in. The output
+/// Async-decoupled promotion of demoted (cold-tier) aggregate state: a row
+/// hitting a demoted vnode is deferred, its slice is fetched off the compute
+/// thread, and the row replays once the slice is merged back. The output
 /// watermark is held behind the oldest deferred row so its eventual
-/// contribution is not treated as late downstream.
+/// contribution is not treated as late.
 #[cfg(feature = "state-tier")]
 struct AggPromotion {
     op_name: Arc<str>,

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -165,6 +165,24 @@ impl AggPromotion {
         }
     }
 
+    /// Best-effort delete of a vnode's slice from the tier after it was
+    /// promoted back into memory, so resident bytes track only truly-cold
+    /// vnodes. Fire-and-forget (the reply is ignored): a full channel just
+    /// leaves the slice to be overwritten by the next demotion or wiped on
+    /// restart. Race-safe against a re-demotion of the same vnode — promotion
+    /// marks the vnode dirty, so it cannot be demoted again until the next
+    /// capture, which happens strictly after this Drop is enqueued, and the
+    /// tier request channel is FIFO.
+    fn drop_slice(&self, vnode: u32) {
+        let (reply, _rx) = oneshot::channel();
+        let req = crate::state_tier::TierRequest::Drop {
+            operator: Arc::clone(&self.op_name),
+            vnode,
+            reply,
+        };
+        let _ = self.tier.try_send(req);
+    }
+
     fn defer(&mut self, watermark: i64, batch: RecordBatch) {
         self.deferred.push_back((watermark, batch));
     }
@@ -545,7 +563,15 @@ impl SqlQueryOperator {
             .unwrap_or_default();
         for (vnode, slice) in ready {
             match slice {
-                Some(bytes) => self.apply_vnode_state(vnode, &bytes)?,
+                Some(bytes) => {
+                    self.apply_vnode_state(vnode, &bytes)?;
+                    // Slice is back in memory and the vnode is now dirty (so it
+                    // can't be re-demoted before the next capture) — delete the
+                    // redundant tier copy so resident bytes track only cold vnodes.
+                    if let Some(p) = self.promotion.as_ref() {
+                        p.drop_slice(vnode);
+                    }
+                }
                 None => {
                     // The tier no longer has the slice (should not happen
                     // mid-run). Re-issue; the deferred batch keeps waiting.
@@ -1147,6 +1173,14 @@ impl GraphOperator for SqlQueryOperator {
     }
 
     #[cfg(feature = "state-tier")]
+    fn can_demote(&self, vnode: u32, vnode_count: u32) -> bool {
+        match self.state {
+            QueryState::Agg(ref agg_state) => agg_state.can_demote(vnode, vnode_count),
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "state-tier")]
     fn attach_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         // Promotion only runs on the aggregate path. If the state is already
         // resolved to aggregate, build the buffer now; otherwise hold the
@@ -1177,8 +1211,15 @@ impl GraphOperator for SqlQueryOperator {
                 let merged = agg_state.merge_groups(&cp)?;
                 // Whether this is a rebalance acquisition or a promotion
                 // from the cold tier, the vnode's state now lives in memory.
+                // `mark_vnode_hot` clears the cold flag (promotion only);
+                // `mark_vnode_dirty` then protects *this* vnode from demotion
+                // until the next capture — without it a rebalance-acquired
+                // vnode (never cold) could be demoted against stale tier bytes.
                 #[cfg(feature = "state-tier")]
-                agg_state.mark_vnode_hot(vnode);
+                {
+                    agg_state.mark_vnode_hot(vnode);
+                    agg_state.mark_vnode_dirty(vnode);
+                }
                 tracing::debug!(
                     query = %self.op_name, vnode, groups = merged,
                     "applied rehydrated vnode aggregate state"

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -180,6 +180,13 @@ impl AggPromotion {
         self.deferred.push_back((watermark, batch));
     }
 
+    /// In-flight fetches or deferred batches still awaiting promotion. The
+    /// operator must keep cycling (even on empty input) while this holds, so
+    /// resolved fetches drain and the held watermark releases.
+    fn has_pending(&self) -> bool {
+        !self.inflight.is_empty() || !self.deferred.is_empty()
+    }
+
     fn take_deferred(&mut self) -> Vec<(i64, RecordBatch)> {
         self.deferred.drain(..).collect()
     }
@@ -243,6 +250,12 @@ pub(crate) struct SqlQueryOperator {
     /// to replay back into `pending_restore` before `lazy_init`.
     #[cfg(feature = "state-tier")]
     pending_cold_rehydrate: Vec<u32>,
+    /// Vnode count for promotion's cold-vnode detection. Set by the graph from
+    /// the shuffle registry (cluster) or the single-node tier count; `1` until
+    /// then. Single-node has no shuffle config to read it from, so it is
+    /// threaded in separately.
+    #[cfg(feature = "state-tier")]
+    vnode_count: u32,
 }
 
 impl SqlQueryOperator {
@@ -275,7 +288,17 @@ impl SqlQueryOperator {
             pending_deferred: Vec::new(),
             #[cfg(feature = "state-tier")]
             pending_cold_rehydrate: Vec::new(),
+            #[cfg(feature = "state-tier")]
+            vnode_count: 1,
         }
+    }
+
+    /// Set the vnode count used by cold-tier promotion to detect rows landing
+    /// on demoted vnodes. Threaded from the graph's topology (shuffle registry
+    /// in cluster mode, or the fixed single-node count).
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn set_vnode_count(&mut self, vnode_count: u32) {
+        self.vnode_count = vnode_count;
     }
 
     /// Install the row-shuffle config. When present and the query
@@ -284,6 +307,10 @@ impl SqlQueryOperator {
     /// `IncrementalAggState`.
     #[cfg(feature = "cluster")]
     pub fn attach_cluster_shuffle(&mut self, config: ClusterShuffleConfig) {
+        #[cfg(feature = "state-tier")]
+        {
+            self.vnode_count = config.registry.vnode_count();
+        }
         self.cluster_shuffle = Some(config);
     }
 
@@ -590,10 +617,7 @@ impl SqlQueryOperator {
             QueryState::Agg(ref agg) => agg.num_group_cols(),
             _ => unreachable!("process_with_promotion on non-agg state"),
         };
-        let vnode_count = self
-            .cluster_shuffle
-            .as_ref()
-            .map_or(1, |c| c.registry.vnode_count());
+        let vnode_count = self.vnode_count;
         let cold: FxHashSet<u32> = match self.state {
             QueryState::Agg(ref agg) => agg.cold_vnodes().clone(),
             _ => FxHashSet::default(),
@@ -897,12 +921,21 @@ impl GraphOperator for SqlQueryOperator {
                 // input gracefully (pre-agg on empty → empty pre-agg,
                 // shuffle drain supplies any remote rows).
                 #[cfg(feature = "cluster")]
-                {
-                    if self.cluster_shuffle.is_some() {
-                        return self.execute_agg(input_batches, watermark).await;
-                    }
+                if self.cluster_shuffle.is_some() {
+                    return self.execute_agg(input_batches, watermark).await;
                 }
-                // Single-node: no shuffle to drain — just emit current state.
+                // Cold-tier promotion: resolved fetches must still be drained on
+                // an empty cycle, or a deferred row (single-node, no shuffle to
+                // force execute_agg) waits indefinitely behind its held watermark.
+                #[cfg(feature = "state-tier")]
+                if self
+                    .promotion
+                    .as_ref()
+                    .is_some_and(AggPromotion::has_pending)
+                {
+                    return self.execute_agg(input_batches, watermark).await;
+                }
+                // Otherwise nothing to drain — just emit current state.
                 return self.emit_agg_output(watermark).await;
             }
             return Ok(Vec::new());

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -28,8 +28,11 @@ use bytes::Bytes;
 use rustc_hash::{FxHashMap, FxHashSet};
 #[cfg(feature = "state-tier")]
 use std::collections::VecDeque;
+// Reply receivers are stored across cycles in `AggPromotion.inflight`, so they
+// must be `Sync` (this operator's `process` future holds `&self` across an
+// await); crossfire's `RxOneshot` is `!Sync`, so replies use tokio oneshot.
 #[cfg(feature = "state-tier")]
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 /// Internal state for the query operator (lazy initialization).
 enum QueryState {
@@ -89,7 +92,7 @@ impl std::fmt::Debug for ClusterShuffleConfig {
 #[cfg(feature = "state-tier")]
 struct AggPromotion {
     op_name: Arc<str>,
-    tier: mpsc::Sender<crate::state_tier::TierRequest>,
+    tier: crate::state_tier::TierTx,
     /// Pre-aggregate batches deferred because they touch a cold vnode, each
     /// with the watermark it was first ingested at (replayed at that
     /// watermark, like lookup-enrich, so a late replay is not mis-aged).
@@ -105,7 +108,7 @@ const MAX_DEFERRED_PROMOTION_ROWS: usize = 8192;
 
 #[cfg(feature = "state-tier")]
 impl AggPromotion {
-    fn new(op_name: Arc<str>, tier: mpsc::Sender<crate::state_tier::TierRequest>) -> Self {
+    fn new(op_name: Arc<str>, tier: crate::state_tier::TierTx) -> Self {
         Self {
             op_name,
             tier,
@@ -156,6 +159,7 @@ impl AggPromotion {
             vnode,
             reply,
         };
+        // crossfire `try_send`: full or closed channel → backpressure, retry.
         if self.tier.try_send(req).is_ok() {
             self.inflight.insert(vnode, rx);
         }
@@ -218,7 +222,7 @@ pub(crate) struct SqlQueryOperator {
     /// Cold-tier sender held until `lazy_init` builds the aggregate state;
     /// then moved into `promotion`. `None` = no tier wired.
     #[cfg(feature = "state-tier")]
-    tier_sender: Option<mpsc::Sender<crate::state_tier::TierRequest>>,
+    tier_sender: Option<crate::state_tier::TierTx>,
     /// Deferred batches restored from a checkpoint, replayed into the
     /// promotion buffer once `lazy_init` builds it.
     #[cfg(feature = "state-tier")]
@@ -1143,7 +1147,7 @@ impl GraphOperator for SqlQueryOperator {
     }
 
     #[cfg(feature = "state-tier")]
-    fn attach_state_tier(&mut self, tier: mpsc::Sender<crate::state_tier::TierRequest>) {
+    fn attach_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         // Promotion only runs on the aggregate path. If the state is already
         // resolved to aggregate, build the buffer now; otherwise hold the
         // sender until `lazy_init` builds it.
@@ -1284,9 +1288,7 @@ mod promotion_tests {
         }
     }
 
-    async fn build_op(
-        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    ) -> SqlQueryOperator {
+    async fn build_op(tier: crate::state_tier::TierTx) -> SqlQueryOperator {
         let ctx = laminar_sql::create_session_context();
         let mem = datafusion::datasource::MemTable::try_new(
             events_schema(),

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -740,15 +740,23 @@ impl GraphOperator for SqlQueryOperator {
     fn checkpoint_by_vnode(
         &mut self,
         vnode_count: u32,
-    ) -> Result<Option<std::collections::HashMap<u32, bytes::Bytes>>, DbError> {
+    ) -> Result<
+        Option<std::collections::HashMap<u32, crate::checkpoint_coordinator::StagedSlice>>,
+        DbError,
+    > {
+        use crate::checkpoint_coordinator::StagedSlice;
         let QueryState::Agg(ref mut agg_state) = self.state else {
             return Ok(None);
         };
         let per_vnode = agg_state.checkpoint_groups_by_vnode(vnode_count)?;
-        if per_vnode.is_empty() {
+        #[cfg(feature = "state-tier")]
+        let cold: Vec<u32> = agg_state.cold_vnodes().iter().copied().collect();
+        #[cfg(not(feature = "state-tier"))]
+        let cold: Vec<u32> = Vec::new();
+        if per_vnode.is_empty() && cold.is_empty() {
             return Ok(None);
         }
-        let mut out = std::collections::HashMap::with_capacity(per_vnode.len());
+        let mut out = std::collections::HashMap::with_capacity(per_vnode.len() + cold.len());
         for (vnode, cp) in per_vnode {
             let data = rkyv::to_bytes::<rkyv::rancor::Error>(&cp)
                 .map(|v| v.to_vec())
@@ -758,9 +766,23 @@ impl GraphOperator for SqlQueryOperator {
                         self.op_name
                     ))
                 })?;
-            out.insert(vnode, bytes::Bytes::from(data));
+            out.insert(vnode, StagedSlice::Bytes(bytes::Bytes::from(data)));
+        }
+        // Demoted vnodes have no groups in memory; stage a cold marker so
+        // the coordinator references (or tier-fetches) their slice instead
+        // of treating the vnode as emptied.
+        for vnode in cold {
+            out.insert(vnode, StagedSlice::Cold);
         }
         Ok(Some(out))
+    }
+
+    #[cfg(feature = "state-tier")]
+    fn demote_vnode(&mut self, vnode: u32, vnode_count: u32) -> bool {
+        match self.state {
+            QueryState::Agg(ref mut agg_state) => agg_state.demote_vnode(vnode, vnode_count),
+            _ => false,
+        }
     }
 
     #[cfg(feature = "cluster")]
@@ -775,6 +797,10 @@ impl GraphOperator for SqlQueryOperator {
         match self.state {
             QueryState::Agg(ref mut agg_state) => {
                 let merged = agg_state.merge_groups(&cp)?;
+                // Whether this is a rebalance acquisition or a promotion
+                // from the cold tier, the vnode's state now lives in memory.
+                #[cfg(feature = "state-tier")]
+                agg_state.mark_vnode_hot(vnode);
                 tracing::debug!(
                     query = %self.op_name, vnode, groups = merged,
                     "applied rehydrated vnode aggregate state"

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -251,7 +251,7 @@ pub(crate) struct SqlQueryOperator {
     #[cfg(feature = "state-tier")]
     pending_cold_rehydrate: Vec<u32>,
     /// Vnode count for promotion's cold-vnode detection. Set by the graph from
-    /// the shuffle registry (cluster) or the single-node tier count; `1` until
+    /// the vnode registry (the shuffle registry in cluster mode); `1` until
     /// then. Single-node has no shuffle config to read it from, so it is
     /// threaded in separately.
     #[cfg(feature = "state-tier")]
@@ -294,8 +294,8 @@ impl SqlQueryOperator {
     }
 
     /// Set the vnode count used by cold-tier promotion to detect rows landing
-    /// on demoted vnodes. Threaded from the graph's topology (shuffle registry
-    /// in cluster mode, or the fixed single-node count).
+    /// on demoted vnodes. Threaded from the graph's topology (the vnode
+    /// registry; the shuffle registry in cluster mode).
     #[cfg(feature = "state-tier")]
     pub(crate) fn set_vnode_count(&mut self, vnode_count: u32) {
         self.vnode_count = vnode_count;

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -165,14 +165,12 @@ impl AggPromotion {
         }
     }
 
-    /// Best-effort delete of a vnode's slice from the tier after it was
-    /// promoted back into memory, so resident bytes track only truly-cold
-    /// vnodes. Fire-and-forget (the reply is ignored): a full channel just
-    /// leaves the slice to be overwritten by the next demotion or wiped on
-    /// restart. Race-safe against a re-demotion of the same vnode — promotion
-    /// marks the vnode dirty, so it cannot be demoted again until the next
-    /// capture, which happens strictly after this Drop is enqueued, and the
-    /// tier request channel is FIFO.
+    /// Best-effort delete of a vnode's slice after promotion put it back in
+    /// memory, so resident bytes track only truly-cold vnodes. Fire-and-forget:
+    /// a full channel just leaves the slice for the next demotion to overwrite
+    /// or restart to wipe. Race-safe against a re-demote — promotion marks the
+    /// vnode dirty (no re-demote until the next capture, after this Drop is
+    /// enqueued) and the request channel is FIFO.
     fn drop_slice(&self, vnode: u32) {
         let (reply, _rx) = oneshot::channel();
         let req = crate::state_tier::TierRequest::Drop {

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -34,33 +34,18 @@ use std::collections::VecDeque;
 #[cfg(feature = "state-tier")]
 use tokio::sync::oneshot;
 
-/// Internal state for the query operator (lazy initialization).
+// Resolved on first `process()` call by introspecting the SQL.
 enum QueryState {
-    /// Not yet initialized -- need to introspect SQL on first call.
     Uninit,
-    /// Aggregate query -- incremental accumulator path.
     Agg(Box<IncrementalAggState>),
-    /// Non-aggregate single-source -- compiled `PhysicalExpr` evaluation.
     Compiled(CompiledProjection),
-    /// Single-source non-compilable -- cached physical plan. `LiveSourceExec`
-    /// reads fresh data from swapped handles on each `execute()`.
+    // Single-source, non-compilable; `LiveSourceExec` feeds fresh data per cycle.
     CachedPlan(Arc<dyn datafusion::physical_plan::ExecutionPlan>),
-    /// Multi-source (JOIN) -- cached physical plan with `LiveSourceExec`
-    /// leaves. Each `collect()` re-runs `HashJoinExec::execute()`, which
-    /// creates a fresh `OnceFut<JoinLeftData>` for the build side, so the
-    /// hash table is rebuilt per cycle from the latest live-source data.
+    // Multi-source JOIN; the hash table is rebuilt each cycle from fresh live-source data.
     CachedPhysical(Arc<dyn datafusion::physical_plan::ExecutionPlan>),
 }
 
-/// Row-shuffle config threaded in cluster mode. Pre-aggregate rows are
-/// hashed by their GROUP BY columns; local rows feed `IncrementalAggState`,
-/// remote rows are serialised and shipped via [`ShuffleSender`]. Remote
-/// rows arriving on [`ShuffleReceiver`] are drained at the start of
-/// every cycle and fed into the same accumulator.
-///
-/// Row-shuffle ships raw rows, not partial-aggregate state. Cheaper
-/// to implement than two-stage partial aggregation, linearly more
-/// bandwidth-hungry.
+/// Pre-aggregate row-shuffle config for cluster mode.
 #[cfg(feature = "cluster")]
 #[derive(Clone)]
 pub struct ClusterShuffleConfig {
@@ -79,22 +64,16 @@ impl std::fmt::Debug for ClusterShuffleConfig {
     }
 }
 
-/// Async-decoupled promotion of demoted (cold-tier) aggregate state: a row
-/// hitting a demoted vnode is deferred, its slice is fetched off the compute
-/// thread, and the row replays once the slice is merged back. The output
-/// watermark is held behind the oldest deferred row so its eventual
-/// contribution is not treated as late.
+/// Async-decoupled promotion of cold-tier aggregate state.
+///
+/// Rows touching a demoted vnode are deferred at their ingest watermark and
+/// replayed once the fetch resolves. The watermark hold prevents late-data drops.
 #[cfg(feature = "state-tier")]
 struct AggPromotion {
     op_name: Arc<str>,
     tier: crate::state_tier::TierTx,
-    /// Pre-aggregate batches deferred because they touch a cold vnode, each
-    /// with the watermark it was first ingested at (replayed at that
-    /// watermark, like lookup-enrich, so a late replay is not mis-aged).
     deferred: VecDeque<(i64, RecordBatch)>,
-    /// Vnodes with a fetch in flight → its reply channel.
     inflight: FxHashMap<u32, oneshot::Receiver<Result<Option<Bytes>, DbError>>>,
-    /// Backpressure cap: stop accepting input past this many deferred rows.
     max_deferred_rows: usize,
 }
 
@@ -113,10 +92,6 @@ impl AggPromotion {
         }
     }
 
-    /// Poll every in-flight fetch; return the slices that resolved this
-    /// cycle as `(vnode, slice_bytes)` (a `None` slice = the tier no longer
-    /// has it, surfaced so the caller can re-fetch). Errored or worker-gone
-    /// fetches are dropped so the still-cold deferred batch re-issues them.
     fn drain_ready(&mut self) -> Vec<(u32, Option<Bytes>)> {
         let mut ready = Vec::new();
         let mut still: FxHashMap<u32, oneshot::Receiver<Result<Option<Bytes>, DbError>>> =
@@ -141,9 +116,6 @@ impl AggPromotion {
         ready
     }
 
-    /// Start a fetch for `vnode` unless one is already in flight. A full or
-    /// closed channel is treated as backpressure: the deferred batch retries
-    /// the fetch next cycle.
     fn issue_fetch(&mut self, vnode: u32) {
         if self.inflight.contains_key(&vnode) {
             return;
@@ -154,18 +126,12 @@ impl AggPromotion {
             vnode,
             reply,
         };
-        // crossfire `try_send`: full or closed channel → backpressure, retry.
         if self.tier.try_send(req).is_ok() {
             self.inflight.insert(vnode, rx);
         }
     }
 
-    /// Best-effort delete of a vnode's slice after promotion put it back in
-    /// memory, so resident bytes track only truly-cold vnodes. Fire-and-forget:
-    /// a full channel just leaves the slice for the next demotion to overwrite
-    /// or restart to wipe. Race-safe against a re-demote — promotion marks the
-    /// vnode dirty (no re-demote until the next capture, after this Drop is
-    /// enqueued) and the request channel is FIFO.
+    // Fire-and-forget: a full channel just leaves the slice for the next demotion to overwrite.
     fn drop_slice(&self, vnode: u32) {
         let (reply, _rx) = oneshot::channel();
         let req = crate::state_tier::TierRequest::Drop {
@@ -180,9 +146,6 @@ impl AggPromotion {
         self.deferred.push_back((watermark, batch));
     }
 
-    /// In-flight fetches or deferred batches still awaiting promotion. The
-    /// operator must keep cycling (even on empty input) while this holds, so
-    /// resolved fetches drain and the held watermark releases.
     fn has_pending(&self) -> bool {
         !self.inflight.is_empty() || !self.deferred.is_empty()
     }
@@ -200,24 +163,13 @@ impl AggPromotion {
     }
 }
 
-/// Whole-operator checkpoint for the aggregate path: the group state plus
-/// any pre-aggregate batches the cold-tier promotion buffer has deferred
-/// (empty unless the state tier is active). Replaces the bare
-/// `AggStateCheckpoint` blob so a checkpoint taken mid-promotion does not
-/// lose deferred rows — the source counts them consumed, so only the
-/// operator can carry them across a restart.
+// Wraps the agg group state + any promotion-deferred batches + demoted-vnode list.
+// A checkpoint taken mid-promotion must carry deferred rows; the source counts them consumed.
 #[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 struct AggOpCheckpoint {
-    /// In-memory group state — only the resident (hot) vnodes; demoted
-    /// vnodes are listed in `cold_vnodes` and recovered from their durable
-    /// partials on restart.
     agg: Option<AggStateCheckpoint>,
-    /// `(ingest watermark, IPC-serialized pre-aggregate batch)`.
-    deferred: Vec<(i64, Vec<u8>)>,
-    /// Vnodes demoted to the cold tier at capture time. Their groups are
-    /// absent from `agg`; restart recovery replays each from its vnode
-    /// partial (the tier itself is wiped on restart). Empty without tiering.
-    cold_vnodes: Vec<u32>,
+    deferred: Vec<(i64, Vec<u8>)>, // (ingest watermark, IPC-serialized pre-agg batch)
+    cold_vnodes: Vec<u32>,         // absent from `agg`; replayed from durable partials on restart
 }
 
 pub(crate) struct SqlQueryOperator {
@@ -233,27 +185,18 @@ pub(crate) struct SqlQueryOperator {
     idle_ttl_ms: Option<u64>,
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<ClusterShuffleConfig>,
-    /// Cold-tier promotion buffer, attached when the engine wires a state
-    /// tier and this operator runs the vnode-sharded aggregate path.
     #[cfg(feature = "state-tier")]
     promotion: Option<AggPromotion>,
-    /// Cold-tier sender held until `lazy_init` builds the aggregate state;
-    /// then moved into `promotion`. `None` = no tier wired.
+    // Held until `lazy_init` builds the aggregate state, then moved into `promotion`.
     #[cfg(feature = "state-tier")]
     tier_sender: Option<crate::state_tier::TierTx>,
-    /// Deferred batches restored from a checkpoint, replayed into the
-    /// promotion buffer once `lazy_init` builds it.
+    // Deferred batches from a restored checkpoint, queued until `lazy_init` builds the buffer.
     #[cfg(feature = "state-tier")]
     pending_deferred: Vec<(i64, RecordBatch)>,
-    /// Vnodes that were demoted at the restored checkpoint; the restart path
-    /// drains this (`take_tier_cold_vnodes`) to know which durable partials
-    /// to replay back into `pending_restore` before `lazy_init`.
+    // Demoted vnodes from a restored checkpoint; drained by `take_tier_cold_vnodes`.
     #[cfg(feature = "state-tier")]
     pending_cold_rehydrate: Vec<u32>,
-    /// Vnode count for promotion's cold-vnode detection. Set by the graph from
-    /// the vnode registry (the shuffle registry in cluster mode); `1` until
-    /// then. Single-node has no shuffle config to read it from, so it is
-    /// threaded in separately.
+    // Set from the vnode registry; threaded separately since single-node has no shuffle config.
     #[cfg(feature = "state-tier")]
     vnode_count: u32,
 }
@@ -293,18 +236,11 @@ impl SqlQueryOperator {
         }
     }
 
-    /// Set the vnode count used by cold-tier promotion to detect rows landing
-    /// on demoted vnodes. Threaded from the graph's topology (the vnode
-    /// registry; the shuffle registry in cluster mode).
     #[cfg(feature = "state-tier")]
     pub(crate) fn set_vnode_count(&mut self, vnode_count: u32) {
         self.vnode_count = vnode_count;
     }
 
-    /// Install the row-shuffle config. When present and the query
-    /// resolves to the aggregate fast-path, each cycle's pre-aggregate
-    /// rows are hash-routed across the cluster before reaching
-    /// `IncrementalAggState`.
     #[cfg(feature = "cluster")]
     pub fn attach_cluster_shuffle(&mut self, config: ClusterShuffleConfig) {
         #[cfg(feature = "state-tier")]
@@ -315,7 +251,6 @@ impl SqlQueryOperator {
     }
 
     async fn lazy_init(&mut self) -> Result<(), DbError> {
-        // 1. Try aggregate path first
         match IncrementalAggState::try_from_sql(&self.ctx, &self.sql, self.emit_changelog).await {
             Ok(Some(mut agg_state)) => {
                 if let Some(ref cp) = self.pending_restore {
@@ -333,9 +268,6 @@ impl SqlQueryOperator {
                 }
                 self.log_tier(agg_state.compiled_projection().is_some());
                 self.state = QueryState::Agg(Box::new(agg_state));
-                // Activate cold-tier promotion now the aggregate path is
-                // live: move the held sender into a promotion buffer and
-                // re-queue any deferred batches restored from a checkpoint.
                 #[cfg(feature = "state-tier")]
                 if let Some(tier) = self.tier_sender.take() {
                     let mut promo = AggPromotion::new(Arc::clone(&self.op_name), tier);
@@ -356,7 +288,6 @@ impl SqlQueryOperator {
             }
         }
 
-        // 2. Non-aggregate: try compiled projection, otherwise cache physical plan.
         let df = self
             .ctx
             .sql(&self.sql)
@@ -374,8 +305,6 @@ impl SqlQueryOperator {
                 self.state = QueryState::Compiled(proj);
                 return Ok(());
             }
-            // Single-source, non-compilable: cache physical plan.
-            // LiveSourceExec reads fresh data per execute(), so reuse is safe.
             let physical = self
                 .ctx
                 .state()
@@ -385,9 +314,6 @@ impl SqlQueryOperator {
             self.log_tier(false);
             self.state = QueryState::CachedPlan(physical);
         } else {
-            // Multi-source (JOIN): bake the physical plan once. Source leaves
-            // are `LiveSourceExec`; each cycle's `collect()` recreates the
-            // HashJoinExec build side from fresh data.
             let physical = self
                 .ctx
                 .state()
@@ -455,7 +381,6 @@ impl SqlQueryOperator {
         })
     }
 
-    /// Build a physical plan from `self.sql` and store it as `CachedPlan`.
     async fn build_and_cache_physical_plan(&mut self) -> Result<(), DbError> {
         let df = self
             .ctx
@@ -473,7 +398,6 @@ impl SqlQueryOperator {
         Ok(())
     }
 
-    /// Execute the cached physical plan. Assumes state is `CachedPlan`.
     async fn execute_cached_plan(&self) -> Result<Vec<RecordBatch>, DbError> {
         let QueryState::CachedPlan(ref plan) = self.state else {
             return Err(DbError::Pipeline(
@@ -486,7 +410,6 @@ impl SqlQueryOperator {
             .map_err(|e| DbError::query_pipeline(&*self.op_name, &e))
     }
 
-    /// Execute the aggregate path: pre-agg -> `process_batch` -> emit -> HAVING.
     async fn execute_agg(
         &mut self,
         inputs: &[RecordBatch],
@@ -498,7 +421,6 @@ impl SqlQueryOperator {
             ));
         };
 
-        // Step 1: Pre-aggregation
         let pre_agg_batches = if let Some(proj) = agg_state.compiled_projection() {
             match try_evaluate_compiled(proj, inputs) {
                 Ok(result) => result,
@@ -527,15 +449,10 @@ impl SqlQueryOperator {
             )));
         };
 
-        // Re-borrow agg_state mutably after the await point.
         let QueryState::Agg(ref mut agg_state) = self.state else {
             unreachable!();
         };
 
-        // Step 1.5: cluster row-shuffle. Hash pre-agg rows by their
-        // group columns, keep local, ship remote via `ShuffleSender`.
-        // Drain inbound remote rows from `ShuffleReceiver` and merge
-        // into this cycle's input. Single-node path is a no-op.
         #[cfg(feature = "cluster")]
         let pre_agg_batches = {
             let num_group_cols = agg_state.num_group_cols();
@@ -548,9 +465,6 @@ impl SqlQueryOperator {
             .await?
         };
 
-        // Step 2: Feed pre-agg batches to incremental accumulators. When a
-        // cold tier is wired, rows hitting a demoted vnode route through the
-        // promotion buffer instead (fetched back off-thread, replayed later).
         #[cfg(feature = "state-tier")]
         if self.promotion.is_some() {
             return self
@@ -564,18 +478,12 @@ impl SqlQueryOperator {
         self.emit_agg_output(watermark).await
     }
 
-    /// Aggregate ingest with cold-tier promotion. Drains resolved fetches
-    /// into memory, splits new + previously-deferred rows into those whose
-    /// groups are resident (processed now) and those still demoted
-    /// (re-deferred, fetch issued), then emits — the output watermark is
-    /// held behind the oldest deferred row by [`Self::watermark_hold`].
     #[cfg(feature = "state-tier")]
     async fn process_with_promotion(
         &mut self,
         pre_agg_batches: Vec<RecordBatch>,
         watermark: i64,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        // 1. Apply slices whose fetch resolved this cycle.
         let ready = self
             .promotion
             .as_mut()
@@ -585,16 +493,11 @@ impl SqlQueryOperator {
             match slice {
                 Some(bytes) => {
                     self.apply_vnode_state(vnode, &bytes)?;
-                    // Slice is back in memory and the vnode is now dirty (so it
-                    // can't be re-demoted before the next capture) — delete the
-                    // redundant tier copy so resident bytes track only cold vnodes.
                     if let Some(p) = self.promotion.as_ref() {
                         p.drop_slice(vnode);
                     }
                 }
                 None => {
-                    // The tier no longer has the slice (should not happen
-                    // mid-run). Re-issue; the deferred batch keeps waiting.
                     if let Some(p) = self.promotion.as_mut() {
                         p.issue_fetch(vnode);
                     }
@@ -602,7 +505,6 @@ impl SqlQueryOperator {
             }
         }
 
-        // 2. Candidate set = previously-deferred batches + this cycle's input.
         let mut candidates = self
             .promotion
             .as_mut()
@@ -612,7 +514,6 @@ impl SqlQueryOperator {
             candidates.push((watermark, batch));
         }
 
-        // 3. Split by whether every touched vnode is now resident.
         let num_group_cols = match self.state {
             QueryState::Agg(ref agg) => agg.num_group_cols(),
             _ => unreachable!("process_with_promotion on non-agg state"),
@@ -636,7 +537,6 @@ impl SqlQueryOperator {
             }
         }
 
-        // 4. Fold the resident rows in, each at its own ingest watermark.
         {
             let QueryState::Agg(ref mut agg_state) = self.state else {
                 unreachable!();
@@ -649,7 +549,6 @@ impl SqlQueryOperator {
         self.emit_agg_output(watermark).await
     }
 
-    /// Shared emit path for aggregate queries: evict → emit → HAVING.
     async fn emit_agg_output(&mut self, watermark: i64) -> Result<Vec<RecordBatch>, DbError> {
         let QueryState::Agg(ref mut agg_state) = self.state else {
             return Err(DbError::Pipeline(
@@ -668,9 +567,8 @@ impl SqlQueryOperator {
 
         let mut batches = agg_state.emit()?;
 
-        // HAVING is skipped in changelog mode — retractions and HAVING interact
-        // incorrectly (a retraction that no longer satisfies HAVING would be
-        // silently dropped, leaving stale state downstream).
+        // HAVING is skipped in changelog mode: a retraction that fails HAVING would be silently
+        // dropped, leaving stale state downstream.
         if !self.emit_changelog {
             let having_filter = agg_state.having_filter().cloned();
             let having_sql = agg_state.having_sql().map(String::from);
@@ -694,13 +592,7 @@ impl SqlQueryOperator {
         Ok(result)
     }
 
-    /// Drop output rows whose group key hashes to a vnode currently
-    /// [`Restoring`](laminar_core::state::VnodeLifecycleState::Restoring), so a
-    /// downstream MV/sink never observes a transiently-incomplete aggregate
-    /// for a vnode whose committed state hasn't been merged in yet. The vnode
-    /// flips back to `Active` (and its rows resume emitting) once the graph
-    /// applies its rehydrated slice. No-op when nothing is restoring — the
-    /// common case, gated by a single atomic scan.
+    // Drops rows for vnodes still restoring so downstream never sees a partial aggregate.
     #[cfg(feature = "cluster")]
     fn suppress_restoring_output(
         &self,
@@ -739,14 +631,10 @@ impl SqlQueryOperator {
                 })?;
                 out.push(filtered);
             }
-            // kept == 0 → entire batch suppressed; drop it.
         }
         Ok(out)
     }
 
-    /// Apply a HAVING predicate via SQL. First call builds a
-    /// `LiveSourceProvider`-backed cache; subsequent calls swap batches into
-    /// the handle and re-run the cached physical plan.
     async fn apply_having_sql(
         &mut self,
         batches: &[RecordBatch],
@@ -779,26 +667,8 @@ impl SqlQueryOperator {
     }
 }
 
-/// Cluster row-shuffle step applied between pre-aggregate compilation
-/// and `IncrementalAggState::process_batch`.
-///
-/// For each pre-aggregate row:
-/// - hash the leading `num_group_cols` columns to a vnode
-/// - if `registry.owner(vnode) == self_id`, keep the row local
-/// - otherwise serialise the row-slice and ship via [`ShuffleSender`]
-///
-/// Inbound rows already on [`ShuffleReceiver`] are drained (non-blocking)
-/// and appended to the local batch set. The returned vector carries
-/// every row that should feed into the local `IncrementalAggState` this
-/// cycle — a mix of originally-local rows and remote rows routed here
-/// by peers.
-///
-/// `num_group_cols == 0` is treated as "hash by all columns" — a degenerate
-/// global aggregate; all rows land on the same vnode deterministically.
-/// Acceptable for `SELECT SUM(x) FROM src`-shape queries: the cluster
-/// agrees on one owner, only that owner produces output.
-///
-/// Single-node fallback: if `config` is `None` the function is a pass-through.
+// Routes pre-aggregate rows by group-key vnode; drains inbound remote rows.
+// `num_group_cols == 0` (global aggregate) hashes everything to vnode 0.
 #[cfg(feature = "cluster")]
 async fn shuffle_pre_agg_batches(
     config: Option<&ClusterShuffleConfig>,
@@ -849,10 +719,6 @@ async fn shuffle_pre_agg_batches(
         }
     }
 
-    // Drain this query's currently-available remote rows into this cycle.
-    // The receiver demuxes by stage, so a co-resident sharded operator
-    // (e.g. a lookup-enrich join) doesn't steal our rows. Bound by channel
-    // depth; never blocks. Rows that arrive after we drain land next cycle.
     for batch in cfg.receiver.drain_vnode_data_for(op_name) {
         if batch.num_rows() > 0 {
             local.push(batch);
@@ -862,9 +728,6 @@ async fn shuffle_pre_agg_batches(
     Ok(local)
 }
 
-/// Vnode per row, hashing the leading `num_group_cols` group columns.
-/// `num_group_cols == 0` is a global aggregate — every row hashes to vnode 0
-/// so a single owner produces output.
 #[cfg(feature = "cluster")]
 fn hash_rows_to_vnodes(batch: &RecordBatch, num_group_cols: usize, vnode_count: u32) -> Vec<u32> {
     if num_group_cols == 0 || batch.num_rows() == 0 {
@@ -874,10 +737,6 @@ fn hash_rows_to_vnodes(batch: &RecordBatch, num_group_cols: usize, vnode_count: 
     laminar_core::shuffle::row_vnodes(batch, &columns, vnode_count)
 }
 
-/// The demoted vnodes a pre-aggregate batch's rows hash to. Uses the same
-/// `row_vnodes` hashing as the cluster shuffle and the per-vnode capture, so
-/// a row's vnode here is exactly the one its group's slice was demoted under.
-/// Empty `cold` (the common case) short-circuits before any row hashing.
 #[cfg(feature = "state-tier")]
 fn cold_vnodes_touched(
     batch: &RecordBatch,
@@ -914,19 +773,11 @@ impl GraphOperator for SqlQueryOperator {
 
         if input_batches.is_empty() || input_batches.iter().all(|b| b.num_rows() == 0) {
             if matches!(self.state, QueryState::Agg(_)) {
-                // In cluster mode, `execute_agg` also drains the shuffle
-                // receiver for remote rows — skipping it here would
-                // strand rows shipped from the leader when the follower
-                // has no local input. `execute_agg` handles empty local
-                // input gracefully (pre-agg on empty → empty pre-agg,
-                // shuffle drain supplies any remote rows).
+                // In cluster mode, drain the shuffle receiver even on empty local input.
                 #[cfg(feature = "cluster")]
                 if self.cluster_shuffle.is_some() {
                     return self.execute_agg(input_batches, watermark).await;
                 }
-                // Cold-tier promotion: resolved fetches must still be drained on
-                // an empty cycle, or a deferred row (single-node, no shuffle to
-                // force execute_agg) waits indefinitely behind its held watermark.
                 #[cfg(feature = "state-tier")]
                 if self
                     .promotion
@@ -935,7 +786,6 @@ impl GraphOperator for SqlQueryOperator {
                 {
                     return self.execute_agg(input_batches, watermark).await;
                 }
-                // Otherwise nothing to drain — just emit current state.
                 return self.emit_agg_output(watermark).await;
             }
             return Ok(Vec::new());
@@ -992,9 +842,6 @@ impl GraphOperator for SqlQueryOperator {
                 None
             }
         };
-        // Carry cold-tier promotion-deferred batches (the source counts them
-        // consumed, so only the operator can restore them). Always empty
-        // without the state tier.
         #[cfg(feature = "state-tier")]
         let deferred: Vec<(i64, Vec<u8>)> = {
             let mut out = Vec::new();
@@ -1015,8 +862,6 @@ impl GraphOperator for SqlQueryOperator {
         #[cfg(not(feature = "state-tier"))]
         let deferred: Vec<(i64, Vec<u8>)> = Vec::new();
 
-        // Demoted vnodes are absent from `agg` (their groups are not in
-        // memory); list them so restart recovery replays them from partials.
         #[cfg(feature = "state-tier")]
         let cold_vnodes: Vec<u32> = match self.state {
             QueryState::Agg(ref agg_state) => agg_state.cold_vnodes().iter().copied().collect(),
@@ -1055,8 +900,6 @@ impl GraphOperator for SqlQueryOperator {
             ))
         })?;
 
-        // Re-queue cold-tier promotion-deferred batches. Before `lazy_init`
-        // they wait in `pending_deferred`; after, straight into the buffer.
         #[cfg(feature = "state-tier")]
         for (wm, blob) in cp.deferred {
             let batch = laminar_core::serialization::deserialize_batch_stream(&blob)
@@ -1076,8 +919,6 @@ impl GraphOperator for SqlQueryOperator {
             );
         }
 
-        // Remember which vnodes were demoted so the restart path can replay
-        // their durable partials into `pending_restore` before `lazy_init`.
         #[cfg(feature = "state-tier")]
         if !cp.cold_vnodes.is_empty() {
             self.pending_cold_rehydrate = cp.cold_vnodes;
@@ -1110,9 +951,6 @@ impl GraphOperator for SqlQueryOperator {
         }
     }
 
-    /// Hold the output watermark behind the oldest pre-aggregate row deferred
-    /// for cold-tier promotion, so its eventual contribution is not dropped as
-    /// late by a downstream window. `None` when nothing is deferred.
     #[cfg(feature = "state-tier")]
     fn watermark_hold(&self) -> Option<i64> {
         self.promotion
@@ -1120,9 +958,6 @@ impl GraphOperator for SqlQueryOperator {
             .and_then(AggPromotion::min_deferred_watermark)
     }
 
-    /// Backpressure the source once too many rows are parked waiting on
-    /// promotion, so a storm of cold-vnode hits can't grow the buffer
-    /// unbounded.
     #[cfg(feature = "state-tier")]
     fn wants_input(&self) -> bool {
         self.promotion
@@ -1137,8 +972,6 @@ impl GraphOperator for SqlQueryOperator {
         batch: RecordBatch,
         watermark: i64,
     ) -> Result<(), DbError> {
-        // A peer's pre-aggregate rows — fold them into the accumulator so they
-        // enter this snapshot, exactly as the per-cycle shuffle drain does.
         if matches!(self.state, QueryState::Uninit) {
             self.lazy_init().await?;
         }
@@ -1181,9 +1014,7 @@ impl GraphOperator for SqlQueryOperator {
                 })?;
             out.insert(vnode, StagedSlice::Bytes(bytes::Bytes::from(data)));
         }
-        // Demoted vnodes have no groups in memory; stage a cold marker so
-        // the coordinator references (or tier-fetches) their slice instead
-        // of treating the vnode as emptied.
+        // Cold markers let the coordinator fetch the slice instead of treating the vnode as empty.
         for vnode in cold {
             out.insert(vnode, StagedSlice::Cold);
         }
@@ -1208,9 +1039,6 @@ impl GraphOperator for SqlQueryOperator {
 
     #[cfg(feature = "state-tier")]
     fn attach_state_tier(&mut self, tier: crate::state_tier::TierTx) {
-        // Promotion only runs on the aggregate path. If the state is already
-        // resolved to aggregate, build the buffer now; otherwise hold the
-        // sender until `lazy_init` builds it.
         if matches!(self.state, QueryState::Agg(_)) {
             self.promotion = Some(AggPromotion::new(Arc::clone(&self.op_name), tier));
         } else {
@@ -1244,6 +1072,7 @@ impl GraphOperator for SqlQueryOperator {
                 #[cfg(feature = "state-tier")]
                 {
                     agg_state.mark_vnode_hot(vnode);
+                    // mark_vnode_dirty prevents re-demotion until next capture.
                     agg_state.mark_vnode_dirty(vnode);
                 }
                 tracing::debug!(
@@ -1252,9 +1081,7 @@ impl GraphOperator for SqlQueryOperator {
                 );
             }
             QueryState::Uninit => {
-                // Not yet initialized (rare — an owning node is normally
-                // running). Fold into the pending restore; vnodes are disjoint
-                // so concatenating their group lists is safe.
+                // Fold into the pending restore; vnodes are disjoint so concatenating groups is safe.
                 match self.pending_restore {
                     Some(ref mut existing) if existing.fingerprint == cp.fingerprint => {
                         existing.groups.extend(cp.groups);

--- a/crates/laminar-db/src/operator/temporal_filter.rs
+++ b/crates/laminar-db/src/operator/temporal_filter.rs
@@ -18,8 +18,7 @@ use crate::error::DbError;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 use crate::sql_analysis::TemporalFilterConfig;
 
-/// Live buffer encoded as one Arrow IPC batch (data + `__enter`/`__exit`/
-/// `__inserted` bookkeeping columns).
+/// Live buffer encoded as one Arrow IPC batch.
 #[derive(
     serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
@@ -29,10 +28,6 @@ pub(crate) struct TemporalFilterCheckpoint {
     batch_ipc: Vec<u8>,
 }
 
-/// `enter_key` = smallest frontier at which the row is a member
-/// (`i64::MIN` ⇒ no upper bound); `exit_key` = smallest frontier at which
-/// it ceases (`i64::MAX` ⇒ no lower bound). Rows share an
-/// `Arc<RecordBatch>` so the per-row cost is one Arc bump.
 #[derive(Clone)]
 struct BufferedRow {
     batch: Arc<RecordBatch>,
@@ -41,14 +36,11 @@ struct BufferedRow {
     exit_key: i64,
 }
 
-/// Which map a row lives in *is* its membership state; `len` is
-/// maintained at every push/remove so the per-cycle metric is O(1).
+// `len` is maintained at every push/remove so the per-cycle buffered-row metric is O(1).
 struct TfState {
     by_enter: BTreeMap<i64, Vec<BufferedRow>>,
     by_exit: BTreeMap<i64, Vec<BufferedRow>>,
-    /// `i64::MIN` = no frontier seen yet, so any first watermark
-    /// (including negative epoch ms) drives `advance`.
-    last_frontier: i64,
+    last_frontier: i64, // i64::MIN = no frontier seen yet
     len: usize,
 }
 
@@ -78,19 +70,14 @@ impl TfState {
         self.by_exit.entry(key).or_default().push(row);
         self.len += 1;
     }
-    /// Drain a key from a map; returns the rows. Caller updates `len`
-    /// based on what it does with them.
     #[inline]
     fn remove_from(map: &mut BTreeMap<i64, Vec<BufferedRow>>, k: i64) -> Vec<BufferedRow> {
         map.remove(&k).unwrap_or_default()
     }
 }
 
-/// `(enter_key, exit_key)` for a row at event time `t_ms` under `cfg`.
-/// Saturating throughout so a pathological timestamp can never panic.
 fn keys_for(t_ms: i64, cfg: &TemporalFilterConfig) -> (i64, i64) {
-    // Lower bound `time_col {>|>=} now()+off` ⇒ member while
-    // `W {<|<=} t-off`. Non-member (exit) at the first `W >= exit_key`.
+    // exit_key: first frontier where the row is no longer a member (lower-bound constraint).
     let exit_key = match cfg.lower {
         Some(b) => {
             let base = t_ms.saturating_sub(b.off_ms);
@@ -102,8 +89,7 @@ fn keys_for(t_ms: i64, cfg: &TemporalFilterConfig) -> (i64, i64) {
         }
         None => i64::MAX,
     };
-    // Upper bound `time_col {<|<=} now()+off` ⇒ member once
-    // `W {>|>=} t-off`. Member at the first `W >= enter_key`.
+    // enter_key: first frontier where the row becomes a member (upper-bound constraint).
     let enter_key = match cfg.upper {
         Some(b) => {
             let base = t_ms.saturating_sub(b.off_ms);
@@ -191,16 +177,14 @@ pub(crate) struct TemporalFilterOperator {
     sql: String,
     cfg: TemporalFilterConfig,
     input_schema: Option<SchemaRef>,
-    /// Output minus `__weight`; may be set early by `restore`.
+    // May be set early by `restore` before the first batch arrives.
     row_schema: Option<SchemaRef>,
     output_schema: Option<SchemaRef>,
-    /// Input-column indices to buffer in projected order; empty for `SELECT *`.
-    proj_indices: Vec<usize>,
+    proj_indices: Vec<usize>, // empty for SELECT *
     time_idx: usize,
     state: TfState,
     prom: Option<Arc<EngineMetrics>>,
-    /// Cap on far-future buffering (`LAMINAR_TEMPORAL_FILTER_HORIZON_MS`,
-    /// falling back to `LAMINAR_MAX_FUTURE_SKEW_MS`; `0` disables).
+    // Reads LAMINAR_TEMPORAL_FILTER_HORIZON_MS (or LAMINAR_MAX_FUTURE_SKEW_MS); 0 disables.
     max_future_ms: i64,
 }
 
@@ -211,8 +195,6 @@ impl TemporalFilterOperator {
         cfg: TemporalFilterConfig,
         prom: Option<Arc<EngineMetrics>>,
     ) -> Self {
-        // Dedicated knob so disabling the source-side future-skew guard
-        // doesn't simultaneously uncap the temporal-filter future buffer.
         let max_future_ms = match std::env::var("LAMINAR_TEMPORAL_FILTER_HORIZON_MS")
             .or_else(|_| std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS"))
         {
@@ -236,7 +218,7 @@ impl TemporalFilterOperator {
         }
     }
 
-    /// Second-floored frontier — matches `apply_dynamic_now_filter`.
+    // Matches the floor in `apply_dynamic_now_filter`.
     fn floor_frontier(wm_ms: i64) -> i64 {
         wm_ms.div_euclid(1000).saturating_mul(1000)
     }
@@ -286,9 +268,7 @@ impl TemporalFilterOperator {
             .map(|&i| schema.field(i).clone())
             .collect();
         if let Some(saved) = &self.row_schema {
-            // `restore` set this from the persisted columns; the live source
-            // must still produce the same projected shape or the buffered
-            // rows can't be combined with new ingest.
+            // Shape must match the restored checkpoint's columns so old and new rows are compatible.
             if saved.fields() != &live_row_fields.clone().into() {
                 return Err(DbError::Pipeline(format!(
                     "[LDB-1001] temporal filter '{}' source schema diverged \
@@ -326,8 +306,6 @@ impl TemporalFilterOperator {
         Ok(crate::aggregate_state::query_fingerprint(&self.sql, schema))
     }
 
-    /// Retractions then insertions; consecutive rows sharing a source
-    /// `Arc<RecordBatch>` are collapsed into one vectorised `take`.
     fn build_delta(
         &self,
         retracts: &[BufferedRow],
@@ -367,8 +345,6 @@ impl TemporalFilterOperator {
         Ok(out_batches)
     }
 
-    /// Already-aged-out rows are dropped (no phantom retract); rows in
-    /// `[enter_key, exit_key)` insert now; the rest park in `by_enter`.
     fn ingest(
         &mut self,
         batch: &RecordBatch,
@@ -400,7 +376,7 @@ impl TemporalFilterOperator {
                 continue;
             }
             if has_frontier && w >= exit_key {
-                *dropped += 1; // arrived already aged out → no emit
+                *dropped += 1; // already aged out
                 continue;
             }
             if has_frontier
@@ -408,7 +384,7 @@ impl TemporalFilterOperator {
                 && enter_key != i64::MIN
                 && enter_key > w.saturating_add(self.max_future_ms)
             {
-                *dropped += 1; // beyond the future horizon → bound the buffer
+                *dropped += 1; // beyond future horizon
                 continue;
             }
             let row = BufferedRow {
@@ -427,7 +403,6 @@ impl TemporalFilterOperator {
         Ok(())
     }
 
-    /// Promote rows whose `enter_key <= w`, retract rows whose `exit_key <= w`.
     fn advance(
         &mut self,
         w: i64,
@@ -437,8 +412,6 @@ impl TemporalFilterOperator {
     ) {
         let entered: Vec<i64> = self.state.by_enter.range(..=w).map(|(k, _)| *k).collect();
         for k in entered {
-            // Each row either drops (len--) or moves to `by_exit` (net 0);
-            // use `entry().push()` directly to avoid double-counting via push_exit.
             for row in TfState::remove_from(&mut self.state.by_enter, k) {
                 if w >= row.exit_key {
                     *dropped += 1;
@@ -462,8 +435,6 @@ impl TemporalFilterOperator {
         self.state.last_frontier = w;
     }
 
-    /// `batch` = first `ncols` data columns + `__tf_enter`/`__tf_exit`/
-    /// `__tf_inserted`; inserted rows go to `by_exit`, the rest to `by_enter`.
     fn rebuild_state(
         batch: &RecordBatch,
         ncols: usize,
@@ -557,7 +528,6 @@ impl GraphOperator for TemporalFilterOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        // `by_enter` = inserted=false; `by_exit` = inserted=true.
         let live: Vec<(&BufferedRow, bool)> = self
             .state
             .by_enter
@@ -578,7 +548,6 @@ impl GraphOperator for TemporalFilterOperator {
                 "temporal filter checkpoint: buffered rows but unresolved schema".into(),
             ));
         };
-        // Per-source-batch `take` + `concat` — vectorised.
         let mut data_batches: Vec<RecordBatch> = Vec::new();
         let mut cur_batch: Option<Arc<RecordBatch>> = None;
         let mut cur_idx: Vec<u32> = Vec::new();
@@ -662,8 +631,6 @@ impl GraphOperator for TemporalFilterOperator {
         }
         let ncols = total - 3;
 
-        // `time_idx` and `proj_indices` are re-resolved on the first
-        // post-restore cycle (the time column may not be projected).
         let row_fields: Vec<Field> = (0..ncols)
             .map(|c| batch.schema().field(c).clone())
             .collect();
@@ -692,8 +659,7 @@ impl GraphOperator for TemporalFilterOperator {
     }
 
     fn estimated_state_bytes(&self) -> usize {
-        // Dedup batches by Arc identity so a shared batch's memory is
-        // counted once.
+        // Dedup by Arc identity so a shared batch is counted once.
         let mut seen: rustc_hash::FxHashSet<*const RecordBatch> = rustc_hash::FxHashSet::default();
         let mut batch_bytes = 0usize;
         let mut row_count = 0usize;
@@ -714,8 +680,7 @@ impl GraphOperator for TemporalFilterOperator {
     }
 }
 
-/// Operator that fails every cycle with a fixed typed error — used to
-/// surface planner-level rejections at run time (matches `nonwhere_now`).
+/// Surfaces planner-level rejections at run time (matches `nonwhere_now`).
 pub(crate) struct RejectingOperator {
     message: String,
 }

--- a/crates/laminar-db/src/operator/temporal_join.rs
+++ b/crates/laminar-db/src/operator/temporal_join.rs
@@ -1,9 +1,4 @@
-//! Temporal join operator for the `OperatorGraph`.
-//!
-//! Wraps the versioned temporal join logic from `laminar-sql`. The stream
-//! side arrives via `inputs[0]`, while the lookup table comes from the
-//! `LookupTableRegistry` (pre-registered by the pipeline lifecycle).
-//! The operator is stateless (no cross-cycle state).
+//! Temporal join operator; stateless wrapper around `VersionedLookupJoinExec`.
 
 use std::sync::Arc;
 
@@ -49,7 +44,6 @@ impl TemporalJoinOperator {
         }
     }
 
-    /// Execute the versioned temporal join using the `VersionedLookupJoinExec`.
     #[allow(clippy::too_many_lines)]
     async fn execute_versioned_join(
         &mut self,
@@ -80,7 +74,6 @@ impl TemporalJoinOperator {
             )));
         };
 
-        // Warn once per query when the temporal table shrinks (non-append-only)
         let current_rows = versioned.batch.num_rows();
         if current_rows < self.last_temporal_row_count {
             tracing::warn!(
@@ -138,7 +131,6 @@ impl TemporalJoinOperator {
 
         let output_schema = build_temporal_output_schema(&stream_schema, &table_schema);
 
-        // Build a MemTable from stream batches as the input plan
         let mem_table = datafusion::datasource::MemTable::try_new(
             Arc::clone(&stream_schema),
             vec![stream_batches],
@@ -188,7 +180,6 @@ impl TemporalJoinOperator {
     }
 }
 
-/// Build the merged output schema: stream fields followed by table fields.
 fn build_temporal_output_schema(stream_schema: &SchemaRef, table_schema: &SchemaRef) -> SchemaRef {
     let mut fields = stream_schema.fields().to_vec();
     fields.extend(table_schema.fields().iter().cloned());
@@ -213,13 +204,11 @@ impl GraphOperator for TemporalJoinOperator {
     }
 
     fn checkpoint(&mut self) -> Result<Option<OperatorCheckpoint>, DbError> {
-        // Stateless — no checkpoint needed.
-        Ok(None)
+        Ok(None) // stateless
     }
 
     fn restore(&mut self, _checkpoint: OperatorCheckpoint) -> Result<(), DbError> {
-        // Stateless — nothing to restore.
-        Ok(())
+        Ok(()) // stateless
     }
 }
 

--- a/crates/laminar-db/src/operator/temporal_probe_join.rs
+++ b/crates/laminar-db/src/operator/temporal_probe_join.rs
@@ -1,10 +1,4 @@
-//! Temporal probe join operator for the `OperatorGraph`.
-//!
-//! Wraps `crate::temporal_probe::TemporalProbeState` and the
-//! `execute_temporal_probe_cycle` function. The operator is **stateful**
-//! across cycles: it buffers right-side reference data and pending probes
-//! for offsets not yet resolvable. Probes are emitted when the watermark
-//! advances past their probe timestamp.
+//! Temporal probe join operator; stateful wrapper around `TemporalProbeState`.
 
 use std::sync::Arc;
 

--- a/crates/laminar-db/src/operator/window_frame.rs
+++ b/crates/laminar-db/src/operator/window_frame.rs
@@ -1,19 +1,8 @@
-//! Sliding-window covariance/correlation operator.
+//! Sliding-window `CORR`/`COVAR_SAMP`/`COVAR_POP` operator.
 //!
-//! Streams the bivariate statistics over a `ROWS N PRECEDING` frame — `CORR`,
-//! `COVAR_SAMP`, `COVAR_POP` — that the batch engine can't slide: `DataFusion`'s
-//! accumulators for them have no `retract_batch`, so they are rejected as
-//! sliding-window accumulators. All three derive from the *same* window moments;
-//! only the final formula differs. The operator recomputes them per window over a
-//! bounded retained buffer — two-pass and mean-centered, which stays accurate for
-//! large-magnitude series where the textbook `nΣxy − ΣxΣy` form loses precision to
-//! cancellation — appends the result column, and re-projects. (`AVG`/`SUM`/… over
-//! frames are a separate concern — `DataFusion` slides those itself.)
-//!
-//! Supports one bivariate call over a single ordered series (no `PARTITION BY`),
-//! preceding bounds only (enforced by `plan_frame_query`). Rows are assumed to
-//! arrive in `ORDER BY` order (true for processing-time buckets), so the buffer
-//! is already ordered and the new arrivals are its tail.
+//! `DataFusion`'s accumulators for these have no `retract_batch`, so they can't
+//! slide natively. This operator recomputes them per window over a bounded buffer
+//! using two-pass mean-centered moments, which avoids precision loss at large magnitudes.
 
 use std::sync::Arc;
 
@@ -30,21 +19,15 @@ use crate::operator::ProjectingJoinState;
 use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 use crate::sql_analysis::FRAME_TMP_TABLE;
 
-/// A bivariate moment-carrying statistic over a sliding frame.
+/// Which bivariate statistic to compute over the sliding frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MomentFn {
-    /// Pearson correlation.
     Corr,
-    /// Sample covariance.
     CovarSamp,
-    /// Population covariance.
     CovarPop,
 }
 
 impl MomentFn {
-    /// Finalize from a window's centered moments — `cxx = Σ(x−x̄)²`, `cyy = Σ(y−ȳ)²`,
-    /// `cxy = Σ(x−x̄)(y−ȳ)` over `n` complete pairs. `None` when the frame has too
-    /// few pairs (or zero variance, for `CORR`).
     fn finalize(self, n: f64, cxx: f64, cyy: f64, cxy: f64) -> Option<f64> {
         match self {
             MomentFn::Corr => {
@@ -56,23 +39,19 @@ impl MomentFn {
     }
 }
 
-/// What the operator computes: the statistic, its two argument columns, the
-/// appended output column, and the rows of preceding history to retain.
+/// Frame config: which statistic, its argument columns, output column, and preceding-row count.
 pub(crate) struct MomentFrameConfig {
     pub func: MomentFn,
     pub x_column: String,
     pub y_column: String,
     pub output_column: String,
-    /// `max(PRECEDING)` — retained so each new row gets a full frame.
-    pub retain: usize,
+    pub retain: usize, // max(PRECEDING) — rows to carry across cycles
 }
 
-/// Streams a sliding-window bivariate statistic (see module docs).
+/// Streams a sliding-window bivariate statistic.
 pub(crate) struct WindowFrameOperator {
     config: MomentFrameConfig,
-    /// Newest `config.retain` input rows, carried across cycles.
-    history: Option<RecordBatch>,
-    /// The user's SELECT with the stat call rewritten to its alias column.
+    history: Option<RecordBatch>, // newest `config.retain` rows carried across cycles
     projection: ProjectingJoinState,
 }
 
@@ -90,7 +69,6 @@ impl WindowFrameOperator {
         }
     }
 
-    /// The newest `n` rows of `batch` (all of it if shorter).
     fn tail(batch: &RecordBatch, n: usize) -> RecordBatch {
         let rows = batch.num_rows();
         if rows <= n {
@@ -100,9 +78,6 @@ impl WindowFrameOperator {
         }
     }
 
-    /// The named column coerced to `Float64`. `CORR`/`COVAR` operate on any
-    /// numeric input (as they do in `DataFusion`, which we bypass), so an integer
-    /// or `Float32` column is cast up; only a genuinely non-numeric column errors.
     fn f64_column(batch: &RecordBatch, name: &str) -> Result<Float64Array, DbError> {
         let column = batch.column_by_name(name).ok_or_else(|| {
             DbError::InvalidOperation(format!("window frame: argument '{name}' not found"))
@@ -119,8 +94,6 @@ impl WindowFrameOperator {
             .clone())
     }
 
-    /// The statistic over the window `lo..=hi` of `x`/`y`. Two passes — means,
-    /// then centered moments — so the result stays precise for large magnitudes.
     fn stat_window(&self, x: &Float64Array, y: &Float64Array, lo: usize, hi: usize) -> Option<f64> {
         let (mut n, mut sx, mut sy) = (0.0_f64, 0.0, 0.0);
         for i in lo..=hi {
@@ -148,7 +121,6 @@ impl WindowFrameOperator {
         self.config.func.finalize(n, cxx, cyy, cxy)
     }
 
-    /// Append the per-new-row statistic column to the `new` batch.
     fn enrich(&self, new: &RecordBatch, buffer: &RecordBatch) -> Result<RecordBatch, DbError> {
         let x = Self::f64_column(buffer, &self.config.x_column)?;
         let y = Self::f64_column(buffer, &self.config.y_column)?;
@@ -196,7 +168,7 @@ impl GraphOperator for WindowFrameOperator {
             .find(|b| b.num_rows() > 0)
             .map(RecordBatch::schema)
         else {
-            return Ok(Vec::new()); // nothing new this cycle
+            return Ok(Vec::new());
         };
 
         let new = concat_batches(&schema, batches.iter())

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -526,7 +526,6 @@ impl OperatorGraph {
     /// operator (and, via the stored copy, every operator added later by
     /// DDL). Vnode-sharded aggregates use it for promotion; others ignore it.
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // wired in pipeline_lifecycle once the demotion trigger lands
     pub(crate) fn set_state_tier(
         &mut self,
         tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -78,14 +78,30 @@ pub(crate) trait GraphOperator: Send {
     /// a value the cluster shuffle routes (the aggregation fast-path); `None`
     /// (default) for operators that aren't vnode-partitionable — those recover
     /// from the whole-node manifest blob instead. The per-vnode bytes are the
-    /// same encoding the operator's own restore/apply path consumes.
+    /// same encoding the operator's own restore/apply path consumes. A vnode
+    /// demoted to the cold tier stages [`StagedSlice::Cold`] instead of
+    /// bytes — staging nothing would read as "emptied" and drop the demoted
+    /// state from recovery truth.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // cold checkpoint path; vnode-keyed map
     fn checkpoint_by_vnode(
         &mut self,
         _vnode_count: u32,
-    ) -> Result<Option<std::collections::HashMap<u32, bytes::Bytes>>, DbError> {
+    ) -> Result<
+        Option<std::collections::HashMap<u32, crate::checkpoint_coordinator::StagedSlice>>,
+        DbError,
+    > {
         Ok(None)
+    }
+
+    /// Drop one vnode's state from memory after its bytes were confirmed
+    /// written to the cold tier. Returns `false` to refuse — the vnode was
+    /// touched since the last capture (the tier bytes would be stale) or
+    /// the operator can't demote at all. Default: refuse.
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // called once the demotion trigger lands with promotion
+    fn demote_vnode(&mut self, _vnode: u32, _vnode_count: u32) -> bool {
+        false
     }
 
     /// Merge one vnode's rehydrated state slice (produced by
@@ -2152,18 +2168,13 @@ impl OperatorGraph {
     #[allow(clippy::disallowed_types)] // std HashMap matches the trait/CheckpointRequest shape
     pub fn snapshot_state_by_vnode(
         &mut self,
-    ) -> Result<
-        std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
-        DbError,
-    > {
+    ) -> Result<crate::checkpoint_coordinator::StagedVnodeStates, DbError> {
         let vnode_count = match &self.cluster_shuffle {
             Some(cfg) => cfg.registry.vnode_count(),
             None => return Ok(std::collections::HashMap::new()),
         };
-        let mut out: std::collections::HashMap<
-            u32,
-            std::collections::HashMap<String, bytes::Bytes>,
-        > = std::collections::HashMap::new();
+        let mut out: crate::checkpoint_coordinator::StagedVnodeStates =
+            std::collections::HashMap::new();
         for node in &mut self.nodes {
             if node.removed {
                 continue;
@@ -2177,6 +2188,22 @@ impl OperatorGraph {
             }
         }
         Ok(out)
+    }
+
+    /// Ask the named operator to drop one vnode's state after its slice
+    /// was confirmed in the cold tier. `false` = refused (the vnode was
+    /// touched since the last capture, or the operator can't demote).
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // called once the demotion trigger lands with promotion
+    pub(crate) fn demote_vnode(&mut self, operator: &str, vnode: u32) -> bool {
+        let Some(cfg) = &self.cluster_shuffle else {
+            return false;
+        };
+        let vnode_count = cfg.registry.vnode_count();
+        self.nodes
+            .iter_mut()
+            .find(|n| !n.removed && &*n.name == operator)
+            .is_some_and(|n| n.operator.demote_vnode(vnode, vnode_count))
     }
 
     pub fn restore_state(&mut self, checkpoint: &GraphCheckpoint) -> Result<usize, DbError> {

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -99,7 +99,6 @@ pub(crate) trait GraphOperator: Send {
     /// touched since the last capture (the tier bytes would be stale) or
     /// the operator can't demote at all. Default: refuse.
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // called once the demotion trigger lands with promotion
     fn demote_vnode(&mut self, _vnode: u32, _vnode_count: u32) -> bool {
         false
     }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -1,4 +1,4 @@
-//! Operator graph for streaming SQL execution.
+//! Operator graph: wires streaming SQL operators into a DAG and drives them in topological order.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -26,9 +26,7 @@ use laminar_sql::translator::{
 
 #[async_trait]
 pub(crate) trait GraphOperator: Send {
-    /// `watermarks[i]` is the watermark for `inputs[i]`, derived from
-    /// the upstream node's output watermark. Multi-input operators use
-    /// per-input watermarks for independent eviction.
+    /// `watermarks[i]` is the upstream output watermark for `inputs[i]`.
     async fn process(
         &mut self,
         inputs: &[Vec<RecordBatch>],
@@ -42,27 +40,21 @@ pub(crate) trait GraphOperator: Send {
         0
     }
 
-    /// Optional ceiling on this operator's output watermark. The graph holds the
-    /// output watermark at `min(input_wm, hold)` so rows the operator has not yet
-    /// emitted (e.g. async AI enrichment still in flight) are not treated as late
-    /// by a downstream window. `None` = no hold. Default: no hold.
+    /// Output watermark ceiling. Holds the watermark at `min(input_wm, hold)` so
+    /// in-flight rows (e.g. async AI enrichment) aren't treated as late downstream.
+    /// `None` = no hold.
     fn watermark_hold(&self) -> Option<i64> {
         None
     }
 
-    /// Whether the operator can accept new input this cycle. When `false`, the
-    /// graph leaves this node's input buffered — so the source backpressures via
-    /// the existing input-buffer gate — and still steps the operator with empty
-    /// input so it can drain and emit. Default: always accept.
+    /// Whether the operator can accept new input this cycle. When `false`, input
+    /// stays buffered and the operator is still stepped with empty input to drain.
     fn wants_input(&self) -> bool {
         true
     }
 
-    /// Fold a peer-shipped shuffle batch into operator state outside the normal
-    /// `process` path. Checkpoint barrier alignment calls this for rows that
-    /// arrived between cycles so they enter the snapshot. Default: no-op (for
-    /// operators that don't consume the cross-node shuffle). `watermark` is the
-    /// checkpoint watermark.
+    /// Fold a peer-shipped shuffle batch into state outside the normal `process`
+    /// path so barrier-aligned rows enter the snapshot.
     #[cfg(feature = "cluster")]
     async fn ingest_shuffle(
         &mut self,
@@ -73,15 +65,10 @@ pub(crate) trait GraphOperator: Send {
         Ok(())
     }
 
-    /// Serialize this operator's state partitioned by vnode, for cross-node
-    /// rehydration. Returns `Some(map)` from operators that key their state by
-    /// a value the cluster shuffle routes (the aggregation fast-path); `None`
-    /// (default) for operators that aren't vnode-partitionable — those recover
-    /// from the whole-node manifest blob instead. The per-vnode bytes are the
-    /// same encoding the operator's own restore/apply path consumes. A vnode
-    /// demoted to the cold tier stages [`StagedSlice::Cold`] instead of
-    /// bytes — staging nothing would read as "emptied" and drop the demoted
-    /// state from recovery truth.
+    /// Per-vnode state snapshot for cross-node rehydration. `None` for operators
+    /// that don't key state by vnode (they recover from the whole-node manifest).
+    /// A cold-tier vnode stages [`StagedSlice::Cold`] rather than bytes so it
+    /// isn't treated as emptied by recovery.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // cold checkpoint path; vnode-keyed map
     fn checkpoint_by_vnode(
@@ -94,45 +81,33 @@ pub(crate) trait GraphOperator: Send {
         Ok(None)
     }
 
-    /// Drop one vnode's state from memory after its bytes were confirmed
-    /// written to the cold tier. Returns `false` to refuse — the vnode was
-    /// touched since the last capture (the tier bytes would be stale) or
-    /// the operator can't demote at all. Default: refuse.
+    /// Drop one vnode's in-memory state after the cold-tier write is confirmed.
+    /// Returns `false` if the vnode was modified since the last capture.
     #[cfg(feature = "state-tier")]
     fn demote_vnode(&mut self, _vnode: u32, _vnode_count: u32) -> bool {
         false
     }
 
-    /// Whether [`demote_vnode`](Self::demote_vnode) would succeed for `vnode`
-    /// right now — the same eligibility guard, without dropping anything. The
-    /// demotion pass checks this *before* writing the slice to the tier so a
-    /// dirty vnode is skipped cheaply instead of written-then-rolled-back.
-    /// Default: not demotable.
+    /// Whether [`demote_vnode`](Self::demote_vnode) would succeed right now.
+    /// Checked before any tier I/O so dirty vnodes are skipped cheaply.
     #[cfg(feature = "state-tier")]
     fn can_demote(&self, _vnode: u32, _vnode_count: u32) -> bool {
         false
     }
 
-    /// Merge one vnode's rehydrated state slice (produced by
-    /// [`checkpoint_by_vnode`](Self::checkpoint_by_vnode) on whichever node
-    /// last owned the vnode) into this operator. Default no-op for operators
-    /// that don't partition by vnode.
+    /// Merge one vnode's rehydrated state slice into this operator.
     #[cfg(feature = "cluster")]
     fn apply_vnode_state(&mut self, _vnode: u32, _bytes: &[u8]) -> Result<(), DbError> {
         Ok(())
     }
 
-    /// Wire the cold-tier request channel so the operator can fetch demoted
-    /// vnode slices back into memory (promotion). Default no-op — only the
-    /// vnode-sharded aggregate operator promotes. The same channel feeds the
-    /// coordinator's forced-full re-uploads.
+    /// Wire the cold-tier channel for vnode promotion. Only vnode-sharded
+    /// aggregates use it; others ignore it.
     #[cfg(feature = "state-tier")]
     fn attach_state_tier(&mut self, _tier: crate::state_tier::TierTx) {}
 
-    /// Drain the vnodes this operator had demoted at the restored checkpoint
-    /// (the cold tier is wiped on restart, so they must be replayed from
-    /// their durable partials). Default: none. The restart path applies each
-    /// vnode's slice via [`apply_vnode_state`](Self::apply_vnode_state).
+    /// Vnodes this operator had demoted at the restored checkpoint; must be
+    /// replayed from durable partials since the cold tier is wiped on restart.
     #[cfg(feature = "state-tier")]
     fn take_tier_cold_vnodes(&mut self) -> Vec<u32> {
         Vec::new()
@@ -151,12 +126,7 @@ enum GateDecision {
 
 const STATS_SAMPLE_INTERVAL: u64 = 32;
 
-/// `operators` uses std `HashMap` so rkyv's stock `Archive`/`Serialize`/
-/// `Deserialize` impls apply (it supports `HashMap<K, V>` natively but
-/// not `HashMap<K, V, FxHasher>`). Cold path — written once per
-/// checkpoint interval, not on the hot query path. The `clippy::disallowed_types`
-/// allow is scoped to the single file-level type alias below rather
-/// than `#![allow]`-ing the whole module.
+// std HashMap: rkyv supports HashMap<K,V> natively but not FxHashMap; cold checkpoint path only.
 #[allow(clippy::disallowed_types)]
 pub(crate) type OperatorStateMap = std::collections::HashMap<String, Vec<u8>>;
 
@@ -292,21 +262,16 @@ pub(crate) struct OperatorGraph {
     topo_dirty: bool,
     source_map: FxHashMap<Arc<str>, usize>,
     source_list: Vec<(Arc<str>, usize)>,
-    /// Cached set of source node IDs for O(1) lookup in `execute_single_operator`.
     source_node_ids: FxHashSet<usize>,
     output_map: FxHashMap<Arc<str>, usize>,
     input_bufs: Vec<Vec<Vec<RecordBatch>>>,
     input_buf_bytes: Vec<Vec<usize>>,
-    /// Per-node, per-input-port upstream node id. `input_sources[node][port] = upstream_node`.
     input_sources: Vec<Vec<usize>>,
-    /// Per-node output watermark, set during `execute_cycle`.
     output_watermarks: Vec<i64>,
     max_input_buf_batches: usize,
     max_input_buf_bytes: Option<usize>,
     backpressure_policy: BackpressurePolicy,
     query_budget_ns: u64,
-    /// Round-robin offset for deferred operator selection. Ensures fair
-    /// scheduling when budget is continuously exceeded (not checkpointed).
     deferred_scan_offset: usize,
     stats_tick: u64,
     max_state_bytes: Option<usize>,
@@ -317,46 +282,27 @@ pub(crate) struct OperatorGraph {
     temporal_configs: Vec<TemporalJoinTranslatorConfig>,
     depends_on_stream: FxHashSet<usize>,
     order_configs: FxHashMap<usize, OrderOperatorConfig>,
-    /// Per-table `LiveSourceHandle` for batch swapping without catalog churn.
-    /// Covers both source tables (from `register_source_schema`) and
-    /// intermediate tables (created lazily on first operator output).
+    // Covers source tables and intermediates (lazily created on first operator output).
     live_handles: FxHashMap<String, LiveSourceHandle>,
-    /// Assembled AI subsystem (registry + providers + cache + call log).
-    /// `None` unless `[ai]`/`[models]` are configured.
+    // None unless [ai]/[models] are configured.
     ai_runtime: Option<Arc<crate::ai::AiRuntime>>,
-    /// Main (multi-threaded) runtime handle for spawning Ring-1 workers (AI
-    /// inference, lookup-enrich fetch) off the compute thread.
+    // Must be the main multi-threaded runtime; Ring-1 workers (AI, lookup-enrich) spawn here.
     main_runtime_handle: Option<tokio::runtime::Handle>,
-    /// Partial (on-demand) lookup tables → their column names. Drives routing of
-    /// lookup-enrich joins to the async operator and output-column disambiguation.
+    // Lookup table name → column names; routes lookup-enrich joins to the async operator.
     partial_lookup_tables: FxHashMap<String, Vec<String>>,
-    /// Plan-time AI routing errors collected during `add_query` (which returns
-    /// `()`); surfaced by [`take_build_errors`](Self::take_build_errors) at start.
+    // Plan-time errors from add_query (returns ()); surfaced by take_build_errors at start.
     build_errors: Vec<DbError>,
-    /// Cluster-mode row-shuffle config for streaming aggregates.
-    /// `None` outside cluster mode; threaded to `SqlQueryOperator` so
-    /// pre-aggregate rows can be hash-routed to vnode owners.
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<crate::operator::sql_query::ClusterShuffleConfig>,
-    /// Vnode count for per-vnode state capture and cold-tier demotion — the
-    /// only piece of the shuffle topology that path needs (groups bucket by
-    /// `key_hash % vnode_count`). Set from the shuffle registry in cluster
-    /// mode, or from the vnode registry directly on a single node (no
-    /// controller). `None` = no per-vnode capture.
+    // Set from the shuffle registry in cluster mode, or directly on a single-node tier path.
     #[cfg(feature = "cluster")]
     vnode_count: Option<u32>,
-    /// Shared handle to the DB's staged per-vnode rehydration map. Drained at
-    /// the start of each cycle by [`apply_rehydrated_vnodes`](Self::apply_rehydrated_vnodes):
-    /// vnodes this node newly acquired in a rebalance have their committed
-    /// state merged into the matching operators before they process new rows.
-    /// `None` outside cluster mode.
+    // Staged per-vnode rehydration map; drained at the top of each cycle.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // shares the DB's std-HashMap-typed handle
     rehydrated_vnode_state:
         Option<Arc<parking_lot::Mutex<std::collections::HashMap<u32, crate::db::RehydratedVnode>>>>,
-    /// Cold-tier request channel, threaded to vnode-sharded aggregate
-    /// operators for promotion of demoted slices. `None` until a state tier
-    /// is wired; kept so operators hot-added by DDL also receive it.
+    // Stored so DDL-added operators also receive the tier channel.
     #[cfg(feature = "state-tier")]
     state_tier: Option<crate::state_tier::TierTx>,
 }
@@ -406,9 +352,7 @@ impl OperatorGraph {
         }
     }
 
-    /// Install the assembled AI subsystem and the main runtime handle its
-    /// inference workers spawn on. The handle MUST be the main multi-threaded
-    /// runtime, never the compute runtime.
+    /// Install the AI subsystem and main runtime handle for inference workers.
     pub fn set_ai_runtime(
         &mut self,
         runtime: Arc<crate::ai::AiRuntime>,
@@ -418,26 +362,21 @@ impl OperatorGraph {
         self.main_runtime_handle = Some(handle);
     }
 
-    /// Install the main runtime handle Ring-1 workers spawn on (independent of
-    /// AI; the lookup-enrich operator needs it too). MUST be the main
-    /// multi-threaded runtime, never the compute runtime.
+    /// Install the main runtime handle for Ring-1 workers (lookup-enrich, AI).
     pub fn set_runtime_handle(&mut self, handle: tokio::runtime::Handle) {
         self.main_runtime_handle = Some(handle);
     }
 
-    /// Register partial (on-demand) lookup tables and their column names so
-    /// `add_query` can route lookup-enrich joins to the async operator.
+    /// Register on-demand lookup tables so `add_query` can route lookup-enrich joins.
     pub fn set_partial_lookup_tables(&mut self, tables: FxHashMap<String, Vec<String>>) {
         self.partial_lookup_tables = tables;
     }
 
-    /// Take the first plan-time AI routing error collected during query
-    /// construction, if any.
+    /// Return the first plan-time build error, if any.
     ///
     /// # Errors
     ///
-    /// Returns the first recorded [`DbError`] (e.g. unknown model, unsupported
-    /// task, malformed AI query).
+    /// Returns the first recorded [`DbError`] (unknown model, unsupported task, etc.).
     pub fn take_build_errors(&mut self) -> Result<(), DbError> {
         match self.build_errors.drain(..).next() {
             Some(e) => Err(e),
@@ -509,10 +448,7 @@ impl OperatorGraph {
         })
     }
 
-    /// Estimated state bytes per operator, for the node-level memory budget
-    /// and the per-operator gauge. Operators serve this from maintained
-    /// counters or a throttled cache, so calling it once per budget probe is
-    /// cheap.
+    /// Estimated state bytes per operator; cheap (operators maintain a counter).
     pub(crate) fn state_bytes_per_operator(&self) -> impl Iterator<Item = (&Arc<str>, usize)> {
         self.nodes
             .iter()
@@ -526,8 +462,7 @@ impl OperatorGraph {
         self.lookup_registry = Some(registry);
     }
 
-    /// Install the row-shuffle config used by streaming aggregates in
-    /// cluster mode.
+    /// Install the cluster shuffle config for streaming aggregates.
     #[cfg(feature = "cluster")]
     pub fn set_cluster_shuffle(
         &mut self,
@@ -537,24 +472,20 @@ impl OperatorGraph {
         self.cluster_shuffle = Some(config);
     }
 
-    /// Install a vnode count for per-vnode capture and cold-tier demotion
-    /// without a full shuffle config — the single-node tier path, where there
-    /// is no controller or row transport but state still partitions by vnode.
-    /// Must stay stable across restarts (demoted partials are keyed by vnode).
+    /// Set the vnode count for the single-node tier path (no shuffle config).
+    /// Must stay stable across restarts; demoted partials are keyed by vnode.
     #[cfg(feature = "state-tier")]
     pub(crate) fn set_vnode_count(&mut self, vnode_count: u32) {
         self.vnode_count = Some(vnode_count);
     }
 
-    /// The vnode count used for per-vnode capture/demotion, if any.
+    /// Vnode count for per-vnode capture/demotion, if set.
     #[cfg(feature = "state-tier")]
     pub(crate) fn vnode_count(&self) -> Option<u32> {
         self.vnode_count
     }
 
-    /// Wire the cold-tier request channel and hand it to every current
-    /// operator (and, via the stored copy, every operator added later by
-    /// DDL). Vnode-sharded aggregates use it for promotion; others ignore it.
+    /// Wire the cold-tier channel to all current operators (and future DDL-added ones).
     #[cfg(feature = "state-tier")]
     pub(crate) fn set_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         for node in &mut self.nodes {
@@ -563,8 +494,7 @@ impl OperatorGraph {
         self.state_tier = Some(tier);
     }
 
-    /// The installed cluster row-shuffle config, if any; lets the pipeline
-    /// callback reuse the shuffle sender to ship subscription output.
+    /// Cluster shuffle config, if installed; reused by the pipeline callback for subscriptions.
     #[cfg(feature = "cluster")]
     pub(crate) fn cluster_shuffle_config(
         &self,
@@ -572,8 +502,7 @@ impl OperatorGraph {
         self.cluster_shuffle.as_ref()
     }
 
-    /// Share the DB's staged per-vnode rehydration map so the graph can drain
-    /// and apply rebalanced state into operators each cycle.
+    /// Share the staged per-vnode rehydration map; drained at the top of each cycle.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // shares the DB's std-HashMap-typed handle
     pub fn set_rehydration_handle(
@@ -583,16 +512,6 @@ impl OperatorGraph {
         self.rehydrated_vnode_state = Some(staged);
     }
 
-    /// Drain the staged rehydration map for vnodes this node currently owns and
-    /// merge each operator's committed slice into the matching live operator,
-    /// then flip those vnodes `Restoring → Active`.
-    ///
-    /// Runs at the start of every [`execute_cycle`](Self::execute_cycle) so a
-    /// newly-acquired vnode's state is in place before the operators process
-    /// the cycle's rows. Best-effort: a slice that fails to decode or apply is
-    /// logged and skipped, and the vnode still flips to `Active` (it serves
-    /// from whatever state did apply, exactly like a vnode with no durable
-    /// state). Cheap no-op when nothing is staged.
     #[cfg(feature = "cluster")]
     fn apply_rehydrated_vnodes(&mut self) {
         // Clone owned handles out so no borrow of `self` survives into the
@@ -607,8 +526,7 @@ impl OperatorGraph {
             _ => return,
         };
 
-        // Drain only the staged vnodes we currently own (ownership may have
-        // changed again since the snapshot was staged).
+        // Ownership may have changed again since staging; only drain what we own now.
         let drained: Vec<(u32, crate::db::RehydratedVnode)> = {
             let mut guard = staged_arc.lock();
             if guard.is_empty() {
@@ -664,7 +582,6 @@ impl OperatorGraph {
                     "rehydrated partial decode failed — vnode resumes from current state"
                 ),
             }
-            // The vnode is now serving regardless of apply outcome.
             registry.mark_active(&[vnode]);
         }
     }
@@ -788,10 +705,7 @@ impl OperatorGraph {
         let handle = provider.handle();
         let _ = self.ctx.deregister_table(name);
         if let Err(e) = self.ctx.register_table(name, Arc::new(provider)) {
-            // This is a programming error — the table was just deregistered,
-            // so registration should always succeed. Panic-worthy in debug,
-            // but in release just log an error. The handle won't be stored,
-            // so subsequent swap() calls will be no-ops for this table.
+            // Table was just deregistered, so re-registration should always succeed.
             tracing::error!(
                 table = %name,
                 error = %e,
@@ -827,7 +741,7 @@ impl OperatorGraph {
         });
         self.input_bufs.push(vec![Vec::new()]);
         self.input_buf_bytes.push(vec![0]);
-        self.input_sources.push(vec![usize::MAX]); // source nodes: no upstream
+        self.input_sources.push(vec![usize::MAX]); // no upstream
         self.output_watermarks.push(i64::MIN);
         self.source_map.insert(name, node_id);
         self.source_node_ids.insert(node_id);
@@ -897,7 +811,7 @@ impl OperatorGraph {
         }
     }
 
-    /// Returns `true` if the query depends on another query (not just raw sources).
+    // Returns true when the node depends on another query output (not just raw sources).
     #[allow(clippy::too_many_arguments)]
     fn wire_query_edges(
         &mut self,
@@ -1002,10 +916,6 @@ impl OperatorGraph {
     ) {
         use laminar_sql::translator::JoinOperatorConfig;
 
-        // AI routing: a query with one `ai_*(...)` call becomes an
-        // AiInferenceOperator over its source table, applying the residual
-        // projection. Resolution/validation errors are recorded and surfaced
-        // at start (this fn returns `()`).
         let ai_calls = crate::sql_analysis::detect_ai_functions(&sql);
         if ai_calls.len() > 1 {
             self.build_errors.push(DbError::InvalidOperation(
@@ -1029,20 +939,13 @@ impl OperatorGraph {
             return;
         }
 
-        // Window-frame routing: a single-source query with a `… OVER (ORDER BY k
-        // ROWS N PRECEDING)` frame (e.g. CORR) becomes a WindowFrameOperator that
-        // retains bounded history and delegates the frame computation to
-        // DataFusion. Detected off the SQL like the AI/join paths.
         if let Some(plan) = crate::sql_analysis::plan_frame_query(&sql) {
             self.build_frame_operator_node(&name, &plan);
             return;
         }
 
-        // The planner's vec lets us short-circuit re-parsing for queries
-        // that have no specialized join step (or no joins at all).
-        // TemporalProbe is parsed off the token stream rather than the
-        // sqlparser AST, so it is never present in `join_config` and
-        // always needs its own detector pass.
+        // TemporalProbe is parsed off the token stream (not the sqlparser AST), so it
+        // never appears in join_config and always needs its own detector pass.
         let needs_specialized_detection = join_config.as_ref().is_none_or(|jcs| {
             jcs.iter().any(|c| {
                 matches!(
@@ -1070,9 +973,7 @@ impl OperatorGraph {
             };
         let stream_join_detection =
             if temporal_probe_config.is_none() && needs_specialized_detection {
-                // Interval join (time-bounded) first; else a plain equi-join as a
-                // processing-time join. `create_operator` distinguishes them by
-                // whether the config has time columns.
+                // Interval join first; falls back to processing-time equi-join.
                 detect_stream_join_query(&sql).or_else(|| detect_processtime_join(&sql))
             } else {
                 None
@@ -1082,9 +983,7 @@ impl OperatorGraph {
             .as_ref()
             .map(|d| d.projection_sql.clone());
 
-        // Lookup-enrich: a partial/on-demand lookup join, hoisted to the
-        // async-decoupled operator. Only when no other specialized join matched
-        // and at least one partial lookup table is registered.
+        // Lookup-enrich: only when no other specialized join matched.
         let (lookup_enrich_config, lookup_projection_sql) = if temporal_probe_config.is_none()
             && asof_config.is_none()
             && temporal_config.is_none()
@@ -1106,7 +1005,6 @@ impl OperatorGraph {
             .or(stream_join_projection_sql)
             .or(lookup_projection_sql);
 
-        // Warn for undetected JOIN+BETWEEN
         if stream_join_config.is_none() && asof_config.is_none() && temporal_config.is_none() {
             let sql_upper = sql.to_uppercase();
             if sql_upper.contains("JOIN") && sql_upper.contains("BETWEEN") {
@@ -1120,18 +1018,15 @@ impl OperatorGraph {
         }
 
         let mut table_refs = extract_table_references(&sql);
-        // The lookup-enrich operator reads its lookup table from the registry,
-        // not as a graph input — drop it so only the stream side is wired.
+        // Lookup-enrich reads its table from the registry, not as a graph input.
         if let Some(cfg) = &lookup_enrich_config {
             table_refs.remove(&cfg.table_name);
         }
 
-        // Store temporal join config
         if let Some(ref tc) = temporal_config {
             self.temporal_configs.push(tc.clone());
         }
 
-        // Create operator based on detection
         let operator: Box<dyn GraphOperator> = self.create_operator(
             &name,
             &sql,
@@ -1146,7 +1041,6 @@ impl OperatorGraph {
             idle_ttl_ms,
         );
 
-        // Determine input port count
         let input_port_count = if asof_config.is_some()
             || stream_join_config.is_some()
             || temporal_probe_config.is_some()
@@ -1156,13 +1050,6 @@ impl OperatorGraph {
             1
         };
 
-        // Install the operator: replace a SourcePassthrough placeholder for this
-        // name in place if a query referenced it before it was registered (so
-        // downstream edges stay valid), else append a fresh node — see
-        // `place_operator_node`. Source nodes are ensured first so their indices
-        // are stable when wiring edges. The placeholder and fresh paths wire
-        // identically, including `temporal_config`, so an out-of-order temporal
-        // join is wired the same as one registered in order.
         self.ensure_query_source_nodes(
             temporal_probe_config.as_ref(),
             asof_config.as_ref(),
@@ -1190,13 +1077,8 @@ impl OperatorGraph {
         self.topo_dirty = true;
     }
 
-    /// Install an operator for `name`, returning its node id. If a
-    /// `SourcePassthrough` placeholder exists for the name (a downstream query
-    /// referenced it before it was created), replace it in place so the
-    /// placeholder's node id and outbound edges stay valid and downstream nodes
-    /// receive this operator's output; otherwise append a fresh node. Callers
-    /// must still ensure source nodes and wire edges around this. The caller
-    /// owns ordering: ensure source nodes before, wire after.
+    // Replace a SourcePassthrough placeholder in place (preserving its id and outbound edges),
+    // or append a fresh node. Callers must ensure source nodes before and wire edges after.
     fn place_operator_node(
         &mut self,
         name: &str,
@@ -1210,10 +1092,8 @@ impl OperatorGraph {
             self.input_buf_bytes[id] = vec![0; input_port_count];
             self.input_sources[id] = vec![usize::MAX; input_port_count];
             self.source_map.remove(name);
-            // No longer a source: let its output watermark advance per run.
             self.source_node_ids.remove(&id);
-            // Downstream nodes already wired to the placeholder now depend on a
-            // real (possibly stream-fed) query.
+            // Downstream nodes already wired to the placeholder now depend on this query.
             for &(target, _) in &self.nodes[id].output_routes {
                 self.depends_on_stream.insert(target);
             }
@@ -1235,8 +1115,6 @@ impl OperatorGraph {
         }
     }
 
-    /// Build an [`AiInferenceOperator`](crate::operator::ai_inference) for a
-    /// planned AI query and wire it as a single-input node over the source table.
     fn build_ai_operator_node(
         &mut self,
         name: &str,
@@ -1249,8 +1127,6 @@ impl OperatorGraph {
         })?;
         let ctx = self.ctx.clone();
 
-        // All runtime-dependent work happens here; the immutable `ai_runtime`
-        // borrow ends before the `&mut self` node creation below.
         let (operator, table_refs): (Box<dyn GraphOperator>, FxHashSet<String>) = {
             let runtime = self.ai_runtime.as_ref().ok_or_else(|| {
                 DbError::InvalidOperation(
@@ -1259,7 +1135,6 @@ impl OperatorGraph {
                 )
             })?;
 
-            // Plan-time validation (task support + labels seam).
             crate::sql_analysis::validate_ai_calls(
                 runtime.registry(),
                 std::slice::from_ref(&plan.call),
@@ -1312,9 +1187,6 @@ impl OperatorGraph {
             (operator, table_refs)
         };
 
-        // Wire as a single-input node reading the source table (no joins),
-        // replacing a placeholder in place if a downstream query referenced this
-        // name before it was created.
         self.ensure_query_source_nodes(None, None, None, None, &table_refs);
         let node_id = self.place_operator_node(name, operator, 1);
         let depends = self.wire_query_edges(node_id, None, None, None, None, None, &table_refs);
@@ -1326,8 +1198,6 @@ impl OperatorGraph {
         Ok(())
     }
 
-    /// Build a [`WindowFrameOperator`](crate::operator::window_frame) for a
-    /// planned frame query and wire it as a single-input node over the source.
     fn build_frame_operator_node(
         &mut self,
         name: &str,
@@ -1375,8 +1245,7 @@ impl OperatorGraph {
     ) -> Box<dyn GraphOperator> {
         use crate::operator;
 
-        // On-demand lookup-enrich join → async-decoupled operator. Falls through
-        // to the DataFusion lookup path if the registry/runtime handle is absent.
+        // Falls through to the DataFusion lookup path if the registry/handle is absent.
         if let Some(cfg) = lookup_enrich_config {
             if let (Some(reg), Some(handle)) = (&self.lookup_registry, &self.main_runtime_handle) {
                 #[cfg_attr(not(feature = "cluster"), allow(unused_mut))]
@@ -1389,8 +1258,7 @@ impl OperatorGraph {
                     handle.clone(),
                     self.prom.clone(),
                 );
-                // In cluster mode, key-shard the probe side across nodes for
-                // cache affinity (same shuffle config the aggregate path uses).
+                // Key-shard the probe side for cache affinity.
                 #[cfg(feature = "cluster")]
                 if let Some(ref sc) = self.cluster_shuffle {
                     op.attach_cluster_shuffle(sc.clone());
@@ -1430,8 +1298,7 @@ impl OperatorGraph {
         }
 
         if let Some(cfg) = stream_join_config {
-            // No time columns ⇒ plain equi-join → per-cycle batch join; with
-            // time columns ⇒ interval join.
+            // No time columns → per-cycle batch join; with time columns → interval join.
             if cfg.left_time_column.is_empty() && cfg.right_time_column.is_empty() {
                 #[cfg_attr(not(feature = "cluster"), allow(unused_mut))]
                 let mut op = operator::process_time_join::ProcessTimeJoinOperator::new(
@@ -1460,10 +1327,8 @@ impl OperatorGraph {
             return Box::new(op);
         }
 
-        // Non-windowed `now()` is only valid as the recognised retracting
-        // temporal-filter shape under EMIT CHANGES; anything else gets a
-        // typed LDB-1001 rejection rather than a silently frozen plan-time
-        // `now()`. Windowed queries keep the existing path.
+        // Non-windowed now() is only valid as a retracting temporal filter under EMIT CHANGES;
+        // anything else gets a typed LDB-1001 rejection.
         if window_config.is_none() {
             use crate::sql_analysis::TemporalFilterAnalysis as Tfa;
             match crate::sql_analysis::analyze_temporal_filter(sql) {
@@ -1532,9 +1397,7 @@ impl OperatorGraph {
         #[cfg(feature = "state-tier")]
         if let Some(tier) = self.state_tier.clone() {
             op.attach_state_tier(tier);
-            // Cold-tier promotion needs the vnode count to detect rows landing
-            // on demoted vnodes (single-node has no shuffle config to read it
-            // from, so it is threaded separately).
+            // Single-node path has no shuffle config to read the count from.
             if let Some(vnode_count) = self.vnode_count {
                 op.set_vnode_count(vnode_count);
             }
@@ -1547,7 +1410,6 @@ impl OperatorGraph {
             return;
         };
 
-        // Collect IDs of this node + any child prefilter nodes (name prefix match).
         let prefix = format!("{name}::");
         let ids_to_remove: smallvec::SmallVec<[usize; 3]> = std::iter::once(node_id)
             .chain(
@@ -1574,7 +1436,6 @@ impl OperatorGraph {
             self.edges.retain(|e| e.source != id && e.target != id);
         }
 
-        // Clean dangling output routes pointing to any removed node
         for node in &mut self.nodes {
             node.output_routes
                 .retain(|&(t, _)| !ids_to_remove.contains(&t));
@@ -1585,7 +1446,6 @@ impl OperatorGraph {
     }
 
     fn compute_topo_order(&mut self) {
-        // Kahn's algorithm
         let n = self.nodes.len();
         let mut in_degree = vec![0usize; n];
         let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
@@ -1597,13 +1457,11 @@ impl OperatorGraph {
             }
         }
 
-        // Deduplicate dependents
         for deps in &mut dependents {
             deps.sort_unstable();
             deps.dedup();
         }
 
-        // Recalculate in_degree from deduped
         in_degree.fill(0);
         for deps in &dependents {
             for &dep in deps {
@@ -1629,7 +1487,7 @@ impl OperatorGraph {
             }
         }
 
-        // Fallback: if cycle detected, append missing non-removed nodes
+        // Cycle detected: fall back to insertion order for remaining nodes.
         let active_count = self.nodes.iter().filter(|n| !n.removed).count();
         if self.topo_order.len() < active_count {
             tracing::warn!(
@@ -1658,8 +1516,7 @@ impl OperatorGraph {
             if batches.is_empty() {
                 continue;
             }
-            // Lazily create the provider if register_source_schema wasn't called
-            // (e.g., tests that skip the lifecycle).
+            // Lazily create the provider if register_source_schema wasn't called (e.g. tests).
             if !self.live_handles.contains_key(name.as_ref()) {
                 let schema = batches[0].schema();
                 self.ensure_live_provider(name, &schema);
@@ -1683,9 +1540,6 @@ impl OperatorGraph {
         current_watermark: i64,
         results: &mut FxHashMap<Arc<str>, Vec<RecordBatch>>,
     ) -> Result<(), DbError> {
-        // If the operator is backpressured (wants_input == false), leave its
-        // input buffered so the upstream gate throttles the source, and step it
-        // with empty input so it can still drain and emit.
         let accept = self.nodes[node_id].operator.wants_input();
         let (mut inputs, mut input_bytes) = if accept {
             (
@@ -1716,17 +1570,13 @@ impl OperatorGraph {
             )
             .await;
 
-        // Source nodes (input_sources = [usize::MAX]) have output_watermarks
-        // pre-seeded from per-source watermarks in execute_cycle. Don't overwrite.
+        // Source nodes have output_watermarks pre-seeded in execute_cycle; don't overwrite.
         if !self.source_node_ids.contains(&node_id) {
             let mut wm = watermarks
                 .iter()
                 .copied()
                 .min()
                 .unwrap_or(current_watermark);
-            // Hold the watermark behind any rows the operator has buffered but
-            // not yet emitted (e.g. in-flight AI enrichment), so a downstream
-            // window doesn't close past them.
             if let Some(hold) = self.nodes[node_id].operator.watermark_hold() {
                 wm = wm.min(hold);
             }
@@ -1740,10 +1590,7 @@ impl OperatorGraph {
 
         let batches = match output_result {
             Ok(b) => {
-                // When backpressured (!accept) the input was never taken, so
-                // leave the buffer intact. Otherwise reuse the outer Vecs and
-                // their capacities; the operator borrowed inputs, so the
-                // RecordBatches are still in place. clear() preserves capacity.
+                // Reuse the Vecs (clear preserves capacity); when !accept, leave buffers intact.
                 if accept {
                     for v in &mut inputs {
                         v.clear();
@@ -1756,7 +1603,7 @@ impl OperatorGraph {
             }
             Err(e) => {
                 if accept && self.depends_on_stream.contains(&node_id) {
-                    // Put batches back so they're retried next cycle.
+                    // Upstream not ready; preserve input for retry next cycle.
                     self.input_bufs[node_id] = inputs;
                     self.input_buf_bytes[node_id] = input_bytes;
                     tracing::debug!(
@@ -1812,7 +1659,6 @@ impl OperatorGraph {
             let has_routes = !self.nodes[node_id].output_routes.is_empty();
             let is_output = self.output_map.values().any(|&id| id == node_id);
 
-            // Register intermediate for downstream SQL queries (catalog lookup).
             if has_routes {
                 let name_ref = node_name.as_ref();
                 if !self.live_handles.contains_key(name_ref) {
@@ -1824,7 +1670,6 @@ impl OperatorGraph {
                 }
             }
 
-            // Collect output for the caller.
             if is_output {
                 results.insert(node_name, batches.clone());
             }
@@ -1835,10 +1680,7 @@ impl OperatorGraph {
                 let (target, port) = self.nodes[node_id].output_routes[0];
                 self.push_to_port(target, port, batches, bytes);
             } else if route_count > 1 {
-                // Clone batches N-1 times (one for each non-final route);
-                // the final route takes ownership of the original. Reading
-                // routes via an indexed loop avoids cloning output_routes
-                // just to iterate it.
+                // Clone batches N-1 times; the last route takes ownership.
                 for i in 0..route_count - 1 {
                     let (target, port) = self.nodes[node_id].output_routes[i];
                     self.push_to_port(target, port, batches.clone(), bytes);
@@ -1858,9 +1700,6 @@ impl OperatorGraph {
         current_watermark: i64,
         source_watermarks: Option<&FxHashMap<Arc<str>, i64>>,
     ) -> Result<FxHashMap<Arc<str>, Vec<RecordBatch>>, DbError> {
-        // Merge any rebalanced-in vnode state into operators before they see
-        // this cycle's rows, so the snapshot a new owner resumes from is in
-        // place first.
         #[cfg(feature = "cluster")]
         self.apply_rehydrated_vnodes();
 
@@ -1910,7 +1749,6 @@ impl OperatorGraph {
                 }
             }
 
-            // Budget check
             if i > 0 {
                 #[allow(clippy::cast_possible_truncation)]
                 let elapsed_ns = cycle_start.elapsed().as_nanos() as u64;
@@ -1921,9 +1759,7 @@ impl OperatorGraph {
                         "per-query budget exceeded — deferring remaining operators"
                     );
 
-                    // Forward progress: run one deferred operator to prevent
-                    // tail-operator starvation. Round-robin ensures fair
-                    // scheduling under continuous input.
+                    // Run one deferred operator (round-robin) to prevent tail starvation.
                     let deferred_count = topo_len - i;
                     let start = self.deferred_scan_offset % deferred_count;
                     for offset in 0..deferred_count {
@@ -1957,7 +1793,7 @@ impl OperatorGraph {
                             return Err(e);
                         }
                         self.deferred_scan_offset = self.deferred_scan_offset.wrapping_add(1);
-                        break; // Only one per cycle
+                        break;
                     }
 
                     break;
@@ -1996,8 +1832,7 @@ impl OperatorGraph {
         Ok(results)
     }
 
-    /// Route one peer-shipped shuffle batch to the operator named `stage`.
-    /// Unknown stage (no such live operator) is dropped.
+    // Unknown stage (no live operator for it) is silently dropped.
     #[cfg(feature = "cluster")]
     async fn ingest_to_stage(
         &mut self,
@@ -2018,21 +1853,14 @@ impl OperatorGraph {
         Ok(())
     }
 
-    /// Chandy–Lamport alignment of the cross-node shuffle, run just before
-    /// `snapshot_state` so the snapshot captures every pre-checkpoint row a peer
-    /// shipped. Fans out `Barrier(checkpoint_id)` to peers, then drains the
-    /// receiver — folding each `VnodeData` into its operator via `ingest_shuffle`
-    /// — until every peer's barrier is observed. No-op without a cross-node
-    /// shuffle. See `docs/plans/cross-node-shuffle-barrier-alignment.md`.
+    /// Chandy–Lamport shuffle alignment: fan out a barrier to peers, drain rows,
+    /// and wait until every peer's barrier is observed before snapshotting.
     ///
-    /// Relies on **full-membership commit** (`wait_for_quorum` requires every
-    /// live follower): no peer resumes the next epoch until all have aligned, so
-    /// no next-epoch frame can arrive mid-alignment. A move to majority quorum
-    /// would reintroduce that case and need per-peer post-barrier buffering.
+    /// Requires full-membership commit — no peer resumes the next epoch until all
+    /// have aligned, so no next-epoch frame can arrive mid-alignment.
     ///
     /// # Errors
-    /// Fails the checkpoint (caller retries) on timeout or a closed receiver —
-    /// the deliberate degradation under a straggling peer.
+    /// Fails the checkpoint on timeout or closed receiver so the caller can retry.
     #[cfg(feature = "cluster")]
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn align_shuffle_barriers(
@@ -2051,11 +1879,8 @@ impl OperatorGraph {
         let Some(cfg) = self.cluster_shuffle.clone() else {
             return Ok(());
         };
-        // Fan-out set: nodes we ship rows to (other vnode owners). Wait set:
-        // nodes that ship to us — the live producers, but only if we own a vnode
-        // (a node owning none, e.g. drained, receives nothing yet still ships, so
-        // the two sets differ under skewed assignment). Producers = live
-        // membership, not the owners.
+        // Fan-out = nodes we ship to. Wait set = live producers that ship to us
+        // (only if we own a vnode; a drained node still ships but receives nothing).
         let output_peers: Vec<u64> = laminar_core::state::peer_owners(&cfg.registry, cfg.self_id)
             .iter()
             .map(|n| n.0)
@@ -2070,11 +1895,10 @@ impl OperatorGraph {
                     .collect()
             };
         if output_peers.is_empty() && input_peers.is_empty() {
-            return Ok(()); // not part of any cross-node shuffle
+            return Ok(());
         }
 
-        // Rows already pulled into the receiver's per-stage holdover are
-        // pre-barrier (the per-cycle drain carries no barriers).
+        // Pre-staged rows arrived before the barrier; fold them in first.
         for (stage, batch) in cfg.receiver.drain_all_staged() {
             self.ingest_to_stage(&stage, batch, watermark).await?;
         }
@@ -2087,7 +1911,7 @@ impl OperatorGraph {
                 .map_err(|e| DbError::Pipeline(format!("shuffle barrier fan-out: {e}")))?;
         }
         if input_peers.is_empty() {
-            return Ok(()); // we receive from no peer — nothing to align on
+            return Ok(());
         }
 
         tracing::info!(
@@ -2106,9 +1930,7 @@ impl OperatorGraph {
             .collect();
         tracker.observe(0, barrier); // our own input
 
-        // A peer that fanned its barrier out before we entered alignment had it
-        // stashed by the per-cycle drain (which would otherwise drop it) — observe
-        // those before blocking on the live wire.
+        // Observe any barriers that arrived before we entered alignment (stashed by the drain).
         for (from, b) in cfg.receiver.drain_staged_barriers() {
             if b.checkpoint_id == checkpoint_id {
                 if let Some(&port) = peer_port.get(&from) {
@@ -2170,16 +1992,8 @@ impl OperatorGraph {
                                     "checkpoint {checkpoint_id} was aborted by leader"
                                 )));
                             }
-                            // Observation is latest-wins, so this checkpoint's
-                            // Abort can be superseded before we ever see it. A
-                            // NEWER announcement is just as conclusive: ids are
-                            // never reused (failed epochs are abandoned), and
-                            // the leader only moves on once this checkpoint is
-                            // aligned cluster-wide or dead — either way the
-                            // peer barriers we are waiting for will never
-                            // arrive. Without this release, a rejoining node
-                            // livelocks one epoch behind the cluster, timing
-                            // out every alignment.
+                            // A newer announcement means the leader moved on; our barriers will
+                            // never arrive, and without this check a rejoining node livelocks.
                             if ann.checkpoint_id > checkpoint_id {
                                 return Err(DbError::Pipeline(format!(
                                     "checkpoint {checkpoint_id} superseded by {} — alignment abandoned",
@@ -2199,8 +2013,6 @@ impl OperatorGraph {
         Ok(())
     }
 
-    /// Append a node with a given operator (test-only, for exercising
-    /// `align_shuffle_barriers` without the full query-build path).
     #[cfg(all(test, feature = "cluster"))]
     pub(crate) fn push_test_node(&mut self, name: &str, operator: Box<dyn GraphOperator>) {
         self.nodes.push(GraphNode {
@@ -2217,7 +2029,6 @@ impl OperatorGraph {
         self.topo_dirty = true;
     }
 
-    // &mut self: some accumulators need &mut for state()
     pub fn snapshot_state(&mut self) -> Result<Option<GraphCheckpoint>, DbError> {
         let mut operators = OperatorStateMap::new();
         for node in &mut self.nodes {
@@ -2237,14 +2048,7 @@ impl OperatorGraph {
         }))
     }
 
-    /// Per-vnode operator-state snapshot for cross-node rehydration.
-    ///
-    /// Returns `vnode → (operator_name → vnode-slice bytes)` for every operator
-    /// that opts into per-vnode checkpointing (see
-    /// [`GraphOperator::checkpoint_by_vnode`]). Empty when no vnode topology is
-    /// installed. The count comes from the shuffle registry in cluster mode, or
-    /// the single-node tier count — the same partition the routing (or, single
-    /// node, all-local ownership) delivered each key under.
+    /// Per-vnode state snapshot (`vnode → operator → bytes`) for cross-node rehydration.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // std HashMap matches the trait/CheckpointRequest shape
     pub fn snapshot_state_by_vnode(
@@ -2270,9 +2074,8 @@ impl OperatorGraph {
         Ok(out)
     }
 
-    /// Ask the named operator to drop one vnode's state after its slice
-    /// was confirmed in the cold tier. `false` = refused (the vnode was
-    /// touched since the last capture, or the operator can't demote).
+    /// Drop one vnode's state after its cold-tier write is confirmed.
+    /// Returns `false` if the operator refuses (vnode modified since last capture).
     #[cfg(feature = "state-tier")]
     pub(crate) fn demote_vnode(&mut self, operator: &str, vnode: u32) -> bool {
         let Some(vnode_count) = self.vnode_count else {
@@ -2283,8 +2086,6 @@ impl OperatorGraph {
             .iter_mut()
             .find(|n| !n.removed && &*n.name == operator)
             .is_some_and(|n| n.operator.demote_vnode(vnode, vnode_count));
-        // Count only effective demotions (the slice actually left memory), so
-        // the metric is not inflated by tier writes that get rolled back.
         if demoted {
             if let Some(ref prom) = self.prom {
                 prom.state_tier_demote_total.inc();
@@ -2293,10 +2094,7 @@ impl OperatorGraph {
         demoted
     }
 
-    /// Whether the named operator could demote `vnode` right now (clean since
-    /// its last capture). Lets the demotion pass skip dirty candidates before
-    /// any tier I/O. `false` when there is no vnode topology or no such
-    /// operator.
+    /// Whether the named operator could demote `vnode` right now (no tier I/O performed).
     #[cfg(feature = "state-tier")]
     pub(crate) fn can_demote(&self, operator: &str, vnode: u32) -> bool {
         let Some(vnode_count) = self.vnode_count else {
@@ -2308,9 +2106,8 @@ impl OperatorGraph {
             .is_some_and(|n| n.operator.can_demote(vnode, vnode_count))
     }
 
-    /// After a restart restore, the vnodes each operator had demoted to the
-    /// cold tier — their groups are absent from the manifest blob and must be
-    /// replayed from their durable partials. `(operator_name, cold_vnodes)`.
+    /// Vnodes each operator had demoted at the last checkpoint; absent from the manifest
+    /// and must be replayed from durable partials. Returns `(operator_name, vnodes)`.
     #[cfg(feature = "state-tier")]
     pub(crate) fn take_tier_cold_vnodes(&mut self) -> Vec<(String, Vec<u32>)> {
         let mut out = Vec::new();
@@ -2326,10 +2123,8 @@ impl OperatorGraph {
         out
     }
 
-    /// Apply one operator's slice of one vnode's partial (restart cold-vnode
-    /// rehydration). Targets a single operator by name so a vnode partial,
-    /// which bundles every operator's slice, doesn't double-apply operators
-    /// already recovered from the manifest.
+    /// Apply one operator's slice of a vnode partial (cold-vnode rehydration on restart).
+    /// Targets a single operator to avoid double-applying slices recovered from the manifest.
     #[cfg(feature = "state-tier")]
     pub(crate) fn apply_vnode_slice(
         &mut self,

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -123,6 +123,15 @@ pub(crate) trait GraphOperator: Send {
         _tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
     ) {
     }
+
+    /// Drain the vnodes this operator had demoted at the restored checkpoint
+    /// (the cold tier is wiped on restart, so they must be replayed from
+    /// their durable partials). Default: none. The restart path applies each
+    /// vnode's slice via [`apply_vnode_state`](Self::apply_vnode_state).
+    #[cfg(feature = "state-tier")]
+    fn take_tier_cold_vnodes(&mut self) -> Vec<u32> {
+        Vec::new()
+    }
 }
 
 pub(crate) struct OperatorCheckpoint {
@@ -2244,6 +2253,45 @@ impl OperatorGraph {
             .iter_mut()
             .find(|n| !n.removed && &*n.name == operator)
             .is_some_and(|n| n.operator.demote_vnode(vnode, vnode_count))
+    }
+
+    /// After a restart restore, the vnodes each operator had demoted to the
+    /// cold tier — their groups are absent from the manifest blob and must be
+    /// replayed from their durable partials. `(operator_name, cold_vnodes)`.
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn take_tier_cold_vnodes(&mut self) -> Vec<(String, Vec<u32>)> {
+        let mut out = Vec::new();
+        for node in &mut self.nodes {
+            if node.removed {
+                continue;
+            }
+            let cold = node.operator.take_tier_cold_vnodes();
+            if !cold.is_empty() {
+                out.push((node.name.to_string(), cold));
+            }
+        }
+        out
+    }
+
+    /// Apply one operator's slice of one vnode's partial (restart cold-vnode
+    /// rehydration). Targets a single operator by name so a vnode partial,
+    /// which bundles every operator's slice, doesn't double-apply operators
+    /// already recovered from the manifest.
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn apply_vnode_slice(
+        &mut self,
+        operator: &str,
+        vnode: u32,
+        bytes: &[u8],
+    ) -> Result<(), DbError> {
+        match self
+            .nodes
+            .iter_mut()
+            .find(|n| !n.removed && &*n.name == operator)
+        {
+            Some(node) => node.operator.apply_vnode_state(vnode, bytes),
+            None => Ok(()),
+        }
     }
 
     pub fn restore_state(&mut self, checkpoint: &GraphCheckpoint) -> Result<usize, DbError> {

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -338,6 +338,13 @@ pub(crate) struct OperatorGraph {
     /// pre-aggregate rows can be hash-routed to vnode owners.
     #[cfg(feature = "cluster")]
     cluster_shuffle: Option<crate::operator::sql_query::ClusterShuffleConfig>,
+    /// Vnode count for per-vnode state capture and cold-tier demotion — the
+    /// only piece of the shuffle topology that path needs (groups bucket by
+    /// `key_hash % vnode_count`). Set from the shuffle registry in cluster
+    /// mode, or to a fixed single-node count when the tier runs without a
+    /// controller. `None` = no per-vnode capture.
+    #[cfg(feature = "cluster")]
+    vnode_count: Option<u32>,
     /// Shared handle to the DB's staged per-vnode rehydration map. Drained at
     /// the start of each cycle by [`apply_rehydrated_vnodes`](Self::apply_rehydrated_vnodes):
     /// vnodes this node newly acquired in a rebalance have their committed
@@ -378,6 +385,8 @@ impl OperatorGraph {
             max_state_bytes: None,
             #[cfg(feature = "cluster")]
             cluster_shuffle: None,
+            #[cfg(feature = "cluster")]
+            vnode_count: None,
             #[cfg(feature = "cluster")]
             rehydrated_vnode_state: None,
             #[cfg(feature = "state-tier")]
@@ -524,7 +533,23 @@ impl OperatorGraph {
         &mut self,
         config: crate::operator::sql_query::ClusterShuffleConfig,
     ) {
+        self.vnode_count = Some(config.registry.vnode_count());
         self.cluster_shuffle = Some(config);
+    }
+
+    /// Install a vnode count for per-vnode capture and cold-tier demotion
+    /// without a full shuffle config — the single-node tier path, where there
+    /// is no controller or row transport but state still partitions by vnode.
+    /// Must stay stable across restarts (demoted partials are keyed by vnode).
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn set_vnode_count(&mut self, vnode_count: u32) {
+        self.vnode_count = Some(vnode_count);
+    }
+
+    /// The vnode count used for per-vnode capture/demotion, if any.
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn vnode_count(&self) -> Option<u32> {
+        self.vnode_count
     }
 
     /// Wire the cold-tier request channel and hand it to every current
@@ -1505,8 +1530,14 @@ impl OperatorGraph {
             op.attach_cluster_shuffle(cfg.clone());
         }
         #[cfg(feature = "state-tier")]
-        if let Some(ref tier) = self.state_tier {
-            op.attach_state_tier(tier.clone());
+        if let Some(tier) = self.state_tier.clone() {
+            op.attach_state_tier(tier);
+            // Cold-tier promotion needs the vnode count to detect rows landing
+            // on demoted vnodes (single-node has no shuffle config to read it
+            // from, so it is threaded separately).
+            if let Some(vnode_count) = self.vnode_count {
+                op.set_vnode_count(vnode_count);
+            }
         }
         Box::new(op)
     }
@@ -2210,18 +2241,17 @@ impl OperatorGraph {
     ///
     /// Returns `vnode → (operator_name → vnode-slice bytes)` for every operator
     /// that opts into per-vnode checkpointing (see
-    /// [`GraphOperator::checkpoint_by_vnode`]). Empty outside cluster mode (no
-    /// shuffle config means no vnode topology to partition by). The vnode count
-    /// is taken from the registry the cluster shuffle was wired with, so the
-    /// partition matches the routing that delivered each key here.
+    /// [`GraphOperator::checkpoint_by_vnode`]). Empty when no vnode topology is
+    /// installed. The count comes from the shuffle registry in cluster mode, or
+    /// the single-node tier count — the same partition the routing (or, single
+    /// node, all-local ownership) delivered each key under.
     #[cfg(feature = "cluster")]
     #[allow(clippy::disallowed_types)] // std HashMap matches the trait/CheckpointRequest shape
     pub fn snapshot_state_by_vnode(
         &mut self,
     ) -> Result<crate::checkpoint_coordinator::StagedVnodeStates, DbError> {
-        let vnode_count = match &self.cluster_shuffle {
-            Some(cfg) => cfg.registry.vnode_count(),
-            None => return Ok(std::collections::HashMap::new()),
+        let Some(vnode_count) = self.vnode_count else {
+            return Ok(std::collections::HashMap::new());
         };
         let mut out: crate::checkpoint_coordinator::StagedVnodeStates =
             std::collections::HashMap::new();
@@ -2244,12 +2274,10 @@ impl OperatorGraph {
     /// was confirmed in the cold tier. `false` = refused (the vnode was
     /// touched since the last capture, or the operator can't demote).
     #[cfg(feature = "state-tier")]
-    #[allow(dead_code)] // called once the demotion trigger lands with promotion
     pub(crate) fn demote_vnode(&mut self, operator: &str, vnode: u32) -> bool {
-        let Some(cfg) = &self.cluster_shuffle else {
+        let Some(vnode_count) = self.vnode_count else {
             return false;
         };
-        let vnode_count = cfg.registry.vnode_count();
         let demoted = self
             .nodes
             .iter_mut()
@@ -2267,14 +2295,13 @@ impl OperatorGraph {
 
     /// Whether the named operator could demote `vnode` right now (clean since
     /// its last capture). Lets the demotion pass skip dirty candidates before
-    /// any tier I/O. `false` when there is no shuffle topology or no such
+    /// any tier I/O. `false` when there is no vnode topology or no such
     /// operator.
     #[cfg(feature = "state-tier")]
     pub(crate) fn can_demote(&self, operator: &str, vnode: u32) -> bool {
-        let Some(cfg) = &self.cluster_shuffle else {
+        let Some(vnode_count) = self.vnode_count else {
             return false;
         };
-        let vnode_count = cfg.registry.vnode_count();
         self.nodes
             .iter()
             .find(|n| !n.removed && &*n.name == operator)

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -104,6 +104,16 @@ pub(crate) trait GraphOperator: Send {
         false
     }
 
+    /// Whether [`demote_vnode`](Self::demote_vnode) would succeed for `vnode`
+    /// right now — the same eligibility guard, without dropping anything. The
+    /// demotion pass checks this *before* writing the slice to the tier so a
+    /// dirty vnode is skipped cheaply instead of written-then-rolled-back.
+    /// Default: not demotable.
+    #[cfg(feature = "state-tier")]
+    fn can_demote(&self, _vnode: u32, _vnode_count: u32) -> bool {
+        false
+    }
+
     /// Merge one vnode's rehydrated state slice (produced by
     /// [`checkpoint_by_vnode`](Self::checkpoint_by_vnode) on whichever node
     /// last owned the vnode) into this operator. Default no-op for operators
@@ -2241,10 +2251,35 @@ impl OperatorGraph {
             return false;
         };
         let vnode_count = cfg.registry.vnode_count();
-        self.nodes
+        let demoted = self
+            .nodes
             .iter_mut()
             .find(|n| !n.removed && &*n.name == operator)
-            .is_some_and(|n| n.operator.demote_vnode(vnode, vnode_count))
+            .is_some_and(|n| n.operator.demote_vnode(vnode, vnode_count));
+        // Count only effective demotions (the slice actually left memory), so
+        // the metric is not inflated by tier writes that get rolled back.
+        if demoted {
+            if let Some(ref prom) = self.prom {
+                prom.state_tier_demote_total.inc();
+            }
+        }
+        demoted
+    }
+
+    /// Whether the named operator could demote `vnode` right now (clean since
+    /// its last capture). Lets the demotion pass skip dirty candidates before
+    /// any tier I/O. `false` when there is no shuffle topology or no such
+    /// operator.
+    #[cfg(feature = "state-tier")]
+    pub(crate) fn can_demote(&self, operator: &str, vnode: u32) -> bool {
+        let Some(cfg) = &self.cluster_shuffle else {
+            return false;
+        };
+        let vnode_count = cfg.registry.vnode_count();
+        self.nodes
+            .iter()
+            .find(|n| !n.removed && &*n.name == operator)
+            .is_some_and(|n| n.operator.can_demote(vnode, vnode_count))
     }
 
     /// After a restart restore, the vnodes each operator had demoted to the

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -452,6 +452,16 @@ impl OperatorGraph {
         })
     }
 
+    /// Estimated state bytes per operator, for the node-level memory budget
+    /// and the per-operator gauge. Operators serve this from maintained
+    /// counters or a throttled cache, so calling it once per budget probe is
+    /// cheap.
+    pub(crate) fn state_bytes_per_operator(&self) -> impl Iterator<Item = (&Arc<str>, usize)> {
+        self.nodes
+            .iter()
+            .map(|n| (&n.name, n.operator.estimated_state_bytes()))
+    }
+
     pub fn set_lookup_registry(
         &mut self,
         registry: Arc<laminar_sql::datafusion::LookupTableRegistry>,

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -112,6 +112,17 @@ pub(crate) trait GraphOperator: Send {
     fn apply_vnode_state(&mut self, _vnode: u32, _bytes: &[u8]) -> Result<(), DbError> {
         Ok(())
     }
+
+    /// Wire the cold-tier request channel so the operator can fetch demoted
+    /// vnode slices back into memory (promotion). Default no-op — only the
+    /// vnode-sharded aggregate operator promotes. The same channel feeds the
+    /// coordinator's forced-full re-uploads.
+    #[cfg(feature = "state-tier")]
+    fn attach_state_tier(
+        &mut self,
+        _tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    ) {
+    }
 }
 
 pub(crate) struct OperatorCheckpoint {
@@ -322,6 +333,11 @@ pub(crate) struct OperatorGraph {
     #[allow(clippy::disallowed_types)] // shares the DB's std-HashMap-typed handle
     rehydrated_vnode_state:
         Option<Arc<parking_lot::Mutex<std::collections::HashMap<u32, crate::db::RehydratedVnode>>>>,
+    /// Cold-tier request channel, threaded to vnode-sharded aggregate
+    /// operators for promotion of demoted slices. `None` until a state tier
+    /// is wired; kept so operators hot-added by DDL also receive it.
+    #[cfg(feature = "state-tier")]
+    state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
 }
 
 impl OperatorGraph {
@@ -350,6 +366,8 @@ impl OperatorGraph {
             cluster_shuffle: None,
             #[cfg(feature = "cluster")]
             rehydrated_vnode_state: None,
+            #[cfg(feature = "state-tier")]
+            state_tier: None,
             ctx,
             prom: None,
             lookup_registry: None,
@@ -493,6 +511,21 @@ impl OperatorGraph {
         config: crate::operator::sql_query::ClusterShuffleConfig,
     ) {
         self.cluster_shuffle = Some(config);
+    }
+
+    /// Wire the cold-tier request channel and hand it to every current
+    /// operator (and, via the stored copy, every operator added later by
+    /// DDL). Vnode-sharded aggregates use it for promotion; others ignore it.
+    #[cfg(feature = "state-tier")]
+    #[allow(dead_code)] // wired in pipeline_lifecycle once the demotion trigger lands
+    pub(crate) fn set_state_tier(
+        &mut self,
+        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    ) {
+        for node in &mut self.nodes {
+            node.operator.attach_state_tier(tier.clone());
+        }
+        self.state_tier = Some(tier);
     }
 
     /// The installed cluster row-shuffle config, if any; lets the pipeline
@@ -1445,7 +1478,10 @@ impl OperatorGraph {
 
         let emit_changelog = emit_clause.is_some_and(|ec| matches!(ec, EmitClause::Changes));
 
-        #[cfg_attr(not(feature = "cluster"), allow(unused_mut))]
+        #[cfg_attr(
+            not(any(feature = "cluster", feature = "state-tier")),
+            allow(unused_mut)
+        )]
         let mut op = operator::sql_query::SqlQueryOperator::new(
             name,
             sql,
@@ -1457,6 +1493,10 @@ impl OperatorGraph {
         #[cfg(feature = "cluster")]
         if let Some(ref cfg) = self.cluster_shuffle {
             op.attach_cluster_shuffle(cfg.clone());
+        }
+        #[cfg(feature = "state-tier")]
+        if let Some(ref tier) = self.state_tier {
+            op.attach_state_tier(tier.clone());
         }
         Box::new(op)
     }

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -341,8 +341,8 @@ pub(crate) struct OperatorGraph {
     /// Vnode count for per-vnode state capture and cold-tier demotion — the
     /// only piece of the shuffle topology that path needs (groups bucket by
     /// `key_hash % vnode_count`). Set from the shuffle registry in cluster
-    /// mode, or to a fixed single-node count when the tier runs without a
-    /// controller. `None` = no per-vnode capture.
+    /// mode, or from the vnode registry directly on a single node (no
+    /// controller). `None` = no per-vnode capture.
     #[cfg(feature = "cluster")]
     vnode_count: Option<u32>,
     /// Shared handle to the DB's staged per-vnode rehydration map. Drained at

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -118,11 +118,7 @@ pub(crate) trait GraphOperator: Send {
     /// vnode-sharded aggregate operator promotes. The same channel feeds the
     /// coordinator's forced-full re-uploads.
     #[cfg(feature = "state-tier")]
-    fn attach_state_tier(
-        &mut self,
-        _tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    ) {
-    }
+    fn attach_state_tier(&mut self, _tier: crate::state_tier::TierTx) {}
 
     /// Drain the vnodes this operator had demoted at the restored checkpoint
     /// (the cold tier is wiped on restart, so they must be replayed from
@@ -346,7 +342,7 @@ pub(crate) struct OperatorGraph {
     /// operators for promotion of demoted slices. `None` until a state tier
     /// is wired; kept so operators hot-added by DDL also receive it.
     #[cfg(feature = "state-tier")]
-    state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
+    state_tier: Option<crate::state_tier::TierTx>,
 }
 
 impl OperatorGraph {
@@ -526,10 +522,7 @@ impl OperatorGraph {
     /// operator (and, via the stored copy, every operator added later by
     /// DDL). Vnode-sharded aggregates use it for promotion; others ignore it.
     #[cfg(feature = "state-tier")]
-    pub(crate) fn set_state_tier(
-        &mut self,
-        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    ) {
+    pub(crate) fn set_state_tier(&mut self, tier: crate::state_tier::TierTx) {
         for node in &mut self.nodes {
             node.operator.attach_state_tier(tier.clone());
         }

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -58,10 +58,6 @@ pub struct SourceRegistration {
     /// Whether this source supports replay from a checkpointed position.
     pub supports_replay: bool,
     /// Checkpoint to restore on startup (set during recovery).
-    ///
-    /// When `Some`, the source adapter calls `connector.restore()` after
-    /// `open()` to seek to the checkpointed position. This is how Kafka
-    /// sources resume from their last checkpoint offset on recovery.
     pub restore_checkpoint: Option<SourceCheckpoint>,
 }
 
@@ -69,14 +65,14 @@ pub struct SourceRegistration {
 /// Trait exists for test seam; production impl is `ConnectorPipelineCallback`.
 #[trait_variant::make(Send)]
 pub trait PipelineCallback: Send + 'static {
-    /// Called with accumulated source batches to execute a SQL cycle.
+    /// Execute a SQL cycle over the accumulated source batches.
     async fn execute_cycle(
         &mut self,
         source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
         watermark: i64,
     ) -> Result<FxHashMap<Arc<str>, Vec<RecordBatch>>, String>;
 
-    /// Called with results to push to stream subscriptions.
+    /// Push cycle results to stream subscriptions.
     fn push_to_streams(&self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>);
 
     /// Update materialized view stores with cycle results.
@@ -84,25 +80,24 @@ pub trait PipelineCallback: Send + 'static {
         let _ = results;
     }
 
-    /// Called with results to write to sinks.
+    /// Write cycle results to sinks.
     async fn write_to_sinks(&mut self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>);
 
     /// Extract watermark from a batch for a given source.
     fn extract_watermark(&mut self, source_name: &str, batch: &RecordBatch);
 
-    /// Filter late rows from a batch. Returns the filtered batch (or None if all late).
+    /// Filter late rows from a batch.
     fn filter_late_rows(&self, source_name: &str, batch: &RecordBatch) -> Option<RecordBatch>;
 
-    /// Get the current pipeline watermark.
+    /// Current pipeline watermark.
     fn current_watermark(&self) -> i64;
 
-    /// Returns `true` if this node is the leader in cluster mode, or if running in single-node mode.
+    /// `true` if this node is the cluster leader, or in single-node mode.
     fn is_leader(&self) -> bool {
         true
     }
 
-    /// Per drain cycle: demote sources idle past their timeout so a quiet
-    /// input doesn't hold back the combined watermark. Default: no-op.
+    /// Demote sources idle past their timeout so a quiet input doesn't pin the combined watermark.
     fn tick_idle_watermark(&mut self) {}
 
     /// Perform a periodic (timer-based) checkpoint. At-least-once semantics.
@@ -116,9 +111,6 @@ pub trait PipelineCallback: Send + 'static {
     ) -> Option<u64>;
 
     /// Called when all sources have aligned on a barrier.
-    /// `checkpoint_id` identifies the barrier round the offsets were
-    /// captured under — implementations must not attribute them to a
-    /// different (e.g. newer, post-abandonment) announcement.
     async fn checkpoint_with_barrier(
         &mut self,
         source_checkpoints: FxHashMap<String, SourceCheckpoint>,
@@ -134,44 +126,39 @@ pub trait PipelineCallback: Send + 'static {
     /// Apply a DDL control message (add/drop stream) to the running pipeline.
     fn apply_control(&mut self, msg: super::ControlMsg);
 
-    /// Returns `true` when internal buffers are near capacity.
+    /// `true` when internal buffers are near capacity.
     fn is_backpressured(&self) -> bool {
         false
     }
 
-    /// Returns `true` while total operator state exceeds the configured
-    /// memory budget. The coordinator then stops coalescing extra source
-    /// messages into the cycle (intake throttles to the select loop's one
-    /// message per cycle, so checkpoint barriers keep flowing) and skips
-    /// idle-watermark ticking, so a paused source is not demoted and its
-    /// queued rows are not dropped as late on resume. Default: never.
+    /// `true` while total operator state exceeds the configured memory budget.
+    ///
+    /// When over budget, the coordinator throttles intake to one message per cycle
+    /// and skips idle-watermark ticking so a paused source is not treated as idle.
     fn state_over_budget(&mut self) -> bool {
         false
     }
 
-    /// When a cold tier is wired and operator state approaches the memory
-    /// budget, shed idle vnode slices to disk (demotion) so the budget is
-    /// relieved before intake backpressures. Runs in the cycle's maintenance
-    /// phase (off the hot path); a no-op without a tier or budget.
+    /// Shed idle vnode slices to the cold tier when state approaches the memory budget.
     ///
-    /// The default body is a ready future expression (not an `async {}`
-    /// block): `trait_variant` rewrites the signature to return
-    /// `impl Future`, so a default must already be a future.
+    /// Runs in the maintenance phase; no-op without a tier or budget.
+    /// The default is a `ready` expression, not `async {}`, because `trait_variant`
+    /// rewrites the signature to `impl Future`.
     fn maybe_demote_state(&mut self) -> impl std::future::Future<Output = ()> + Send {
         std::future::ready(())
     }
 
-    /// Returns `true` when deferred operators have pending input to drain.
+    /// `true` when deferred operators have pending input to drain.
     fn has_deferred_input(&self) -> bool {
         false
     }
 
-    /// Forward a durable checkpoint epoch to external SUBSCRIBE consumers.
+    /// Forward a committed epoch to external SUBSCRIBE consumers.
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
         let _ = (epoch, checkpoint_id);
     }
 
-    /// Get the next checkpoint ID if managed externally.
+    /// Next checkpoint ID when managed externally.
     fn next_checkpoint_id(&self) -> Option<u64> {
         None
     }

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -139,6 +139,16 @@ pub trait PipelineCallback: Send + 'static {
         false
     }
 
+    /// Returns `true` while total operator state exceeds the configured
+    /// memory budget. The coordinator then stops coalescing extra source
+    /// messages into the cycle (intake throttles to the select loop's one
+    /// message per cycle, so checkpoint barriers keep flowing) and skips
+    /// idle-watermark ticking, so a paused source is not demoted and its
+    /// queued rows are not dropped as late on resume. Default: never.
+    fn state_over_budget(&mut self) -> bool {
+        false
+    }
+
     /// Returns `true` when deferred operators have pending input to drain.
     fn has_deferred_input(&self) -> bool {
         false

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -149,6 +149,18 @@ pub trait PipelineCallback: Send + 'static {
         false
     }
 
+    /// When a cold tier is wired and operator state approaches the memory
+    /// budget, shed idle vnode slices to disk (demotion) so the budget is
+    /// relieved before intake backpressures. Runs in the cycle's maintenance
+    /// phase (off the hot path); a no-op without a tier or budget.
+    ///
+    /// The default body is a ready future expression (not an `async {}`
+    /// block): `trait_variant` rewrites the signature to return
+    /// `impl Future`, so a default must already be a future.
+    fn maybe_demote_state(&mut self) -> impl std::future::Future<Output = ()> + Send {
+        std::future::ready(())
+    }
+
     /// Returns `true` when deferred operators have pending input to drain.
     fn has_deferred_input(&self) -> bool {
         false

--- a/crates/laminar-db/src/pipeline/config.rs
+++ b/crates/laminar-db/src/pipeline/config.rs
@@ -15,62 +15,37 @@ pub struct PipelineConfig {
     /// Channel capacity for per-source `mpsc` sender → coordinator.
     pub channel_capacity: usize,
 
-    /// Fallback poll interval when a source returns `data_ready_notify() == None`.
+    /// Fallback poll interval when a source returns no `data_ready_notify`.
     pub fallback_poll_interval: Duration,
 
-    /// Checkpoint interval (if checkpointing is enabled).
+    /// Timer-based checkpoint interval (at-least-once). `None` disables auto-checkpointing.
     ///
-    /// This controls the **timer-based** checkpoint mode (at-least-once).
-    /// For exactly-once semantics, use barrier-aligned checkpoints via
-    /// [`PipelineCallback::checkpoint_with_barrier`](super::callback::PipelineCallback::checkpoint_with_barrier) instead. Timer-based
-    /// checkpoints capture offsets *before* operator state, which means
-    /// on recovery the consumer replays from the offset and operators may
-    /// re-process some records (at-least-once, not exactly-once).
+    /// For exactly-once, use barrier-aligned checkpoints via
+    /// [`PipelineCallback::checkpoint_with_barrier`](super::callback::PipelineCallback::checkpoint_with_barrier).
     pub checkpoint_interval: Option<Duration>,
 
-    /// Coordinator micro-batch window.
+    /// Sleep after the first event in a cycle to let more data accumulate.
     ///
-    /// After receiving the first event in a cycle, the coordinator sleeps
-    /// for this duration to let more events accumulate in the channel
-    /// before executing the SQL cycle. This bounds the number of SQL
-    /// executions per second while preserving low latency.
-    ///
-    /// During this window the coordinator does **not** drain the channel,
-    /// so the bounded channel provides natural backpressure to source
-    /// tasks (they block on `tx.send().await` when the channel fills).
-    ///
-    /// Set to `Duration::ZERO` to execute immediately (no batching).
+    /// Bounds SQL executions per second without sacrificing data. The bounded
+    /// channel provides natural backpressure during the window. `ZERO` = no batching.
     pub batch_window: Duration,
 
-    /// Maximum time to wait for all sources to align on a checkpoint
-    /// barrier before cancelling the checkpoint.
+    /// Maximum time to wait for all sources to align on a checkpoint barrier.
     pub barrier_alignment_timeout: Duration,
 
     /// End-to-end delivery guarantee for the pipeline.
-    ///
-    /// Validated at startup: `ExactlyOnce` requires all sources to support
-    /// replay, all sinks to support exactly-once, and checkpointing to be
-    /// enabled. See [`DeliveryGuarantee`] for details.
     pub delivery_guarantee: DeliveryGuarantee,
 
-    /// Maximum wall-clock time for a single processing cycle (nanoseconds).
-    /// Logged at DEBUG when exceeded. Default: 10ms.
+    /// Maximum wall-clock time for a single processing cycle (nanoseconds). Default: 10ms.
     pub cycle_budget_ns: u64,
 
-    /// Maximum wall-clock time for the message drain phase (nanoseconds).
-    /// The drain loop terminates early when this budget is exhausted.
-    /// Default: 1ms.
+    /// Maximum wall-clock time for the message drain phase (nanoseconds). Default: 1ms.
     pub drain_budget_ns: u64,
 
-    /// Maximum wall-clock time for per-query execution within a cycle
-    /// (nanoseconds). When elapsed time exceeds this budget, remaining
-    /// queries are deferred to the next cycle. At least one query always
-    /// executes for forward progress. Default: 8ms.
+    /// Maximum wall-clock time for per-query execution within a cycle (nanoseconds). Default: 8ms.
     pub query_budget_ns: u64,
 
-    /// Maximum wall-clock time for background work (barriers, checkpoint,
-    /// table polling) after SQL execution (nanoseconds). When exceeded,
-    /// low-priority tasks (table polling) are skipped. Default: 5ms.
+    /// Maximum wall-clock time for background work after SQL execution (nanoseconds). Default: 5ms.
     pub background_budget_ns: u64,
 
     /// Per-input-port batch cap. Default: 256.

--- a/crates/laminar-db/src/pipeline/mod.rs
+++ b/crates/laminar-db/src/pipeline/mod.rs
@@ -16,8 +16,7 @@ use arrow::datatypes::SchemaRef;
 use laminar_sql::parser::EmitClause;
 use laminar_sql::translator::{JoinOperatorConfig, OrderOperatorConfig, WindowOperatorConfig};
 
-/// Control message sent from `LaminarDB` DDL handlers to the running
-/// `StreamingCoordinator` for live schema changes (add/drop streams).
+/// Live DDL message from `LaminarDB` to the running `StreamingCoordinator`.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum ControlMsg {
@@ -27,13 +26,13 @@ pub enum ControlMsg {
         name: String,
         /// SQL query text.
         sql: String,
-        /// EMIT clause (e.g., `OnWindowClose`).
+        /// EMIT clause.
         emit_clause: Option<EmitClause>,
-        /// Window configuration (tumbling, hopping, session).
+        /// Window configuration.
         window_config: Option<WindowOperatorConfig>,
         /// ORDER BY configuration.
         order_config: Option<OrderOperatorConfig>,
-        /// Per-step join configs from the planner (left-deep).
+        /// Per-step join configs (left-deep).
         join_config: Option<Vec<JoinOperatorConfig>>,
     },
     /// Remove a streaming query from the running pipeline.
@@ -41,8 +40,7 @@ pub enum ControlMsg {
         /// Stream name to remove.
         name: String,
     },
-    /// Register a new source schema (for queries that depend on a source
-    /// created after `start()`).
+    /// Register a source schema for queries added after `start()`.
     AddSourceSchema {
         /// Source name.
         name: String,

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -1,22 +1,9 @@
-//! Simplified pipeline coordinator.
-//!
-//! Sources push directly to the coordinator via `crossfire::mpsc`.
-//! The coordinator runs on a dedicated single-threaded tokio runtime
-//! (`laminar-compute` thread), isolating CPU-bound event processing
-//! from IO tasks (Kafka poll, S3 checkpoint writes, HTTP) on the main
-//! work-stealing runtime. SQL execution is delegated to [`PipelineCallback`].
-//!
-//! # Architecture
+//! Single-task pipeline coordinator on the dedicated `laminar-compute` thread.
 //!
 //! ```text
-//! Source task (main tokio runtime)
-//!   │  connector.poll_batch().await
-//!   │
-//!   └──── MAsyncTx ────► StreamingCoordinator (dedicated compute thread)
-//!                              │  callback.execute_cycle()
-//!                              │  callback.write_to_sinks()
-//!                              ▼
-//!                            Sinks
+//! Source task (main runtime) ──MAsyncTx──► StreamingCoordinator
+//!                                               │  execute_cycle / write_to_sinks
+//!                                               ▼  Sinks
 //! ```
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -35,32 +22,23 @@ use super::callback::{BarrierOutcome, PipelineCallback, SourceRegistration};
 use super::config::PipelineConfig;
 use crate::error::DbError;
 
-/// Single-consumer async receiver for source → coordinator batches.
 type SourceMsgRx = AsyncRx<mpsc::Array<SourceMsg>>;
-/// Single-consumer async receiver for live DDL control messages.
 type ControlMsgRx = AsyncRx<mpsc::Array<super::ControlMsg>>;
 
 /// Message sent from a source task to the coordinator.
 ///
-/// Each variant carries the [`SourceCheckpoint`] captured at the point the
-/// message was produced.  Co-locating the offset with the data guarantees
-/// the coordinator never checkpoints an offset for data it has not yet
-/// processed (eliminates the offset-before-batch race).
+/// Each variant carries the [`SourceCheckpoint`] captured at production time,
+/// so the coordinator never checkpoints an offset for data it hasn't processed.
 enum SourceMsg {
-    /// A batch of records from a source.
     Batch {
         source_idx: usize,
         batch: RecordBatch,
-        /// Offset snapshot captured *after* `poll_batch` drained the reader
-        /// channel.  Committed to `committed_offsets` only when the batch
-        /// is actually processed (not when deferred to `post_barrier_buf`).
+        /// Committed to `committed_offsets` only after a successful `execute_cycle`.
         checkpoint: SourceCheckpoint,
     },
-    /// Checkpoint barrier injected at the source.
     Barrier {
         source_idx: usize,
         barrier: CheckpointBarrier,
-        /// Offset snapshot captured at barrier injection (consistent cut).
         checkpoint: SourceCheckpoint,
     },
 }
@@ -70,72 +48,48 @@ struct SourceHandle {
     name: Arc<str>,
     shutdown: Arc<tokio::sync::Notify>,
     join: tokio::task::JoinHandle<()>,
-    /// Injector for Chandy-Lamport checkpoint barriers.
     barrier_injector: CheckpointBarrierInjector,
-    /// Latest committed `(epoch, persisted-checkpoint)`. The checkpoint is
-    /// the per-source `SourceCheckpoint` that was actually written to the
-    /// manifest for `epoch` — sources rebuild downstream offset state
-    /// (Kafka group offsets, NATS acks, etc.) from this exact value
-    /// rather than from `self.offsets`, which may have advanced past
-    /// the durability cut. Empty for timer-driven commits.
+    /// Notifies the source of a committed `(epoch, checkpoint)` so it can ack to
+    /// its external system. The checkpoint is what was actually written to the manifest,
+    /// which may lag `self.offsets`. Empty for timer-driven commits.
     epoch_committed_tx: tokio::sync::watch::Sender<Option<(u64, SourceCheckpoint)>>,
 }
 
 /// `(epoch, per-source fan-out)` sent back when a background checkpoint completes.
 type CheckpointCompletion = (u64, rustc_hash::FxHashMap<String, SourceCheckpoint>);
 
-/// Simplified pipeline coordinator — single tokio task, no core threads.
+/// Single-task pipeline coordinator — no core threads.
 pub struct StreamingCoordinator {
     config: PipelineConfig,
-    /// Receives all source messages (batches + barriers).
     rx: SourceMsgRx,
-    /// Handles to source tasks (for shutdown + checkpoint queries).
     source_handles: Vec<SourceHandle>,
-    /// Source name cache indexed by `source_idx`.
     source_names: Vec<Arc<str>>,
-    /// Shutdown signal.
     shutdown: Arc<tokio::sync::Notify>,
-    /// Pending barrier alignment.
     pending_barrier: PendingBarrier,
-    /// Next checkpoint ID for barrier injection.
     next_checkpoint_id: u64,
-    /// Last checkpoint time.
     last_checkpoint: Instant,
-    /// Source-initiated checkpoint request flags.
     checkpoint_request_flags: Vec<Arc<AtomicBool>>,
-    /// Pre-allocated source batches buffer (cleared per cycle).
     source_batches_buf: FxHashMap<Arc<str>, Vec<RecordBatch>>,
-    /// Batches received after a barrier from the same source in the same
-    /// drain cycle. These belong to the NEXT checkpoint epoch and must not
-    /// be included in the current checkpoint state. Bounded in practice by
-    /// `channel_capacity` (max messages available per drain cycle).
+    /// Batches received from a source after it sent a barrier in the same drain cycle.
+    /// They belong to the next epoch and are deferred to the next cycle.
     post_barrier_buf: Vec<SourceMsg>,
     pending_watermark_batches: Vec<(Arc<str>, RecordBatch)>,
-    /// Source indices that have delivered a barrier during the current drain
-    /// cycle. Any subsequent batch from these sources goes to
-    /// `post_barrier_buf`.
+    /// Sources that delivered a barrier this drain cycle; subsequent batches from
+    /// them go to `post_barrier_buf`.
     barrier_seen: FxHashSet<usize>,
-    /// Latest durably-processed source offset per source index.  Merged
-    /// from `pending_offsets` only after a successful `execute_cycle`.
+    /// Per-source offset merged from `pending_offsets` after a successful `execute_cycle`.
     committed_offsets: Vec<Option<SourceCheckpoint>>,
-    /// Offsets staged by `process_msg`.  Merged into `committed_offsets`
-    /// after a successful `execute_cycle`, discarded on failure.
+    /// Offsets staged by `process_msg`; merged on success, discarded on failure.
     pending_offsets: Vec<Option<SourceCheckpoint>>,
-    /// Control channel for live DDL (add/drop stream) from `LaminarDB`.
     control_rx: ControlMsgRx,
     checkpoint_complete_rx:
         Option<crossfire::AsyncRx<crossfire::mpsc::Array<CheckpointCompletion>>>,
-    /// Epochs between admission and restorable (durable tails still
-    /// running). Shared with the callback; gated against
-    /// `max_in_flight_epochs`.
+    /// Epochs between admission and durable (tails still running); shared with callback.
     checkpoint_in_flight: Arc<AtomicU64>,
-    /// Barrier admission cap on `checkpoint_in_flight`. Exactly-once
-    /// pipelines are wired with 1.
+    /// Admission cap on `checkpoint_in_flight`. Exactly-once pipelines use 1.
     max_in_flight_epochs: u64,
-    /// Captured-state bytes held by in-flight epochs (shared with the
-    /// callback).
+    /// Captured-state bytes held by in-flight epochs; shared with callback.
     staged_bytes: Arc<AtomicU64>,
-    /// Barrier admission cap on `staged_bytes`.
     max_staged_bytes: u64,
 }
 
@@ -197,10 +151,7 @@ enum SourceWake {
 }
 
 impl StreamingCoordinator {
-    /// Fan out a committed epoch to every source so they can ack. Each
-    /// source receives the per-source checkpoint that was persisted into
-    /// the manifest for `epoch`, or an empty checkpoint when no per-source
-    /// state was captured (timer-driven commits).
+    /// Notify every source of a committed epoch so they can ack to their broker.
     fn broadcast_epoch_committed(
         &self,
         epoch: u64,
@@ -215,15 +166,11 @@ impl StreamingCoordinator {
         }
     }
 
-    /// Create a new streaming coordinator.
-    ///
-    /// Spawns a tokio task for each source that polls the connector and
-    /// sends batches/barriers to the coordinator via mpsc.
+    /// Build the coordinator, open each source connector, and spawn source tasks.
     ///
     /// # Errors
     ///
-    /// Returns an error if delivery guarantee constraints are violated
-    /// or if any source connector fails to open.
+    /// Returns an error if delivery guarantee constraints are violated or a source fails to open.
     #[allow(clippy::too_many_lines)]
     pub async fn new(
         sources: Vec<SourceRegistration>,
@@ -254,7 +201,6 @@ impl StreamingCoordinator {
             ));
         }
 
-        // Channel for all source messages.
         let (tx, rx) = mpsc::bounded_async::<SourceMsg>(config.channel_capacity);
 
         let mut source_handles = Vec::with_capacity(sources.len());
@@ -277,13 +223,11 @@ impl StreamingCoordinator {
             let mut connector = src.connector;
             let connector_config = src.config;
 
-            // Open connector eagerly so startup fails fast on bad config.
             connector
                 .open(&connector_config)
                 .await
                 .map_err(|e| DbError::Config(format!("source '{src_name}' open failed: {e}")))?;
 
-            // Restore checkpoint if available.
             if let Some(ref cp) = restore {
                 if let Err(e) = connector.restore(cp).await {
                     tracing::warn!(
@@ -293,11 +237,9 @@ impl StreamingCoordinator {
                 }
             }
 
-            // Seed committed_offsets with the restore checkpoint so a
-            // shutdown before any data still checkpoints the restore position.
+            // Seed with the restore checkpoint so a pre-data shutdown still checkpoints it.
             committed_offsets.push(src.restore_checkpoint);
 
-            // Barrier injection: coordinator triggers → source polls → sends SourceMsg::Barrier
             let barrier_injector = CheckpointBarrierInjector::new();
             let barrier_handle = barrier_injector.handle();
 
@@ -344,9 +286,6 @@ impl StreamingCoordinator {
 
                     match poll_result {
                         Ok(Some(batch)) => {
-                            // Offset travels with the batch — no separate
-                            // watch channel.  The coordinator commits the
-                            // offset only after processing the batch.
                             let cp = connector.checkpoint();
                             let msg = SourceMsg::Batch {
                                 source_idx: idx,
@@ -358,7 +297,6 @@ impl StreamingCoordinator {
                             }
                         }
                         Ok(None) => {
-                            // No data — sleep briefly (cancellable).
                             tokio::select! {
                                 biased;
                                 () = task_shutdown_clone.notified() => break,
@@ -379,7 +317,6 @@ impl StreamingCoordinator {
                         }
                     }
 
-                    // Poll for pending checkpoint barrier.
                     if let Some(barrier) = barrier_handle.poll(epoch) {
                         epoch += 1;
                         let cp = connector.checkpoint();
@@ -394,9 +331,7 @@ impl StreamingCoordinator {
                     }
                 }
 
-                // Drain remaining data from the connector's internal
-                // buffer before closing — close() drops the buffer and
-                // anything not drained here is lost.
+                // Drain before close() so buffered data isn't lost.
                 while let Ok(Some(batch)) = connector.poll_batch(max_poll).await {
                     let cp = connector.checkpoint();
                     let msg = SourceMsg::Batch {
@@ -409,13 +344,8 @@ impl StreamingCoordinator {
                     }
                 }
 
-                // Drain any post-shutdown EpochCommitted broadcasts before
-                // close — the coordinator's final checkpoint fires after
-                // signalling shutdown, and sources need to ack it so
-                // external state (Kafka group offsets, NATS msg acks) for
-                // the last durable epoch is advanced.  Loop until the
-                // sender is dropped (which happens when the coordinator
-                // joins this task).
+                // Drain EpochCommitted broadcasts before close so the final checkpoint
+                // epoch is acked to the broker. Loop until the sender is dropped.
                 while let Ok(()) = epoch_committed_rx.changed().await {
                     let snapshot = epoch_committed_rx.borrow_and_update().clone();
                     if let Some((e, cp)) = snapshot {
@@ -471,9 +401,7 @@ impl StreamingCoordinator {
         })
     }
 
-    /// Share the callback's admission state so the coordinator admits a
-    /// new barrier only while in-flight epochs and staged bytes are
-    /// under their caps.
+    /// Wire in the callback's admission counters so the coordinator gates new barriers.
     pub(crate) fn with_checkpoint_admission(
         mut self,
         in_flight: Arc<AtomicU64>,
@@ -496,19 +424,10 @@ impl StreamingCoordinator {
         self
     }
 
-    /// Run the coordinator loop.
+    /// Run the coordinator loop until shutdown is signaled.
     ///
-    /// Receives batches from sources via mpsc, executes SQL cycles via
-    /// the callback, and handles checkpoint barriers. Returns when
-    /// shutdown is signaled.
-    ///
-    /// Cycle priority ordering:
-    /// 1. Shutdown signal (biased select — checked first)
-    /// 2. Event drain + SQL execution (up to `MAX_DRAIN_PER_CYCLE` messages)
-    /// 3. Barrier alignment (after SQL so checkpoint state includes processed data)
-    /// 4. Periodic checkpoint (if interval elapsed)
-    /// 5. Table source polling (idle maintenance)
-    /// 6. Barrier timeout check
+    /// Cycle priority: (1) shutdown, (2) drain + SQL, (3) barrier alignment,
+    /// (4) periodic checkpoint, (5) table polling, (6) barrier timeout.
     #[allow(clippy::too_many_lines)]
     pub async fn run<C: PipelineCallback>(mut self, mut callback: C) {
         /// Maximum messages to drain per cycle before yielding for maintenance work.
@@ -544,8 +463,6 @@ impl StreamingCoordinator {
                 msg = self.rx.recv() => {
                     match msg {
                         Ok(m) => {
-                            // If batch_window > 0, coalesce: sleep briefly
-                            // to let more data accumulate.
                             if !batch_window.is_zero() {
                                 tokio::time::sleep(batch_window).await;
                             }
@@ -564,9 +481,7 @@ impl StreamingCoordinator {
             let mut cycle_events: u64 = 0;
             let cycle_start = Instant::now();
 
-            // First, drain any post-barrier messages deferred from the
-            // previous cycle — these are pre-next-barrier data that should
-            // be processed in this cycle.
+            // Drain post-barrier messages deferred from the previous cycle.
             let deferred = std::mem::take(&mut self.post_barrier_buf);
             for deferred_msg in deferred {
                 self.process_msg(
@@ -587,15 +502,11 @@ impl StreamingCoordinator {
                 );
             }
 
-            // Drain any additional buffered messages (batch coalescing).
-            // Terminates on count limit, time budget, or backpressure.
-            // Only check backpressure on active wakeups to avoid bumping
-            // the counter on idle timeouts.
+            // Coalesce additional buffered messages; stop at count, time budget, or backpressure.
             let mut drain_count = 0;
             let drain_budget_ns = self.config.drain_budget_ns;
-            // Over budget: skip the coalescing drain (queued messages stay in the
-            // channel as backpressure). Holds on idle wakeups too, hence not gated
-            // on `had_data`; `is_backpressured()` bumps a counter, so that is.
+            // When over budget, skip the coalescing drain entirely. `is_backpressured()` bumps a
+            // counter so it's only called on active wakeups, not idle timeouts.
             let state_paused = callback.state_over_budget();
             let backpressured = state_paused || (had_data && callback.is_backpressured());
             if backpressured {
@@ -619,21 +530,15 @@ impl StreamingCoordinator {
                 callback.extract_watermark(&name, &batch);
             }
 
-            // Demote watermarked sources idle past their timeout so a quiet
-            // input doesn't pin the combined watermark (active sources keep
-            // driving the cycle below, which then closes pending windows).
-            // Not while intake is paused by the state budget: a paused
-            // source isn't idle — demoting it would advance the combined
-            // watermark past its queued rows, which would then be dropped
-            // as late on resume.
+            // Skip idle-watermark ticking while intake is budget-paused: a paused source
+            // isn't actually idle and demoting it would advance the watermark past its
+            // queued rows, dropping them as late on resume.
             if !state_paused {
                 callback.tick_idle_watermark();
             }
 
-            // Step: Execute SQL cycle. Also runs on idle wakeups when
-            // operators have deferred input from a prior budget-exceeded
-            // cycle — otherwise that data is stuck forever once the source
-            // goes idle.
+            // Run on idle wakeups too when operators have deferred input; otherwise
+            // deferred data stalls once the source goes quiet.
             if !self.source_batches_buf.is_empty() || callback.has_deferred_input() {
                 let wm = callback.current_watermark();
                 match callback.execute_cycle(&self.source_batches_buf, wm).await {
@@ -661,38 +566,29 @@ impl StreamingCoordinator {
                 }
             }
 
-            // Hoist elapsed_ns so the background phase can use it.
             #[allow(clippy::cast_possible_truncation)]
             let cycle_elapsed_ns = cycle_start.elapsed().as_nanos() as u64;
 
             let bg_start = Instant::now();
             let bg_budget = self.config.background_budget_ns;
 
-            // Step: Handle barriers — always process (cheap, O(num_sources)
-            // hash lookups, must not be deferred for correctness).
+            // Barriers are cheap (O(num_sources) lookups) and must not be skipped.
             for (source_idx, barrier, cp) in &barriers_buf {
                 self.handle_barrier(*source_idx, barrier, cp, &mut callback)
                     .await;
             }
 
-            // Step: Periodic checkpoint — skip if background budget already
-            // exhausted (checkpoint is expensive I/O).
             #[allow(clippy::cast_possible_truncation)]
             if (bg_start.elapsed().as_nanos() as u64) < bg_budget {
                 self.maybe_checkpoint(&mut callback).await;
             }
 
-            // Step: Cold-tier demotion — shed idle state to disk as it nears
-            // the memory budget. Cheap to skip (the callback gates on a wired
-            // tier, the budget watermark, and no checkpoint in flight), so it
-            // runs whenever there's background headroom.
             #[allow(clippy::cast_possible_truncation)]
             if (bg_start.elapsed().as_nanos() as u64) < bg_budget {
                 callback.maybe_demote_state().await;
             }
 
-            // Step: Poll table sources — skip if cycle OR background budget
-            // exceeded (lowest priority background work).
+            // Table polling is the lowest-priority background work.
             #[allow(clippy::cast_possible_truncation)]
             let bg_elapsed = bg_start.elapsed().as_nanos() as u64;
             if cycle_elapsed_ns < self.config.cycle_budget_ns && bg_elapsed < bg_budget {
@@ -701,14 +597,11 @@ impl StreamingCoordinator {
                 tracing::debug!("skipping poll_tables (budget exhausted)");
             }
 
-            // Step: Drain control messages (add/drop stream DDL).
-            // Processed AFTER checkpoint so newly added queries don't have
-            // inconsistent state in the checkpoint.
+            // DDL after checkpoint so newly added queries don't appear in the same snapshot.
             while let Ok(msg) = self.control_rx.try_recv() {
                 callback.apply_control(msg);
             }
 
-            // Step: Barrier timeout check.
             if self.pending_barrier.active
                 && self.pending_barrier.started_at.elapsed() > self.config.barrier_alignment_timeout
             {
@@ -720,16 +613,12 @@ impl StreamingCoordinator {
             }
         }
 
-        // Signal source tasks to stop.
         for handle in &self.source_handles {
             handle.shutdown.notify_one();
         }
 
-        // Drain rx BEFORE joining source tasks. Source tasks may be
-        // blocked on task_tx.send() (channel full because the pipeline
-        // is slower than the source). Draining first frees channel
-        // slots so those source tasks can unblock, see the shutdown
-        // signal, and exit. Joining before draining deadlocks.
+        // Drain before joining: source tasks blocked on a full channel can't see
+        // the shutdown signal until slots free. Joining first deadlocks.
         self.source_batches_buf.clear();
         self.barrier_seen.clear();
         self.discard_pending_offsets();
@@ -771,8 +660,7 @@ impl StreamingCoordinator {
             }
         }
 
-        // Second drain: pick up any messages source tasks sent between
-        // the first drain and finishing their data-drain phase.
+        // Second drain: messages sent between the first drain and source task exit.
         self.source_batches_buf.clear();
         self.barrier_seen.clear();
         self.discard_pending_offsets();
@@ -800,10 +688,8 @@ impl StreamingCoordinator {
             }
         }
 
-        // Final checkpoint uses committed_offsets — only reflects data
-        // that successfully passed through execute_cycle. Run BEFORE
-        // dropping source senders so sources receive the EpochCommitted
-        // and ack to their external systems (Kafka group offsets, etc.).
+        // Run the final checkpoint before dropping source senders so the EpochCommitted
+        // ack reaches the broker (Kafka group offsets, etc.).
         let checkpoint_enabled = self.config.checkpoint_interval.is_some();
         if checkpoint_enabled {
             let source_offsets: FxHashMap<String, SourceCheckpoint> = self
@@ -827,9 +713,8 @@ impl StreamingCoordinator {
             }
         }
 
-        // Drop epoch_committed_tx senders before awaiting join: source
-        // tasks block on epoch_committed_rx.changed() in their drain
-        // phase and only exit once the sender is dropped.
+        // Drop senders before join: source tasks wait on `epoch_committed_rx.changed()`
+        // and exit only when the sender is dropped.
         for handle in std::mem::take(&mut self.source_handles) {
             let SourceHandle {
                 name,
@@ -845,11 +730,7 @@ impl StreamingCoordinator {
         }
     }
 
-    /// Process a single source message.
-    ///
-    /// When a barrier is seen from a source, subsequent batches from that
-    /// source are diverted to `post_barrier_buf` to ensure they are not
-    /// included in the current checkpoint state.
+    /// Process one source message. Post-barrier batches are diverted to `post_barrier_buf`.
     fn process_msg(
         &mut self,
         msg: SourceMsg,
@@ -863,8 +744,6 @@ impl StreamingCoordinator {
                 batch,
                 checkpoint,
             } => {
-                // If this source already delivered a barrier in this drain
-                // cycle, this batch is post-barrier data — defer it.
                 if self.barrier_seen.contains(&source_idx) {
                     self.post_barrier_buf.push(SourceMsg::Batch {
                         source_idx,
@@ -874,7 +753,6 @@ impl StreamingCoordinator {
                     return;
                 }
 
-                // Stage offset (committed after successful execute_cycle).
                 if source_idx < self.pending_offsets.len() {
                     self.pending_offsets[source_idx] = Some(checkpoint);
                 }
@@ -884,10 +762,9 @@ impl StreamingCoordinator {
                     {
                         *cycle_events += batch.num_rows() as u64;
                     }
-                    // Filter with the PRE-DRAIN watermark. Watermark extraction
-                    // is deferred to after all batches in this drain cycle are
-                    // filtered — otherwise batch N's watermark advance causes
-                    // batch N+1's slightly-older rows to be dropped as "late."
+                    // Filter against the pre-drain watermark. Extraction is deferred
+                    // until after all batches are filtered so one batch's watermark
+                    // advance can't cause the next batch's rows to be dropped as late.
                     if let Some(filtered) = callback.filter_late_rows(name, &batch) {
                         self.source_batches_buf
                             .entry(Arc::clone(name))
@@ -914,8 +791,7 @@ impl StreamingCoordinator {
         }
     }
 
-    /// Merge staged offsets into `committed_offsets`.  Called after a
-    /// successful `execute_cycle`.
+    /// Merge staged offsets into `committed_offsets` after a successful cycle.
     fn commit_pending_offsets(&mut self) {
         for (i, pending) in self.pending_offsets.iter_mut().enumerate() {
             if let Some(cp) = pending.take() {
@@ -924,7 +800,7 @@ impl StreamingCoordinator {
         }
     }
 
-    /// Discard staged offsets.  Called when `execute_cycle` fails.
+    /// Discard staged offsets when `execute_cycle` fails.
     fn discard_pending_offsets(&mut self) {
         for slot in &mut self.pending_offsets {
             *slot = None;
@@ -950,8 +826,6 @@ impl StreamingCoordinator {
             return;
         }
 
-        // Use the checkpoint that traveled atomically with the barrier
-        // message — no watch-channel race.
         if let Some(name) = self.source_names.get(source_idx) {
             self.pending_barrier
                 .source_checkpoints
@@ -960,13 +834,9 @@ impl StreamingCoordinator {
 
         self.pending_barrier.sources_aligned.insert(source_idx);
 
-        // Check if all sources aligned.
         if self.pending_barrier.sources_aligned.len() >= self.pending_barrier.sources_total {
             let checkpoints = std::mem::take(&mut self.pending_barrier.source_checkpoints);
-            // Clone for fan-out — `checkpoint_with_barrier` consumes the
-            // map. The fan-out passes each source the exact `SourceCheckpoint`
-            // that was persisted, so external offset state (Kafka group
-            // offsets, ack tokens) advances only with the durable manifest.
+            // Clone for fan-out so each source gets the exact checkpoint that was persisted.
             let fan_out = checkpoints.clone();
             let checkpoint_id = self.pending_barrier.checkpoint_id;
             match callback
@@ -997,21 +867,15 @@ impl StreamingCoordinator {
         }
     }
 
-    /// Check if a periodic checkpoint should be triggered.
-    ///
-    /// When barriers are supported (sources present), injects barriers for
-    /// Chandy-Lamport consistent snapshots. When no sources are present,
-    /// falls back to timer-based offset-only checkpoints.
+    /// Trigger a periodic checkpoint if the interval has elapsed and admission permits.
     async fn maybe_checkpoint(&mut self, callback: &mut impl PipelineCallback) {
         if self.pending_barrier.active {
-            return; // Already tracking a barrier.
+            return;
         }
         if self.checkpoint_in_flight.load(Ordering::Acquire) >= self.max_in_flight_epochs {
-            return; // The in-flight epoch backlog is at its cap.
+            return;
         }
         if self.staged_bytes.load(Ordering::Acquire) >= self.max_staged_bytes {
-            // Cadence degrades to upload speed rather than buffering
-            // unbounded captured state.
             warn_staged_cap_throttled(
                 self.staged_bytes.load(Ordering::Acquire),
                 self.max_staged_bytes,
@@ -1019,16 +883,11 @@ impl StreamingCoordinator {
             return;
         }
 
-        // Always give the callback a chance to run cluster-follower
-        // polling. `ConnectorPipelineCallback::maybe_checkpoint` routes
-        // to `maybe_follower_checkpoint` on non-leader nodes before
-        // checking the timer, so a follower with no data-path events
-        // still picks up the leader's PREPARE announcements from gossip.
-        // Leader-side nodes short-circuit here (no checkpoint_interval
-        // configured in the tests that drive `db.checkpoint()` manually).
+        // Give the callback a chance to run follower polling. On non-leaders this routes
+        // to `maybe_follower_checkpoint` so gossip PREPARE announcements are picked up
+        // even with no data-path events.
         let offsets = FxHashMap::default();
         if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
-            // Timer-driven follower path — no per-source state captured.
             self.broadcast_epoch_committed(epoch, &FxHashMap::default());
         }
 
@@ -1047,7 +906,6 @@ impl StreamingCoordinator {
         }
 
         if self.source_handles.is_empty() {
-            // No sources — timer-based checkpoint only.
             let offsets = FxHashMap::default();
             if let Some(epoch) = callback.maybe_checkpoint(false, offsets).await {
                 self.last_checkpoint = Instant::now();
@@ -1056,7 +914,6 @@ impl StreamingCoordinator {
             return;
         }
 
-        // Inject barriers into all source tasks for Chandy-Lamport alignment.
         let checkpoint_id = if let Some(external_id) = callback.next_checkpoint_id() {
             self.next_checkpoint_id = external_id + 1;
             external_id

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -593,7 +593,13 @@ impl StreamingCoordinator {
             // the counter on idle timeouts.
             let mut drain_count = 0;
             let drain_budget_ns = self.config.drain_budget_ns;
-            let backpressured = had_data && callback.is_backpressured();
+            // Over the state memory budget, intake throttles to the one
+            // message the select loop already received: skipping the
+            // coalescing drain leaves the rest queued in the channel
+            // (senders block when it fills) while barriers keep flowing
+            // and operators keep draining state.
+            let state_paused = callback.state_over_budget();
+            let backpressured = had_data && (state_paused || callback.is_backpressured());
             if backpressured {
                 tracing::debug!("operator graph backpressured — skipping drain");
             }
@@ -618,7 +624,13 @@ impl StreamingCoordinator {
             // Demote watermarked sources idle past their timeout so a quiet
             // input doesn't pin the combined watermark (active sources keep
             // driving the cycle below, which then closes pending windows).
-            callback.tick_idle_watermark();
+            // Not while intake is paused by the state budget: a paused
+            // source isn't idle — demoting it would advance the combined
+            // watermark past its queued rows, which would then be dropped
+            // as late on resume.
+            if !state_paused {
+                callback.tick_idle_watermark();
+            }
 
             // Step: Execute SQL cycle. Also runs on idle wakeups when
             // operators have deferred input from a prior budget-exceeded
@@ -1664,5 +1676,184 @@ mod tests {
                 "cycle {i} saw {events} events, expected <=1 under backpressure"
             );
         }
+    }
+
+    #[allow(clippy::disallowed_types)] // test-only: std::sync::Mutex is fine here
+    struct StateBudgetCallback {
+        inner: MockCallback,
+        events_per_cycle: Arc<std::sync::Mutex<Vec<u64>>>,
+        idle_ticks: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    impl PipelineCallback for StateBudgetCallback {
+        async fn execute_cycle(
+            &mut self,
+            source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
+            watermark: i64,
+        ) -> Result<FxHashMap<Arc<str>, Vec<RecordBatch>>, String> {
+            let total: u64 = source_batches
+                .values()
+                .flat_map(|bs| bs.iter())
+                .map(|b| b.num_rows() as u64)
+                .sum();
+            self.events_per_cycle.lock().unwrap().push(total);
+            self.inner.execute_cycle(source_batches, watermark).await
+        }
+
+        fn push_to_streams(&self, r: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
+            self.inner.push_to_streams(r);
+        }
+        async fn write_to_sinks(&mut self, r: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
+            self.inner.write_to_sinks(r).await;
+        }
+        fn extract_watermark(&mut self, s: &str, b: &RecordBatch) {
+            self.inner.extract_watermark(s, b);
+        }
+        fn filter_late_rows(&self, s: &str, b: &RecordBatch) -> Option<RecordBatch> {
+            self.inner.filter_late_rows(s, b)
+        }
+        fn current_watermark(&self) -> i64 {
+            self.inner.current_watermark()
+        }
+        async fn maybe_checkpoint(
+            &mut self,
+            force: bool,
+            offsets: FxHashMap<String, SourceCheckpoint>,
+        ) -> Option<u64> {
+            self.inner.maybe_checkpoint(force, offsets).await
+        }
+        async fn checkpoint_with_barrier(
+            &mut self,
+            cp: FxHashMap<String, SourceCheckpoint>,
+            checkpoint_id: u64,
+        ) -> BarrierOutcome {
+            self.inner.checkpoint_with_barrier(cp, checkpoint_id).await
+        }
+        fn record_cycle(&self, e: u64, b: u64, ns: u64) {
+            self.inner.record_cycle(e, b, ns);
+        }
+        async fn poll_tables(&mut self) {
+            self.inner.poll_tables().await;
+        }
+        fn apply_control(&mut self, msg: crate::pipeline::ControlMsg) {
+            self.inner.apply_control(msg);
+        }
+
+        fn state_over_budget(&mut self) -> bool {
+            true // Permanently over budget — drain must skip, idle tick must not run.
+        }
+
+        fn tick_idle_watermark(&mut self) {
+            self.idle_ticks
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    /// With `state_over_budget() == true`, the coordinator throttles intake
+    /// exactly like buffer backpressure (one wakeup message per cycle, no
+    /// drain coalescing, no data loss) and never ticks the idle-watermark
+    /// demotion — a budget-paused source must not be treated as idle.
+    #[tokio::test]
+    async fn test_state_budget_pause_throttles_intake_and_holds_idle_tick() {
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let (tx, rx) = mpsc::bounded_async::<SourceMsg>(64);
+        let (_control_tx, control_rx) = mpsc::bounded_async::<crate::pipeline::ControlMsg>(64);
+
+        let coordinator = StreamingCoordinator {
+            config: PipelineConfig {
+                batch_window: Duration::ZERO,
+                max_poll_records: 1000,
+                channel_capacity: 64,
+                fallback_poll_interval: Duration::from_millis(10),
+                checkpoint_interval: None,
+                delivery_guarantee: DeliveryGuarantee::AtLeastOnce,
+                barrier_alignment_timeout: Duration::from_secs(30),
+                cycle_budget_ns: 10_000_000,
+                drain_budget_ns: 1_000_000,
+                query_budget_ns: 8_000_000,
+                background_budget_ns: 5_000_000,
+                max_input_buf_batches: 256,
+                max_input_buf_bytes: None,
+                backpressure_policy: crate::config::BackpressurePolicy::Backpressure,
+            },
+            rx,
+            source_handles: Vec::new(),
+            source_names: vec![Arc::from("src")],
+            shutdown: Arc::clone(&shutdown),
+            pending_barrier: PendingBarrier::new(),
+            next_checkpoint_id: 1,
+            last_checkpoint: Instant::now(),
+            checkpoint_request_flags: Vec::new(),
+            source_batches_buf: FxHashMap::default(),
+            post_barrier_buf: Vec::new(),
+            pending_watermark_batches: Vec::new(),
+            barrier_seen: FxHashSet::default(),
+            committed_offsets: vec![None],
+            pending_offsets: vec![None],
+            control_rx,
+            checkpoint_complete_rx: None,
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
+        };
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, false)]));
+        for i in 0..5 {
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(Int64Array::from(vec![i]))],
+            )
+            .unwrap();
+            tx.send(SourceMsg::Batch {
+                source_idx: 0,
+                batch,
+                checkpoint: SourceCheckpoint::new(u64::try_from(i).unwrap()),
+            })
+            .await
+            .unwrap();
+        }
+
+        #[allow(clippy::disallowed_types)]
+        let events_per_cycle = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let idle_ticks = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        // The shutdown drain legitimately ticks (everything queued was
+        // drained and watermark-extracted first), so the budget-pause
+        // assertion is on the count snapshotted just before shutdown.
+        let ticks_before_shutdown = Arc::new(std::sync::atomic::AtomicU32::new(u32::MAX));
+        let shutdown_clone = Arc::clone(&shutdown);
+        let idle_ticks_clone = Arc::clone(&idle_ticks);
+        let ticks_before_clone = Arc::clone(&ticks_before_shutdown);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            ticks_before_clone.store(
+                idle_ticks_clone.load(std::sync::atomic::Ordering::SeqCst),
+                std::sync::atomic::Ordering::SeqCst,
+            );
+            shutdown_clone.notify_one();
+        });
+
+        let callback = StateBudgetCallback {
+            inner: MockCallback::new(),
+            events_per_cycle: Arc::clone(&events_per_cycle),
+            idle_ticks: Arc::clone(&idle_ticks),
+        };
+        coordinator.run(callback).await;
+
+        let epc = events_per_cycle.lock().unwrap();
+        let total: u64 = epc.iter().sum();
+        assert_eq!(total, 5, "all events must be processed, got {total}");
+        for (i, &events) in epc.iter().enumerate() {
+            assert!(
+                events <= 1,
+                "cycle {i} saw {events} events, expected <=1 while over budget"
+            );
+        }
+        assert_eq!(
+            ticks_before_shutdown.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "idle-watermark tick must not run while intake is budget-paused"
+        );
     }
 }

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -684,6 +684,15 @@ impl StreamingCoordinator {
                 self.maybe_checkpoint(&mut callback).await;
             }
 
+            // Step: Cold-tier demotion — shed idle state to disk as it nears
+            // the memory budget. Cheap to skip (the callback gates on a wired
+            // tier, the budget watermark, and no checkpoint in flight), so it
+            // runs whenever there's background headroom.
+            #[allow(clippy::cast_possible_truncation)]
+            if (bg_start.elapsed().as_nanos() as u64) < bg_budget {
+                callback.maybe_demote_state().await;
+            }
+
             // Step: Poll table sources — skip if cycle OR background budget
             // exceeded (lowest priority background work).
             #[allow(clippy::cast_possible_truncation)]

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -593,13 +593,11 @@ impl StreamingCoordinator {
             // the counter on idle timeouts.
             let mut drain_count = 0;
             let drain_budget_ns = self.config.drain_budget_ns;
-            // Over the state memory budget, intake throttles to the one
-            // message the select loop already received: skipping the
-            // coalescing drain leaves the rest queued in the channel
-            // (senders block when it fills) while barriers keep flowing
-            // and operators keep draining state.
+            // Over budget: skip the coalescing drain (queued messages stay in the
+            // channel as backpressure). Holds on idle wakeups too, hence not gated
+            // on `had_data`; `is_backpressured()` bumps a counter, so that is.
             let state_paused = callback.state_over_budget();
-            let backpressured = had_data && (state_paused || callback.is_backpressured());
+            let backpressured = state_paused || (had_data && callback.is_backpressured());
             if backpressured {
                 tracing::debug!("operator graph backpressured — skipping drain");
             }

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -31,16 +31,8 @@ enum SinkFilterDispatch {
     None,
 }
 
-/// Implements [`PipelineCallback`](crate::pipeline::PipelineCallback) to bridge
-/// the event-driven pipeline coordinator to the rest of the database (stream
-/// executor, sinks, watermarks, checkpoints, table sources).
-///
-/// `ConnectorPipelineCallback` runs on a dedicated single-threaded tokio runtime
-/// (laminar-compute thread). Serialization and checkpoint I/O run inline because:
-/// 1. `tokio::spawn` on `current_thread` has no parallelism benefit
-/// 2. `spawn_blocking` on `current_thread` has no dedicated blocking pool
-/// 3. The compute thread is dedicated — blocking is acceptable
-// Throttled (~once/10s) WARN so silent watermark drops are diagnosable.
+/// Bridges the coordinator to the rest of the database (sinks, watermarks, checkpoints).
+// Throttled WARN so silent watermark drops are diagnosable.
 fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize) {
     static THROTTLE: crate::log_throttle::LogThrottle =
         crate::log_throttle::LogThrottle::every(Duration::from_secs(10));
@@ -57,18 +49,14 @@ fn warn_late_drops(source: &str, column: &str, watermark_ms: i64, dropped: usize
     );
 }
 
-/// Bounded subscription-routing channel depth; drop-on-full caps memory when a
-/// subscriber peer stalls.
+/// Subscription routing channel depth; drop-on-full caps memory when a subscriber stalls.
 #[cfg(feature = "cluster")]
 const SUB_ROUTE_CAPACITY: usize = 1024;
 
-/// Per-peer send timeout in the routing consumer, so one slow peer can't
-/// head-of-line block delivery to the others.
+/// Per-peer send timeout so one slow peer can't head-of-line block others.
 #[cfg(feature = "cluster")]
 const SUB_ROUTE_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Throttled (~once/10s) WARN when subscription routing drops a batch, tagged
-/// with `cause` so a full queue isn't confused with a slow peer.
 #[cfg(feature = "cluster")]
 fn warn_subscription_route_drop(cause: &str) {
     static THROTTLE: crate::log_throttle::LogThrottle =
@@ -78,9 +66,7 @@ fn warn_subscription_route_drop(cause: &str) {
     }
 }
 
-/// Releases an in-flight epoch's admission slot and staged-bytes
-/// budget on drop, so a panicking tail can't leave them leaked and
-/// permanently stall checkpoint admission.
+/// RAII guard that releases an epoch's admission slot and staged-byte budget on drop.
 struct EpochInFlightGuard {
     in_flight: Arc<std::sync::atomic::AtomicU64>,
     staged_bytes: Arc<std::sync::atomic::AtomicU64>,
@@ -88,7 +74,7 @@ struct EpochInFlightGuard {
 }
 
 impl EpochInFlightGuard {
-    /// Claim one admission slot and `bytes` of the staged budget.
+    /// Claim one admission slot and `bytes` of staged budget.
     fn claim(
         in_flight: &Arc<std::sync::atomic::AtomicU64>,
         staged_bytes: &Arc<std::sync::atomic::AtomicU64>,
@@ -113,8 +99,7 @@ impl Drop for EpochInFlightGuard {
     }
 }
 
-/// Everything the leader's spawned durable tail needs
-/// (see [`ConnectorPipelineCallback::run_leader_tail`]).
+/// State for the leader's spawned durable tail.
 struct LeaderTail {
     in_flight: EpochInFlightGuard,
     coordinator:
@@ -127,7 +112,6 @@ struct LeaderTail {
     vnode_states: crate::checkpoint_coordinator::StagedVnodeStates,
     fan_out: FxHashMap<String, SourceCheckpoint>,
     local_watermark_ms: Option<i64>,
-    /// `Some` when this node admitted the barrier as cluster leader.
     leader_ids: Option<(u64, u64)>,
     #[cfg(feature = "cluster")]
     controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
@@ -135,10 +119,7 @@ struct LeaderTail {
     quorum_timeout: Duration,
 }
 
-/// Captured-state bytes a pending [`CheckpointRequest`]
-/// (plus per-vnode slices) holds in memory while its epoch is between
-/// capture and upload — the unit the `max_staged_bytes` admission cap
-/// counts.
+/// Bytes held in memory by a pending checkpoint (operator states + per-vnode slices).
 #[allow(clippy::disallowed_types)]
 fn staged_request_bytes(
     request: &crate::checkpoint_coordinator::CheckpointRequest,
@@ -154,26 +135,20 @@ fn staged_request_bytes(
         .flat_map(|m| m.values())
         .map(|s| match s {
             crate::checkpoint_coordinator::StagedSlice::Bytes(b) => b.len(),
-            // Cold slices stage no bytes — they hold tier capacity, not RAM.
+            // Cold slices are on disk; they hold no RAM.
             crate::checkpoint_coordinator::StagedSlice::Cold => 0,
         })
         .sum();
     (ops + vnodes) as u64
 }
 
-/// Follower durable-tail bookkeeping shared between the pipeline task
-/// and the spawned tail task. Epochs
-/// start at 1, so `0` encodes "none".
+/// Follower durable-tail bookkeeping. Epoch `0` encodes "none" (epochs start at 1).
 #[cfg(feature = "cluster")]
 #[derive(Debug, Default)]
 pub(crate) struct FollowerTailState {
-    /// Epoch whose durable tail (prepare + decision wait + 2PC commit)
-    /// is currently running in a background task.
+    /// Epoch whose durable tail is currently running.
     in_flight_epoch: std::sync::atomic::AtomicU64,
-    /// Highest epoch this follower has successfully committed; dedups
-    /// the leader's idempotent `Prepare` re-announcements. Advanced
-    /// only on commit so a failed-then-retried epoch is reprocessed,
-    /// not deduped.
+    /// Highest committed epoch; advanced only on commit so a failed epoch is retried, not deduped.
     committed_epoch: std::sync::atomic::AtomicU64,
 }
 
@@ -204,9 +179,7 @@ impl FollowerTailState {
             .store(epoch, std::sync::atomic::Ordering::Release);
     }
 
-    /// Record the tail's outcome. The in-flight slot is cleared only if
-    /// it still belongs to `epoch` so a late-finishing stale tail can't
-    /// clobber a newer epoch's bookkeeping.
+    /// Record the tail's outcome; clears the in-flight slot only if it still belongs to `epoch`.
     fn finish(&self, epoch: u64, committed: bool) {
         if committed {
             self.committed_epoch
@@ -235,7 +208,6 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) watermark_states: FxHashMap<String, SourceWatermarkState>,
     pub(crate) source_entries_for_wm: FxHashMap<String, Arc<crate::catalog::SourceEntry>>,
     pub(crate) source_ids: FxHashMap<String, usize>,
-    /// Pre-interned source names keyed by source id; avoids `Arc::from` per cycle.
     pub(crate) source_name_arcs: FxHashMap<usize, Arc<str>>,
     pub(crate) source_wms_buf: FxHashMap<Arc<str>, i64>,
     pub(crate) tracker: Option<laminar_core::time::WatermarkTracker>,
@@ -251,63 +223,42 @@ pub(crate) struct ConnectorPipelineCallback {
     )>,
     pub(crate) table_store: Arc<parking_lot::RwLock<crate::table_store::TableStore>>,
     pub(crate) mv_store: Arc<parking_lot::RwLock<crate::mv_store::MvStore>>,
-    /// Mirrors `MvStore::has_any`; read per cycle to skip the write lock.
+    /// Mirrors `MvStore::has_any` so the per-cycle check skips the write lock.
     pub(crate) mv_store_has_any: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) lookup_registry: Arc<laminar_sql::datafusion::LookupTableRegistry>,
     pub(crate) filter_ctx: SessionContext,
     pub(crate) compiled_sink_filters: Vec<SinkFilter>,
     pub(crate) pending_sink_filter_compiles: usize,
     pub(crate) last_checkpoint: std::time::Instant,
-    /// `None` = no automatic checkpointing (manual only via coordinator).
     pub(crate) checkpoint_interval: Option<std::time::Duration>,
     pub(crate) pipeline_hash: Option<u64>,
     pub(crate) delivery_guarantee: laminar_connectors::connector::DeliveryGuarantee,
-    /// Maximum time to wait for operator state serialization.
     pub(crate) serialization_timeout: Duration,
-    /// Drained once per cycle by `write_to_sinks` to update sink metrics.
     pub(crate) sink_event_rx: laminar_core::streaming::AsyncConsumer<crate::sink_task::SinkEvent>,
-    /// Set when a sink write times out in this cycle. Suppresses the next
-    /// checkpoint to preserve the replay window.
+    /// Set when a sink write times out; suppresses the next checkpoint to preserve the replay window.
     pub(crate) sink_timed_out: bool,
     pub(crate) shutdown_signal: Arc<tokio::sync::Notify>,
-    /// Cluster control facade. Present only when this instance was
-    /// built with a controller. Used to gate the periodic checkpoint
-    /// trigger on `is_leader()` and to run `follower_checkpoint` on
-    /// non-leaders.
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
-    /// Shared follower durable-tail bookkeeping: the epoch whose tail is
-    /// in flight and the highest committed epoch (dedup, advanced only
-    /// on commit — see [`Self::follower_should_skip`]). Epochs awaiting
-    /// local source barriers are tracked separately by
-    /// [`Self::pending_follower_checkpoint`].
+    /// In-flight epoch + highest committed epoch for follower tail dedup.
     #[cfg(feature = "cluster")]
     pub(crate) follower_tail: Arc<FollowerTailState>,
-    /// Local source barrier injectors to trigger follower-side checkpoints.
     #[cfg(feature = "cluster")]
     pub(crate) barrier_injectors: Vec<(
         Arc<str>,
         laminar_core::checkpoint::CheckpointBarrierInjector,
     )>,
-    /// Pending follower checkpoint announcement from gossip, waiting for local sources to align.
     #[cfg(feature = "cluster")]
     pub(crate) pending_follower_checkpoint:
         Option<laminar_core::cluster::control::BarrierAnnouncement>,
-    /// Inbound channel for `db.checkpoint()` requests. The db sends a
-    /// oneshot sender here; on the next cycle the callback captures
-    /// operator state (via `checkpoint_with_barrier`-style path) and
-    /// replies on that sender. Without this, `db.checkpoint()` reaches
-    /// the coordinator with an empty `CheckpointRequest` and the
-    /// leader's manifest is useless for restart recovery.
+    /// Receives `db.checkpoint()` requests; the callback captures state and replies on the oneshot.
     pub(crate) force_ckpt_rx: Option<crate::db::ForceCheckpointRx>,
     pub(crate) subscription_registry: Arc<crate::subscription::SubscriptionRegistry>,
-    /// Stream/MV name → subscribing node ids, written by the gossip poller and
-    /// read each cycle to route output to remote subscribers.
+    /// Stream → subscribing node ids; written by the gossip poller, read each cycle.
     #[cfg(feature = "cluster")]
     pub(crate) active_subs:
         Arc<parking_lot::RwLock<std::collections::HashMap<String, std::collections::HashSet<u64>>>>,
-    /// Ordered single-consumer channel shipping SUBSCRIBE output to remote
-    /// subscribers; one consumer preserves order a per-cycle spawn would not.
+    /// Single-consumer SUBSCRIBE routing channel; one consumer preserves emission order.
     #[cfg(feature = "cluster")]
     pub(crate) sub_route:
         std::sync::OnceLock<tokio::sync::mpsc::Sender<(String, RecordBatch, Vec<u64>)>>,
@@ -315,65 +266,43 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) checkpoint_complete_tx: crossfire::MAsyncTx<
         crossfire::mpsc::Array<(u64, rustc_hash::FxHashMap<String, SourceCheckpoint>)>,
     >,
-    /// Count of epochs between admission and restorable (tails still
-    /// running). The streaming coordinator compares it against
-    /// `max_in_flight_epochs` to admit the next barrier.
+    /// In-flight epoch count; the coordinator gates new barriers against `max_in_flight_epochs`.
     pub(crate) checkpoint_in_flight: Arc<std::sync::atomic::AtomicU64>,
-    /// Captured-state bytes held by in-flight epochs; admission pauses
-    /// at `max_staged_bytes`.
     pub(crate) staged_bytes: Arc<std::sync::atomic::AtomicU64>,
-    /// Shared id allocator (cloned from the coordinator) so barrier
-    /// admission claims ids without the coordinator mutex, which an
-    /// earlier epoch's durable tail may hold.
+    /// Lock-free id allocator shared with the coordinator so barrier admission doesn't
+    /// queue behind an earlier epoch's durable tail holding the coordinator mutex.
     pub(crate) epoch_allocator: Option<Arc<crate::checkpoint_coordinator::EpochAllocator>>,
-    /// Copied from `CheckpointConfig` for the pre-mutex quorum stage.
     #[cfg(feature = "cluster")]
     pub(crate) quorum_timeout: Duration,
-    /// True when any registered sink is exactly-once: durable tails
-    /// then run INLINE (pipeline blocked until the commit decision).
-    /// A single transactional producer must not receive post-barrier
-    /// rows while the epoch's transaction is open — an early resume
-    /// would commit them with epoch N and duplicate them on replay.
-    /// Producer pooling is the follow-up that lifts this.
+    /// When true, durable tails run inline so a transactional producer never sees
+    /// post-barrier rows while its epoch-N transaction is still open.
     pub(crate) exactly_once_sinks: bool,
-    /// Node-level cap on total operator state bytes; `None` = unlimited.
-    /// See [`PipelineCallback::state_over_budget`].
     pub(crate) state_memory_budget_bytes: Option<usize>,
-    /// When the budget was last probed (the probe is throttled).
     pub(crate) state_budget_probe_at: std::time::Instant,
-    /// Verdict of the last probe, served between probes.
     pub(crate) state_budget_exceeded: bool,
-    /// Cold-tier request channel; demote candidates over the watermark are
-    /// written here before being dropped from memory. `None` = no tier.
+    /// Cold-tier send channel; `None` = no tier configured.
     #[cfg(feature = "state-tier")]
     pub(crate) state_tier: Option<crate::state_tier::TierTx>,
 }
 
-/// Minimum interval between state-memory-budget probes. Each probe sums
-/// every operator's state estimate and refreshes the state gauges.
+/// Minimum interval between budget probes; each probe walks all operator estimates.
 const STATE_BUDGET_PROBE_INTERVAL: Duration = Duration::from_millis(500);
 
-/// Fraction of the memory budget at which demotion begins shedding idle
-/// vnodes to the cold tier — below the 100% backpressure point so demotion
-/// relieves pressure before intake stalls.
+/// Demotion begins at 4/5 of the budget — below the 100% backpressure point.
 #[cfg(feature = "state-tier")]
 const STATE_DEMOTE_WATERMARK_NUM: usize = 4;
 #[cfg(feature = "state-tier")]
 const STATE_DEMOTE_WATERMARK_DEN: usize = 5;
-/// Demotion drains down to this fraction of the budget per pass (hysteresis
-/// so it doesn't thrash right at the watermark).
+/// Demotion target per pass: 13/20 of the budget (hysteresis against thrash).
 #[cfg(feature = "state-tier")]
 const STATE_DEMOTE_TARGET_NUM: usize = 13;
 #[cfg(feature = "state-tier")]
 const STATE_DEMOTE_TARGET_DEN: usize = 20;
-/// Cap on vnodes demoted per maintenance pass — bounds the per-pass tier
-/// write volume and keeps the compute thread's maintenance slice short.
+/// Max vnodes demoted per maintenance pass.
 #[cfg(feature = "state-tier")]
 const STATE_DEMOTE_MAX_PER_PASS: usize = 32;
 
-/// Write one demoted slice to the cold tier and wait for confirmation.
-/// `true` = durably written; `false` = the worker is gone or errored (the
-/// caller then leaves the slice resident).
+/// Send a slice to the cold tier; returns `false` if the worker is gone.
 #[cfg(feature = "state-tier")]
 async fn tier_demote(
     tier: &crate::state_tier::TierTx,
@@ -394,8 +323,7 @@ async fn tier_demote(
     matches!(rx.await, Ok(Ok(())))
 }
 
-/// Roll back a tier write when the operator refused to drop the slice (it was
-/// touched since the last capture, so it stays resident).
+/// Roll back a tier write when the operator refused to drop the slice (dirty since capture).
 #[cfg(feature = "state-tier")]
 async fn tier_drop(tier: &crate::state_tier::TierTx, operator: &str, vnode: u32) {
     let (reply, rx) = tokio::sync::oneshot::channel();
@@ -409,17 +337,10 @@ async fn tier_drop(tier: &crate::state_tier::TierTx, operator: &str, vnode: u32)
     }
 }
 
-/// Shed idle vnode slices to the cold tier until projected memory falls below
-/// `target_bytes` (or candidates / the per-pass cap run out). Candidates are
-/// pre-filtered to operators that can demote the vnode now (clean since their
-/// last capture), so a dirty vnode is skipped before any tier I/O. For each
-/// surviving `(operator, vnode)`: persist its durable bytes, then drop the
-/// groups — the drop is still guarded and rolls the write back on the rare
-/// race, but the common dirty case no longer costs a write. Returns the number
-/// of slices demoted.
+/// Demote idle vnode slices to the cold tier until memory falls below `target_bytes`.
 ///
-/// Caller-side safety contract: invoke only with no checkpoint in flight, so
-/// the bytes recorded for a candidate equal the operator's resident state.
+/// Only candidates clean since their last capture are eligible, so dirty vnodes
+/// are skipped before any tier I/O. Must be called with no checkpoint in flight.
 #[cfg(feature = "state-tier")]
 pub(crate) async fn run_demotion_pass(
     graph: &mut crate::operator_graph::OperatorGraph,
@@ -430,8 +351,7 @@ pub(crate) async fn run_demotion_pass(
     total_bytes: usize,
     target_bytes: usize,
 ) -> u64 {
-    // Plan under the coordinator lock: rank idle candidates and copy their
-    // durable slice bytes. Release the lock before any tier I/O.
+    // Build the plan under the lock; release before any tier I/O.
     let plan: Vec<(u32, Vec<(String, bytes::Bytes)>)> = {
         let guard = coordinator.lock().await;
         let Some(coord) = guard.as_ref() else {
@@ -445,9 +365,7 @@ pub(crate) async fn run_demotion_pass(
             {
                 break;
             }
-            // Keep only operators that can demote this vnode *now* (clean since
-            // their last capture). Filtering here, before any tier write, turns
-            // a dirty candidate into a no-op instead of a write-then-rollback.
+            // Pre-filter to operators that can demote now; avoids a write-then-rollback.
             let eligible: Vec<(String, bytes::Bytes)> = coord
                 .slices_for_demotion(vnode)
                 .into_iter()
@@ -456,7 +374,6 @@ pub(crate) async fn run_demotion_pass(
             if eligible.is_empty() {
                 continue;
             }
-            // Credit only the eligible slices' bytes; overcounting ends the pass early.
             let eligible_bytes: usize = eligible.iter().map(|(_, b)| b.len()).sum();
             freed = freed.saturating_add(eligible_bytes);
             plan.push((vnode, eligible));
@@ -485,7 +402,7 @@ pub(crate) async fn run_demotion_pass(
 }
 
 impl ConnectorPipelineCallback {
-    /// `BackpressureFail` raises `shutdown`; coordinator exits via its drain path.
+    /// Map a graph error to a string; `BackpressureFail` also triggers shutdown.
     fn map_graph_error(err: &crate::error::DbError, shutdown: &tokio::sync::Notify) -> String {
         if let crate::error::DbError::BackpressureFail(msg) = err {
             tracing::error!(reason = %msg, "backpressure_policy=Fail tripped; halting pipeline");
@@ -494,10 +411,9 @@ impl ConnectorPipelineCallback {
         format!("{err}")
     }
 
-    /// Cap each source's tracker-reported watermark by the cluster-wide
-    /// minimum, when one has been published. A `None` `cluster_wm`
-    /// leaves the map untouched — blindly capping to MIN would freeze
-    /// every downstream event-time decision and hang the pipeline.
+    /// Cap each source watermark by the cluster-wide min, if one has been published.
+    ///
+    /// `None` leaves the map untouched — capping to `i64::MIN` would freeze the pipeline.
     #[cfg(feature = "cluster")]
     fn cap_source_watermarks_by_cluster_min(
         source_wms: &mut FxHashMap<Arc<str>, i64>,
@@ -511,8 +427,7 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Ship this cycle's output to remote subscribers under the `__sub::<stream>`
-    /// shuffle stage (disjoint from operator stages). No-op without remote interest.
+    /// Route this cycle's output to remote SUBSCRIBE peers. No-op without remote interest.
     #[cfg(feature = "cluster")]
     fn route_to_remote_subscribers(&self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
         use laminar_core::shuffle::ShuffleMessage;
@@ -548,8 +463,7 @@ impl ConnectorPipelineCallback {
             return;
         }
 
-        // One long-lived consumer drains in order so emission order survives to
-        // the peer; a per-cycle spawn would let later batches overtake earlier.
+        // One long-lived consumer preserves emission order to the peer.
         let tx = self.sub_route.get_or_init(|| {
             let (tx, mut rx) =
                 tokio::sync::mpsc::channel::<(String, RecordBatch, Vec<u64>)>(SUB_ROUTE_CAPACITY);
@@ -570,7 +484,7 @@ impl ConnectorPipelineCallback {
                             Ok(Ok(())) => {}
                             Ok(Err(e)) => {
                                 prom.remote_subscription_batches_dropped.inc();
-                                tracing::warn!(node, error = %e, "subscription batch send failed");
+                                tracing::warn!(node, error = %e, "subscription send failed");
                             }
                             Err(_) => {
                                 prom.remote_subscription_batches_dropped.inc();
@@ -582,8 +496,7 @@ impl ConnectorPipelineCallback {
             });
             tx
         });
-        // Bounded, best-effort: if a stalled peer backs the queue up, drop the
-        // batch (subscriptions are at-most-once under backpressure) and warn.
+        // At-most-once under backpressure: drop if the routing queue is full.
         for item in to_send {
             if tx.try_send(item).is_err() {
                 self.prom.remote_subscription_batches_dropped.inc();
@@ -592,25 +505,14 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Follower-side dispatch: poll the leader's announcement, and
-    /// if a fresh PREPARE is visible, capture local state and run
-    /// `CheckpointCoordinator::follower_checkpoint`. Returns `true`
-    /// when a checkpoint was driven this tick.
-    /// Driven by `db.checkpoint()` via the `force_ckpt_rx` channel.
-    /// Captures operator state (plus table/watermark metadata) and
-    /// commits the manifest through the coordinator, returning the
-    /// full `CheckpointResult` for the caller. Mirrors
-    /// `checkpoint_with_barrier` but without the barrier-alignment
-    /// gate — the caller has chosen to take a consistent snapshot
-    /// of whatever state is currently in the accumulators.
+    /// Capture operator state and commit a checkpoint for a `db.checkpoint()` request.
     async fn force_capture_and_checkpoint(
         &mut self,
     ) -> Result<crate::checkpoint_coordinator::CheckpointResult, DbError> {
         self.sync_sinks_and_drain_events().await;
 
-        // Ids allocated at alignment must be threaded through to the
-        // checkpoint, otherwise the inner allocation would burn a second
-        // pair and checkpoint a different epoch than was announced.
+        // Thread the pre-allocated ids through; a second allocation would checkpoint
+        // a different epoch than the one announced.
         #[cfg(feature = "cluster")]
         let leader_ids = self.align_shuffle_for_leader().await?;
         #[cfg(not(feature = "cluster"))]
@@ -630,8 +532,6 @@ impl ConnectorPipelineCallback {
             )
         })?;
         coord.set_pending_vnode_states(vnode_states);
-        // Seed leader-side local watermark so `await_prepare_quorum`
-        // can fold it into the cluster-wide min.
         let wm = self
             .pipeline_watermark
             .load(std::sync::atomic::Ordering::Acquire);
@@ -655,11 +555,7 @@ impl ConnectorPipelineCallback {
         Ok(result)
     }
 
-    /// Skip a follower `Prepare` for `ann_epoch` only if it is already
-    /// committed (`last_committed`), already awaiting local source
-    /// barriers (`pending`), or its durable tail is already running
-    /// (`tail_in_flight`). Comparisons are monotonic — leaders abandon
-    /// failed epochs, so gaps in the announced sequence are normal.
+    /// `true` when `ann_epoch` is already committed, pending, or in flight.
     #[cfg(feature = "cluster")]
     fn follower_should_skip(
         last_committed: Option<u64>,
@@ -672,17 +568,11 @@ impl ConnectorPipelineCallback {
             || tail_in_flight.is_some_and(|e| e >= ann_epoch)
     }
 
-    /// The leader's durable tail, spawned per admitted barrier
-    /// (`run_leader_tail`). Stage 1 (cluster): capture quorum +
-    /// `Aligned` announce, run *before* the coordinator mutex so the
-    /// resume gate never queues behind an earlier epoch's uploads.
-    /// Stage 2: the durable remainder under the FIFO mutex, which keeps
-    /// epochs restorable in order. Commit completion flows back through
-    /// `complete_tx` (`EpochCommitted` fan-out + wire barrier).
+    /// Leader durable tail: quorum + `Aligned` pre-mutex, then durable writes under the FIFO mutex.
     async fn run_leader_tail(tail: LeaderTail) {
         use crate::checkpoint_coordinator::QuorumStage;
 
-        let _in_flight = tail.in_flight; // released on drop, even on panic
+        let _in_flight = tail.in_flight; // released on drop
 
         #[allow(unused_mut)]
         let mut quorum = QuorumStage::RunInline;
@@ -759,14 +649,9 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Build the follower's durable tail — capture ack, durable
-    /// prepare, decision wait, 2PC commit/rollback. Spawned so the
-    /// pipeline resumes on `Aligned`, or awaited inline for
-    /// exactly-once (see [`Self::exactly_once_sinks`]). The capture
-    /// ack is sent before queuing on the coordinator mutex so the
-    /// leader's quorum never waits on an earlier epoch's uploads.
-    /// Commit completion flows through `checkpoint_complete_tx` — the
-    /// same path the leader's background persist uses.
+    /// Build the follower's durable tail future (ack → prepare → decision wait → 2PC).
+    ///
+    /// Spawned for at-least-once (resumes on `Aligned`) or awaited inline for exactly-once.
     #[cfg(feature = "cluster")]
     fn follower_tail_future(
         &mut self,
@@ -781,9 +666,7 @@ impl ConnectorPipelineCallback {
             .load(std::sync::atomic::Ordering::Acquire);
         self.follower_tail.begin(epoch);
 
-        // Charge the in-flight slot + staged bytes on followers too —
-        // without it, follower memory between capture and upload is
-        // unaccounted and unbounded by the admission caps.
+        // Charge followers too; otherwise their capture-to-upload memory is unaccounted.
         let in_flight = EpochInFlightGuard::claim(
             &self.checkpoint_in_flight,
             &self.staged_bytes,
@@ -796,7 +679,7 @@ impl ConnectorPipelineCallback {
         async move {
             use crate::checkpoint_coordinator::CheckpointCoordinator;
 
-            let _in_flight = in_flight; // released on drop, even on panic
+            let _in_flight = in_flight; // released on drop
 
             let wm_opt = if wm == i64::MIN { None } else { Some(wm) };
             if let Some(ref cc) = cc {
@@ -810,7 +693,6 @@ impl ConnectorPipelineCallback {
                 .ok();
             }
 
-            // Stage 1: durable prepare under the FIFO mutex.
             let decision_store = {
                 let mut guard = coordinator.lock().await;
                 match guard.as_mut() {
@@ -832,9 +714,7 @@ impl ConnectorPipelineCallback {
                 }
             };
 
-            // Stage 2: await the leader's decision WITHOUT the mutex —
-            // the next epoch's prepare/uploads must not queue behind a
-            // wait that can last the full decision timeout.
+            // Await the decision outside the mutex so the next epoch's prepare can proceed.
             let committed = match (decision_store, cc.as_ref()) {
                 (Some(decision_store), Some(cc)) => {
                     let verdict = CheckpointCoordinator::await_follower_decision(
@@ -845,7 +725,6 @@ impl ConnectorPipelineCallback {
                         std::time::Duration::from_secs(10),
                     )
                     .await;
-                    // Stage 3: act on the verdict under the mutex.
                     let mut guard = coordinator.lock().await;
                     match guard.as_mut() {
                         Some(coord) => {
@@ -864,8 +743,6 @@ impl ConnectorPipelineCallback {
                 _ => false,
             };
 
-            // Record only on commit so a failed-then-retried epoch is
-            // reprocessed, not deduped.
             tail.finish(epoch, committed);
             if committed {
                 let _ = complete_tx.send((epoch, fan_out)).await;
@@ -873,15 +750,10 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Block the pipeline until the leader announces `Aligned` for
-    /// `epoch` (full-membership capture quorum): no peer may ship
-    /// epoch-N+1 shuffle rows while another node is still folding
-    /// pre-barrier rows into its epoch-N snapshot. `Commit`, `Abort`,
-    /// or any newer epoch's announcement also releases the gate.
+    /// Hold the pipeline until the leader announces `Aligned` (or `Commit`/`Abort`/newer epoch).
     ///
-    /// No-op without a cross-node shuffle; bounded — on timeout the
-    /// pipeline resumes and the epoch aborts via the leader's gate.
-    /// Associated fn (no `&self`) so callers' futures stay `Send`.
+    /// Prevents epoch-N+1 shuffle rows from reaching a peer still snapshotting epoch-N.
+    /// No-op without a cross-node shuffle; bounded — on timeout the epoch aborts via the leader.
     #[cfg(feature = "cluster")]
     async fn wait_for_aligned_resume(
         has_cluster_shuffle: bool,
@@ -936,8 +808,6 @@ impl ConnectorPipelineCallback {
             return None;
         }
 
-        // Inject barriers into local sources so they flow through this node's
-        // streaming tasks and emit the shuffle barriers required for alignment.
         for (name, injector) in &self.barrier_injectors {
             tracing::debug!(
                 source = %name,
@@ -957,8 +827,6 @@ impl ConnectorPipelineCallback {
             return None;
         }
 
-        // Drain + align the cross-node shuffle on the leader's checkpoint id so
-        // the snapshot includes peers' pre-checkpoint rows.
         {
             let live: Vec<u64> = controller.live_instances().iter().map(|n| n.0).collect();
             let wm = self
@@ -977,10 +845,6 @@ impl ConnectorPipelineCallback {
         let request =
             self.build_checkpoint_request(std::collections::HashMap::new(), &source_offsets);
 
-        // Durable tail off the pipeline task; resume once every node has
-        // captured (Aligned). Completion is reported asynchronously via
-        // `checkpoint_complete_tx`, so there is no epoch to return here.
-        // Exactly-once runs the tail inline (see `exactly_once_sinks`).
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
@@ -1006,8 +870,6 @@ impl ConnectorPipelineCallback {
     ) -> crate::pipeline::BarrierOutcome {
         use crate::pipeline::BarrierOutcome;
 
-        // Owned clone: `controller` outlives the `&mut self` calls below
-        // (state capture, tail spawn) without borrowing `self`.
         let Some(controller) = self.cluster_controller.clone() else {
             return BarrierOutcome::Failed;
         };
@@ -1038,13 +900,6 @@ impl ConnectorPipelineCallback {
         };
         let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
-        // Durable tail (pre-commit + manifest + uploads + decision wait
-        // + 2PC) off the pipeline task; resume processing once every
-        // node has captured (Aligned) instead of stalling until Commit.
-        // Commit completion flows through `checkpoint_complete_tx`
-        // (EpochCommitted fan-out + wire barrier), so the outcome here
-        // is Async, not Committed. Exactly-once runs the tail inline
-        // (see `run_follower_checkpoint_deferred`).
         let stall_start = std::time::Instant::now();
         let epoch = ann.epoch;
         let has_shuffle = self.graph.cluster_shuffle_config().is_some();
@@ -1063,15 +918,10 @@ impl ConnectorPipelineCallback {
         BarrierOutcome::Async
     }
 
-    /// Leader-side barrier admission: allocate this barrier's ids
-    /// (lock-free — an earlier epoch's durable tail may hold the
-    /// coordinator mutex), announce `Prepare` so followers begin
-    /// aligning, then drain + align the cross-node shuffle so the
-    /// snapshot includes peers' pre-barrier rows. Returns the allocated
-    /// `(epoch, checkpoint_id)`; `None` when this node isn't the
-    /// cluster leader or no coordinator is wired. On alignment failure
-    /// the allocated epoch is abandoned (Abort + rollback + next epoch
-    /// begun).
+    /// Allocate barrier ids, announce `Prepare`, and align the cross-node shuffle.
+    ///
+    /// Returns `None` when not the leader or no coordinator is wired. On alignment
+    /// failure the epoch is abandoned.
     #[cfg(feature = "cluster")]
     async fn align_shuffle_for_leader(&mut self) -> Result<Option<(u64, u64)>, DbError> {
         use laminar_core::cluster::control::{BarrierAnnouncement, Phase};
@@ -1118,11 +968,7 @@ impl ConnectorPipelineCallback {
         Ok(Some((epoch, checkpoint_id)))
     }
 
-    /// Assemble a [`CheckpointRequest`](crate::checkpoint_coordinator::CheckpointRequest)
-    /// from the given operator states and barrier-captured source
-    /// offsets, folding in table-source offsets and per-source
-    /// watermarks. Shared by every checkpoint entry point (leader
-    /// barrier, follower, timer, forced).
+    /// Build a `CheckpointRequest` from operator states and source offsets.
     fn build_checkpoint_request(
         &self,
         operator_states: std::collections::HashMap<String, bytes::Bytes>,
@@ -1169,7 +1015,6 @@ impl ConnectorPipelineCallback {
             Ok(None) => return Ok(operator_states),
             Err(e) => return Err(format!("snapshot failed: {e}")),
         };
-        // Offload CPU-bound serialization to blocking thread pool.
         let timeout = self.serialization_timeout;
         let bytes = tokio::time::timeout(
             timeout,
@@ -1183,7 +1028,6 @@ impl ConnectorPipelineCallback {
         .map_err(|e| format!("serialize error: {e}"))?;
         operator_states.insert("operator_graph".to_string(), bytes::Bytes::from(bytes));
 
-        // Serialize MV result store — each MV gets its own entry keyed "mv:{name}".
         let mv_states = self
             .mv_store
             .read()
@@ -1194,12 +1038,10 @@ impl ConnectorPipelineCallback {
         Ok(operator_states)
     }
 
-    /// Per-vnode operator-state slices for the in-flight checkpoint
-    /// (`vnode → operator_name → bytes`), staged on the coordinator so each
-    /// owned vnode's `partial.bin` carries real, rehydratable state. Empty
-    /// outside cluster mode. Best-effort: a snapshot error logs and yields an
-    /// empty map — the partial then carries no operator state for that epoch,
-    /// exactly as the legacy marker did, so the checkpoint still succeeds.
+    /// Capture per-vnode operator state for the in-flight checkpoint.
+    ///
+    /// Empty outside cluster mode. On error, logs and returns an empty map so the
+    /// checkpoint still succeeds (the partial carries no operator state for this epoch).
     #[allow(clippy::unused_self, clippy::disallowed_types)] // matches the coordinator/graph map shape
     fn capture_vnode_states(&mut self) -> crate::checkpoint_coordinator::StagedVnodeStates {
         #[cfg(feature = "cluster")]
@@ -1221,9 +1063,7 @@ impl ConnectorPipelineCallback {
         }
     }
 
-    /// Wait for every sink to finish processing previously-enqueued
-    /// `WriteBatch` commands, then drain any `SinkEvent`s they produced.
-    /// Callers rely on `sink_timed_out` being current after this returns.
+    /// Sync all sinks and drain their events; `sink_timed_out` is current after this returns.
     async fn sync_sinks_and_drain_events(&mut self) {
         let sync_futures = self.sinks.iter().map(|(name, handle, _, _, _)| {
             let name = name.clone();
@@ -1238,8 +1078,6 @@ impl ConnectorPipelineCallback {
         self.drain_sink_events();
     }
 
-    /// Non-blocking drain of `sink_event_rx` into Prometheus counters and
-    /// `sink_timed_out`.
     fn drain_sink_events(&mut self) {
         while let Ok(event) = self.sink_event_rx.try_recv() {
             tracing::debug!(?event, "sink event");
@@ -1341,8 +1179,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn push_to_streams(&self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
-        // Cluster mode: ship this cycle's output to any remote nodes holding a
-        // SUBSCRIBE interest before publishing to local subscribers below.
         #[cfg(feature = "cluster")]
         self.route_to_remote_subscribers(results);
 
@@ -1365,10 +1201,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        // Ephemeral/dynamic streams (e.g. console live queries) have no
-        // downstream sink, so they aren't in `stream_sources` and the loop
-        // above never forwards them — push their batches to any subscribers.
-        // MVs are skipped here; they reach subscribers via their own path.
+        // Ephemeral streams (console live queries) aren't in `stream_sources`; push them here.
+        // MVs reach subscribers via their own path below.
         let mv_has_any = self
             .mv_store_has_any
             .load(std::sync::atomic::Ordering::Acquire);
@@ -1430,7 +1264,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     async fn write_to_sinks(&mut self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {
         self.compile_pending_sink_filters(results).await;
 
-        // Share per-stream batches across sinks so fan-out doesn't reclone the Vec.
+        // Shared Arc per stream so multiple sinks don't each clone the Vec.
         let mut shared_inputs: FxHashMap<&str, Arc<[RecordBatch]>> = FxHashMap::default();
 
         let sink_futures: Vec<_> = self
@@ -1439,7 +1273,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             .enumerate()
             .filter_map(
                 |(sink_idx, (sink_name, handle, _filter_sql, sink_input, changelog_capable))| {
-                    // Route by FROM clause: only send matching results.
                     let batches = results.get(sink_input.as_str())?;
                     if batches.is_empty() {
                         return None;
@@ -1450,7 +1283,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         .clone();
                     let sink_name = sink_name.clone();
                     let handle = handle.clone();
-                    // Rejected → drop (fail-closed). Pending → None (no filter SQL set).
                     let filter_state = match self.compiled_sink_filters.get(sink_idx).cloned() {
                         Some(SinkFilter::Compiled(phys)) => SinkFilterDispatch::Compiled(phys),
                         Some(SinkFilter::Rejected) => SinkFilterDispatch::Rejected,
@@ -1508,14 +1340,12 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             .collect();
         futures::future::join_all(sink_futures).await;
 
-        // Opportunistic; the strict "all prior writes settled" barrier
-        // runs in the checkpoint paths, not on every cycle.
+        // Opportunistic; the strict barrier runs in the checkpoint path.
         self.drain_sink_events();
     }
 
     fn extract_watermark(&mut self, source_name: &str, batch: &RecordBatch) {
         if let Some(wm_state) = self.watermark_states.get_mut(source_name) {
-            // Check external watermarks from Source::watermark() calls.
             if let Some(entry) = self.source_entries_for_wm.get(source_name) {
                 let external_wm = entry.source.current_watermark();
                 if let Some(wm) = wm_state.generator.advance_watermark(external_wm) {
@@ -1536,7 +1366,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
 
-            // Extract watermark from batch data.
             if let Ok(max_ts) = wm_state.extractor.extract(batch) {
                 if let Some(wm) = wm_state.generator.on_event(max_ts) {
                     if let Some(entry) = self.source_entries_for_wm.get(source_name) {
@@ -1560,7 +1389,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
 
-        // Update ingestion counters.
         #[allow(clippy::cast_possible_truncation)]
         let row_count = batch.num_rows() as u64;
         self.prom.events_ingested.inc_by(row_count);
@@ -1569,10 +1397,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
     fn filter_late_rows(&self, source_name: &str, batch: &RecordBatch) -> Option<RecordBatch> {
         if let Some(wm_state) = self.watermark_states.get(source_name) {
-            // A processing-time watermark is wall-clock, not derived from the event
-            // column — every real (past) timestamp is "older than" it, so filtering
-            // would drop all rows. Windows still close on the wall-clock watermark;
-            // window-level late handling applies downstream.
+            // Processing-time watermarks are wall-clock; filtering would drop every real row.
             if wm_state.generator.is_processing_time() {
                 return Some(batch.clone());
             }
@@ -1602,7 +1427,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         return out;
                     }
                     Err(e) => {
-                        // Schema drift, not lateness: fail-safe drop + error.
+                        // Schema drift, not lateness.
                         tracing::error!(
                             source = source_name,
                             column = %wm_state.column,
@@ -1614,7 +1439,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
         }
-        // No watermark configured → pass through all rows.
         Some(batch.clone())
     }
 
@@ -1637,8 +1461,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let Some(ref mut trk) = self.tracker else {
             return;
         };
-        // Drive periodic generators (ProcessingTime) and pull external
-        // `Source::watermark()` so a quiet source still advances the frontier.
         for (name, state) in &mut self.watermark_states {
             if let Some(wm) = state.generator.on_periodic() {
                 if let Some(&id) = self.source_ids.get(name) {
@@ -1664,8 +1486,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
         }
-        // `update_combined` is monotone, so a re-activating source with an
-        // older watermark can't regress the combined value.
         if let Some(global) = trk.check_idle_sources() {
             self.pipeline_watermark
                 .store(global.timestamp(), std::sync::atomic::Ordering::Relaxed);
@@ -1682,25 +1502,13 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         }
     }
 
-    /// Timer-based checkpoint (at-least-once semantics).
-    ///
-    /// Source offsets are captured BEFORE operator state. On recovery:
-    /// consumer replays from offset → operator may re-process some
-    /// records. This is correct for at-least-once but NOT exactly-once.
-    /// For exactly-once, use barrier-aligned checkpoints instead.
+    /// Timer-based checkpoint (at-least-once). For exactly-once use barrier-aligned checkpoints.
     async fn maybe_checkpoint(
         &mut self,
         force: bool,
         source_offsets: FxHashMap<String, SourceCheckpoint>,
     ) -> Option<u64> {
-        // Drain any pending `db.checkpoint()` requests first. Each
-        // request gets a capture of operator state (the same path the
-        // periodic barrier-aligned checkpoint uses), committed through
-        // the coordinator, and the full `CheckpointResult` returned on
-        // the oneshot. Without this, `db.checkpoint()` reaches the
-        // coordinator with an empty `CheckpointRequest` and the
-        // manifest has no operator state — restart loses every
-        // `IncrementalAggState` accumulator on the invoking node.
+        // Drain `db.checkpoint()` requests; each gets a full operator-state capture.
         let mut force_reqs: Vec<
             crossfire::oneshot::TxOneshot<
                 Result<crate::checkpoint_coordinator::CheckpointResult, DbError>,
@@ -1717,24 +1525,18 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             reply_tx.send(result);
         }
 
-        // Cluster mode: only the leader fires periodic checkpoints.
-        // Followers mirror the leader's epoch via `follower_checkpoint`
-        // on observed PREPARE announcements. Forced checkpoints
-        // (shutdown) run on whatever instance is shutting down.
+        // Only the leader fires periodic checkpoints; followers pick up PREPARE via gossip.
         #[cfg(feature = "cluster")]
         if !force {
             if let Some(cc) = self.cluster_controller.clone() {
                 if cc.is_leader() {
-                    // Leader in cluster mode: do not trigger timer-based checkpoints here.
-                    // Periodic checkpoints are driven by barrier injection from the streaming coordinator.
+                    // Periodic checkpoints are injected by the coordinator, not here.
                     return None;
                 }
                 return self.maybe_follower_checkpoint(cc, source_offsets).await;
             }
         }
 
-        // Under exactly-once, only barrier-aligned checkpoints are consistent.
-        // Timer-based checkpoints are skipped (barrier path handles exactly-once).
         if !force
             && self.delivery_guarantee
                 == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
@@ -1749,10 +1551,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
         self.sync_sinks_and_drain_events().await;
 
-        // After a sink timeout, skip one checkpoint cycle so that source
-        // offsets don't advance past the dropped batch. The NEXT cycle will
-        // clear this flag and checkpoint normally. This preserves at-least-once:
-        // on recovery, the source replays from the pre-drop checkpoint.
+        // Skip after a sink timeout so offsets don't advance past the dropped batch.
         if !force && self.sink_timed_out {
             self.sink_timed_out = false;
             tracing::info!("skipping checkpoint after sink timeout to preserve replay window");
@@ -1760,18 +1559,14 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         }
 
         if !force {
-            let Some(interval) = self.checkpoint_interval else {
-                return None; // no auto-checkpointing configured
-            };
+            let interval = self.checkpoint_interval?;
             if self.last_checkpoint.elapsed() < interval {
                 return None;
             }
         }
 
-        // Capture stream executor aggregate state and serialize on blocking thread.
-        // Abort the checkpoint if serialization fails — persisting source
-        // offsets without matching operator state would cause data loss on
-        // recovery (offsets advance past unreplayable state).
+        // Abort if serialization fails — advancing offsets without matching operator state
+        // would lose data on recovery.
         let operator_states = match self.capture_and_serialize_operator_state().await {
             Ok(states) => states,
             Err(e) => {
@@ -1784,7 +1579,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let vnode_states = self.capture_vnode_states();
         let mut committed = None;
         if force {
-            // Blocking checkpoint at shutdown.
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
                 coord.set_pending_vnode_states(vnode_states);
@@ -1806,8 +1600,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                 }
             }
         } else {
-            // Persist in the background; the in-flight slot + staged
-            // bytes are released by the guard when the tail finishes.
             let in_flight = EpochInFlightGuard::claim(
                 &self.checkpoint_in_flight,
                 &self.staged_bytes,
@@ -1816,7 +1608,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             let coordinator_clone = Arc::clone(&self.coordinator);
             let tx = self.checkpoint_complete_tx.clone();
             tokio::spawn(async move {
-                let _in_flight = in_flight; // released on drop, even on panic
+                let _in_flight = in_flight; // released on drop
                 let mut guard = coordinator_clone.lock().await;
                 if let Some(ref mut coord) = *guard {
                     coord.set_pending_vnode_states(vnode_states);
@@ -1855,10 +1647,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         if let Some(cc) = self.cluster_controller.clone() {
             if !cc.is_leader() {
                 if let Some(ann) = self.pending_follower_checkpoint.take() {
-                    // Leaders abandon failed epochs, so a slow barrier
-                    // round can complete after its announcement was
-                    // superseded — the captured offsets must never be
-                    // attributed to the newer epoch's announcement.
+                    // A slow round can finish after its epoch was abandoned; never attribute
+                    // captured offsets to a newer announcement.
                     if ann.checkpoint_id != checkpoint_id {
                         tracing::warn!(
                             round_checkpoint_id = checkpoint_id,
@@ -1884,20 +1674,15 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
 
         self.sync_sinks_and_drain_events().await;
 
-        // Clear after one suppression — the timer-based path that also
-        // clears this flag is unreachable when barrier checkpointing is active.
+        // Clear after one suppression; the timer path is unreachable under barrier checkpointing.
         if self.sink_timed_out {
             self.sink_timed_out = false;
             return BarrierOutcome::Skipped(SkipReason::PreservingReplayWindowAfterSinkTimeout);
         }
 
-        // Everything from here until the Aligned resume gate releases is
-        // pipeline stall — what checkpoint_pipeline_stall_duration measures.
         let stall_start = std::time::Instant::now();
 
-        // Drain + align the cross-node shuffle before capture so peers'
-        // pre-barrier rows enter the snapshot (announces Prepare early).
-        // The returned ids key this barrier's tail and resume gate.
+        // Align the shuffle before capture so peers' pre-barrier rows enter the snapshot.
         #[cfg(feature = "cluster")]
         let leader_ids = match self.align_shuffle_for_leader().await {
             Ok(ids) => ids,
@@ -1909,10 +1694,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         #[cfg(not(feature = "cluster"))]
         let leader_ids: Option<(u64, u64)> = None;
 
-        // Capture stream executor aggregate state — now consistent because
-        // all pre-barrier data has been executed. Serialize on blocking thread.
-        // Abort if serialization fails — persisting source offsets without
-        // matching operator state would cause data loss on recovery.
         let operator_states = match self.capture_and_serialize_operator_state().await {
             Ok(states) => states,
             Err(e) => {
@@ -1921,15 +1702,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         };
 
-        // The barrier-captured source offsets are consistent with the
-        // operator state at the barrier point and must not be re-queried
-        // from the live connectors.
         let vnode_states = self.capture_vnode_states();
         let request = self.build_checkpoint_request(operator_states, &source_checkpoints);
 
-        // Two-stage tail: capture quorum + `Aligned` run pre-mutex
-        // (never queued behind an earlier epoch's uploads); the durable
-        // remainder serializes on the FIFO mutex.
         let in_flight = EpochInFlightGuard::claim(
             &self.checkpoint_in_flight,
             &self.staged_bytes,
@@ -1953,17 +1728,10 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             quorum_timeout: self.quorum_timeout,
         };
         if self.exactly_once_sinks {
-            // Inline — no early resume (see `exactly_once_sinks`).
             Self::run_leader_tail(tail).await;
         } else {
             tokio::spawn(Self::run_leader_tail(tail));
 
-            // Leader resume gate: hold the pipeline until the tail
-            // above announces `Aligned` (full-membership capture
-            // quorum) — resuming earlier could ship epoch-N+1 shuffle
-            // rows to a peer still folding pre-barrier rows into its
-            // epoch-N snapshot. Abort (quorum miss) also releases; the
-            // gate is bounded.
             #[cfg(feature = "cluster")]
             if let (Some((epoch, _)), Some(cc)) = (leader_ids, self.cluster_controller.clone()) {
                 let has_shuffle = self.graph.cluster_shuffle_config().is_some();
@@ -1979,7 +1747,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn record_cycle(&self, events_ingested: u64, _batches: u64, elapsed_ns: u64) {
-        let _ = events_ingested; // already recorded in extract_watermark
+        let _ = events_ingested; // counted in extract_watermark
         self.prom.cycles.inc();
         #[allow(clippy::cast_precision_loss)]
         self.prom
@@ -2030,9 +1798,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let Some(budget) = self.state_memory_budget_bytes else {
             return false;
         };
-        // Probing walks every operator's estimate (each O(1)-ish, but e.g.
-        // the temporal filter still walks its buffer), so throttle it; the
-        // verdict between probes is the cached one.
+        // Probe is throttled; cached verdict is served between probes.
         if self.state_budget_probe_at.elapsed() >= STATE_BUDGET_PROBE_INTERVAL {
             self.state_budget_probe_at = std::time::Instant::now();
             #[allow(clippy::cast_possible_wrap)]
@@ -2087,10 +1853,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         let Some(budget) = self.state_memory_budget_bytes else {
             return;
         };
-        // Demote only with no checkpoint in flight: the latest per-vnode
-        // capture is then committed, so a clean vnode's in-memory state
-        // equals the durable upload bytes handed to the tier (no half-staged
-        // newer epoch to disagree with).
+        // Require no checkpoint in flight: a clean vnode's resident state then equals
+        // the durable bytes recorded by the coordinator.
         if self.checkpoint_in_flight.load(Ordering::Acquire) != 0 {
             return;
         }
@@ -2108,10 +1872,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn has_deferred_input(&self) -> bool {
-        // In cluster mode, always claim pending input so the coordinator
-        // runs `execute_cycle` each idle tick — otherwise a follower with
-        // no local source events never drains the shuffle receiver and
-        // remote rows sit stranded. Non-cluster path unchanged.
+        // In cluster mode, always return true so the coordinator runs `execute_cycle` each idle
+        // tick; without this a follower with no local sources never drains the shuffle receiver.
         #[cfg(feature = "cluster")]
         {
             if self.cluster_controller.is_some() {
@@ -2130,7 +1892,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
             match source.poll_changes().await {
                 Ok(Some(batch)) => {
-                    // Single registry lookup — dispatch by variant.
                     let entry = self.lookup_registry.get_entry(name);
                     if let Some(
                         laminar_sql::datafusion::lookup_join_exec::RegisteredLookup::Partial(
@@ -2156,8 +1917,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                         ),
                     ) = &entry
                     {
-                        // Versioned path: append new CDC rows, preserving
-                        // all versions for temporal point-in-time lookups.
                         let combined = if versioned.batch.num_rows() == 0
                             || versioned.batch.schema().fields().is_empty()
                         {
@@ -2174,13 +1933,10 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                                         "Versioned table concat error (schema mismatch?); \
                                          keeping existing state"
                                     );
-                                    // Preserve existing versioned history rather than
-                                    // discarding it. The CDC batch is silently dropped.
                                     continue;
                                 }
                             }
                         };
-                        // Build versioned index from the combined batch.
                         let key_indices: Vec<usize> = versioned
                             .key_columns
                             .iter()
@@ -2253,9 +2009,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                                 ts.to_record_batch(name)
                             }
                         };
-                        // Update lookup registry for join operators.
-                        // DataFusion table registration is NOT needed here — all
-                        // tables use ReferenceTableProvider which reads live data.
+                        // `ReferenceTableProvider` reads live data; no DataFusion re-registration needed.
                         if let Some(rb) = maybe_batch {
                             self.lookup_registry.register(
                                 name,
@@ -2273,8 +2027,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     fn next_checkpoint_id(&self) -> Option<u64> {
-        // Lock-free: an in-flight epoch's tail may hold the coordinator
-        // mutex for the duration of its uploads.
+        // Lock-free: an in-flight tail may hold the coordinator mutex.
         self.epoch_allocator.as_ref().map(|a| a.peek().1)
     }
 
@@ -2296,12 +2049,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 }
 
-/// Update a partial lookup cache from a CDC batch by inserting or deleting
-/// each row keyed by the primary key column(s).
+/// Upsert or delete each row in a CDC batch from the partial lookup cache.
 ///
-/// CDC delete detection: if the batch has a column named `__op`, `__operation`,
-/// or `op` with values `"d"`, `"D"`, `"delete"`, or `"DELETE"`, the row is
-/// removed from the cache instead of upserted.
+/// Deletes are detected via an `__op`/`__operation`/`op` column with value `d`/`D`/`delete`/`DELETE`.
 fn update_partial_cache_from_batch(
     partial: &laminar_sql::datafusion::PartialLookupState,
     batch: &RecordBatch,
@@ -2334,7 +2084,6 @@ fn update_partial_cache_from_batch(
         return;
     };
 
-    // Detect CDC operation column for delete handling.
     let op_col_idx = batch
         .schema()
         .fields()
@@ -2365,7 +2114,7 @@ fn update_partial_cache_from_batch(
     }
 }
 
-/// Encode an Arrow schema as a hex-encoded IPC flatbuffer for `ConnectorConfig`.
+/// Encode an Arrow schema as a hex-encoded IPC flatbuffer.
 pub(crate) fn encode_arrow_schema(schema: &arrow_schema::Schema) -> String {
     laminar_connectors::config::encode_arrow_schema_ipc(schema)
 }

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -332,7 +332,18 @@ pub(crate) struct ConnectorPipelineCallback {
     /// would commit them with epoch N and duplicate them on replay.
     /// Producer pooling is the follow-up that lifts this.
     pub(crate) exactly_once_sinks: bool,
+    /// Node-level cap on total operator state bytes; `None` = unlimited.
+    /// See [`PipelineCallback::state_over_budget`].
+    pub(crate) state_memory_budget_bytes: Option<usize>,
+    /// When the budget was last probed (the probe is throttled).
+    pub(crate) state_budget_probe_at: std::time::Instant,
+    /// Verdict of the last probe, served between probes.
+    pub(crate) state_budget_exceeded: bool,
 }
+
+/// Minimum interval between state-memory-budget probes. Each probe sums
+/// every operator's state estimate and refreshes the state gauges.
+const STATE_BUDGET_PROBE_INTERVAL: Duration = Duration::from_millis(500);
 
 impl ConnectorPipelineCallback {
     /// `BackpressureFail` raises `shutdown`; coordinator exits via its drain path.
@@ -1876,6 +1887,53 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             self.prom.cycles_backpressured.inc();
         }
         bp
+    }
+
+    fn state_over_budget(&mut self) -> bool {
+        let Some(budget) = self.state_memory_budget_bytes else {
+            return false;
+        };
+        // Probing walks every operator's estimate (each O(1)-ish, but e.g.
+        // the temporal filter still walks its buffer), so throttle it; the
+        // verdict between probes is the cached one.
+        if self.state_budget_probe_at.elapsed() >= STATE_BUDGET_PROBE_INTERVAL {
+            self.state_budget_probe_at = std::time::Instant::now();
+            #[allow(clippy::cast_possible_wrap)]
+            self.prom.state_memory_budget_bytes.set(budget as i64);
+            let mut total = 0usize;
+            for (name, bytes) in self.graph.state_bytes_per_operator() {
+                #[allow(clippy::cast_possible_wrap)]
+                self.prom
+                    .operator_state_bytes
+                    .with_label_values(&[name.as_ref()])
+                    .set(bytes as i64);
+                total = total.saturating_add(bytes);
+            }
+            #[allow(clippy::cast_possible_wrap)]
+            self.prom.state_bytes.set(total as i64);
+            let exceeded = total >= budget;
+            if exceeded != self.state_budget_exceeded {
+                if exceeded {
+                    tracing::warn!(
+                        state_bytes = total,
+                        budget_bytes = budget,
+                        "operator state over memory budget — pausing source intake"
+                    );
+                } else {
+                    tracing::info!(
+                        state_bytes = total,
+                        budget_bytes = budget,
+                        "operator state back under memory budget — resuming source intake"
+                    );
+                }
+            }
+            self.state_budget_exceeded = exceeded;
+            self.prom.state_over_budget.set(i64::from(exceeded));
+        }
+        if self.state_budget_exceeded {
+            self.prom.state_budget_paused_cycles.inc();
+        }
+        self.state_budget_exceeded
     }
 
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -439,7 +439,7 @@ pub(crate) async fn run_demotion_pass(
         };
         let mut plan = Vec::new();
         let mut freed = 0usize;
-        for (vnode, bytes) in coord.demotion_candidates() {
+        for (vnode, _) in coord.demotion_candidates() {
             if plan.len() >= STATE_DEMOTE_MAX_PER_PASS
                 || total_bytes.saturating_sub(freed) < target_bytes
             {
@@ -456,7 +456,9 @@ pub(crate) async fn run_demotion_pass(
             if eligible.is_empty() {
                 continue;
             }
-            freed = freed.saturating_add(bytes);
+            // Credit only the eligible slices' bytes; overcounting ends the pass early.
+            let eligible_bytes: usize = eligible.iter().map(|(_, b)| b.len()).sum();
+            freed = freed.saturating_add(eligible_bytes);
             plan.push((vnode, eligible));
         }
         plan

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -346,7 +346,7 @@ pub(crate) struct ConnectorPipelineCallback {
     /// Cold-tier request channel; demote candidates over the watermark are
     /// written here before being dropped from memory. `None` = no tier.
     #[cfg(feature = "state-tier")]
-    pub(crate) state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
+    pub(crate) state_tier: Option<crate::state_tier::TierTx>,
     /// Highest epoch known restorable (committed), tracked from
     /// [`publish_barrier`](PipelineCallback::publish_barrier). A slice is
     /// demotable only once its base upload is durable at or below this.
@@ -381,7 +381,7 @@ const STATE_DEMOTE_MAX_PER_PASS: usize = 32;
 /// caller then leaves the slice resident).
 #[cfg(feature = "state-tier")]
 async fn tier_demote(
-    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    tier: &crate::state_tier::TierTx,
     operator: &str,
     vnode: u32,
     bytes: bytes::Bytes,
@@ -402,11 +402,7 @@ async fn tier_demote(
 /// Roll back a tier write when the operator refused to drop the slice (it was
 /// touched since the last capture, so it stays resident).
 #[cfg(feature = "state-tier")]
-async fn tier_drop(
-    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    operator: &str,
-    vnode: u32,
-) {
+async fn tier_drop(tier: &crate::state_tier::TierTx, operator: &str, vnode: u32) {
     let (reply, rx) = tokio::sync::oneshot::channel();
     let req = crate::state_tier::TierRequest::Drop {
         operator: Arc::from(operator),
@@ -433,7 +429,7 @@ pub(crate) async fn run_demotion_pass(
     coordinator: &Arc<
         tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>,
     >,
-    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    tier: &crate::state_tier::TierTx,
     total_bytes: usize,
     target_bytes: usize,
     restorable: u64,
@@ -2697,9 +2693,7 @@ mod demotion_tests {
         }
     }
 
-    async fn build_agg_graph(
-        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-    ) -> OperatorGraph {
+    async fn build_agg_graph(tier: crate::state_tier::TierTx) -> OperatorGraph {
         let mut graph = OperatorGraph::new(laminar_sql::create_session_context());
         graph.set_cluster_shuffle(single_node_shuffle().await);
         graph.set_state_tier(tier);

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -343,11 +343,145 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) state_budget_probe_at: std::time::Instant,
     /// Verdict of the last probe, served between probes.
     pub(crate) state_budget_exceeded: bool,
+    /// Cold-tier request channel; demote candidates over the watermark are
+    /// written here before being dropped from memory. `None` = no tier.
+    #[cfg(feature = "state-tier")]
+    pub(crate) state_tier: Option<tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>>,
+    /// Highest epoch known restorable (committed), tracked from
+    /// [`publish_barrier`](PipelineCallback::publish_barrier). A slice is
+    /// demotable only once its base upload is durable at or below this.
+    #[cfg(feature = "state-tier")]
+    pub(crate) restorable_epoch: std::sync::atomic::AtomicU64,
 }
 
 /// Minimum interval between state-memory-budget probes. Each probe sums
 /// every operator's state estimate and refreshes the state gauges.
 const STATE_BUDGET_PROBE_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Fraction of the memory budget at which demotion begins shedding idle
+/// vnodes to the cold tier — below the 100% backpressure point so demotion
+/// relieves pressure before intake stalls.
+#[cfg(feature = "state-tier")]
+const STATE_DEMOTE_WATERMARK_NUM: usize = 4;
+#[cfg(feature = "state-tier")]
+const STATE_DEMOTE_WATERMARK_DEN: usize = 5;
+/// Demotion drains down to this fraction of the budget per pass (hysteresis
+/// so it doesn't thrash right at the watermark).
+#[cfg(feature = "state-tier")]
+const STATE_DEMOTE_TARGET_NUM: usize = 13;
+#[cfg(feature = "state-tier")]
+const STATE_DEMOTE_TARGET_DEN: usize = 20;
+/// Cap on vnodes demoted per maintenance pass — bounds the per-pass tier
+/// write volume and keeps the compute thread's maintenance slice short.
+#[cfg(feature = "state-tier")]
+const STATE_DEMOTE_MAX_PER_PASS: usize = 32;
+
+/// Write one demoted slice to the cold tier and wait for confirmation.
+/// `true` = durably written; `false` = the worker is gone or errored (the
+/// caller then leaves the slice resident).
+#[cfg(feature = "state-tier")]
+async fn tier_demote(
+    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    operator: &str,
+    vnode: u32,
+    bytes: bytes::Bytes,
+) -> bool {
+    let (reply, rx) = tokio::sync::oneshot::channel();
+    let req = crate::state_tier::TierRequest::Demote {
+        operator: Arc::from(operator),
+        vnode,
+        bytes,
+        reply,
+    };
+    if tier.send(req).await.is_err() {
+        return false;
+    }
+    matches!(rx.await, Ok(Ok(())))
+}
+
+/// Roll back a tier write when the operator refused to drop the slice (it was
+/// touched since the last capture, so it stays resident).
+#[cfg(feature = "state-tier")]
+async fn tier_drop(
+    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    operator: &str,
+    vnode: u32,
+) {
+    let (reply, rx) = tokio::sync::oneshot::channel();
+    let req = crate::state_tier::TierRequest::Drop {
+        operator: Arc::from(operator),
+        vnode,
+        reply,
+    };
+    if tier.send(req).await.is_ok() {
+        let _ = rx.await;
+    }
+}
+
+/// Shed idle vnode slices to the cold tier until projected memory falls below
+/// `target_bytes` (or candidates / the per-pass cap run out). For each
+/// `(operator, vnode)` candidate: persist its durable bytes, then ask the
+/// operator to drop the groups — which it refuses if the vnode was touched
+/// since its last capture, in which case the tier write is rolled back.
+/// Returns the number of slices demoted.
+///
+/// Caller-side safety contract: invoke only with no checkpoint in flight, so
+/// the bytes recorded for a candidate equal the operator's resident state.
+#[cfg(feature = "state-tier")]
+pub(crate) async fn run_demotion_pass(
+    graph: &mut crate::operator_graph::OperatorGraph,
+    coordinator: &Arc<
+        tokio::sync::Mutex<Option<crate::checkpoint_coordinator::CheckpointCoordinator>>,
+    >,
+    tier: &tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    total_bytes: usize,
+    target_bytes: usize,
+    restorable: u64,
+) -> u64 {
+    // Plan under the coordinator lock: rank idle candidates and copy their
+    // durable slice bytes. Release the lock before any tier I/O.
+    let plan: Vec<(u32, Vec<(String, bytes::Bytes)>)> = {
+        let guard = coordinator.lock().await;
+        let Some(coord) = guard.as_ref() else {
+            return 0;
+        };
+        let mut plan = Vec::new();
+        let mut freed = 0usize;
+        for (vnode, _base, bytes) in coord.demotion_candidates(restorable) {
+            if plan.len() >= STATE_DEMOTE_MAX_PER_PASS
+                || total_bytes.saturating_sub(freed) < target_bytes
+            {
+                break;
+            }
+            let slices = coord.slices_for_demotion(vnode);
+            if slices.is_empty() {
+                continue;
+            }
+            freed = freed.saturating_add(bytes);
+            plan.push((vnode, slices));
+        }
+        plan
+    };
+
+    let mut demoted = 0u64;
+    for (vnode, slices) in plan {
+        for (op, bytes) in &slices {
+            if !tier_demote(tier, op, vnode, bytes.clone()).await {
+                continue;
+            }
+            if graph.demote_vnode(op, vnode) {
+                let mut guard = coordinator.lock().await;
+                if let Some(coord) = guard.as_mut() {
+                    coord.mark_slice_demoted(vnode, op);
+                }
+                demoted += 1;
+            } else {
+                tier_drop(tier, op, vnode).await;
+            }
+        }
+    }
+    demoted
+}
 
 impl ConnectorPipelineCallback {
     /// `BackpressureFail` raises `shutdown`; coordinator exits via its drain path.
@@ -1941,6 +2075,50 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
         self.subscription_registry
             .broadcast_barrier(epoch, checkpoint_id);
+        // A published barrier is a committed (restorable) epoch — the demote
+        // trigger only sheds slices whose base upload is durable at or below
+        // it.
+        #[cfg(feature = "state-tier")]
+        self.restorable_epoch
+            .fetch_max(epoch, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "state-tier")]
+    async fn maybe_demote_state(&mut self) {
+        use std::sync::atomic::Ordering;
+        let Some(tier) = self.state_tier.clone() else {
+            return;
+        };
+        let Some(budget) = self.state_memory_budget_bytes else {
+            return;
+        };
+        // Demote only with no checkpoint in flight: the latest per-vnode
+        // capture is then committed, so a clean vnode's in-memory state
+        // equals the durable upload bytes handed to the tier (no half-staged
+        // newer epoch to disagree with).
+        if self.checkpoint_in_flight.load(Ordering::Acquire) != 0 {
+            return;
+        }
+        let total: usize = self.graph.state_bytes_per_operator().map(|(_, b)| b).sum();
+        let watermark = budget / STATE_DEMOTE_WATERMARK_DEN * STATE_DEMOTE_WATERMARK_NUM;
+        if total < watermark {
+            return;
+        }
+        let target = budget / STATE_DEMOTE_TARGET_DEN * STATE_DEMOTE_TARGET_NUM;
+        let restorable = self.restorable_epoch.load(Ordering::Relaxed);
+        let coordinator = Arc::clone(&self.coordinator);
+        let demoted = run_demotion_pass(
+            &mut self.graph,
+            &coordinator,
+            &tier,
+            total,
+            target,
+            restorable,
+        )
+        .await;
+        if demoted > 0 {
+            tracing::debug!(demoted, "demoted idle vnode slices to the cold tier");
+        }
     }
 
     fn has_deferred_input(&self) -> bool {
@@ -2467,5 +2645,161 @@ mod tests {
         assert_eq!(tail.committed(), Some(5));
         tail.finish(7, true);
         assert_eq!(tail.committed(), Some(7));
+    }
+}
+
+#[cfg(all(test, feature = "state-tier"))]
+mod demotion_tests {
+    use super::run_demotion_pass;
+    use crate::operator_graph::OperatorGraph;
+    use arrow::array::{Int64Array, RecordBatch, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use laminar_core::state::{NodeId, StateBackend, VnodeRegistry};
+    use laminar_sql::parser::EmitClause;
+    use rustc_hash::FxHashMap;
+    use std::sync::Arc;
+
+    const VNODES: u32 = 8;
+
+    fn events_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("val", DataType::Int64, false),
+        ]))
+    }
+
+    fn events_batch(keys: &[&str], vals: &[i64]) -> RecordBatch {
+        RecordBatch::try_new(
+            events_schema(),
+            vec![
+                Arc::new(StringArray::from(keys.to_vec())),
+                Arc::new(Int64Array::from(vals.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn single_node_shuffle() -> crate::operator::sql_query::ClusterShuffleConfig {
+        let registry = Arc::new(VnodeRegistry::new(VNODES));
+        let assignment: Arc<[NodeId]> = (0..VNODES).map(|_| NodeId(1)).collect::<Vec<_>>().into();
+        registry.set_assignment(assignment);
+        let sender = laminar_core::shuffle::ShuffleSender::new(1);
+        let receiver = Arc::new(
+            laminar_core::shuffle::ShuffleReceiver::bind(1, "127.0.0.1:0".parse().unwrap())
+                .await
+                .unwrap(),
+        );
+        crate::operator::sql_query::ClusterShuffleConfig {
+            registry,
+            sender: Arc::new(sender),
+            receiver,
+            self_id: NodeId(1),
+        }
+    }
+
+    async fn build_agg_graph(
+        tier: tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+    ) -> OperatorGraph {
+        let mut graph = OperatorGraph::new(laminar_sql::create_session_context());
+        graph.set_cluster_shuffle(single_node_shuffle().await);
+        graph.set_state_tier(tier);
+        graph.set_runtime_handle(tokio::runtime::Handle::current());
+        graph.register_source_schema("events".to_string(), events_schema());
+        graph.add_query(
+            "out".to_string(),
+            "SELECT key, SUM(val) AS total FROM events GROUP BY key".to_string(),
+            Some(EmitClause::Changes),
+            None,
+            None,
+            None,
+            None,
+        );
+        graph.take_build_errors().unwrap();
+        graph
+    }
+
+    fn graph_state_bytes(graph: &OperatorGraph) -> usize {
+        graph.state_bytes_per_operator().map(|(_, b)| b).sum()
+    }
+
+    /// End-to-end trigger: an agg with resident vnode state, checkpointed so
+    /// the coordinator holds durable upload bytes, is demoted by the pass —
+    /// the slices land in the tier, drop from operator memory, and the
+    /// coordinator marks them cold (no longer candidates).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn demotion_pass_sheds_idle_slices() {
+        use crate::checkpoint_coordinator::{
+            CheckpointConfig, CheckpointCoordinator, CheckpointRequest,
+        };
+        use laminar_core::state::InProcessBackend;
+        use laminar_core::storage::checkpoint_store::FileSystemCheckpointStore;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            crate::state_tier::StateTierStore::open(tmp.path().join("tier"), None).unwrap(),
+        );
+        let tier_tx = crate::state_tier::spawn_worker(
+            &tokio::runtime::Handle::current(),
+            Arc::clone(&store),
+            64,
+        );
+
+        let mut graph = build_agg_graph(tier_tx.clone()).await;
+        let mut src: FxHashMap<Arc<str>, Vec<RecordBatch>> = FxHashMap::default();
+        src.insert(
+            Arc::from("events"),
+            vec![events_batch(&["a", "b", "c", "d"], &[1, 2, 3, 4])],
+        );
+        graph.execute_cycle(&src, i64::MAX, None).await.unwrap();
+        let before = graph_state_bytes(&graph);
+        assert!(before > 0, "operator should hold group state");
+
+        // Capture per-vnode state and commit it through a coordinator so the
+        // durable upload bytes are recorded.
+        let states = graph.snapshot_state_by_vnode().unwrap();
+        assert!(!states.is_empty(), "agg state should partition by vnode");
+
+        let ckpt_dir = tempfile::tempdir().unwrap();
+        let store_box = Box::new(FileSystemCheckpointStore::new(ckpt_dir.path(), 3));
+        let mut coord = CheckpointCoordinator::new(CheckpointConfig::default(), store_box)
+            .await
+            .unwrap();
+        coord.set_state_backend(Arc::new(InProcessBackend::new(VNODES)) as Arc<dyn StateBackend>);
+        coord.set_vnode_set((0..VNODES).collect());
+        coord.set_pending_vnode_states(states);
+        let r = coord
+            .checkpoint(CheckpointRequest::default())
+            .await
+            .unwrap();
+        assert!(r.success, "checkpoint must commit: {:?}", r.error);
+        let epoch = r.epoch;
+        assert!(
+            !coord.demotion_candidates(epoch).is_empty(),
+            "committed slices should be demotion candidates"
+        );
+        let coordinator = Arc::new(tokio::sync::Mutex::new(Some(coord)));
+
+        // Drain target 0 → demote every candidate.
+        let demoted = run_demotion_pass(&mut graph, &coordinator, &tier_tx, before, 0, epoch).await;
+        assert!(demoted > 0, "the pass should demote at least one slice");
+
+        assert_eq!(
+            graph_state_bytes(&graph),
+            0,
+            "demoted slices leave operator memory"
+        );
+        assert!(
+            store.logical_slices() > 0,
+            "demoted slices are written to the tier"
+        );
+        let guard = coordinator.lock().await;
+        assert!(
+            guard
+                .as_ref()
+                .unwrap()
+                .demotion_candidates(epoch)
+                .is_empty(),
+            "demoted slices are marked cold and no longer candidates"
+        );
     }
 }

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1937,48 +1937,14 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
                                 }
                             }
                         };
-                        let key_indices: Vec<usize> = versioned
-                            .key_columns
-                            .iter()
-                            .filter_map(|k| combined.schema().index_of(k).ok())
-                            .collect();
-                        let Ok(version_col_idx) =
-                            combined.schema().index_of(&versioned.version_column)
-                        else {
+                        let Some(state) = rebuild_versioned_state(versioned, combined) else {
                             tracing::warn!(
-                                table=%name,
-                                version_col=%versioned.version_column,
-                                "Version column not found; skipping index rebuild"
+                                table=%name, version_col=%versioned.version_column,
+                                "versioned index rebuild skipped (version column missing or build failed)"
                             );
                             continue;
                         };
-                        let index =
-                            match laminar_sql::datafusion::lookup_join_exec::VersionedIndex::build(
-                                &combined,
-                                &key_indices,
-                                version_col_idx,
-                                versioned.max_versions_per_key,
-                            ) {
-                                Ok(idx) => Arc::new(idx),
-                                Err(e) => {
-                                    tracing::warn!(
-                                        table=%name, error=%e,
-                                        "Versioned index build error"
-                                    );
-                                    continue;
-                                }
-                            };
-                        self.lookup_registry.register_versioned(
-                            name,
-                            laminar_sql::datafusion::VersionedLookupState {
-                                batch: combined,
-                                index,
-                                key_columns: versioned.key_columns.clone(),
-                                version_column: versioned.version_column.clone(),
-                                stream_time_column: versioned.stream_time_column.clone(),
-                                max_versions_per_key: versioned.max_versions_per_key,
-                            },
-                        );
+                        self.lookup_registry.register_versioned(name, state);
                         let mut ts = self.table_store.write();
                         if let Err(e) = ts.upsert_and_rebuild(name, &batch) {
                             #[allow(clippy::cast_possible_truncation)]
@@ -2112,6 +2078,36 @@ fn update_partial_cache_from_batch(
             partial.lookup_cache.insert(key.as_ref(), row_batch);
         }
     }
+}
+
+/// Rebuild a versioned lookup state over `batch`, reusing the prior state's key
+/// and version columns. `None` if the version column is absent or the index
+/// fails to build.
+pub(crate) fn rebuild_versioned_state(
+    prior: &laminar_sql::datafusion::VersionedLookupState,
+    batch: RecordBatch,
+) -> Option<laminar_sql::datafusion::VersionedLookupState> {
+    let key_indices: Vec<usize> = prior
+        .key_columns
+        .iter()
+        .filter_map(|k| batch.schema().index_of(k).ok())
+        .collect();
+    let version_col_idx = batch.schema().index_of(&prior.version_column).ok()?;
+    let index = laminar_sql::datafusion::lookup_join_exec::VersionedIndex::build(
+        &batch,
+        &key_indices,
+        version_col_idx,
+        prior.max_versions_per_key,
+    )
+    .ok()?;
+    Some(laminar_sql::datafusion::VersionedLookupState {
+        batch,
+        index: Arc::new(index),
+        key_columns: prior.key_columns.clone(),
+        version_column: prior.version_column.clone(),
+        stream_time_column: prior.stream_time_column.clone(),
+        max_versions_per_key: prior.max_versions_per_key,
+    })
 }
 
 /// Encode an Arrow schema as a hex-encoded IPC flatbuffer.

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -410,11 +410,13 @@ async fn tier_drop(tier: &crate::state_tier::TierTx, operator: &str, vnode: u32)
 }
 
 /// Shed idle vnode slices to the cold tier until projected memory falls below
-/// `target_bytes` (or candidates / the per-pass cap run out). For each
-/// `(operator, vnode)` candidate: persist its durable bytes, then ask the
-/// operator to drop the groups — which it refuses if the vnode was touched
-/// since its last capture, in which case the tier write is rolled back.
-/// Returns the number of slices demoted.
+/// `target_bytes` (or candidates / the per-pass cap run out). Candidates are
+/// pre-filtered to operators that can demote the vnode now (clean since their
+/// last capture), so a dirty vnode is skipped before any tier I/O. For each
+/// surviving `(operator, vnode)`: persist its durable bytes, then drop the
+/// groups — the drop is still guarded and rolls the write back on the rare
+/// race, but the common dirty case no longer costs a write. Returns the number
+/// of slices demoted.
 ///
 /// Caller-side safety contract: invoke only with no checkpoint in flight, so
 /// the bytes recorded for a candidate equal the operator's resident state.
@@ -443,12 +445,19 @@ pub(crate) async fn run_demotion_pass(
             {
                 break;
             }
-            let slices = coord.slices_for_demotion(vnode);
-            if slices.is_empty() {
+            // Keep only operators that can demote this vnode *now* (clean since
+            // their last capture). Filtering here, before any tier write, turns
+            // a dirty candidate into a no-op instead of a write-then-rollback.
+            let eligible: Vec<(String, bytes::Bytes)> = coord
+                .slices_for_demotion(vnode)
+                .into_iter()
+                .filter(|(op, _)| graph.can_demote(op, vnode))
+                .collect();
+            if eligible.is_empty() {
                 continue;
             }
             freed = freed.saturating_add(bytes);
-            plan.push((vnode, slices));
+            plan.push((vnode, eligible));
         }
         plan
     };

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -124,7 +124,7 @@ struct LeaderTail {
     >,
     request: crate::checkpoint_coordinator::CheckpointRequest,
     #[allow(clippy::disallowed_types)]
-    vnode_states: std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+    vnode_states: crate::checkpoint_coordinator::StagedVnodeStates,
     fan_out: FxHashMap<String, SourceCheckpoint>,
     local_watermark_ms: Option<i64>,
     /// `Some` when this node admitted the barrier as cluster leader.
@@ -142,7 +142,7 @@ struct LeaderTail {
 #[allow(clippy::disallowed_types)]
 fn staged_request_bytes(
     request: &crate::checkpoint_coordinator::CheckpointRequest,
-    vnode_states: &std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>>,
+    vnode_states: &crate::checkpoint_coordinator::StagedVnodeStates,
 ) -> u64 {
     let ops: usize = request
         .operator_states
@@ -152,7 +152,11 @@ fn staged_request_bytes(
     let vnodes: usize = vnode_states
         .values()
         .flat_map(|m| m.values())
-        .map(bytes::Bytes::len)
+        .map(|s| match s {
+            crate::checkpoint_coordinator::StagedSlice::Bytes(b) => b.len(),
+            // Cold slices stage no bytes — they hold tier capacity, not RAM.
+            crate::checkpoint_coordinator::StagedSlice::Cold => 0,
+        })
         .sum();
     (ops + vnodes) as u64
 }
@@ -1062,9 +1066,7 @@ impl ConnectorPipelineCallback {
     /// empty map — the partial then carries no operator state for that epoch,
     /// exactly as the legacy marker did, so the checkpoint still succeeds.
     #[allow(clippy::unused_self, clippy::disallowed_types)] // matches the coordinator/graph map shape
-    fn capture_vnode_states(
-        &mut self,
-    ) -> std::collections::HashMap<u32, std::collections::HashMap<String, bytes::Bytes>> {
+    fn capture_vnode_states(&mut self) -> crate::checkpoint_coordinator::StagedVnodeStates {
         #[cfg(feature = "cluster")]
         {
             match self.graph.snapshot_state_by_vnode() {

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -347,11 +347,6 @@ pub(crate) struct ConnectorPipelineCallback {
     /// written here before being dropped from memory. `None` = no tier.
     #[cfg(feature = "state-tier")]
     pub(crate) state_tier: Option<crate::state_tier::TierTx>,
-    /// Highest epoch known restorable (committed), tracked from
-    /// [`publish_barrier`](PipelineCallback::publish_barrier). A slice is
-    /// demotable only once its base upload is durable at or below this.
-    #[cfg(feature = "state-tier")]
-    pub(crate) restorable_epoch: std::sync::atomic::AtomicU64,
 }
 
 /// Minimum interval between state-memory-budget probes. Each probe sums
@@ -432,7 +427,6 @@ pub(crate) async fn run_demotion_pass(
     tier: &crate::state_tier::TierTx,
     total_bytes: usize,
     target_bytes: usize,
-    restorable: u64,
 ) -> u64 {
     // Plan under the coordinator lock: rank idle candidates and copy their
     // durable slice bytes. Release the lock before any tier I/O.
@@ -443,7 +437,7 @@ pub(crate) async fn run_demotion_pass(
         };
         let mut plan = Vec::new();
         let mut freed = 0usize;
-        for (vnode, _base, bytes) in coord.demotion_candidates(restorable) {
+        for (vnode, bytes) in coord.demotion_candidates() {
             if plan.len() >= STATE_DEMOTE_MAX_PER_PASS
                 || total_bytes.saturating_sub(freed) < target_bytes
             {
@@ -2071,12 +2065,6 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     fn publish_barrier(&self, epoch: u64, checkpoint_id: u64) {
         self.subscription_registry
             .broadcast_barrier(epoch, checkpoint_id);
-        // A published barrier is a committed (restorable) epoch — the demote
-        // trigger only sheds slices whose base upload is durable at or below
-        // it.
-        #[cfg(feature = "state-tier")]
-        self.restorable_epoch
-            .fetch_max(epoch, std::sync::atomic::Ordering::Relaxed);
     }
 
     #[cfg(feature = "state-tier")]
@@ -2101,17 +2089,8 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             return;
         }
         let target = budget / STATE_DEMOTE_TARGET_DEN * STATE_DEMOTE_TARGET_NUM;
-        let restorable = self.restorable_epoch.load(Ordering::Relaxed);
         let coordinator = Arc::clone(&self.coordinator);
-        let demoted = run_demotion_pass(
-            &mut self.graph,
-            &coordinator,
-            &tier,
-            total,
-            target,
-            restorable,
-        )
-        .await;
+        let demoted = run_demotion_pass(&mut self.graph, &coordinator, &tier, total, target).await;
         if demoted > 0 {
             tracing::debug!(demoted, "demoted idle vnode slices to the cold tier");
         }
@@ -2766,15 +2745,14 @@ mod demotion_tests {
             .await
             .unwrap();
         assert!(r.success, "checkpoint must commit: {:?}", r.error);
-        let epoch = r.epoch;
         assert!(
-            !coord.demotion_candidates(epoch).is_empty(),
+            !coord.demotion_candidates().is_empty(),
             "committed slices should be demotion candidates"
         );
         let coordinator = Arc::new(tokio::sync::Mutex::new(Some(coord)));
 
         // Drain target 0 → demote every candidate.
-        let demoted = run_demotion_pass(&mut graph, &coordinator, &tier_tx, before, 0, epoch).await;
+        let demoted = run_demotion_pass(&mut graph, &coordinator, &tier_tx, before, 0).await;
         assert!(demoted > 0, "the pass should demote at least one slice");
 
         assert_eq!(
@@ -2788,11 +2766,7 @@ mod demotion_tests {
         );
         let guard = coordinator.lock().await;
         assert!(
-            guard
-                .as_ref()
-                .unwrap()
-                .demotion_candidates(epoch)
-                .is_empty(),
+            guard.as_ref().unwrap().demotion_candidates().is_empty(),
             "demoted slices are marked cold and no longer candidates"
         );
     }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1120,7 +1120,8 @@ impl LaminarDB {
             let entry = self.lookup_registry.get_entry(name);
             if let Some(laminar_sql::datafusion::RegisteredLookup::Versioned(v)) = &entry {
                 if let Some(batch) = self.table_store.read().to_record_batch(name) {
-                    if let Some(state) = crate::pipeline_callback::rebuild_versioned_state(v, batch) {
+                    if let Some(state) = crate::pipeline_callback::rebuild_versioned_state(v, batch)
+                    {
                         self.lookup_registry.register_versioned(name, state);
                     }
                 }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -599,21 +599,34 @@ impl LaminarDB {
                 .unwrap_or_else(tokio::runtime::Handle::current),
         );
 
-        // Disk cold tier: when `state_tier_dir` is configured and the
-        // per-vnode capture path is live (cluster shuffle + state backend),
+        // Disk cold tier: when `state_tier_dir` is configured and the per-vnode
+        // capture path can run (a vnode topology + a durable state backend),
         // open the tier, spawn its Ring-1 worker, and share the channel with
         // the graph (promotion) and — below — the coordinator (forced-full
-        // re-uploads) and the callback (demotion trigger). Without the
-        // preconditions a set dir is a loud no-op, never silent data loss.
-        // `set_state_tier` must precede `add_query` so operators built below
-        // pick up the stored sender.
+        // re-uploads) and the callback (demotion trigger). Cluster mode already
+        // installed a vnode count from the shuffle registry; a single node
+        // without a controller gets a fixed local count here, so the tier works
+        // without cluster row transport. The backend stays mandatory — it holds
+        // the demoted truth that restart replays. A set dir without a backend is
+        // a loud no-op, never silent data loss. `set_state_tier` must precede
+        // `add_query` so operators built below pick up the stored sender.
         #[cfg(feature = "state-tier")]
         let state_tier_sender: Option<crate::state_tier::TierTx> = {
             match self.config.state_tier_dir.clone() {
                 Some(dir) => {
                     let has_backend = self.state_backend.lock().is_some();
-                    let has_shuffle = graph.cluster_shuffle_config().is_some();
-                    if has_backend && has_shuffle {
+                    // Cluster mode set the vnode count from the shuffle registry.
+                    // A single node (no controller/shuffle) takes it from its
+                    // vnode registry directly — the same registry the durability
+                    // gate already wired the coordinator from — so per-vnode
+                    // capture and demotion run without cluster row transport.
+                    if graph.vnode_count().is_none() {
+                        if let Some(registry) = self.vnode_registry.lock().clone() {
+                            graph.set_vnode_count(registry.vnode_count());
+                        }
+                    }
+                    let has_topology = graph.vnode_count().is_some();
+                    if has_backend && has_topology {
                         let handle = self
                             .ai_handle
                             .clone()
@@ -640,9 +653,11 @@ impl LaminarDB {
                     } else {
                         tracing::warn!(
                             has_backend,
-                            has_shuffle,
-                            "state_tier_dir set but cluster shuffle and/or state \
-                             backend missing — demotion disabled"
+                            has_topology,
+                            "state_tier_dir set but demotion disabled — the tier \
+                             needs a durable [state] backend (holds demoted state \
+                             for restart) and a vnode registry (single-node: a \
+                             single-owner registry)"
                         );
                         None
                     }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1,4 +1,4 @@
-//! Pipeline lifecycle management: start, close, shutdown.
+//! Pipeline lifecycle: start, close, shutdown.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -11,12 +11,9 @@ use rustc_hash::FxHashMap;
 use crate::db::{DbState, LaminarDB, SourceWatermarkState};
 use crate::error::DbError;
 
-/// Resolves each `CREATE STREAM`'s output Arrow schema by planning its SQL.
-/// Temporary `EmptyTable` placeholders let downstream streams plan against
-/// upstream streams; they are removed before returning.
-/// Resolve a query's output schema by planning it. `DataFusion` can't lower
-/// `ASOF JOIN`, so on failure retry with the schema-equivalent rewrite. `None`
-/// if it still can't be planned (e.g. a dependency isn't registered yet).
+/// Resolve a query's output schema by planning it. On `ASOF JOIN` failure,
+/// retries with the schema-equivalent rewrite. Returns `None` if the query
+/// still can't be planned (e.g. a dependency isn't registered yet).
 pub(crate) async fn plan_output_schema(
     ctx: &datafusion::prelude::SessionContext,
     sql: &str,
@@ -46,7 +43,6 @@ async fn resolve_stream_output_schemas(
         HashMap::with_capacity(stream_regs.len());
     let mut pending: Vec<&crate::connector_manager::StreamRegistration> =
         stream_regs.values().collect();
-    // Placeholders we own and must clean up; pre-existing tables are left alone.
     let mut placeholders: Vec<String> = Vec::new();
 
     let result: Result<(), DbError> = async {
@@ -76,9 +72,8 @@ async fn resolve_stream_output_schemas(
             if !progressed {
                 let mut unresolved: Vec<&str> = next.iter().map(|r| r.name.as_str()).collect();
                 unresolved.sort_unstable();
-                // Report the rewritten-plan error when the query is an ASOF join:
-                // the raw plan only ever says "AsOf unsupported", which masks the
-                // real blocker (the rewrite is what we actually plan against).
+                // For ASOF joins, report the rewritten-plan error (the raw planner
+                // just says "AsOf unsupported", which masks the real blocker).
                 let sql = &next[0].query_sql;
                 let err = match crate::sql_analysis::rewrite_asof_joins_for_planning(sql) {
                     Some(rewritten) => ctx.state().create_logical_plan(&rewritten).await.err(),
@@ -110,12 +105,10 @@ impl LaminarDB {
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Replay each operator's demoted vnodes from their durable partials on
-    /// restart (the cold tier is wiped; the manifest holds only resident
-    /// vnodes). Applies only the demoting operator's slice of each vnode.
+    /// Replay demoted vnode partials into the operator graph on restart.
     ///
-    /// Fails loud on any unrecoverable vnode: offsets are already staged, so
-    /// resuming with it empty would silently corrupt that aggregate.
+    /// Fails loud on any unrecoverable vnode: source offsets are already staged,
+    /// so resuming with empty state would silently corrupt that aggregate.
     #[cfg(feature = "state-tier")]
     async fn rehydrate_cold_vnodes(
         &self,
@@ -155,7 +148,7 @@ impl LaminarDB {
                         continue;
                     }
                 };
-                // Operator absent from the partial held no groups in this vnode.
+                // Absence from the partial means the operator had no groups in this vnode.
                 if let Some((_, slice)) = partial.operators.iter().find(|(n, _)| n == op_name) {
                     match graph.apply_vnode_slice(op_name, v, slice) {
                         Ok(()) => applied += 1,
@@ -192,9 +185,7 @@ impl LaminarDB {
 
     /// Start the streaming pipeline. Idempotent if already running.
     ///
-    /// Activates registered connectors and spawns the background processing
-    /// task. On failure the instance is unwound back to `Created` so the
-    /// caller can retry after fixing the offending config.
+    /// On failure the instance is reset to `Created` so the caller can retry.
     ///
     /// # Errors
     ///
@@ -217,7 +208,6 @@ impl LaminarDB {
 
         DbState::Starting.store(&self.state);
 
-        // Fallback for embedded use without a server.
         {
             let mut guard = self.engine_metrics.lock();
             if guard.is_none() {
@@ -227,10 +217,6 @@ impl LaminarDB {
             }
         }
 
-        // Rebuild any catalog objects this node lacks from the shared manifest
-        // before wiring the pipeline — replaying DDL here is the same pre-start
-        // path users take when they CREATE before start(). Best-effort/no-op
-        // outside cluster mode or with no manifest stored.
         #[cfg(feature = "cluster")]
         self.restore_catalog_from_manifest().await;
 
@@ -240,8 +226,7 @@ impl LaminarDB {
                 Ok(())
             }
             Err(e) => {
-                // Unwind so a retry actually re-runs startup instead of
-                // silently succeeding against a wedged Starting state.
+                // Reset so a retry re-runs startup rather than silently returning Ok.
                 DbState::Created.store(&self.state);
                 Err(e)
             }
@@ -250,7 +235,6 @@ impl LaminarDB {
 
     #[allow(clippy::too_many_lines)]
     async fn start_inner(&self) -> Result<(), DbError> {
-        // Snapshot connector registrations under the lock
         let (source_regs, sink_regs, stream_regs, table_regs, has_external) = {
             let mgr = self.connector_manager.lock();
             (
@@ -262,7 +246,6 @@ impl LaminarDB {
             )
         };
 
-        // Log which sources have external connectors for debugging.
         for (name, reg) in &source_regs {
             tracing::debug!(source = %name, connector_type = ?reg.connector_type, "Registered source");
         }
@@ -270,7 +253,6 @@ impl LaminarDB {
             tracing::debug!(sink = %name, connector_type = ?reg.connector_type, "Registered sink");
         }
 
-        // Initialize checkpoint coordinator (shared across all pipeline modes)
         if let Some(ref cp_config) = self.config.checkpoint {
             use crate::checkpoint_coordinator::{
                 CheckpointConfig as CkpConfig, CheckpointCoordinator,
@@ -282,8 +264,6 @@ impl LaminarDB {
                 |r| u16::try_from(r.vnode_count()).unwrap_or(u16::MAX),
             );
 
-            // Resolve once; both the checkpoint store and the decision
-            // store want the same root.
             let data_dir = cp_config
                 .data_dir
                 .clone()
@@ -294,9 +274,6 @@ impl LaminarDB {
                 Box<dyn laminar_core::storage::CheckpointStore>,
                 Arc<dyn object_store::ObjectStore>,
             ) = if let Some(ref url) = self.config.object_store_url {
-                // The builder roots the store at the URL's path prefix,
-                // so the checkpoint store (and the decision store
-                // sharing `obj`) need no extra key prefix.
                 let obj = laminar_core::storage::object_store_builder::build_object_store(
                     url,
                     &self.config.object_store_options,
@@ -342,19 +319,11 @@ impl LaminarDB {
                 coord.set_metrics(Arc::clone(prom));
             }
 
-            // Cluster mode: install the controller so the coordinator
-            // can consult it for leader / follower role once the
-            // barrier-protocol flow change lands.
             #[cfg(feature = "cluster")]
             if let Some(controller) = self.cluster_controller.lock().clone() {
                 coord.set_cluster_controller(controller);
             }
 
-            // Durability gate wiring: if both the state backend and vnode
-            // registry are installed, tell the coordinator which vnodes
-            // this instance owns. In cluster mode the owner id comes from
-            // the cluster controller; in single-instance mode we assume
-            // a `single_owner` registry and pass `NodeId(0)`.
             if let (Some(backend), Some(registry)) = (
                 self.state_backend.lock().clone(),
                 self.vnode_registry.lock().clone(),
@@ -374,28 +343,18 @@ impl LaminarDB {
                         laminar_core::state::NodeId(0)
                     }
                 };
-                // Both sides of the split-brain guard must see the same
-                // generation. The coordinator stamps outgoing writes with
-                // it (caller side), and the backend rejects incoming
-                // writes below it (authority side).
-                // Without the backend call the authoritative version
-                // stays at 0 and the fence is a silent no-op — the
-                // registry's version carries the snapshot generation
-                // across a restart, but only in-memory.
+                // Coordinator and backend must agree on the same generation —
+                // the coordinator stamps writes, the backend rejects stale ones.
+                // Without the backend call the fence is a silent no-op.
                 let version = registry.assignment_version();
                 backend.set_authoritative_version(version);
                 coord.set_state_backend(backend);
                 coord.set_assignment_version(version);
                 coord.set_vnode_set(laminar_core::state::owned_vnodes(&registry, owner));
-                // Leader's gate checks the full registry — across all
-                // instances — so the 2PC commit only fires when every
-                // follower has also persisted its markers.
+                // Leader gate covers all instances; 2PC only fires when every follower committed.
                 coord.set_gate_vnode_set((0..registry.vnode_count()).collect());
             }
 
-            // Decision store: caller-supplied (cluster) wins, else
-            // auto-wire one on the same backing so recovery can read
-            // the commit marker.
             let ds = {
                 #[cfg(feature = "cluster")]
                 {
@@ -418,8 +377,6 @@ impl LaminarDB {
             };
             coord.set_decision_store(ds);
 
-            // Reconcile any Pending sinks from the last manifest against
-            // the durable commit marker before accepting new traffic.
             coord.reconcile_prepared_on_init().await;
 
             *self.coordinator.lock().await = Some(coord);
@@ -454,15 +411,6 @@ impl LaminarDB {
     }
 
     /// Build and start the unified pipeline with sources, sinks, and streams.
-    ///
-    /// Handles both embedded (in-memory only) and connector-backed sources
-    /// through a single code path. Connector-less sources are wrapped as
-    /// `CatalogSourceConnector` to participate in the pipeline alongside
-    /// external connectors (Kafka, CDC, etc.).
-    ///
-    /// Each source runs as a tokio task pushing batches via mpsc channel
-    /// to a `StreamingCoordinator` that drives SQL cycles, sink writes,
-    /// and checkpoint coordination.
     #[allow(clippy::too_many_lines)]
     async fn start_connector_pipeline(
         &self,
@@ -479,8 +427,6 @@ impl LaminarDB {
         use crate::pipeline::{PipelineConfig, SourceRegistration};
         use laminar_connectors::reference::{ReferenceTableSource, RefreshMode};
 
-        // Build OperatorGraph context mirroring the rules + partition
-        // count installed on `LaminarDB::ctx` via the builder.
         let ctx = {
             use datafusion::execution::SessionStateBuilder;
             let mut session_config = laminar_sql::datafusion::base_session_config();
@@ -504,8 +450,6 @@ impl LaminarDB {
         };
         laminar_sql::register_streaming_functions(&ctx);
 
-        // Register lookup/reference tables in the operator graph's
-        // SessionContext so JOIN queries can resolve them.
         let lookup_tables: Vec<(String, arrow::datatypes::SchemaRef)> = {
             let ts = self.table_store.read();
             ts.table_names()
@@ -541,9 +485,6 @@ impl LaminarDB {
             graph.set_ai_runtime(Arc::clone(runtime), handle.clone());
         }
 
-        // Install the cluster row-shuffle config if all the pieces are
-        // present (registry, sender, receiver, controller). Without any
-        // one of them, aggregate queries run single-node.
         #[cfg(feature = "cluster")]
         {
             let sender = self.shuffle_sender.lock().clone();
@@ -560,26 +501,16 @@ impl LaminarDB {
                     receiver,
                     self_id,
                 });
-                // Share the DB's staged rehydration map so the graph applies
-                // rebalanced-in vnode state into operators each cycle.
                 graph.set_rehydration_handle(Arc::clone(&self.rehydrated_vnode_state));
             }
         }
 
-        // Register source schemas for ALL sources (both external connectors
-        // and catalog-bridge sources) so the graph can create empty
-        // placeholder tables when no data arrives in a given cycle.
         for name in source_regs.keys() {
             if let Some(entry) = self.catalog.get_source(name) {
                 graph.register_source_schema(name.clone(), entry.schema.clone());
             }
         }
 
-        // Partial (on-demand) lookup tables: route their enrichment joins to the
-        // async-decoupled operator. A table is partial iff it refreshes Manually
-        // — the same condition the on-demand phase below uses to register it as
-        // `RegisteredLookup::Partial`. Map each to its column names so the
-        // operator can disambiguate colliding output columns.
         let partial_lookup_tables: rustc_hash::FxHashMap<String, Vec<String>> = table_regs
             .values()
             .filter(|r| matches!(r.refresh, Some(RefreshMode::Manual)))
@@ -590,36 +521,21 @@ impl LaminarDB {
             })
             .collect();
         graph.set_partial_lookup_tables(partial_lookup_tables);
-        // Ring-1 workers (lookup-enrich fetch, AI) spawn on the main runtime.
         graph.set_runtime_handle(
             self.ai_handle
                 .clone()
                 .unwrap_or_else(tokio::runtime::Handle::current),
         );
 
-        // Disk cold tier: when `state_tier_dir` is configured and the per-vnode
-        // capture path can run (a vnode topology + a durable state backend),
-        // open the tier, spawn its Ring-1 worker, and share the channel with
-        // the graph (promotion) and — below — the coordinator (forced-full
-        // re-uploads) and the callback (demotion trigger). Cluster mode already
-        // installed a vnode count from the shuffle registry; a single node
-        // without a controller takes it from its vnode registry here, so the
-        // tier works without cluster row transport. The backend stays mandatory — it holds
-        // the demoted truth that restart replays. A set dir without a backend is
-        // a loud no-op, never silent data loss. `set_state_tier` must precede
-        // `add_query` so operators built below pick up the stored sender.
+        // `set_state_tier` must precede `add_query` so operators built below pick up the sender.
         #[cfg(feature = "state-tier")]
         let state_tier_sender: Option<crate::state_tier::TierTx> = {
             match self.config.state_tier_dir.clone() {
                 Some(dir) => {
                     let has_backend = self.state_backend.lock().is_some();
-                    // Cluster mode set the vnode count from the shuffle registry.
-                    // A single node (no controller/shuffle) takes it from its
-                    // vnode registry directly — the same registry the durability
-                    // gate already wired the coordinator from — so per-vnode
-                    // capture and demotion run without cluster row transport.
                     if graph.vnode_count().is_none() {
                         if let Some(registry) = self.vnode_registry.lock().clone() {
+                            // Single-node (no controller): take vnode count from the registry.
                             graph.set_vnode_count(registry.vnode_count());
                         }
                     }
@@ -632,11 +548,6 @@ impl LaminarDB {
                         let metrics = self.engine_metrics.lock().clone();
                         match crate::state_tier::StateTierStore::open(&dir, metrics) {
                             Ok(store) => {
-                                // The worker owns the only `Arc`; the store
-                                // lives until the pipeline's senders drop, then
-                                // wipes on the next restart (recovery replays
-                                // demoted vnodes from durable partials, so the
-                                // tier never needs to survive a restart).
                                 let sender =
                                     crate::state_tier::spawn_worker(&handle, Arc::new(store), 256);
                                 graph.set_state_tier(sender.clone());
@@ -682,16 +593,10 @@ impl LaminarDB {
                 reg.join_config.clone(),
             );
         }
-        // Surface any plan-time AI routing errors (unknown model, unsupported
-        // task, malformed AI query) collected during `add_query`.
         graph.take_build_errors()?;
 
-        // Register temporal join tables as Versioned in the lookup registry
-        // so that temporal join operators can use persistent versioned state.
         for tcfg in graph.temporal_join_configs() {
             if self.lookup_registry.get_entry(&tcfg.table_name).is_none() {
-                // Get initial data. If none exists yet, use an empty batch
-                // with the correct schema from the catalog (not Schema::empty).
                 let initial_batch = self
                     .table_store
                     .read()
@@ -710,9 +615,8 @@ impl LaminarDB {
                     .filter_map(|k| initial_batch.schema().index_of(k).ok())
                     .collect();
 
-                // When table_version_column is empty (translator couldn't resolve it
-                // from the AS OF clause), pick the first timestamp/int column that
-                // isn't the join key.
+                // If the AS OF clause didn't resolve a version column, pick the first
+                // timestamp/int column that isn't the join key.
                 let resolved_version_col = if tcfg.table_version_column.is_empty() {
                     let schema = initial_batch.schema();
                     schema
@@ -742,7 +646,7 @@ impl LaminarDB {
                              will resolve on first CDC batch"
                         );
                     }
-                    // Register with empty index — built on first CDC update.
+                    // Index built on first CDC update.
                     self.lookup_registry.register_versioned(
                         &tcfg.table_name,
                         laminar_sql::datafusion::VersionedLookupState {
@@ -782,11 +686,8 @@ impl LaminarDB {
             }
         }
 
-        // Grab the shared Prometheus registry (if set) so connectors can
-        // register their metrics on it.
         let prom_registry = self.prometheus_registry.lock().clone();
 
-        // Build sources as owned SourceRegistrations (no Arc<Mutex>).
         let mut sources: Vec<SourceRegistration> = Vec::new();
         for (name, reg) in &source_regs {
             if reg.connector_type.is_none() {
@@ -794,8 +695,6 @@ impl LaminarDB {
             }
             let mut config = build_source_config(reg)?;
 
-            // Pass the SQL-defined Arrow schema to the connector so it can
-            // deserialize records with the correct column names and types.
             if let Some(entry) = self.catalog.get_source(name) {
                 let schema_str = crate::pipeline_callback::encode_arrow_schema(&entry.schema);
                 config.set("_arrow_schema".to_string(), schema_str);
@@ -812,9 +711,6 @@ impl LaminarDB {
                         config.connector_type()
                     ))
                 })?;
-            // Cluster mode: hand the source the vnode topology so a partitioned
-            // source (Kafka) consumes only the partitions this node owns and
-            // re-binds on rotation. No-op for non-partitioned sources.
             #[cfg(feature = "cluster")]
             if let (Some(registry), Some(self_id)) = (
                 self.vnode_registry.lock().clone(),
@@ -833,13 +729,8 @@ impl LaminarDB {
                      are degraded to at-most-once for this source"
                 );
             }
-            // Property-driven watermark wiring. `[source.watermark]` in
-            // TOML is the preferred path (honours max_out_of_orderness);
-            // this exists for sources that pass `event.time.column` /
-            // `event.time.field` as a connector property instead. The
-            // second pass below builds the matching SourceWatermarkState.
-            // Kafka uses `column`, WebSocket uses `field` — both spellings
-            // are live.
+            // Connector-property watermark wiring: `event.time.column` (Kafka)
+            // and `event.time.field` (WebSocket) as an alternative to `WATERMARK FOR`.
             if let Some(entry) = self.catalog.get_source(name) {
                 if entry.source.event_time_column().is_none() {
                     if let Some(col) = config.get("event.time.column") {
@@ -848,9 +739,6 @@ impl LaminarDB {
                         entry.source.set_event_time_column(col);
                     }
                 }
-                // Carry the out-of-orderness bound alongside the column so
-                // the fallback watermark path below uses the configured
-                // tolerance instead of Duration::ZERO.
                 if let Some(ms_str) = config.get("max.out.of.orderness.ms") {
                     match ms_str.parse::<u64>() {
                         Ok(ms) => {
@@ -880,19 +768,11 @@ impl LaminarDB {
             });
         }
 
-        // Bridge connector-less sources into the pipeline so db.insert()
-        // data flows through the standard source task → coordinator path.
-        // This covers two cases:
-        //   1. Sources in source_regs with connector_type == None (registered
-        //      in connector manager but without a FROM clause).
-        //   2. Sources in the catalog but NOT in source_regs at all (pure
-        //      embedded sources created without any connector specification).
         let bridged_names: rustc_hash::FxHashSet<String> =
             sources.iter().map(|s| s.name.clone()).collect();
-        // First: bridge sources in source_regs that have no connector.
         for (name, reg) in &source_regs {
             if reg.connector_type.is_some() {
-                continue; // Already created as external connector above
+                continue;
             }
             if let Some(entry) = self.catalog.get_source(name) {
                 let subscription = entry.sink.subscribe();
@@ -910,8 +790,6 @@ impl LaminarDB {
                 });
             }
         }
-        // Second: bridge catalog sources not in source_regs (embedded-only
-        // sources that were never registered with the connector manager).
         for name in self.catalog.list_sources() {
             if bridged_names.contains(&name) || source_regs.contains_key(&name) {
                 continue;
@@ -934,10 +812,6 @@ impl LaminarDB {
             }
         }
 
-        // Resolve each stream's output schema with DataFusion so sinks
-        // downstream see it via `_arrow_schema` (mirrors the source path
-        // above). Publish the result into `LaminarDB::stream_schemas` so
-        // SUBSCRIBE WHERE can compile predicates against the real schema.
         let stream_output_schemas = resolve_stream_output_schemas(&self.ctx, &stream_regs).await?;
         {
             let mut schemas = self.stream_schemas.write();
@@ -949,9 +823,6 @@ impl LaminarDB {
             );
         }
 
-        // Build sinks. Each runs in its own tokio task with a bounded
-        // command channel and shares one event channel back to the
-        // pipeline callback.
         let (sink_event_tx, sink_event_rx) =
             laminar_core::streaming::channel::channel::<crate::sink_task::SinkEvent>(
                 crate::sink_task::SINK_EVENT_CHANNEL_CAPACITY,
@@ -969,8 +840,6 @@ impl LaminarDB {
                 continue;
             }
             let mut config = build_sink_config(reg)?;
-            // Resolve the upstream schema from a stream first, then fall back
-            // to a source — `CREATE SINK ... FROM <name>` accepts either.
             let upstream_schema = stream_output_schemas.get(&reg.input).cloned().or_else(|| {
                 self.catalog
                     .get_source(&reg.input)
@@ -990,13 +859,10 @@ impl LaminarDB {
                         config.connector_type()
                     ))
                 })?;
-            // Open the connector before handing it to the task.
             sink.open(&config)
                 .await
                 .map_err(|e| DbError::Connector(format!("Failed to open sink '{name}': {e}")))?;
             let caps = sink.capabilities();
-            // Resolve per-sink write timeout: user override (property)
-            // takes precedence over the sink's declared suggestion.
             let write_timeout =
                 match config
                     .get_parsed::<u64>("sink.write.timeout.ms")
@@ -1035,11 +901,8 @@ impl LaminarDB {
                 caps.changelog,
             ));
         }
-        // Drop the local sender so the channel disconnects when all
-        // sink tasks exit.
         drop(sink_event_tx);
 
-        // Build table sources from registrations
         let mut table_sources: Vec<(String, Box<dyn ReferenceTableSource>, RefreshMode)> =
             Vec::new();
         for (name, reg) in &table_regs {
@@ -1057,9 +920,6 @@ impl LaminarDB {
             table_sources.push((name.clone(), source, mode));
         }
 
-        // Register sinks with the checkpoint coordinator.
-        // Sources are owned by the TPC runtime — checkpoint reads go
-        // through lock-free watch channels instead.
         {
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
@@ -1070,16 +930,9 @@ impl LaminarDB {
             }
         }
 
-        // Recovery: restore sink/table state via unified coordinator.
-        // Must run BEFORE begin_initial_epoch so the coordinator's epoch
-        // reflects the recovered state. We also hoist the recovered
-        // per-source watermarks out of the coordinator lock so the later
-        // watermark-state construction can seed each generator + the
-        // combined tracker. Without this, generators restart at
-        // `i64::MIN` while source offsets resume mid-stream — windowed
-        // operators re-fire and late-drop diverges from the pre-crash
-        // run, breaking deterministic recovery for every event-time
-        // pipeline.
+        // Must run BEFORE begin_initial_epoch so the epoch reflects the recovered state.
+        // Hoist watermarks now so generators are seeded before watermark-state construction;
+        // without this, generators restart at i64::MIN while offsets resume mid-stream.
         let mut recovered_source_wms: rustc_hash::FxHashMap<String, i64> =
             rustc_hash::FxHashMap::default();
         {
@@ -1108,10 +961,6 @@ impl LaminarDB {
                                 }
                             }
                         }
-                        // Attach recovered source offsets to SourceRegistrations.
-                        // These will be passed to the TPC source adapters, which
-                        // call connector.restore() after open() to seek Kafka
-                        // consumers to their checkpoint positions.
                         for src in &mut sources {
                             if !src.supports_replay {
                                 continue;
@@ -1161,14 +1010,10 @@ impl LaminarDB {
                                         );
                                     }
                                     Err(e) => {
-                                        // Source offsets were already staged
-                                        // for the connectors above. Resuming
-                                        // with empty operator state would
-                                        // silently lose every in-flight
-                                        // window / aggregator. Fail loud
-                                        // instead — the operator can drop
-                                        // the checkpoint and restart fresh
-                                        // explicitly if that's the intent.
+                                        // Source offsets are already staged; resuming with
+                                        // empty operator state would silently lose in-flight
+                                        // windows. Fail loud so the intent to start fresh
+                                        // must be explicit.
                                         return Err(DbError::Checkpoint(format!(
                                             "[LDB-6029] operator graph restore failed: \
                                              {e} — refusing to start with checkpointed \
@@ -1193,13 +1038,9 @@ impl LaminarDB {
                             );
                         }
 
-                        // Tier-capable operators keep only their resident
-                        // (hot) vnodes in the manifest blob; the cold tier is
-                        // wiped on restart, so replay each demoted vnode from
-                        // its durable partial. Only the demoting operator's
-                        // slice of each vnode is applied — the partial bundles
-                        // every operator, and the others already restored from
-                        // the manifest (double-applying would corrupt them).
+                        // Cold-tier vnodes are wiped on restart; replay them from durable partials.
+                        // Only the demoting operator's slice is applied — others restored from
+                        // the manifest (double-applying would corrupt state).
                         #[cfg(feature = "state-tier")]
                         if !graph_restore_failed {
                             let cold_map = graph.take_tier_cold_vnodes();
@@ -1208,9 +1049,6 @@ impl LaminarDB {
                             }
                         }
 
-                        // Skip MV restore when operator state failed to load —
-                        // stale MV data with fresh operators is inconsistent.
-                        // No operator state at all (stateless pipeline) is fine.
                         if !graph_restore_failed {
                             let prefix = crate::mv_store::CHECKPOINT_KEY_PREFIX;
                             let mut store = self.mv_store.write();
@@ -1220,7 +1058,7 @@ impl LaminarDB {
                                     if let Some(bytes) = op.decode_inline() {
                                         match store.restore_from_ipc(name, &bytes) {
                                             Ok(true) => restored += 1,
-                                            Ok(false) => {} // MV no longer registered
+                                            Ok(false) => {}
                                             Err(e) => {
                                                 tracing::warn!(mv = name, error = %e, "MV restore failed");
                                             }
@@ -1249,8 +1087,6 @@ impl LaminarDB {
             }
         }
 
-        // Begin the initial epoch on exactly-once sinks AFTER recovery
-        // so the coordinator's epoch reflects the recovered checkpoint.
         {
             let guard = self.coordinator.lock().await;
             if let Some(ref coord) = *guard {
@@ -1258,7 +1094,6 @@ impl LaminarDB {
             }
         }
 
-        // Snapshot phase: populate tables before stream processing begins
         for (name, source, mode) in &mut table_sources {
             if matches!(mode, RefreshMode::Manual) {
                 continue;
@@ -1279,23 +1114,17 @@ impl LaminarDB {
                 ts.rebuild_xor_filter(name);
                 ts.set_ready(name, true);
             }
-            // Update lookup registry so join queries see fresh data.
-            // Skip if already registered as Versioned (temporal join tables
-            // must keep their version history, not be overwritten as Snapshot).
+            // Don't downgrade temporal join tables (Versioned) to Snapshot.
             if matches!(
                 self.lookup_registry.get_entry(name),
                 Some(laminar_sql::datafusion::RegisteredLookup::Versioned(_))
             ) {
-                // Already versioned — don't downgrade to Snapshot.
             } else if let Some(batch) = self.table_store.read().to_record_batch(name) {
                 self.lookup_registry
                     .register(name, laminar_sql::datafusion::LookupSnapshot { batch });
             }
         }
 
-        // On-demand (Manual) tables: register as Partial in the lookup
-        // registry so lookup joins use the lookup cache + source fallback path,
-        // then promote to SnapshotPlusCdc so poll_tables() calls poll_changes().
         for (name, _source, mode) in &mut table_sources {
             if !matches!(mode, RefreshMode::Manual) {
                 continue;
@@ -1303,7 +1132,6 @@ impl LaminarDB {
             let Some(reg) = table_regs.get(name.as_str()) else {
                 continue;
             };
-            // 64 MiB default budget; the cache is byte-weighted, not entry-counted.
             let capacity_bytes = reg.cache_max_bytes.unwrap_or(64 * 1024 * 1024);
             let Some(schema) = self.table_store.read().table_schema(name) else {
                 continue;
@@ -1331,8 +1159,6 @@ impl LaminarDB {
                     ttl: reg.cache_ttl,
                 },
             ));
-            // Try to create a lookup source for cache-miss fallback via
-            // the registry factory (no cross-crate type dependency).
             let lookup_source = if let Ok(mut config) = build_table_config(reg) {
                 config.set("_primary_key_columns", pk_csv.as_str());
                 match self
@@ -1354,8 +1180,6 @@ impl LaminarDB {
                 None
             };
 
-            // Projection pushdown: fetch only the columns any query references
-            // (a per-table superset, since the cache is shared), plus the key.
             let projection = crate::sql_analysis::compute_lookup_projection(
                 &schema,
                 &pk_cols,
@@ -1385,7 +1209,6 @@ impl LaminarDB {
             );
         }
 
-        // Get stream source handles so results also flow to db.subscribe().
         let mut stream_sources: Vec<(String, streaming::Source<crate::catalog::ArrowRecord>)> =
             Vec::new();
         for reg in stream_regs.values() {
@@ -1394,8 +1217,7 @@ impl LaminarDB {
             }
         }
 
-        // Per-source watermark state. Future-skew ceiling;
-        // `LAMINAR_MAX_FUTURE_SKEW_MS=0` disables it (legacy unbounded).
+        // `LAMINAR_MAX_FUTURE_SKEW_MS=0` disables the future-skew ceiling (legacy unbounded).
         let future_skew_ms = match std::env::var("LAMINAR_MAX_FUTURE_SKEW_MS") {
             Ok(v) => v.parse::<i64>().unwrap_or_else(|_| {
                 tracing::warn!(
@@ -1447,13 +1269,8 @@ impl LaminarDB {
             }
         }
 
-        // Fallback watermark path for sources that set `event_time_column`
-        // without an SQL `WATERMARK FOR` clause — exercised by the
-        // programmatic API (`handle.set_event_time_column`) and by the
-        // connector-property wiring above. Uses the bound from
-        // `source.max_out_of_orderness()` if one was wired from connector
-        // properties (e.g. Kafka `max.out.of.orderness.ms`), otherwise
-        // falls back to `Duration::ZERO`.
+        // Fallback watermark path for sources that use the programmatic API
+        // or connector properties instead of `WATERMARK FOR`.
         for name in self.catalog.list_sources() {
             if watermark_states.contains_key(&name) {
                 continue;
@@ -1493,9 +1310,7 @@ impl LaminarDB {
             }
         }
 
-        // Idle-source detection off by default (opt in via
-        // LAMINAR_SOURCE_IDLE_TIMEOUT_MS > 0, applied to all sources;
-        // unset/0/invalid ⇒ disabled). Tracker is per-source capable.
+        // LAMINAR_SOURCE_IDLE_TIMEOUT_MS > 0 enables idle-source detection; unset/0 = disabled.
         let idle_timeout_ms: Option<u64> = match std::env::var("LAMINAR_SOURCE_IDLE_TIMEOUT_MS") {
             Ok(v) => match v.parse::<u64>() {
                 Ok(0) => None,
@@ -1524,12 +1339,9 @@ impl LaminarDB {
             Some(t)
         };
 
-        // A pipeline with some watermarked and some un-watermarked sources
-        // is a semantic hazard: an un-watermarked source's per-stream
-        // watermark falls back to the global, so a join/window over both
-        // closes on the *watermarked* source's clock. Surface this so it
-        // isn't an invisible source of "where did my late rows go?"
-        // bug reports. The real fix needs planner-level rejection.
+        // Mixed watermarked/un-watermarked sources: un-watermarked ones inherit
+        // the global clock, so joins/windows close on the watermarked source's
+        // time. Surface the mismatch rather than silently dropping late rows.
         let registered = self.catalog.list_sources();
         let unwatermarked: Vec<&str> = registered
             .iter()
@@ -1548,10 +1360,6 @@ impl LaminarDB {
             );
         }
 
-        // Seed every restored generator and the combined tracker with the
-        // watermark captured at checkpoint time. Anything not in the
-        // recovered map (or `i64::MIN`) starts cold, which is correct for
-        // first-run / fresh sources.
         if !recovered_source_wms.is_empty() {
             let mut combined = i64::MIN;
             for (name, wm) in &recovered_source_wms {
@@ -1592,11 +1400,6 @@ impl LaminarDB {
             "Starting event-driven connector pipeline"
         );
 
-        // Build pipeline config.
-        // Embedded mode (no external connectors): zero batch window for
-        // minimal latency — data is processed as soon as it arrives.
-        // Connector mode: 5ms batch window amortizes SQL overhead across
-        // high-throughput external sources (Kafka, CDC).
         let drain_budget_ns = self.config.pipeline_drain_budget_ns.unwrap_or(1_000_000);
         let query_budget_ns = self.config.pipeline_query_budget_ns.unwrap_or(8_000_000);
         let pipeline_config = PipelineConfig {
@@ -1626,8 +1429,6 @@ impl LaminarDB {
                     std::time::Duration::from_millis,
                 ),
             delivery_guarantee: self.config.delivery_guarantee,
-            // cycle_budget is a soft cap for logging; ensure it's at least
-            // drain + query so sub-budgets can actually be used.
             cycle_budget_ns: 10_000_000_u64.max(drain_budget_ns + query_budget_ns),
             drain_budget_ns,
             query_budget_ns,
@@ -1637,7 +1438,6 @@ impl LaminarDB {
             backpressure_policy: self.config.pipeline_backpressure_policy,
         };
 
-        // Validate delivery guarantee constraints.
         {
             use laminar_connectors::connector::DeliveryGuarantee;
 
@@ -1682,11 +1482,9 @@ impl LaminarDB {
 
         let shutdown = self.shutdown_signal.clone();
 
-        // Build the PipelineCallback implementation that bridges to db.rs internals.
         let pipeline_watermark = Arc::clone(&self.pipeline_watermark);
         let coordinator = Arc::clone(&self.coordinator);
         let table_store_for_loop = self.table_store.clone();
-        // Compute a pipeline hash for change detection across checkpoints.
         let pipeline_hash = {
             use std::hash::{Hash, Hasher};
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -1703,7 +1501,6 @@ impl LaminarDB {
             Some(hasher.finish())
         };
 
-        // Wire per-query budget and input buffer cap from pipeline config.
         graph.set_query_budget_ns(pipeline_config.query_budget_ns);
         graph.set_max_input_buf_batches(pipeline_config.max_input_buf_batches);
         graph.set_max_input_buf_bytes(pipeline_config.max_input_buf_bytes);
@@ -1729,11 +1526,6 @@ impl LaminarDB {
             .clone()
             .expect("EngineMetrics must be set before start()");
 
-        // Force-checkpoint channel: `db.checkpoint()` on the caller side
-        // hands a oneshot sender across to the callback, which captures
-        // operator state and replies. Installed here so both ends exist
-        // before the compute thread spawns. Crossfire for consistency
-        // with the rest of the pipeline plumbing (sink_task, coordinator).
         let (force_ckpt_tx, force_ckpt_rx) = crossfire::mpsc::bounded_async::<
             crate::db::ForceCheckpointReply,
         >(crate::db::FORCE_CHECKPOINT_CHANNEL_CAPACITY);
@@ -1743,15 +1535,9 @@ impl LaminarDB {
             u64,
             rustc_hash::FxHashMap<String, laminar_connectors::checkpoint::SourceCheckpoint>,
         )>(16);
-        // Shared admission state: the callback claims a slot (and staged
-        // bytes) per in-flight epoch; the streaming coordinator gates new
-        // barriers on the caps. A single-open-transaction sink cannot
-        // overlap epochs, so depth is capped at 1 whenever ANY registered
-        // sink is exactly-once — not just when the pipeline-level
-        // guarantee says so. (DDL/server-configured sinks declare
-        // exactly-once via connector capabilities without ever setting
-        // the pipeline-level guarantee; keying off the pipeline config
-        // alone would pipeline epochs over an open Kafka transaction.)
+        // Cap in-flight epochs at 1 when any sink is exactly-once — DDL-configured
+        // sinks declare this via capabilities, not the pipeline-level guarantee,
+        // so checking capabilities guards against pipelining over an open transaction.
         let has_exactly_once_sink = sinks
             .iter()
             .any(|(_, handle, _, _, _)| handle.exactly_once());
@@ -1774,8 +1560,7 @@ impl LaminarDB {
                         Some(coord.epoch_allocator()),
                         cfg.quorum_timeout,
                         depth,
-                        // 0 would pause admission permanently.
-                        cfg.max_staged_bytes.max(1),
+                        cfg.max_staged_bytes.max(1), // 0 would pause admission permanently
                     )
                 }
                 None => (None, std::time::Duration::from_secs(3), 1, u64::MAX),
@@ -1855,12 +1640,7 @@ impl LaminarDB {
             state_tier: state_tier_sender,
         };
 
-        // Start the streaming coordinator on a dedicated compute thread.
-        // Source tasks were already spawned on the main tokio runtime in
-        // StreamingCoordinator::new(). The coordinator communicates with
-        // them via crossfire mpsc which works across runtimes.
         {
-            // Control channel for live DDL (add/drop stream).
             let (control_tx, control_rx) =
                 crossfire::mpsc::bounded_async::<crate::pipeline::ControlMsg>(64);
             *self.control_tx.lock() = Some(control_tx);
@@ -1910,7 +1690,7 @@ impl LaminarDB {
                             .or_else(|| panic.downcast_ref::<&str>().copied())
                             .unwrap_or("unknown");
                         tracing::error!(panic = msg, "laminar-compute thread panicked");
-                        // done_tx dropped → done_rx returns Err → logged by watcher task
+                        // done_tx dropped → done_rx returns Err, logged by the watcher
                         return;
                     }
                     done_tx.send(());
@@ -1923,7 +1703,6 @@ impl LaminarDB {
                 }
             }
 
-            // Wait for the thread to confirm the runtime started.
             match startup_rx.await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => return Err(DbError::Config(e)),
@@ -1953,7 +1732,7 @@ impl LaminarDB {
     ///
     /// # Errors
     ///
-    /// Returns an error if shutdown encounters an error.
+    /// Returns `Err` if the watcher task panicked.
     pub async fn shutdown(&self) -> Result<(), DbError> {
         if matches!(
             DbState::load(&self.state),
@@ -1964,8 +1743,6 @@ impl LaminarDB {
 
         DbState::ShuttingDown.store(&self.state);
 
-        // Drop the force-checkpoint sender first so any later db.checkpoint()
-        // errors cleanly instead of waiting on a oneshot that will never reply.
         *self.force_ckpt_tx.lock() = None;
 
         self.shutdown_signal.notify_one();
@@ -1990,14 +1767,9 @@ impl LaminarDB {
     /// Returns [`DbError::InvalidOperation`] if the pipeline is still starting
     /// or the coordinator does not exit within the stop timeout.
     pub async fn stop_pipeline(&self) -> Result<(), DbError> {
-        // Atomically claim the stop: only the caller that flips Running ->
-        // ShuttingDown tears down, so a concurrent stop can't race in and mark
-        // the pipeline restartable while the coordinator is still shutting down.
         match DbState::compare_exchange(DbState::Running, DbState::ShuttingDown, &self.state) {
             Ok(_) => {}
-            // Already stopped / never started — idempotent no-op.
             Err(DbState::Created | DbState::Stopped) => return Ok(()),
-            // Starting, or a stop is already in progress — refuse.
             Err(_) => {
                 return Err(DbError::InvalidOperation(
                     "cannot stop pipeline: not running (starting, or a stop already in progress)"
@@ -2006,19 +1778,16 @@ impl LaminarDB {
             }
         }
 
-        // Clear the force-checkpoint sender.
         *self.force_ckpt_tx.lock() = None;
 
         self.shutdown_signal.notify_one();
 
-        // Take runtime handle before awaiting.
         let handle = self.runtime_handle.lock().take();
         if let Some(handle) = handle {
             match tokio::time::timeout(std::time::Duration::from_secs(10), handle).await {
                 Ok(Ok(())) => tracing::info!("Pipeline stopped cleanly"),
                 Ok(Err(e)) => tracing::warn!(error = %e, "Pipeline task panicked during stop"),
                 Err(_) => {
-                    // Coordinator did not exit, keep state as ShuttingDown.
                     tracing::error!("Pipeline stop timed out after 10s; coordinator still running");
                     return Err(DbError::InvalidOperation(
                         "pipeline stop timed out; coordinator did not exit".into(),
@@ -2027,7 +1796,6 @@ impl LaminarDB {
             }
         }
 
-        // Drop control channel and reset state to allow restart.
         *self.control_tx.lock() = None;
         DbState::Created.store(&self.state);
         Ok(())

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -599,6 +599,67 @@ impl LaminarDB {
                 .unwrap_or_else(tokio::runtime::Handle::current),
         );
 
+        // Disk cold tier: when `state_tier_dir` is configured and the
+        // per-vnode capture path is live (cluster shuffle + state backend),
+        // open the tier, spawn its Ring-1 worker, and share the channel with
+        // the graph (promotion) and — below — the coordinator (forced-full
+        // re-uploads) and the callback (demotion trigger). Without the
+        // preconditions a set dir is a loud no-op, never silent data loss.
+        // `set_state_tier` must precede `add_query` so operators built below
+        // pick up the stored sender.
+        #[cfg(feature = "state-tier")]
+        let state_tier_sender: Option<
+            tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
+        > = {
+            match self.config.state_tier_dir.clone() {
+                Some(dir) => {
+                    let has_backend = self.state_backend.lock().is_some();
+                    let has_shuffle = graph.cluster_shuffle_config().is_some();
+                    if has_backend && has_shuffle {
+                        let handle = self
+                            .ai_handle
+                            .clone()
+                            .unwrap_or_else(tokio::runtime::Handle::current);
+                        let metrics = self.engine_metrics.lock().clone();
+                        match crate::state_tier::StateTierStore::open(&dir, metrics) {
+                            Ok(store) => {
+                                // The worker owns the only `Arc`; the store
+                                // lives until the pipeline's senders drop, then
+                                // wipes on the next restart (recovery replays
+                                // demoted vnodes from durable partials, so the
+                                // tier never needs to survive a restart).
+                                let sender =
+                                    crate::state_tier::spawn_worker(&handle, Arc::new(store), 256);
+                                graph.set_state_tier(sender.clone());
+                                tracing::info!(dir = %dir.display(), "state cold tier enabled");
+                                Some(sender)
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, dir = %dir.display(), "failed to open state cold tier — demotion disabled");
+                                None
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            has_backend,
+                            has_shuffle,
+                            "state_tier_dir set but cluster shuffle and/or state \
+                             backend missing — demotion disabled"
+                        );
+                        None
+                    }
+                }
+                None => None,
+            }
+        };
+        #[cfg(feature = "state-tier")]
+        if let Some(ref sender) = state_tier_sender {
+            let mut guard = self.coordinator.lock().await;
+            if let Some(ref mut coord) = *guard {
+                coord.set_state_tier(sender.clone());
+            }
+        }
+
         for reg in stream_regs.values() {
             graph.add_query(
                 reg.name.clone(),
@@ -1779,6 +1840,10 @@ impl LaminarDB {
                 .checked_sub(std::time::Duration::from_secs(3600))
                 .unwrap_or_else(std::time::Instant::now),
             state_budget_exceeded: false,
+            #[cfg(feature = "state-tier")]
+            state_tier: state_tier_sender,
+            #[cfg(feature = "state-tier")]
+            restorable_epoch: std::sync::atomic::AtomicU64::new(0),
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -608,9 +608,7 @@ impl LaminarDB {
         // `set_state_tier` must precede `add_query` so operators built below
         // pick up the stored sender.
         #[cfg(feature = "state-tier")]
-        let state_tier_sender: Option<
-            tokio::sync::mpsc::Sender<crate::state_tier::TierRequest>,
-        > = {
+        let state_tier_sender: Option<crate::state_tier::TierTx> = {
             match self.config.state_tier_dir.clone() {
                 Some(dir) => {
                     let has_backend = self.state_backend.lock().is_some();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -605,8 +605,8 @@ impl LaminarDB {
         // the graph (promotion) and — below — the coordinator (forced-full
         // re-uploads) and the callback (demotion trigger). Cluster mode already
         // installed a vnode count from the shuffle registry; a single node
-        // without a controller gets a fixed local count here, so the tier works
-        // without cluster row transport. The backend stays mandatory — it holds
+        // without a controller takes it from its vnode registry here, so the
+        // tier works without cluster row transport. The backend stays mandatory — it holds
         // the demoted truth that restart replays. A set dir without a backend is
         // a loud no-op, never silent data loss. `set_state_tier` must precede
         // `add_query` so operators built below pick up the stored sender.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -110,6 +110,76 @@ impl LaminarDB {
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Replay each operator's demoted vnodes from their durable partials on
+    /// restart (the cold tier itself is wiped, and the manifest blob carries
+    /// only resident vnodes). Best-effort: a missing or undecodable partial
+    /// logs and leaves that vnode empty — the same outcome as any lost
+    /// partial. Applies only the demoting operator's slice of each vnode so a
+    /// partial (which bundles every operator) does not double-apply operators
+    /// already recovered from the manifest.
+    #[cfg(feature = "state-tier")]
+    async fn rehydrate_cold_vnodes(
+        &self,
+        graph: &mut crate::operator_graph::OperatorGraph,
+        cold_map: &[(String, Vec<u32>)],
+    ) {
+        let Some(backend) = self.state_backend.lock().clone() else {
+            tracing::warn!(
+                "tier operators report demoted vnodes but no state backend is \
+                 wired — demoted state lost on restart"
+            );
+            return;
+        };
+        let mut all_cold: Vec<u32> = cold_map
+            .iter()
+            .flat_map(|(_, vs)| vs.iter().copied())
+            .collect();
+        all_cold.sort_unstable();
+        all_cold.dedup();
+        let rehy = crate::recovery_manager::VnodeRehydrator::new(backend.as_ref())
+            .rehydrate(&all_cold)
+            .await;
+
+        let (mut applied, mut lost) = (0usize, 0usize);
+        for (op_name, cold_vnodes) in cold_map {
+            for &v in cold_vnodes {
+                let Some(partial_bytes) = rehy.restored.get(&v) else {
+                    tracing::warn!(
+                        operator = %op_name, vnode = v,
+                        "demoted-vnode partial missing on restart — state lost"
+                    );
+                    lost += 1;
+                    continue;
+                };
+                let partial = match crate::vnode_partial::VnodePartial::decode(partial_bytes) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::warn!(vnode = v, error = %e, "demoted-vnode partial decode failed");
+                        lost += 1;
+                        continue;
+                    }
+                };
+                // The rehydrator resolves reference partials to their base, so
+                // `operators` is populated; an operator absent from it simply
+                // held no groups in this vnode.
+                if let Some((_, slice)) = partial.operators.iter().find(|(n, _)| n == op_name) {
+                    match graph.apply_vnode_slice(op_name, v, slice) {
+                        Ok(()) => applied += 1,
+                        Err(e) => {
+                            tracing::warn!(operator = %op_name, vnode = v, error = %e, "demoted-vnode apply failed");
+                            lost += 1;
+                        }
+                    }
+                }
+            }
+        }
+        tracing::info!(
+            applied,
+            lost,
+            "Rehydrated demoted vnodes from durable partials on restart"
+        );
+    }
+
     /// Returns `true` if the database has been shut down.
     pub fn is_closed(&self) -> bool {
         self.shutdown.load(std::sync::atomic::Ordering::Relaxed)
@@ -1049,6 +1119,21 @@ impl LaminarDB {
                                 "Found old stream_executor checkpoint format; \
                                  skipping restore (clean break). Starting fresh."
                             );
+                        }
+
+                        // Tier-capable operators keep only their resident
+                        // (hot) vnodes in the manifest blob; the cold tier is
+                        // wiped on restart, so replay each demoted vnode from
+                        // its durable partial. Only the demoting operator's
+                        // slice of each vnode is applied — the partial bundles
+                        // every operator, and the others already restored from
+                        // the manifest (double-applying would corrupt them).
+                        #[cfg(feature = "state-tier")]
+                        if !graph_restore_failed {
+                            let cold_map = graph.take_tier_cold_vnodes();
+                            if !cold_map.is_empty() {
+                                self.rehydrate_cold_vnodes(&mut graph, &cold_map).await;
+                            }
                         }
 
                         // Skip MV restore when operator state failed to load —

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1688,6 +1688,12 @@ impl LaminarDB {
             #[cfg(feature = "cluster")]
             quorum_timeout: ckpt_quorum_timeout,
             exactly_once_sinks: has_exactly_once_sink,
+            state_memory_budget_bytes: self.config.state_memory_budget_bytes,
+            // Backdated so the first cycle probes immediately.
+            state_budget_probe_at: std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(3600))
+                .unwrap_or_else(std::time::Instant::now),
+            state_budget_exceeded: false,
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -111,24 +111,23 @@ impl LaminarDB {
     }
 
     /// Replay each operator's demoted vnodes from their durable partials on
-    /// restart (the cold tier itself is wiped, and the manifest blob carries
-    /// only resident vnodes). Best-effort: a missing or undecodable partial
-    /// logs and leaves that vnode empty — the same outcome as any lost
-    /// partial. Applies only the demoting operator's slice of each vnode so a
-    /// partial (which bundles every operator) does not double-apply operators
-    /// already recovered from the manifest.
+    /// restart (the cold tier is wiped; the manifest holds only resident
+    /// vnodes). Applies only the demoting operator's slice of each vnode.
+    ///
+    /// Fails loud on any unrecoverable vnode: offsets are already staged, so
+    /// resuming with it empty would silently corrupt that aggregate.
     #[cfg(feature = "state-tier")]
     async fn rehydrate_cold_vnodes(
         &self,
         graph: &mut crate::operator_graph::OperatorGraph,
         cold_map: &[(String, Vec<u32>)],
-    ) {
+    ) -> Result<(), DbError> {
         let Some(backend) = self.state_backend.lock().clone() else {
-            tracing::warn!(
-                "tier operators report demoted vnodes but no state backend is \
-                 wired — demoted state lost on restart"
-            );
-            return;
+            return Err(DbError::Checkpoint(
+                "[LDB-6030] demoted vnodes recorded but no state backend is \
+                 wired — cannot recover them on restart"
+                    .to_string(),
+            ));
         };
         let mut all_cold: Vec<u32> = cold_map
             .iter()
@@ -144,40 +143,39 @@ impl LaminarDB {
         for (op_name, cold_vnodes) in cold_map {
             for &v in cold_vnodes {
                 let Some(partial_bytes) = rehy.restored.get(&v) else {
-                    tracing::warn!(
-                        operator = %op_name, vnode = v,
-                        "demoted-vnode partial missing on restart — state lost"
-                    );
+                    tracing::error!(operator = %op_name, vnode = v, "demoted-vnode partial missing on restart");
                     lost += 1;
                     continue;
                 };
                 let partial = match crate::vnode_partial::VnodePartial::decode(partial_bytes) {
                     Ok(p) => p,
                     Err(e) => {
-                        tracing::warn!(vnode = v, error = %e, "demoted-vnode partial decode failed");
+                        tracing::error!(operator = %op_name, vnode = v, error = %e, "demoted-vnode partial decode failed");
                         lost += 1;
                         continue;
                     }
                 };
-                // The rehydrator resolves reference partials to their base, so
-                // `operators` is populated; an operator absent from it simply
-                // held no groups in this vnode.
+                // Operator absent from the partial held no groups in this vnode.
                 if let Some((_, slice)) = partial.operators.iter().find(|(n, _)| n == op_name) {
                     match graph.apply_vnode_slice(op_name, v, slice) {
                         Ok(()) => applied += 1,
                         Err(e) => {
-                            tracing::warn!(operator = %op_name, vnode = v, error = %e, "demoted-vnode apply failed");
+                            tracing::error!(operator = %op_name, vnode = v, error = %e, "demoted-vnode apply failed");
                             lost += 1;
                         }
                     }
                 }
             }
         }
-        tracing::info!(
-            applied,
-            lost,
-            "Rehydrated demoted vnodes from durable partials on restart"
-        );
+        if lost > 0 {
+            return Err(DbError::Checkpoint(format!(
+                "[LDB-6030] {lost} demoted vnode slice(s) unrecoverable on restart \
+                 — refusing to start with staged source offsets and lost state \
+                 (see per-vnode errors above)"
+            )));
+        }
+        tracing::info!(applied, "rehydrated demoted vnodes from durable partials");
+        Ok(())
     }
 
     /// Returns `true` if the database has been shut down.
@@ -1206,7 +1204,7 @@ impl LaminarDB {
                         if !graph_restore_failed {
                             let cold_map = graph.take_tier_cold_vnodes();
                             if !cold_map.is_empty() {
-                                self.rehydrate_cold_vnodes(&mut graph, &cold_map).await;
+                                self.rehydrate_cold_vnodes(&mut graph, &cold_map).await?;
                             }
                         }
 

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1840,8 +1840,6 @@ impl LaminarDB {
             state_budget_exceeded: false,
             #[cfg(feature = "state-tier")]
             state_tier: state_tier_sender,
-            #[cfg(feature = "state-tier")]
-            restorable_epoch: std::sync::atomic::AtomicU64::new(0),
         };
 
         // Start the streaming coordinator on a dedicated compute thread.

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1114,11 +1114,16 @@ impl LaminarDB {
                 ts.rebuild_xor_filter(name);
                 ts.set_ready(name, true);
             }
-            // Don't downgrade temporal join tables (Versioned) to Snapshot.
-            if matches!(
-                self.lookup_registry.get_entry(name),
-                Some(laminar_sql::datafusion::RegisteredLookup::Versioned(_))
-            ) {
+            // Setup built the Versioned (temporal-join) state before the
+            // snapshot existed; rebuild it over the snapshot now instead of
+            // downgrading it to a plain Snapshot.
+            let entry = self.lookup_registry.get_entry(name);
+            if let Some(laminar_sql::datafusion::RegisteredLookup::Versioned(v)) = &entry {
+                if let Some(batch) = self.table_store.read().to_record_batch(name) {
+                    if let Some(state) = crate::pipeline_callback::rebuild_versioned_state(v, batch) {
+                        self.lookup_registry.register_versioned(name, state);
+                    }
+                }
             } else if let Some(batch) = self.table_store.read().to_record_batch(name) {
                 self.lookup_registry
                     .register(name, laminar_sql::datafusion::LookupSnapshot { batch });

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -66,10 +66,7 @@ impl RebalanceConfig {
     }
 }
 
-/// Surface the rehydration outcome of an adopted snapshot. A node that
-/// gained vnodes pulled their last committed state off the shared backend
-/// in [`LaminarDB::adopt_assignment_snapshot`]; log what moved so operators
-/// have an audit trail of every rebalance-driven state transfer.
+/// Log what moved so there's an audit trail of every rebalance-driven state transfer.
 fn log_adoption(source: &str, adoption: &SnapshotAdoption) {
     if adoption.newly_acquired.is_empty() {
         return;
@@ -127,7 +124,6 @@ pub fn spawn_snapshot_watcher(
                 }
             }
 
-            // Refresh placement metrics only when the assignment changed.
             let version = registry.assignment_version();
             if version != published_version {
                 published_version = version;
@@ -145,8 +141,7 @@ pub fn spawn_snapshot_watcher(
     })
 }
 
-/// Publish per-domain owner counts and the blast-radius ratio. The gauge vector
-/// is reset so domains that disappear don't leave stale series.
+/// Publish per-domain owner counts. Resets the gauge so disappeared domains don't leave stale series.
 #[allow(clippy::cast_precision_loss)]
 fn publish_placement_metrics(
     metrics: &EngineMetrics,
@@ -202,7 +197,6 @@ pub fn spawn_rebalance_controller(
             }
             debug!("membership change observed; debouncing");
 
-            // Debounce: absorb further churn before acting.
             loop {
                 tokio::select! {
                     biased;
@@ -219,18 +213,12 @@ pub fn spawn_rebalance_controller(
                 }
             }
 
-            // Retry transient failures so a single hiccup doesn't
-            // leave the cluster on a stale assignment.
             loop {
                 if !controller.is_leader() {
                     debug!("membership changed; not the leader — skipping rotation check");
                     break;
                 }
-                // Use assignable (Active, non-draining) instances so
-                // Draining/Suspected nodes are never handed vnodes. The
-                // weak leader gate above still uses live membership;
-                // `LeaderLeaseManager` is the fencing authority for split-
-                // brain hardening (kept standalone, see leader_lease.rs).
+                // Assignable = Active, non-draining — Draining/Suspected nodes never receive vnodes.
                 let live = controller.assignable_instances();
                 match try_rebalance(&db, &controller, &store, &registry, &live, config).await {
                     Ok(Some(v)) => {
@@ -288,8 +276,6 @@ pub async fn wait_until_drained(
     }
 }
 
-/// `Ok(Some(version))` on rotation (ours or a peer's), `Ok(None)` if
-/// no change is needed.
 async fn try_rebalance(
     db: &Arc<LaminarDB>,
     controller: &Arc<ClusterController>,
@@ -298,9 +284,7 @@ async fn try_rebalance(
     live: &[NodeId],
     config: RebalanceConfig,
 ) -> Result<Option<u64>, String> {
-    // No assignable instances (whole cluster draining/joining) — nothing to
-    // rotate to. Hold the current assignment rather than panicking the
-    // placement call on an empty node set.
+    // Whole cluster draining — hold the current assignment rather than panicking on an empty node set.
     if live.is_empty() {
         return Ok(None);
     }
@@ -317,21 +301,11 @@ async fn try_rebalance(
         return Ok(None);
     }
 
-    // Drain in-flight shuffle rows into durable state at the old
-    // fence version before rotating. When the rotation sheds a DEAD
-    // node, skip the drain entirely: its durability gate needs captures
-    // from a node that will never provide them, so it can only burn its
-    // full timeout and abort — deadlocking rotation against the gate
-    // when rotation is the only thing that restores commit
-    // availability. The dead node's in-flight rows are unrecoverable
-    // regardless; survivors rehydrate its vnodes from the last
-    // committed epoch — the same at-least-once duplication window every
-    // ungraceful failover already has.
-    //
-    // "Dead" must be judged from MEMBERSHIP, not the assignable set:
-    // a Draining node is excluded from assignment but is alive and can
-    // checkpoint — its graceful handoff depends on this drain sealing
-    // its in-flight rows before the rotation takes its vnodes.
+    // When shedding a dead node, skip the pre-rotation drain: the dead node can't provide captures,
+    // so the durability gate would time out and deadlock against rotation — which is the only thing
+    // that restores commit availability. Survivors rehydrate from the last committed epoch.
+    // "Dead" is from MEMBERSHIP, not the assignable set: a Draining node is alive and must drain
+    // before rotation takes its vnodes.
     let shedding_dead = {
         use laminar_core::cluster::discovery::NodeState;
         let owners = current.to_vnode_vec(registry.vnode_count());
@@ -377,8 +351,7 @@ async fn try_rebalance(
             let adoption = db.adopt_assignment_snapshot(proposal).await;
             log_adoption("rebalance", &adoption);
             controller.announce_snapshot_version(v).await;
-            // Keep the current plus one prior as slack for in-flight
-            // readers — `prune_before(v - 1)` retains `[v-1, v]`.
+            // Retain [v-1, v] as slack for in-flight readers.
             let prune = v.saturating_sub(1);
             if let Err(e) = store.prune_before(prune).await {
                 warn!(error = %e, "snapshot prune failed");

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -1,26 +1,5 @@
-//! Unified recovery manager.
-//!
-//! Single recovery path that loads a
-//! [`CheckpointManifest`](laminar_core::storage::checkpoint_manifest::CheckpointManifest) and restores
-//! ALL state: source offsets, sink epochs, operator states, table offsets,
-//! and watermarks.
-//!
-//! ## Recovery Protocol
-//!
-//! 1. `store.load_latest()` → `Option<CheckpointManifest>`
-//! 2. If `None` → fresh start (no recovery needed)
-//! 3. For each source: `source.restore(manifest.source_offsets[name])`
-//! 4. For each table source: `source.restore(manifest.table_offsets[name])`
-//! 5. For each exactly-once sink: `sink.rollback_epoch(manifest.epoch)`
-//! 6. Return recovered state (watermark, epoch, operator states)
-//!    — caller is responsible for restoring DAG/TPC operators from `operator_states`
-//!
-//! ## Fallback Recovery
-//!
-//! If the latest checkpoint is corrupt or fails to restore, the manager
-//! iterates through all available checkpoints in reverse chronological order
-//! until one succeeds. This prevents a single corrupt checkpoint from causing
-//! total data loss.
+//! Checkpoint recovery: loads the latest manifest and restores sources, sinks,
+//! and operator state. Falls back to older checkpoints if the latest is corrupt.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -40,7 +19,7 @@ use crate::error::DbError;
 /// Result of a successful recovery from a checkpoint.
 #[derive(Debug)]
 pub struct RecoveredState {
-    /// The manifest that was loaded and restored from.
+    /// Manifest that was restored from.
     pub manifest: CheckpointManifest,
     /// Number of sources successfully restored.
     pub sources_restored: usize,
@@ -67,13 +46,13 @@ impl RecoveredState {
         self.manifest.watermark
     }
 
-    /// Returns whether there were any errors during recovery.
+    /// Returns `true` if any source or sink failed during recovery.
     #[must_use]
     pub fn has_errors(&self) -> bool {
         !self.source_errors.is_empty() || !self.sink_errors.is_empty()
     }
 
-    /// Returns the recovered operator states (for DAG restoration).
+    /// Returns the recovered operator states.
     #[must_use]
     pub fn operator_states(
         &self,
@@ -81,7 +60,7 @@ impl RecoveredState {
         &self.manifest.operator_states
     }
 
-    /// Returns the table store checkpoint path, if any.
+    /// Table store checkpoint path, if recorded in the manifest.
     #[must_use]
     pub fn table_store_checkpoint_path(&self) -> Option<&str> {
         self.manifest.table_store_checkpoint_path.as_deref()
@@ -90,56 +69,44 @@ impl RecoveredState {
 
 /// Outcome of rehydrating a set of vnodes from durable state.
 ///
-/// Best-effort by construction: a per-vnode read failure is recorded in
-/// [`errors`](Self::errors) rather than aborting the others, so a single
-/// transient object-store hiccup can't strand an entire rebalance.
+/// Per-vnode read failures land in `errors` rather than aborting the rest, so
+/// a transient object-store hiccup can't strand an entire rebalance.
 #[derive(Debug, Default)]
 pub struct VnodeRehydration {
-    /// Committed epoch the partials were read from. `None` when the
-    /// backend reported no committed epoch (every requested vnode is
-    /// treated as a fresh start).
+    /// Committed epoch the partials were read from. `None` when the backend
+    /// has no committed epoch — every vnode starts fresh.
     pub epoch: Option<u64>,
-    /// vnode → restored partial bytes, for vnodes that had durable state
-    /// at [`epoch`](Self::epoch).
+    /// vnode → restored partial bytes at `epoch`.
     pub restored: HashMap<u32, Bytes>,
-    /// Requested vnodes with no durable partial — never written, or
-    /// pruned below the committed epoch. These resume from empty state.
+    /// Vnodes with no durable partial at `epoch`; resume from empty state.
     pub missing: Vec<u32>,
-    /// vnode → error message for reads that failed.
+    /// vnode → error for reads that failed.
     pub errors: HashMap<u32, String>,
 }
 
 impl VnodeRehydration {
-    /// Number of vnodes whose state was successfully read back.
+    /// Number of vnodes successfully read back.
     #[must_use]
     pub fn restored_count(&self) -> usize {
         self.restored.len()
     }
 
-    /// Whether any per-vnode read failed.
+    /// Returns `true` if any per-vnode read failed.
     #[must_use]
     pub fn has_errors(&self) -> bool {
         !self.errors.is_empty()
     }
 }
 
-/// Reads committed per-vnode partial state from a durable
-/// [`StateBackend`] so a node that newly acquires vnodes during a
-/// rebalance resumes from the last committed epoch instead of empty
-/// state.
-///
-/// This is the read half of the rehydration life cycle: it resolves the
-/// highest committed epoch once via
-/// [`StateBackend::latest_committed_epoch`] and pulls each vnode's
-/// `partial.bin` at that epoch. Applying the bytes into live operators is
-/// the caller's responsibility (operators that adopt the per-vnode state
-/// backend consume the staged blobs on their next cycle).
+/// Reads the latest committed `partial.bin` for each requested vnode so a
+/// newly-acquired node resumes from the last committed epoch rather than
+/// empty state. Applying the bytes is the caller's responsibility.
 pub struct VnodeRehydrator<'a> {
     backend: &'a dyn StateBackend,
 }
 
 impl<'a> VnodeRehydrator<'a> {
-    /// Wrap the durable backend the partials live on.
+    /// Create a rehydrator over `backend`.
     #[must_use]
     pub fn new(backend: &'a dyn StateBackend) -> Self {
         Self { backend }
@@ -147,11 +114,10 @@ impl<'a> VnodeRehydrator<'a> {
 
     /// Read the latest committed partial for each vnode in `vnodes`.
     ///
-    /// Resolves the highest committed epoch once, then reads each
-    /// vnode's `partial.bin` at that epoch. Best-effort: a read failure
-    /// for one vnode is recorded in [`VnodeRehydration::errors`] and does
-    /// not abort the rest. Returns an empty report (with `epoch = None`,
-    /// every vnode in `missing`) when the store has no committed epoch.
+    /// Resolves the highest committed epoch once, then reads each vnode's
+    /// `partial.bin` at that epoch. A per-vnode failure is recorded in
+    /// [`VnodeRehydration::errors`] without aborting the rest. Returns an
+    /// empty report when the store has no committed epoch.
     pub async fn rehydrate(&self, vnodes: &[u32]) -> VnodeRehydration {
         let mut report = VnodeRehydration::default();
         if vnodes.is_empty() {
@@ -183,11 +149,9 @@ impl<'a> VnodeRehydrator<'a> {
         for &vnode in vnodes {
             match self.backend.read_partial(vnode, epoch).await {
                 Ok(Some(bytes)) => {
-                    // An unchanged-vnode partial is a reference to the
-                    // epoch of its last full upload —
-                    // follow the single hop to the real state. A blob
-                    // that doesn't decode is handed through unchanged
-                    // (the apply path skips undecodable partials).
+                    // An unchanged-vnode partial is a reference to its last full
+                    // upload — follow the single hop. An undecodable blob passes
+                    // through unchanged (the apply path skips it).
                     let bytes = match crate::vnode_partial::VnodePartial::decode(&bytes) {
                         Ok(p) => match p.base_epoch {
                             Some(base) => match self.backend.read_partial(vnode, base).await {
@@ -254,25 +218,18 @@ impl<'a> VnodeRehydrator<'a> {
     }
 }
 
-/// Recovery manager.
-///
-/// Loads the latest [`CheckpointManifest`] from a [`CheckpointStore`] and
-/// restores all registered sources, sinks, and tables to their checkpointed
-/// state.
+/// Loads the latest [`CheckpointManifest`] and restores sources, sinks, and
+/// tables. In strict mode any restore failure aborts and triggers fallback; in
+/// lenient mode failures are recorded and recovery continues.
 pub struct RecoveryManager<'a> {
     store: &'a dyn CheckpointStore,
-    /// When true, any source/sink restore failure aborts the entire recovery.
-    /// When false (default), failures are logged and recorded in `RecoveredState`
-    /// but recovery continues — the pipeline resumes with potentially
-    /// mismatched offsets.
     strict: bool,
 }
 
 impl<'a> RecoveryManager<'a> {
-    /// Creates a new recovery manager using the given checkpoint store.
+    /// Create a strict recovery manager (any restore failure triggers fallback).
     ///
-    /// Defaults to strict mode: any source/sink restore failure aborts
-    /// the entire recovery. Use [`Self::lenient`] to allow partial recovery.
+    /// Use [`Self::lenient`] to allow partial recovery.
     #[must_use]
     pub fn new(store: &'a dyn CheckpointStore) -> Self {
         Self {
@@ -281,11 +238,10 @@ impl<'a> RecoveryManager<'a> {
         }
     }
 
-    /// Creates a lenient recovery manager.
+    /// Create a lenient recovery manager.
     ///
-    /// In lenient mode, source/sink restore failures are logged and
-    /// recorded in `RecoveredState` but do not abort recovery. The
-    /// pipeline resumes with potentially mismatched offsets.
+    /// Restore failures are recorded in `RecoveredState` but do not abort
+    /// recovery; the pipeline resumes with potentially mismatched offsets.
     #[must_use]
     pub fn lenient(store: &'a dyn CheckpointStore) -> Self {
         Self {
@@ -294,27 +250,14 @@ impl<'a> RecoveryManager<'a> {
         }
     }
 
-    /// Attempts to recover from the latest checkpoint, with fallback to older
-    /// checkpoints if the latest is corrupt or fails to restore.
+    /// Recover from the latest checkpoint, falling back to older ones on failure.
     ///
-    /// Returns `Ok(None)` if no checkpoint exists (fresh start).
-    /// Returns `Ok(Some(RecoveredState))` on successful recovery.
-    ///
-    /// Recovery is best-effort: individual source/sink failures are recorded
-    /// in `RecoveredState` but do not abort the entire recovery. This allows
-    /// partial recovery (e.g., one source fails to seek but others succeed).
-    ///
-    /// ## Fallback Behavior
-    ///
-    /// If the latest checkpoint fails (corrupt manifest, deserialization error),
-    /// the manager iterates through all available checkpoints in reverse
-    /// chronological order until one succeeds or all are exhausted. This
-    /// prevents a single corrupt checkpoint from causing total data loss.
+    /// Returns `Ok(None)` for a fresh start (no checkpoint found).
     ///
     /// # Errors
     ///
-    /// Returns `DbError::Checkpoint` if the checkpoint store fails, or
-    /// in strict mode, if any source/sink restore fails.
+    /// Returns `DbError::Checkpoint` if the store fails or strict-mode
+    /// restore errors exhaust all available checkpoints.
     pub(crate) async fn recover(
         &self,
         sources: &[RegisteredSource],
@@ -416,16 +359,10 @@ impl<'a> RecoveryManager<'a> {
         Ok(None)
     }
 
-    /// Resolves external operator states by loading the sidecar file.
+    /// Resolve external operator states from the sidecar file into inline entries.
     ///
-    /// For any operator state marked as `external`, loads the corresponding
-    /// bytes from `state.bin` and replaces it with an inline entry. This
-    /// makes the rest of recovery code work uniformly with inline state.
-    ///
-    /// Returns `true` if all external states were resolved successfully.
-    /// Returns `false` if any state could not be resolved (missing sidecar,
-    /// truncated sidecar, or I/O error). In strict mode, the caller should
-    /// treat a `false` return as a corrupt checkpoint and try fallback.
+    /// Returns `true` if all resolved successfully; `false` on missing/truncated
+    /// sidecar. In strict mode the caller treats `false` as corruption.
     async fn resolve_external_states(&self, manifest: &mut CheckpointManifest) -> bool {
         let external_ops: Vec<String> = manifest
             .operator_states
@@ -463,9 +400,7 @@ impl<'a> RecoveryManager<'a> {
                 error!(
                     checkpoint_id = manifest.checkpoint_id,
                     error = %e,
-                    operators = ?external_ops,
-                    "[LDB-6010] failed to load sidecar state.bin — external operator states \
-                     cannot be resolved; operators will start with empty state"
+                    "[LDB-6010] failed to load sidecar state.bin"
                 );
                 for name in &external_ops {
                     if let Some(op) = manifest.operator_states.get_mut(name) {
@@ -482,9 +417,7 @@ impl<'a> RecoveryManager<'a> {
         let mut all_resolved = true;
         for (name, op) in &mut manifest.operator_states {
             if op.external {
-                // `external_offset`/`external_length` are u64 from the on-disk
-                // manifest; use checked arithmetic so a corrupt/tampered
-                // manifest can't overflow past the length check.
+                // Checked arithmetic: a corrupt manifest can't overflow the length check.
                 let range = match (
                     usize::try_from(op.external_offset),
                     usize::try_from(op.external_length),
@@ -525,10 +458,7 @@ impl<'a> RecoveryManager<'a> {
         all_resolved
     }
 
-    /// Restores pipeline state from a loaded manifest.
-    ///
-    /// This is the inner restore logic shared by both the fast path
-    /// (latest checkpoint) and fallback path (older checkpoints).
+    /// Inner restore logic shared by the fast path and the fallback loop.
     #[allow(clippy::too_many_lines)]
     async fn restore_from(
         &self,
@@ -537,9 +467,7 @@ impl<'a> RecoveryManager<'a> {
         sinks: &[RegisteredSink],
         table_sources: &[RegisteredSource],
     ) -> RecoveredState {
-        // Resolve external operator states from sidecar before recovery.
-        // In strict mode, unresolved sidecar state is recorded as a source
-        // error so check_strict() will reject this checkpoint.
+        // In strict mode an unresolved sidecar is recorded so check_strict() rejects this checkpoint.
         let sidecar_ok = self.resolve_external_states(&mut manifest).await;
         if !sidecar_ok && self.strict {
             warn!(
@@ -549,9 +477,7 @@ impl<'a> RecoveryManager<'a> {
             );
         }
 
-        // Validate manifest consistency before restoring state.
-        // `DEFAULT_VNODE_COUNT` is a placeholder; the runtime
-        // `VnodeRegistry` value is not threaded through recovery yet.
+        // DEFAULT_VNODE_COUNT is a placeholder; the runtime registry isn't threaded here yet.
         let validation_errors =
             manifest.validate(laminar_core::storage::checkpoint_manifest::DEFAULT_VNODE_COUNT);
         if !validation_errors.is_empty() {
@@ -564,8 +490,7 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Topology drift detection: compare current sources/sinks against
-        // the checkpoint to warn the operator about changes.
+        // Warn about topology changes since the checkpoint.
         if !manifest.source_names.is_empty() {
             let mut current_sources: Vec<&str> = sources.iter().map(|s| s.name.as_str()).collect();
             current_sources.sort_unstable();
@@ -635,7 +560,6 @@ impl<'a> RecoveryManager<'a> {
             sink_errors: HashMap::new(),
         };
 
-        // Record sidecar failure so check_strict() rejects this checkpoint.
         if !sidecar_ok {
             result.source_errors.insert(
                 "__sidecar__".into(),
@@ -645,7 +569,6 @@ impl<'a> RecoveryManager<'a> {
             );
         }
 
-        // Restore source offsets.
         for source in sources {
             if !source.supports_replay {
                 info!(
@@ -687,7 +610,6 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Restore table source offsets.
         for table_source in table_sources {
             if let Some(cp) = manifest.table_offsets.get(&table_source.name) {
                 let source_cp = connector_to_source_checkpoint(cp);
@@ -706,11 +628,9 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Roll back exactly-once sinks that did NOT commit (Pending or Failed).
-        // Already-Committed sinks are left alone.
+        // Roll back exactly-once sinks that did not commit. Committed sinks are left alone.
         for sink in sinks {
             if sink.exactly_once {
-                // Check per-sink commit status — if the sink committed, skip rollback.
                 let already_committed = manifest
                     .sink_commit_statuses
                     .get(&sink.name)
@@ -758,25 +678,12 @@ impl<'a> RecoveryManager<'a> {
         result
     }
 
-    /// Checks whether a checkpoint's sidecar data is corrupt.
-    ///
-    /// Returns `true` if the checkpoint has a `state_checksum` and
-    /// [`CheckpointStore::validate_checkpoint`] reports a checksum mismatch
-    /// or missing sidecar. Returns `false` if there is no sidecar, or
-    /// if the sidecar is valid, or if validation I/O fails (we proceed
-    /// with caution rather than blocking recovery).
     /// Returns `true` if the checkpoint fails integrity validation.
     ///
-    /// Checks both sidecar checksum and manifest validity. Any validation
-    /// failure (sidecar corruption, missing data, or manifest issues like
-    /// epoch=0) causes the checkpoint to be rejected so fallback can try
-    /// an older one.
-    ///
-    /// Only returns `false` (proceed) when validation passes OR when the
-    /// checkpoint has no sidecar to validate.
+    /// I/O errors during validation are treated as corruption — if the sidecar
+    /// can't be verified, don't trust the checkpoint. Returns `false` when there
+    /// is nothing to validate (no sidecar, no state checksum).
     async fn is_checkpoint_corrupt(&self, manifest: &CheckpointManifest) -> bool {
-        // No sidecar and no state_checksum → nothing to validate beyond
-        // manifest parsing (which already succeeded if we got here).
         if manifest.state_checksum.is_none() && manifest.operator_states.is_empty() {
             return false;
         }
@@ -795,8 +702,6 @@ impl<'a> RecoveryManager<'a> {
             }
             Ok(_) => false, // valid
             Err(e) => {
-                // I/O errors during validation are treated as corruption —
-                // if we can't verify the checkpoint, don't trust it.
                 error!(
                     checkpoint_id = manifest.checkpoint_id,
                     error = %e,
@@ -808,12 +713,10 @@ impl<'a> RecoveryManager<'a> {
         }
     }
 
-    /// In strict mode, returns an error if any source or sink had restore failures.
-    /// Returns true if any exactly-once sink has Pending commit status.
+    /// Returns `true` if any exactly-once sink has `Pending` commit status.
     ///
-    /// A checkpoint with Pending sinks was persisted before sink commit
-    /// completed. Recovering from it would advance source offsets past
-    /// data the sinks never received — causing silent data loss.
+    /// A Pending sink means the manifest was persisted before commit finished;
+    /// recovering from it advances source offsets past data the sink never wrote.
     fn has_pending_sinks(manifest: &CheckpointManifest) -> bool {
         manifest
             .sink_commit_statuses
@@ -840,9 +743,7 @@ impl<'a> RecoveryManager<'a> {
         )))
     }
 
-    /// Loads the latest manifest without performing recovery.
-    ///
-    /// Useful for inspecting checkpoint state or building a recovery plan.
+    /// Load the latest manifest without restoring state.
     ///
     /// # Errors
     ///
@@ -851,7 +752,7 @@ impl<'a> RecoveryManager<'a> {
         self.store.load_latest().await.map_err(DbError::from)
     }
 
-    /// Loads a specific checkpoint by ID.
+    /// Load a checkpoint by ID.
     ///
     /// # Errors
     ///

--- a/crates/laminar-db/src/retractable_accumulator.rs
+++ b/crates/laminar-db/src/retractable_accumulator.rs
@@ -1,23 +1,5 @@
-//! Weight-aware accumulators for Z-set changelog aggregation.
-//!
-//! When aggregating over a changelog stream (one with a `__weight` column),
-//! standard `DataFusion` accumulators produce incorrect results because they
-//! are purely additive — they have no concept of retraction.
-//!
-//! This module provides [`datafusion_expr::Accumulator`] implementations that
-//! receive the weight as the **last element** of `update_batch` inputs and
-//! handle retraction internally.
-//!
-//! # Supported aggregates
-//!
-//! | Function | Strategy | State | Retract |
-//! |----------|----------|-------|---------|
-//! | SUM | `SUM(value * weight)` | `(sum, count)` | O(1) |
-//! | COUNT(\*) | `SUM(weight)` | `count` | O(1) |
-//! | COUNT(col) | `SUM(weight)` where col IS NOT NULL | `count` | O(1) |
-//! | AVG | `SUM(value * weight) / SUM(weight)` | `(sum, wt_sum)` | O(1) |
-//! | MIN | Counted multiset, result = first key | `BTreeMap` | O(log n) |
-//! | MAX | Counted multiset, result = last key | `BTreeMap` | O(log n) |
+//! `DataFusion` accumulators that understand Z-set weights (`__weight` column, last in `update_batch`).
+//! SUM/COUNT/AVG retract in O(1); MIN/MAX use a counted multiset (`BTreeMap`) in O(log n).
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -30,10 +12,8 @@ use datafusion_expr::Accumulator;
 
 use crate::error::DbError;
 
-/// Extract `i64` weights from the last array in the inputs slice.
-/// Returns an error rather than panicking if the contract is violated
-/// (empty input, wrong dtype) — the upstream is internal but a corrupt
-/// checkpoint or hand-rolled CDC source must not crash the engine task.
+/// Extracts `__weight` (last input column) as `Int64Array`. Errors instead of panicking
+/// so a corrupt checkpoint or hand-rolled CDC source can't crash the engine task.
 fn weight_array(values: &[ArrayRef]) -> datafusion_common::Result<&arrow::array::Int64Array> {
     let last = values.last().ok_or_else(|| {
         datafusion_common::DataFusionError::Internal(
@@ -50,7 +30,6 @@ fn weight_array(values: &[ArrayRef]) -> datafusion_common::Result<&arrow::array:
         })
 }
 
-/// Cast a numeric array element at `row` to `f64`.
 fn to_f64(arr: &ArrayRef, row: usize) -> Option<f64> {
     if arr.is_null(row) {
         return None;
@@ -101,7 +80,6 @@ fn to_f64(arr: &ArrayRef, row: usize) -> Option<f64> {
     }
 }
 
-/// Convert an `f64` value back to the target `ScalarValue` type.
 #[allow(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
@@ -122,11 +100,11 @@ fn f64_to_scalar(v: f64, dt: &DataType) -> ScalarValue {
     }
 }
 
-/// Create a retractable accumulator for the given aggregate function name.
+/// Create a retractable accumulator for the named aggregate function.
 ///
-/// Returns `Ok(accumulator)` for supported functions, or `Err` for unsupported.
-/// The `return_type` is the expected output data type (used for casting on
-/// evaluate).
+/// # Errors
+///
+/// Returns `DbError::Pipeline` for unsupported function names.
 pub(crate) fn create_retractable(
     func_name: &str,
     return_type: &DataType,
@@ -157,13 +135,6 @@ pub(crate) fn create_retractable(
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// SUM
-// ═══════════════════════════════════════════════════════════════════
-
-/// Read an integer-typed value as `i128` (covers Int8/16/32/64,
-/// UInt8/16/32/64, and Decimal128). Returns `None` for nulls or
-/// non-integer types.
 fn read_i128(arr: &ArrayRef, row: usize) -> Option<i128> {
     if arr.is_null(row) {
         return None;
@@ -204,9 +175,7 @@ fn read_i128(arr: &ArrayRef, row: usize) -> Option<i128> {
     }
 }
 
-/// Cast an `i128` sum back to a `ScalarValue` of the target type.
-/// Saturates on out-of-range integer targets so a pathological sum can
-/// never panic; Decimal128 keeps full precision.
+/// Casts `i128` back to the target type, saturating on out-of-range integers.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn i128_to_scalar(v: i128, dt: &DataType) -> ScalarValue {
     let clamp = |lo: i128, hi: i128| v.clamp(lo, hi);
@@ -228,9 +197,6 @@ fn i128_to_scalar(v: i128, dt: &DataType) -> ScalarValue {
         DataType::UInt32 => ScalarValue::UInt32(Some(clamp(0, i128::from(u32::MAX)) as u32)),
         DataType::UInt64 => ScalarValue::UInt64(Some(clamp(0, i128::from(u64::MAX)) as u64)),
         DataType::Decimal128(p, s) => ScalarValue::Decimal128(Some(v), *p, *s),
-        // Float / unknown: fall back to f64 via i128 → f64 (precision loss
-        // only at very large magnitudes, which couldn't have been an
-        // integer-typed sum to begin with).
         #[allow(clippy::cast_precision_loss)]
         _ => ScalarValue::Float64(Some(v as f64)),
     }
@@ -251,12 +217,7 @@ fn is_integer_or_decimal(dt: &DataType) -> bool {
     )
 }
 
-/// Retractable SUM: `SUM(value * weight)`.
-///
-/// Integer / `Decimal128` types accumulate in `i128` so a SUM beyond
-/// `2^53` no longer silently loses precision — `f64` is reserved for
-/// genuinely floating-point targets where the precision tradeoff is
-/// inherent to the type.
+/// Retractable SUM: integer/Decimal128 paths accumulate in `i128` to preserve precision above 2^53.
 #[derive(Debug)]
 struct RetractableSumAccum {
     return_type: DataType,
@@ -280,7 +241,6 @@ impl RetractableSumAccum {
 }
 
 impl Accumulator for RetractableSumAccum {
-    /// Inputs: `[value_col, weight_col]`.
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
         let weights = weight_array(values)?;
         let value_arr = &values[0];
@@ -354,20 +314,13 @@ impl Accumulator for RetractableSumAccum {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// COUNT(*)
-// ═══════════════════════════════════════════════════════════════════
-
-/// Retractable COUNT(\*): `SUM(weight)`.
-///
-/// The dummy boolean input column is ignored. Only the weight column matters.
+/// Retractable COUNT(\*): `SUM(weight)`. The dummy boolean input is ignored.
 #[derive(Debug, Default)]
 struct RetractableCountStarAccum {
     count: i64,
 }
 
 impl Accumulator for RetractableCountStarAccum {
-    /// Inputs: `[dummy_bool, weight_col]`.
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
         let weights = weight_array(values)?;
         for row in 0..weights.len() {
@@ -399,10 +352,6 @@ impl Accumulator for RetractableCountStarAccum {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// COUNT(col)
-// ═══════════════════════════════════════════════════════════════════
-
 /// Retractable COUNT(col): `SUM(weight)` where col IS NOT NULL.
 #[derive(Debug, Default)]
 struct RetractableCountAccum {
@@ -410,7 +359,6 @@ struct RetractableCountAccum {
 }
 
 impl Accumulator for RetractableCountAccum {
-    /// Inputs: `[value_col, weight_col]`.
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
         let weights = weight_array(values)?;
         let value_arr = &values[0];
@@ -445,10 +393,6 @@ impl Accumulator for RetractableCountAccum {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// AVG
-// ═══════════════════════════════════════════════════════════════════
-
 /// Retractable AVG: `SUM(value * weight) / SUM(weight)`.
 #[derive(Debug, Default)]
 struct RetractableAvgAccum {
@@ -457,7 +401,6 @@ struct RetractableAvgAccum {
 }
 
 impl Accumulator for RetractableAvgAccum {
-    /// Inputs: `[value_col, weight_col]`.
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
         let weights = weight_array(values)?;
         let value_arr = &values[0];
@@ -509,29 +452,14 @@ impl Accumulator for RetractableAvgAccum {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════
-// MIN / MAX (shared implementation)
-// ═══════════════════════════════════════════════════════════════════
-
-/// Whether the extremum accumulator tracks the minimum or maximum.
 #[derive(Debug, Clone, Copy)]
 enum Extremum {
     Min,
     Max,
 }
 
-/// Retractable MIN/MAX using a counted multiset keyed by an Arrow
-/// row-encoded value. `arrow::row::RowConverter` produces a stable
-/// lexicographically-sortable byte representation for every relevant
-/// scalar type (integers, decimals, dates, timestamps, strings,
-/// binaries, booleans, floats), so the same operator works correctly
-/// for any of them — no more silent NULLs from `to_f64` on Decimal /
-/// Date / Utf8 columns.
-///
-/// On insert (weight > 0): increment count for the value's row key.
-/// On retract (weight < 0): decrement; remove the entry at zero.
-/// Result: first key (MIN) or last key (MAX), re-materialised via the
-/// same row converter back to a `ScalarValue` of the return type.
+/// Retractable MIN/MAX: counted multiset keyed by `arrow::row::RowConverter` bytes.
+/// Handles all scalar types including Decimal, Date, Utf8 — no silent NULLs.
 #[derive(Debug)]
 struct RetractableExtremumAccum {
     counts: BTreeMap<arrow::row::OwnedRow, i64>,
@@ -559,7 +487,6 @@ impl RetractableExtremumAccum {
 }
 
 impl Accumulator for RetractableExtremumAccum {
-    /// Inputs: `[value_col, weight_col]`.
     fn update_batch(&mut self, values: &[ArrayRef]) -> datafusion_common::Result<()> {
         use std::collections::btree_map::Entry;
         let weights = weight_array(values)?;
@@ -612,14 +539,11 @@ impl Accumulator for RetractableExtremumAccum {
     }
 
     fn size(&self) -> usize {
-        // Each entry: key bytes + 8B count + ~64B BTreeMap node overhead.
         let key_bytes: usize = self.counts.keys().map(|k| k.as_ref().len()).sum();
         std::mem::size_of::<Self>() + key_bytes + self.counts.len() * 72
     }
 
     fn state(&mut self) -> datafusion_common::Result<Vec<ScalarValue>> {
-        // Materialise the keys back into an Arrow array of the value
-        // type, then expose key+count as List columns.
         let key_arrays = self
             .row_converter
             .convert_rows(self.counts.keys().map(arrow::row::OwnedRow::row))
@@ -679,10 +603,6 @@ impl Accumulator for RetractableExtremumAccum {
         Ok(())
     }
 }
-
-// ═══════════════════════════════════════════════════════════════════
-// Tests
-// ═══════════════════════════════════════════════════════════════════
 
 #[cfg(test)]
 mod tests {

--- a/crates/laminar-db/src/show_commands.rs
+++ b/crates/laminar-db/src/show_commands.rs
@@ -1,6 +1,4 @@
-//! SHOW and DESCRIBE command builders for `LaminarDB`.
-//!
-//! Reopens `impl LaminarDB` to keep the main `db.rs` focused on dispatch.
+//! SHOW and DESCRIBE command builders; reopens `impl LaminarDB` to keep `db.rs` focused.
 
 use std::sync::Arc;
 
@@ -34,7 +32,6 @@ impl LaminarDB {
             None => (None, vec![]),
         };
 
-        // Build single-row result with checkpoint metadata.
         let (cp_id, epoch, ts_ms, sources, sinks, total_checkpoints) = if let Some(ref m) = latest {
             (
                 m.checkpoint_id,
@@ -156,7 +153,6 @@ impl LaminarDB {
 
         for s in &sinks {
             names.push(s.name.as_str());
-            // Input comes from catalog (always registered), connector metadata from ConnectorManager
             let catalog_input = self.catalog.get_sink_input(&s.name);
             if let Some(reg) = regs.get(&s.name) {
                 inputs.push(Some(reg.input.clone()));
@@ -329,13 +325,10 @@ impl LaminarDB {
 
     /// Build a DESCRIBE result.
     pub(crate) fn build_describe(&self, name: &str) -> Result<RecordBatch, DbError> {
-        // Try sources first
         let schema = if let Some(s) = self.catalog.describe_source(name) {
             s
-        // Then reference/dimension tables
         } else if let Some(s) = self.table_store.read().table_schema(name) {
             s
-        // Then materialized views
         } else if let Some(s) = self
             .mv_registry
             .lock()
@@ -343,12 +336,10 @@ impl LaminarDB {
             .map(|mv| mv.schema.clone())
         {
             s
-        // Then check sinks (no schema, but confirm existence)
         } else if self.catalog.list_sinks().contains(&name.to_string()) {
             return Err(DbError::InvalidOperation(
                 "DESCRIBE is not supported for sinks. Use SHOW SINKS for details.".to_string(),
             ));
-        // Then streams (no stored schema yet)
         } else if self.catalog.list_streams().contains(&name.to_string()) {
             return Err(DbError::InvalidOperation(format!(
                 "Stream '{name}' exists but schema is only available after pipeline start"

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -13,9 +13,7 @@ use laminar_connectors::error::ConnectorError;
 use laminar_core::streaming::Producer;
 use tokio::task::JoinHandle;
 
-/// Cloneable async sender for the sink command channel.
 type SinkCommandTx = MAsyncTx<mpsc::Array<SinkCommand>>;
-/// Single-consumer async receiver for the sink command channel.
 type SinkCommandRx = AsyncRx<mpsc::Array<SinkCommand>>;
 
 /// Default capacity for the sink command channel.
@@ -24,13 +22,9 @@ pub(crate) const DEFAULT_CHANNEL_CAPACITY: usize = 128;
 /// Default periodic flush interval for sink tasks.
 pub(crate) const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Capacity of the sink event channel. Events are exception-path; a
-/// generous bound is fine and avoids unbounded growth on stuck drains.
 pub(crate) const SINK_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
-/// Out-of-band events emitted by a sink task. Drained once per cycle by
-/// the pipeline callback to update metrics and suppress checkpoints.
-/// Fields are read via `Debug` when the drain loop logs them.
+/// Out-of-band events emitted by a sink task; drained once per cycle.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub(crate) enum SinkEvent {
@@ -51,10 +45,8 @@ pub(crate) enum SinkEvent {
     },
 }
 
-/// Configuration for spawning a sink task.
 pub(crate) struct SinkTaskConfig {
     pub name: String,
-    /// Stable identifier carried in [`SinkEvent`]s.
     pub sink_id: Arc<str>,
     pub connector: Box<dyn SinkConnector>,
     pub exactly_once: bool,
@@ -64,46 +56,37 @@ pub(crate) struct SinkTaskConfig {
     pub event_tx: Producer<SinkEvent>,
 }
 
-/// Commands sent to a sink's dedicated task.
 pub(crate) enum SinkCommand {
-    /// Write a batch to the sink.
-    WriteBatch { batch: RecordBatch },
-    /// Begin a new epoch (starts Kafka transaction for exactly-once sinks).
+    WriteBatch {
+        batch: RecordBatch,
+    },
     BeginEpoch {
         epoch: u64,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// Explicitly flush buffered data (test-only).
     #[cfg(test)]
     Flush {
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// Checkpoint 2PC phase 1: flush and prepare.
     PreCommit {
         epoch: u64,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// Checkpoint 2PC phase 2: finalize transaction.
     CommitEpoch {
         epoch: u64,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// Abort a failed epoch. `force = true` (restart/recovery) always
-    /// rolls the connector back; `force = false` (live coordination
-    /// failure) keeps a healthy sink's pending transactional output —
-    /// sources do not rewind on a live abort, so an aborted
-    /// transaction's rows would be lost forever. The next successful
-    /// epoch's commit covers them.
+    /// `force = false` keeps a healthy sink's pending transactional output —
+    /// sources don't rewind on a live abort so those rows must not be discarded.
     RollbackEpoch {
         epoch: u64,
         force: bool,
         ack: oneshot::TxOneshot<Result<(), ConnectorError>>,
     },
-    /// No-op barrier: acks once every prior command has been processed.
-    /// Used by the pipeline to make sure write results have surfaced as
-    /// `SinkEvent`s before checkpoint suppression decisions.
-    Sync { ack: oneshot::TxOneshot<()> },
-    /// Flush + close the connector and exit the task (test-only).
+    /// Acks once all prior commands have been processed.
+    Sync {
+        ack: oneshot::TxOneshot<()>,
+    },
     #[cfg(test)]
     Close,
 }
@@ -115,14 +98,9 @@ pub(crate) struct SinkTaskHandle {
     sink_id: Arc<str>,
     tx: SinkCommandTx,
     exactly_once: bool,
-    /// Held so `close()` can join the task; implicit shutdown happens
-    /// when the command channel drops. `parking_lot::Mutex` is correct
-    /// here because `close()` extracts the handle under the lock and
-    /// awaits on it *after* dropping the guard — the lock never spans
-    /// an `.await`.
+    // `close()` extracts the handle under the lock then awaits outside it — lock never spans `.await`.
     #[allow(dead_code)]
     task: Arc<parking_lot::Mutex<Option<JoinHandle<()>>>>,
-    /// Used by `write_batch` to emit `ChannelClosed` if the task is gone.
     event_tx: Producer<SinkEvent>,
 }
 
@@ -171,14 +149,10 @@ impl SinkTaskHandle {
         }
     }
 
-    /// Builds the error returned when the command channel is closed —
-    /// i.e. the sink task has exited and our `send()` failed.
     fn closed_err(&self) -> ConnectorError {
         ConnectorError::ConnectionFailed(format!("sink task '{}' closed unexpectedly", self.name))
     }
 
-    /// Builds the error returned when the sink task drops its ack sender
-    /// before responding to `op` — usually because the task panicked mid-op.
     fn ack_dropped_err(&self, op: &'static str) -> ConnectorError {
         ConnectorError::ConnectionFailed(format!(
             "sink task '{}' dropped {op} acknowledgment",
@@ -186,9 +160,7 @@ impl SinkTaskHandle {
         ))
     }
 
-    /// Sends a batch to be written. Backpressures via the bounded channel
-    /// when the sink task is behind. On channel-closed, emits
-    /// `SinkEvent::ChannelClosed` and returns an error.
+    /// Send a batch; backpressures when the sink is behind.
     pub async fn write_batch(&self, batch: RecordBatch) -> Result<(), ConnectorError> {
         self.tx
             .send(SinkCommand::WriteBatch { batch })
@@ -201,8 +173,7 @@ impl SinkTaskHandle {
             })
     }
 
-    /// Sends a no-op `Sync` barrier and waits for the sink task to ack.
-    /// When it returns, every previously queued command has been processed.
+    /// Wait until all previously queued commands have been processed.
     pub async fn sync(&self) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -212,10 +183,7 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("sync"))
     }
 
-    /// Begins a new epoch (starts a Kafka transaction for exactly-once sinks).
-    ///
-    /// Must be called before `write_batch()` for each epoch when using
-    /// exactly-once delivery. For at-least-once sinks this is a no-op.
+    /// Begin a new epoch; starts a transaction for exactly-once sinks.
     pub async fn begin_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -227,10 +195,6 @@ impl SinkTaskHandle {
             .map_err(|_| self.ack_dropped_err("begin-epoch"))?
     }
 
-    /// Requests an explicit flush and waits for acknowledgment.
-    ///
-    /// Not called on the normal shutdown path (channel drop triggers
-    /// flush implicitly in `run_sink_task`). Available for manual use.
     #[cfg(test)]
     pub async fn flush(&self) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
@@ -241,7 +205,7 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("flush"))?
     }
 
-    /// Checkpoint 2PC phase 1: pre-commit.
+    /// 2PC phase 1: flush and prepare.
     pub async fn pre_commit(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -253,7 +217,7 @@ impl SinkTaskHandle {
             .map_err(|_| self.ack_dropped_err("pre-commit"))?
     }
 
-    /// Checkpoint 2PC phase 2: commit epoch.
+    /// 2PC phase 2: finalize the transaction.
     pub async fn commit_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -263,8 +227,7 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("commit"))?
     }
 
-    /// Roll the connector back unconditionally (restart/recovery, or
-    /// cleanup of a partially-begun epoch).
+    /// Roll back unconditionally (restart/recovery path).
     pub async fn rollback_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -278,10 +241,7 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("rollback"))?
     }
 
-    /// Live coordination failure: abandon the epoch but keep a healthy
-    /// sink's pending transactional output for the next epoch's commit
-    /// (see [`SinkCommand::RollbackEpoch`]). Rolls back for real only
-    /// if the sink itself failed (poisoned epoch).
+    /// Live coordination failure: keep pending output unless the epoch is poisoned.
     pub async fn abandon_epoch(&self, epoch: u64) -> Result<(), ConnectorError> {
         let (ack_tx, ack_rx) = oneshot::oneshot();
         self.tx
@@ -295,29 +255,20 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("abandon"))?
     }
 
-    /// Signals the sink task to close and waits for it to finish (30s timeout).
-    ///
-    /// Not called on the normal shutdown path — dropping the `SinkTaskHandle`
-    /// closes the command channel, which triggers flush+close in `run_sink_task`.
-    /// This method is for explicit shutdown when you need to wait for completion.
     #[cfg(test)]
     pub async fn close(&self) {
         let _ = self.tx.send(SinkCommand::Close).await;
-        // Extract under the lock, release before awaiting. Keeps the
-        // lock scope a handful of ns instead of seconds.
         let handle = self.task.lock().take();
         if let Some(handle) = handle {
             let _ = tokio::time::timeout(Duration::from_secs(30), handle).await;
         }
     }
 
-    /// Returns whether this sink supports exactly-once semantics.
     pub fn exactly_once(&self) -> bool {
         self.exactly_once
     }
 }
 
-/// Owned state for a single sink task. Constructed by `spawn`.
 struct SinkTaskInner {
     name: String,
     sink_id: Arc<str>,
@@ -328,15 +279,12 @@ struct SinkTaskInner {
     event_tx: Producer<SinkEvent>,
 }
 
-/// Main loop for a sink task. Owns the `SinkConnector` exclusively.
-/// `epoch_poisoned` is local: `pre_commit`/`commit_epoch` reject poisoned
-/// epochs, which the coordinator surfaces and turns into `rollback_sinks`.
+// `epoch_poisoned` causes `pre_commit`/`commit_epoch` to fail so the coordinator rolls back.
 #[allow(clippy::too_many_lines)]
 async fn run_sink_task(mut inner: SinkTaskInner) {
     let mut flush_timer = tokio::time::interval(inner.flush_interval);
     flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    // Skip the first immediate tick.
-    flush_timer.tick().await;
+    flush_timer.tick().await; // skip the first immediate tick
 
     let preserves_pending_on_abandon = inner.sink.capabilities().preserves_pending_on_abandon;
     let mut current_epoch: u64 = 0;
@@ -346,7 +294,6 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
         tokio::select! {
             cmd = inner.rx.recv() => {
                 let Ok(cmd) = cmd else {
-                    // All senders dropped — shut down gracefully.
                     tracing::debug!(sink = %inner.name, "Sink command channel closed");
                     if let Err(e) = inner.sink.flush().await {
                         tracing::warn!(sink = %inner.name, error = %e,
@@ -432,12 +379,6 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                         ack.send(result);
                     }
                     SinkCommand::RollbackEpoch { epoch, force, ack } => {
-                        // Keeping pending output across an abandoned
-                        // epoch is only sound when the CONNECTOR says
-                        // so (`preserves_pending_on_abandon`, e.g. a
-                        // Kafka transactional producer); a staging-style
-                        // sink must roll back or its per-epoch state
-                        // diverges.
                         let result = if force
                             || !preserves_pending_on_abandon
                             || epoch_poisoned.load(Ordering::Acquire)
@@ -478,10 +419,6 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                 }
             }
             _ = flush_timer.tick() => {
-                // `SinkConnector::flush` is contract-bound to be internally
-                // bounded; wrapping it in an outer tokio timeout here used
-                // to orphan `spawn_blocking` flush tasks on the blocking
-                // pool when the backstop fired before the inner deadline.
                 if let Err(e) = inner.sink.flush().await {
                     tracing::warn!(sink = %inner.name, error = %e, "Periodic sink flush error");
                 }

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -1,4 +1,4 @@
-//! SQL analysis and join detection utilities.
+//! SQL analysis: table-reference extraction, join detection, and projection rewriting.
 
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -30,10 +30,6 @@ use laminar_sql::translator::{
     TemporalJoinTranslatorConfig, WindowOperatorConfig, WindowType,
 };
 
-// ---------------------------------------------------------------------------
-// Emit conversion
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 pub(crate) fn sql_emit_to_core(
     s: &SqlEmitStrategy,
@@ -57,13 +53,9 @@ pub(crate) fn emit_clause_to_core(
     Ok(sql_emit_to_core(&sql_strategy))
 }
 
-// ---------------------------------------------------------------------------
-// Table reference extraction
-// ---------------------------------------------------------------------------
-
-/// Returns a deduplicated set of table names from FROM/JOIN clauses.
-/// Not deduplicated by occurrence count -- for self-join detection use
-/// [`single_source_table`] instead.
+/// Returns the deduplicated set of table names from FROM/JOIN clauses.
+///
+/// For self-join detection use [`single_source_table`] (which counts occurrences).
 pub(crate) fn extract_table_references(sql: &str) -> FxHashSet<String> {
     let mut tables = FxHashSet::default();
     let dialect = GenericDialect {};
@@ -74,7 +66,7 @@ pub(crate) fn extract_table_references(sql: &str) -> FxHashSet<String> {
             }
         }
     }
-    // sqlparser drops TEMPORAL PROBE JOIN; merge its tables from the detector.
+    // sqlparser can't parse TEMPORAL PROBE JOIN; pull its tables separately.
     if let (Some(config), _) = detect_temporal_probe_query(sql) {
         tables.insert(config.left_table.clone());
         tables.insert(config.right_table.clone());
@@ -82,16 +74,11 @@ pub(crate) fn extract_table_references(sql: &str) -> FxHashSet<String> {
     tables
 }
 
-/// Column indices of `schema` to fetch for partial lookup `table`, given the
-/// stream `queries` — for projection pushdown. The result is the union of every
-/// column any query referencing `table` uses, plus `pk_cols` (the source
-/// realigns results by the key, so the key must always come back).
+/// Column indices of `schema` to fetch for partial lookup `table`, for projection pushdown.
 ///
-/// Returns an empty vec meaning "fetch all columns": when a referencing query
-/// is anything but a plain wildcard-free `SELECT` (so we can't be sure which
-/// columns it needs), or when the union already covers the whole schema. The
-/// cache is shared per table, so this is deliberately a *superset* — fetching a
-/// spare column is harmless; missing one is not.
+/// Returns the union of columns referenced by any query over `table`, plus `pk_cols`.
+/// Returns an empty vec (fetch all) when a query uses wildcards, subqueries, or
+/// non-table factors, or when the union already covers the whole schema.
 pub(crate) fn compute_lookup_projection(
     schema: &SchemaRef,
     pk_cols: &[String],
@@ -106,7 +93,7 @@ pub(crate) fn compute_lookup_projection(
         }
         match collect_referenced_columns(sql) {
             Some(cols) => referenced.extend(cols),
-            None => return Vec::new(), // can't narrow safely → fetch all
+            None => return Vec::new(),
         }
     }
 
@@ -118,7 +105,6 @@ pub(crate) fn compute_lookup_projection(
         .map(|(i, _)| u32::try_from(i).expect("column index fits u32"))
         .collect();
 
-    // Full coverage → empty keeps the source and operator on the simple path.
     if indices.len() == schema.fields().len() {
         Vec::new()
     } else {
@@ -126,11 +112,7 @@ pub(crate) fn compute_lookup_projection(
     }
 }
 
-/// Column names referenced by `sql`, or `None` when it isn't a plain
-/// wildcard-free `SELECT` over base tables (subquery, `SELECT *`, set op, …) —
-/// shapes where we can't enumerate referenced columns without risking an
-/// under-count. Identifier collection uses sqlparser's exhaustive
-/// `visit_expressions`, so no expression branch is missed.
+// Returns None for shapes that could hide wildcards (subquery, SELECT *, set op, non-table factor).
 fn collect_referenced_columns(sql: &str) -> Option<FxHashSet<String>> {
     let dialect = GenericDialect {};
     let statements = Parser::parse_sql(&dialect, sql).ok()?;
@@ -149,8 +131,6 @@ fn collect_referenced_columns(sql: &str) -> Option<FxHashSet<String>> {
     if select.projection.iter().any(is_wildcard) {
         return None;
     }
-    // Only plain base-table relations; a derived/subquery factor could hide a
-    // wildcard that yields no identifier expression.
     for twj in &select.from {
         if !matches!(twj.relation, TableFactor::Table { .. }) {
             return None;
@@ -176,8 +156,7 @@ fn collect_referenced_columns(sql: &str) -> Option<FxHashSet<String>> {
                     cols.insert(last.value.clone());
                 }
             }
-            // A subquery elsewhere (WHERE/SELECT) could reference columns via a
-            // wildcard we can't see — bail rather than under-count.
+            // A subquery could reference columns via a wildcard we can't see.
             Expr::Subquery(_) | Expr::Exists { .. } | Expr::InSubquery { .. } => {
                 complex = true;
                 return ControlFlow::Break(());
@@ -193,10 +172,9 @@ fn collect_referenced_columns(sql: &str) -> Option<FxHashSet<String>> {
     }
 }
 
-/// Unlike [`extract_table_references`] (which deduplicates), this counts every
-/// FROM/JOIN table occurrence. A self-join like `events e1 JOIN events e2`
-/// returns `None` because there are two occurrences even though the base table
-/// name is the same.
+/// Returns the single source table name only if there is exactly one FROM/JOIN occurrence.
+///
+/// A self-join (`events e1 JOIN events e2`) returns `None` even though the base name repeats.
 pub(crate) fn single_source_table(sql: &str) -> Option<String> {
     let dialect = GenericDialect {};
     let statements = Parser::parse_sql(&dialect, sql).ok()?;
@@ -254,7 +232,6 @@ fn collect_tables_from_factor(factor: &TableFactor, tables: &mut FxHashSet<Strin
     }
 }
 
-/// Not deduplicated -- collects every occurrence for counting.
 fn collect_tables_counting(set_expr: &SetExpr, tables: &mut Vec<String>) {
     match set_expr {
         SetExpr::Select(select) => {
@@ -264,8 +241,7 @@ fn collect_tables_counting(set_expr: &SetExpr, tables: &mut Vec<String>) {
                     collect_factor_counting(&join.relation, tables);
                 }
             }
-            // UNNEST in the projection expands rows just like a FROM-clause
-            // UNNEST; the single-source fast path can't, so force the full plan.
+            // UNNEST in the projection expands rows; the single-source path can't handle it.
             if projection_has_unnest(&select.projection) {
                 tables.push("\u{0}non_table_factor".to_string());
             }
@@ -281,9 +257,7 @@ fn collect_tables_counting(set_expr: &SetExpr, tables: &mut Vec<String>) {
     }
 }
 
-/// True if any projection item is (or wraps) an `UNNEST(..)`. Checked on the
-/// serialized item, so it's robust to the parser's UNNEST representation; a
-/// false positive only forces the safe full-plan path.
+// Checked on the serialized item; a false positive only forces the safe full-plan path.
 fn projection_has_unnest(items: &[SelectItem]) -> bool {
     items
         .iter()
@@ -306,17 +280,15 @@ fn collect_factor_counting(factor: &TableFactor, tables: &mut Vec<String>) {
                 collect_factor_counting(&join.relation, tables);
             }
         }
-        // A non-table factor (lateral UNNEST, TVF, ...) can't be evaluated by
-        // the single-source fast path; count it so the query uses the full
-        // per-cycle plan instead of silently dropping the factor.
+        // Lateral UNNEST, TVFs, etc. block the single-source path.
         _ => tables.push("\u{0}non_table_factor".to_string()),
     }
 }
 
-/// Rewrite `ASOF JOIN … MATCH_CONDITION(..)` to a `LEFT JOIN … ON ..` for
-/// schema resolution: `DataFusion` can't lower `AsOf`, and the match condition
-/// picks the matching right row at runtime, not the columns. Left keeps the
-/// right side nullable. `None` if there is no ASOF join.
+/// Rewrite `ASOF JOIN … MATCH_CONDITION(..)` to `LEFT JOIN … ON ..` for schema planning.
+///
+/// `DataFusion` can't lower `AsOf`; left outer keeps the right side nullable. Returns `None`
+/// if the query has no ASOF join.
 pub(crate) fn rewrite_asof_joins_for_planning(sql: &str) -> Option<String> {
     use sqlparser::ast::{JoinConstraint, JoinOperator};
 
@@ -353,18 +325,15 @@ pub(crate) fn rewrite_asof_joins_for_planning(sql: &str) -> Option<String> {
     })
 }
 
-/// Resolve the source table name from a `TableFactor::Table`.
+/// Resolve the real source table from a `TableFactor::Table`.
 ///
-/// sqlparser parses `FROM TUMBLE(events, ts, ...)` as `TableFactor::Table`
-/// with `name = "TUMBLE"` and `args = Some([events, ts, ...])`. For window
-/// TVFs the first argument is the actual source table — return that instead
-/// of the function name.
+/// sqlparser parses `FROM TUMBLE(events, ts, ...)` as a table named `TUMBLE` with args;
+/// for window TVFs the first arg is the actual source.
 fn resolve_tvf_source(
     name: &sqlparser::ast::ObjectName,
     args: Option<&sqlparser::ast::TableFunctionArgs>,
 ) -> String {
     let name_str = name.to_string();
-    // Handle schema-qualified names like "schema.TUMBLE"
     let base_name = name_str.rsplit('.').next().unwrap_or(&name_str);
     if let Some(tfa) = args {
         if is_window_tvf(base_name) {
@@ -383,7 +352,6 @@ fn is_window_tvf(name: &str) -> bool {
         || name.eq_ignore_ascii_case("SLIDE")
 }
 
-/// Extract the first bare identifier from a function arg list.
 fn first_ident_arg(args: &[FunctionArg]) -> Option<String> {
     match args.first()? {
         FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(id))) => Some(id.value.clone()),
@@ -401,14 +369,7 @@ fn first_ident_arg(args: &[FunctionArg]) -> Option<String> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Compiled post-projection
-// ---------------------------------------------------------------------------
-
-/// Lazily compiled post-join projection for ASOF/temporal queries.
-///
-/// Compiled from the projection SQL (e.g., `SELECT a, b AS alias FROM __asof_tmp`)
-/// on first execution when the join output schema is known.
+/// Compiled post-join projection for ASOF/temporal queries.
 pub(crate) struct CompiledPostProjection {
     pub(crate) exprs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) output_schema: SchemaRef,
@@ -422,18 +383,13 @@ impl std::fmt::Debug for CompiledPostProjection {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Projection / filter extraction
-// ---------------------------------------------------------------------------
-
 pub(crate) struct ProjectionFilterInfo {
     pub(crate) proj_exprs: Vec<datafusion_expr::Expr>,
     pub(crate) filter_predicate: Option<datafusion_expr::Expr>,
     pub(crate) input_df_schema: Arc<datafusion_common::DFSchema>,
 }
 
-/// Returns `Some` only for plans of the shape
-/// `Projection? -> Filter? -> TableScan` (with optional `SubqueryAlias` wrappers).
+/// Returns `Some` only for `Projection? -> Filter? -> TableScan` plans.
 pub(crate) fn extract_projection_filter(plan: &LogicalPlan) -> Option<ProjectionFilterInfo> {
     match plan {
         LogicalPlan::Projection(proj) => {
@@ -446,10 +402,8 @@ pub(crate) fn extract_projection_filter(plan: &LogicalPlan) -> Option<Projection
                 }
             })
         }
-        // No Projection wrapper — check for Filter -> TableScan directly
         _ => match extract_filter_or_scan(plan) {
             Some((filter_pred, input_schema, _)) => {
-                // Build identity projection from the scan schema
                 let proj_exprs: Vec<datafusion_expr::Expr> = input_schema
                     .fields()
                     .iter()
@@ -539,17 +493,10 @@ pub(crate) fn extract_projection_exprs(
     Some((exprs, output_schema))
 }
 
-// ---------------------------------------------------------------------------
-// Window boundary computation
-// ---------------------------------------------------------------------------
-
-/// Compute the closed-window boundary given a watermark and window config.
+/// Compute the closed-window boundary for a given watermark.
 ///
-/// - **Tumbling**: floor to nearest window boundary.
-/// - **Session**: `watermark - gap` (best approximation without session state).
-/// - **Sliding**: align to slide interval — the earliest open window starts at
-///   `((watermark - size) / slide + 1) * slide`, so data below that threshold
-///   belongs only to closed windows.
+/// Tumbling: floor to the nearest boundary. Session: `watermark - gap`.
+/// Sliding: first slide-aligned boundary after `watermark - size`.
 pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperatorConfig) -> i64 {
     match config.window_type {
         WindowType::Tumbling => {
@@ -558,8 +505,7 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
                 tracing::warn!("tumbling window size is zero or negative, EOWC filtering disabled");
                 return watermark_ms;
             }
-            // floor((ts - offset) / size) * size + offset, saturating so
-            // the i64::MIN initial-watermark sentinel doesn't panic.
+            // Saturating so the i64::MIN initial-watermark sentinel doesn't panic.
             let offset = config.offset_ms;
             let adjusted = watermark_ms.saturating_sub(offset);
             let floored = adjusted.div_euclid(size).saturating_mul(size);
@@ -584,10 +530,7 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
                 );
                 return watermark_ms;
             }
-            // The earliest open window starts at the first slide-aligned
-            // boundary after (watermark - size). Data below that start
-            // belongs only to fully closed windows.
-            // Account for window offset to match SlidingWindowAssigner.
+            // Earliest open window starts at first slide-aligned boundary after (watermark - size).
             let offset = config.offset_ms;
             let base = watermark_ms.saturating_sub(offset).saturating_sub(size);
             let boundary = base
@@ -597,8 +540,6 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
             boundary.saturating_add(offset)
         }
         WindowType::Cumulate => {
-            // Cumulate windows share the same epoch alignment as tumbling.
-            // A full epoch is closed when watermark >= epoch_end.
             let size = i64::try_from(config.size.as_millis()).unwrap_or(i64::MAX);
             if size <= 0 {
                 tracing::warn!("cumulate window size is zero or negative, EOWC filtering disabled");
@@ -612,17 +553,11 @@ pub(crate) fn compute_closed_boundary(watermark_ms: i64, config: &WindowOperator
     }
 }
 
-// ---------------------------------------------------------------------------
-// Join detection
-// ---------------------------------------------------------------------------
-
 pub(crate) fn detect_asof_query(sql: &str) -> (Option<AsofJoinTranslatorConfig>, Option<String>) {
-    // Parse using the streaming parser which understands ASOF syntax
     let Ok(statements) = laminar_sql::parse_streaming_sql(sql) else {
         return (None, None);
     };
 
-    // We need a raw sqlparser Statement::Query to inspect the SELECT AST
     let Some(laminar_sql::parser::StreamingStatement::Standard(stmt)) = statements.first() else {
         return (None, None);
     };
@@ -639,7 +574,6 @@ pub(crate) fn detect_asof_query(sql: &str) -> (Option<AsofJoinTranslatorConfig>,
         return (None, None);
     };
 
-    // Find the first ASOF join step
     let Some(asof_analysis) = multi.joins.iter().find(|j| j.is_asof_join) else {
         return (None, None);
     };
@@ -648,28 +582,20 @@ pub(crate) fn detect_asof_query(sql: &str) -> (Option<AsofJoinTranslatorConfig>,
         return (None, None);
     };
 
-    // Build a projection SQL that rewrites the original SELECT list to reference
-    // the flattened __asof_tmp table (no table qualifiers, disambiguated names).
     let projection_sql = build_projection_sql(select, asof_analysis, &config);
 
     (Some(config), Some(projection_sql))
 }
 
-// ---------------------------------------------------------------------------
-// Lookup-enrich detection (on-demand / partial lookup joins → GraphOperator)
-// ---------------------------------------------------------------------------
-
 use crate::operator::lookup_enrich::{disambiguated_lookup_name, LookupEnrichConfig};
 
-/// Detect a `partial`/`none` lookup-enrich join: a single equi-join whose right
-/// table is a registered partial lookup table. Returns the operator config plus
-/// the residual projection over `__lookup_enrich_tmp`. `partial_cols` maps a
-/// partial lookup table to its column names; `source_schemas` supplies the
-/// stream side's columns for collision disambiguation.
+/// Detect a partial lookup-enrich join and return its operator config plus residual projection.
 ///
-/// v1 constraints (else returns `None`, so the existing `DataFusion` path runs):
-/// single join step, single-column key, stream on the left, INNER/LEFT only,
-/// and the stream schema must be known.
+/// `partial_cols` maps each partial lookup table to its columns; `source_schemas` supplies
+/// stream-side schemas for collision disambiguation.
+///
+/// Returns `None` (`DataFusion` path) for anything other than: single INNER/LEFT equi-join step,
+/// single-column key, stream on the left, known stream schema.
 pub(crate) fn detect_lookup_enrich_query(
     sql: &str,
     partial_cols: &FxHashMap<String, Vec<String>>,
@@ -721,7 +647,6 @@ pub(crate) fn detect_lookup_enrich_query(
     {
         return (None, None);
     }
-    // v1: stream on the left, partial lookup table on the right.
     let lookup_table = j.right_table.clone();
     let Some(lookup_cols) = partial_cols.get(&lookup_table) else {
         return (None, None);
@@ -756,8 +681,6 @@ pub(crate) fn detect_lookup_enrich_query(
     (Some(config), Some(projection_sql))
 }
 
-/// Context for rewriting a SELECT to read from the flattened
-/// `__lookup_enrich_tmp` table.
 struct LookupRewriteCtx<'a> {
     stream_alias: Option<&'a str>,
     stream_table: &'a str,
@@ -855,12 +778,6 @@ fn rewrite_lookup_expr(expr: &Expr, ctx: &LookupRewriteCtx) -> String {
     })
 }
 
-// ---------------------------------------------------------------------------
-// AI function detection (plan-time seam)
-// ---------------------------------------------------------------------------
-
-/// AI-function detection, plan-time validation, and query planning. Consumed by
-/// `add_query` routing in `operator_graph`.
 mod ai {
     use super::{
         BackendKind, DbError, Expr, FunctionArg, FunctionArgExpr, FunctionArguments, Ident,
@@ -868,28 +785,19 @@ mod ai {
         Task,
     };
 
-    /// The temp table the AI operator registers its enriched batches under for
-    /// the residual projection.
     pub(crate) const AI_TMP_TABLE: &str = "__ai_tmp";
 
-    /// A query that contains exactly one `ai_*` call: the detected call plus the
-    /// residual projection to run over the operator's enriched output, and the
-    /// single source table the operator reads.
+    /// A query routable to the AI operator: exactly one `ai_*` call plus residual projection.
     pub(crate) struct AiQueryPlan {
-        /// The detected AI call.
         pub call: AiCallSpec,
-        /// Residual SQL over [`AI_TMP_TABLE`] with the `ai_*` projection item
-        /// rewritten to its alias column.
+        /// Residual SQL over [`AI_TMP_TABLE`] with the `ai_*` item rewritten to its alias column.
         pub projection_sql: String,
-        /// The source table the AI operator reads from.
         pub source_table: String,
     }
 
-    /// Plan a query for AI routing. Returns `Some` only when the query has
-    /// exactly one `ai_*` call, written with an `AS` alias, over a single
-    /// (un-joined) source table — the supported shape for v0.1. Multiple AI
-    /// calls, a missing alias, or joins return `None` (the caller rejects or
-    /// routes normally).
+    /// Plan a query for AI routing: exactly one aliased `ai_*` call over a single source table.
+    ///
+    /// Returns `None` for multiple AI calls, missing alias, or any join.
     pub(crate) fn plan_ai_query(sql: &str) -> Option<AiQueryPlan> {
         let statements = laminar_sql::parse_streaming_sql(sql).ok()?;
         let mut statement = match statements.into_iter().next()? {
@@ -910,7 +818,6 @@ mod ai {
             _ => return None,
         };
 
-        // Find the single AI-call projection item.
         let mut found: Option<(usize, AiCallSpec)> = None;
         for (index, item) in select.projection.iter().enumerate() {
             let (expr, alias) = match item {
@@ -920,16 +827,15 @@ mod ai {
             };
             if let Some(spec) = ai_call_from_expr(expr, alias) {
                 if found.is_some() {
-                    return None; // more than one AI call — unsupported in v0.1
+                    return None;
                 }
                 found = Some((index, spec));
             }
         }
         let (index, call) = found?;
 
-        // Rewrite: the AI projection item becomes a plain alias column, and the
-        // FROM table becomes the enriched temp table. Reuse the original alias
-        // `Ident` (an alias is required) so quoted aliases stay quoted.
+        // Rewrite: AI item → bare alias column; FROM → temp table.
+        // Reuse the original alias Ident so quoted aliases stay quoted.
         let SelectItem::ExprWithAlias { alias, .. } = &select.projection[index] else {
             return None;
         };
@@ -950,29 +856,20 @@ mod ai {
     /// One detected `ai_*(...)` call in a query's SELECT projection.
     #[derive(Debug, Clone, PartialEq)]
     pub(crate) struct AiCallSpec {
-        /// The task implied by the function name.
         pub task: Task,
-        /// The model named via `model => '<name>'`, or `None` to use the task default.
         pub model: Option<String>,
-        /// The candidate label set from `labels => [...]`, if supplied.
         pub labels: Option<Vec<String>>,
-        /// The input column name (a simple identifier). Empty if the first
-        /// argument was missing or not a plain column — a parse error.
+        /// Empty when the first argument was missing or not a plain column.
         pub input: String,
-        /// The projection alias, if the call was written `... AS <alias>`.
         pub output_alias: Option<String>,
-        /// Argument-shape errors found while parsing (bad input, wrong argument
-        /// types). Non-empty means the call is malformed; surfaced by
-        /// [`validate_ai_calls`] as a build error rather than silently ignored.
+        /// Non-empty means the call is malformed; surfaced by [`validate_ai_calls`].
         pub parse_errors: Vec<String>,
     }
 
     /// Detect `ai_*` calls in the top-level SELECT projection of `sql`.
     ///
-    /// Only top-level projection calls are recognised in v0.1 (e.g.
-    /// `SELECT ai_classify(text, model => 'finbert') AS label FROM s`); an `ai_*`
-    /// nested inside another expression or in `WHERE` is left for the marker UDF to
-    /// reject. Returns an empty vec if the SQL does not parse or has no AI calls.
+    /// Calls nested in expressions or `WHERE` are not recognised here; the marker UDF
+    /// rejects them. Returns an empty vec if the SQL does not parse or has no AI calls.
     pub(crate) fn detect_ai_functions(sql: &str) -> Vec<AiCallSpec> {
         let Ok(statements) = laminar_sql::parse_streaming_sql(sql) else {
             return Vec::new();
@@ -1002,7 +899,6 @@ mod ai {
         calls
     }
 
-    /// Extract an [`AiCallSpec`] from a projection expression if it is an `ai_*` call.
     fn ai_call_from_expr(expr: &Expr, alias: Option<String>) -> Option<AiCallSpec> {
         let Expr::Function(func) = expr else {
             return None;
@@ -1026,9 +922,7 @@ mod ai {
                             .push("AI functions take a single positional input column".to_string());
                     } else {
                         seen_input = true;
-                        // The operator looks the input up by column name in the
-                        // source batch, so only a plain column reference is
-                        // supported — an arbitrary expression would fail lookup.
+                        // Only a plain column reference — the operator does a name-based lookup.
                         match column_name(value) {
                             Some(col) => input = Some(col),
                             None => parse_errors.push(format!(
@@ -1078,9 +972,6 @@ mod ai {
         })
     }
 
-    /// A plain column reference (`col`), which the operator can look up in the
-    /// source batch. Anything else (a function call, arithmetic, a qualified
-    /// name) is unsupported as AI input in v0.1.
     fn column_name(expr: &Expr) -> Option<String> {
         match expr {
             Expr::Identifier(ident) => Some(ident.value.clone()),
@@ -1088,8 +979,7 @@ mod ai {
         }
     }
 
-    /// Map an `ai_*` function name to its task. Must stay in step with the marker
-    /// list in `laminar-sql`'s `ai_udf`.
+    // Must stay in step with the marker list in laminar-sql's ai_udf.
     fn task_from_ai_function(name: &str) -> Option<Task> {
         match name {
             "ai_classify" => Some(Task::Classify),
@@ -1104,7 +994,6 @@ mod ai {
         }
     }
 
-    /// A single- or double-quoted string literal value.
     fn string_literal(expr: &Expr) -> Option<String> {
         let Expr::Value(value) = expr else {
             return None;
@@ -1116,7 +1005,6 @@ mod ai {
         }
     }
 
-    /// An array literal of string values (`['a', 'b']` or `ARRAY['a', 'b']`).
     fn string_array_literal(expr: &Expr) -> Option<Vec<String>> {
         let Expr::Array(array) = expr else {
             return None;
@@ -1124,9 +1012,9 @@ mod ai {
         array.elem.iter().map(string_literal).collect()
     }
 
-    /// Validate every detected AI call against the model registry. Fails the query
-    /// at plan time for an unknown model, a model that cannot perform the task, or a
-    /// labels-seam violation.
+    /// Validate every detected AI call against the model registry.
+    ///
+    /// Fails at plan time for an unknown model, unsupported task, or a labels mismatch.
     pub(crate) fn validate_ai_calls(
         registry: &ModelRegistry,
         calls: &[AiCallSpec],
@@ -1159,8 +1047,6 @@ mod ai {
             .validate(&model_name, call.task)
             .map_err(|e| DbError::InvalidOperation(e.to_string()))?;
 
-        // The labels seam: ONNX classifiers carry labels intrinsically; remote
-        // classifiers take them as the candidate set at call time.
         match entry.kind() {
             BackendKind::Local => {
                 if let Some(requested) = &call.labels {
@@ -1181,8 +1067,7 @@ mod ai {
                 }
             }
             BackendKind::Remote => {
-                // Remote classification needs a candidate set; remote sentiment is
-                // numeric (the model returns a score), so it needs no labels.
+                // Remote sentiment returns a numeric score, so no candidate set needed.
                 if call.task == Task::Classify && call.labels.is_none() {
                     return Err(DbError::InvalidOperation(format!(
                     "remote classification with model '{model_name}' requires a 'labels' argument"
@@ -1368,32 +1253,26 @@ mod ai {
 
 pub(crate) use ai::{detect_ai_functions, plan_ai_query, validate_ai_calls, AiQueryPlan};
 
-/// Private table a window-frame operator registers its enriched batch under; the
-/// residual projection reads from it. (Mirrors the AI path's `__ai_tmp`.)
+/// Temp table a window-frame operator writes enriched batches to; the residual projection reads from it.
 pub(crate) const FRAME_TMP_TABLE: &str = "__frame_tmp";
 
-/// A single-source query carrying one bivariate moment frame
-/// (`CORR`/`COVAR_SAMP`/`COVAR_POP` `OVER (ORDER BY k ROWS N PRECEDING)`). The
-/// call is lifted out — the operator computes it from carried moments — and
-/// replaced by its alias in the residual projection.
+/// A routable bivariate moment frame query (`CORR`/`COVAR_SAMP`/`COVAR_POP OVER …`).
 pub(crate) struct FrameQueryPlan {
     pub func: MomentFn,
     pub x_column: String,
     pub y_column: String,
     pub output_alias: String,
-    /// Residual SELECT over [`FRAME_TMP_TABLE`] with the stat call replaced by
-    /// its alias column.
+    /// Residual SELECT over [`FRAME_TMP_TABLE`] with the stat call replaced by its alias.
     pub projection_sql: String,
     pub source_table: String,
-    /// `max(PRECEDING)` — rows of preceding history to retain per new row.
+    /// Rows of preceding history to retain per new row (`max(PRECEDING)`).
     pub retain: usize,
 }
 
-/// Plan a query for window-frame routing. Returns `Some` only for the supported
-/// shape: a single (un-joined) source, exactly one bivariate moment call
-/// (`CORR`/`COVAR_SAMP`/`COVAR_POP`) `OVER (ORDER BY … ROWS N PRECEDING) AS
-/// alias`, no `PARTITION BY`, no `FOLLOWING` bound (streaming cannot buffer the
-/// future). Anything else returns `None` (routed normally).
+/// Plan a query for window-frame routing.
+///
+/// Returns `Some` only for: single un-joined source, one `CORR`/`COVAR_SAMP`/`COVAR_POP`
+/// `OVER (ORDER BY … ROWS N PRECEDING) AS alias`, no `PARTITION BY` or `FOLLOWING`.
 pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
     let statements = laminar_sql::parse_streaming_sql(sql).ok()?;
     let mut statement = match statements.into_iter().next()? {
@@ -1401,7 +1280,6 @@ pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
         _ => return None,
     };
 
-    // Validate the frame shape (single ordered series, preceding bounds only).
     let analysis = laminar_sql::parser::analytic_parser::analyze_window_frames(&statement)?;
     if !analysis.partition_columns.is_empty() || analysis.has_following() {
         return None;
@@ -1425,7 +1303,6 @@ pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
         _ => return None,
     };
 
-    // Find the single bivariate-moment OVER (...) AS alias projection item.
     let mut found: Option<(usize, MomentFn, String, String, String)> = None;
     for (index, item) in select.projection.iter().enumerate() {
         let SelectItem::ExprWithAlias { expr, alias } = item else {
@@ -1433,14 +1310,14 @@ pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
         };
         if let Some((func, x, y)) = moment_call(expr) {
             if found.is_some() {
-                return None; // only one frame call is supported
+                return None;
             }
             found = Some((index, func, x, y, alias.value.clone()));
         }
     }
     let (index, func, x_column, y_column, output_alias) = found?;
 
-    // Rewrite: the stat call AS alias → the bare alias column; FROM → temp table.
+    // Rewrite: stat call → bare alias column; FROM → temp table.
     select.projection[index] =
         SelectItem::UnnamedExpr(Expr::Identifier(Ident::new(output_alias.clone())));
     if let TableFactor::Table { name, .. } = &mut select.from[0].relation {
@@ -1460,8 +1337,6 @@ pub(crate) fn plan_frame_query(sql: &str) -> Option<FrameQueryPlan> {
     })
 }
 
-/// The statistic and two plain-column arguments of a bivariate moment call with
-/// an `OVER` clause (`CORR`/`COVAR_SAMP`/`COVAR_POP`), or `None` otherwise.
 fn moment_call(expr: &Expr) -> Option<(MomentFn, String, String)> {
     let Expr::Function(func) = expr else {
         return None;
@@ -1477,7 +1352,6 @@ fn moment_call(expr: &Expr) -> Option<(MomentFn, String, String)> {
     Some((kind, x, y))
 }
 
-/// The two plain-column arguments of a 2-arg function call, or `None`.
 fn bivariate_column_args(func: &sqlparser::ast::Function) -> Option<(String, String)> {
     let FunctionArguments::List(list) = &func.args else {
         return None;
@@ -1673,8 +1547,8 @@ fn expr_mentions_alias(expr: &Expr, alias: &str) -> bool {
     }
 }
 
-/// False for the non-preserved side of an outer join (removing its
-/// WHERE predicate would let NULL-extended rows through).
+// Returns false for the non-preserved side of an outer join; removing its predicate
+// would pass NULL-extended rows that the original WHERE would have rejected.
 fn can_remove_from_post_where(join_type: StreamJoinType, is_left_side: bool) -> bool {
     !matches!(
         (join_type, is_left_side),
@@ -1684,7 +1558,7 @@ fn can_remove_from_post_where(join_type: StreamJoinType, is_left_side: bool) -> 
     )
 }
 
-/// `p.col` → `col`, literals and other nodes pass through via `to_string()`.
+// `p.col` → `col`; literals and other nodes pass through via `to_string()`.
 fn expr_to_sql_strip_alias(expr: &Expr, alias: &str) -> String {
     match expr {
         Expr::CompoundIdentifier(parts)
@@ -1879,7 +1753,6 @@ pub(crate) fn detect_stream_join_query(sql: &str) -> Option<StreamJoinDetection>
 
     let multi = analyze_joins(select).ok()??;
 
-    // Find the first stream-stream join step (has time_bound, not ASOF/temporal/lookup)
     let stream_analysis = multi.joins.iter().find(|j| {
         j.time_bound.is_some() && !j.is_asof_join && !j.is_temporal_join && !j.is_lookup_join
     })?;
@@ -1890,12 +1763,11 @@ pub(crate) fn detect_stream_join_query(sql: &str) -> Option<StreamJoinDetection>
         return None;
     };
 
-    // Only route to interval join if we have time columns
     if config.left_time_column.is_empty() || config.right_time_column.is_empty() {
         return None;
     }
 
-    // RightSemi/RightAnti mapped to Inner by translator — reject to avoid wrong semantics.
+    // RightSemi/RightAnti are mapped to Inner by the translator — wrong semantics.
     if matches!(
         stream_analysis.join_type,
         laminar_sql::parser::join_parser::JoinType::RightSemi
@@ -1947,12 +1819,10 @@ pub(crate) fn detect_stream_join_query(sql: &str) -> Option<StreamJoinDetection>
     })
 }
 
-/// Detect a processing-time equi-join: a single `INNER` `a JOIN b ON a.k = b.k`
-/// with no temporal predicate. It routes to a per-cycle batch join that matches
-/// the current cycle's emissions from both sides — what aligns two windowed
-/// views closing the same bucket on processing time. Returns the same shape as
-/// [`detect_stream_join_query`] but with **empty time columns**, which is how
-/// `create_operator` tells the two join operators apart.
+/// Detect a processing-time equi-join: `INNER a JOIN b ON a.k = b.k` with no temporal predicate.
+///
+/// Returns the same shape as [`detect_stream_join_query`] with empty time columns, which is
+/// how `create_operator` distinguishes this from an interval join.
 pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> {
     use laminar_sql::parser::join_parser::JoinType;
 
@@ -1968,16 +1838,13 @@ pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> 
     };
     let multi = analyze_joins(select).ok()??;
 
-    // Exactly one INNER equi-join step, no temporal predicate, distinct tables
-    // (self-joins would collide on the suffixed output schema).
+    // Self-joins would collide on the suffixed output schema.
     if multi.joins.len() != 1 {
         return None;
     }
     let step = &multi.joins[0];
-    // A no-time-bound equi-join is tagged `is_lookup_join` by `analyze_joins`
-    // (it can't tell a windowed-view join from a stream/dim lookup); real lookup
-    // joins never reach this detector — the planner emits a Lookup config, which
-    // turns `needs_specialized_detection` off in `add_query`. So accept it here.
+    // `analyze_joins` tags no-time-bound equi-joins as is_lookup_join; real lookup joins
+    // never reach this detector (the planner emits a Lookup config first), so accept it.
     if step.time_bound.is_some()
         || step.is_asof_join
         || step.is_temporal_join
@@ -1985,9 +1852,7 @@ pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> 
     {
         return None;
     }
-    // Build the StreamStream config directly from the analysis (going through
-    // `from_analysis` would yield a Lookup config for this shape). Empty time
-    // columns are the processing-time marker `create_operator` keys on.
+    // `from_analysis` would yield a Lookup config for this shape; build directly.
     let config = StreamJoinConfig {
         left_key: step.left_key_column.clone(),
         right_key: step.right_key_column.clone(),
@@ -2029,8 +1894,7 @@ pub(crate) fn detect_processtime_join(sql: &str) -> Option<StreamJoinDetection> 
     })
 }
 
-/// TEMPORAL PROBE JOIN is not in sqlparser's grammar — recognize it by
-/// walking the token stream directly.
+/// Detect a `TEMPORAL PROBE JOIN`, which is not in sqlparser's grammar.
 pub(crate) fn detect_temporal_probe_query(
     sql: &str,
 ) -> (
@@ -2148,7 +2012,7 @@ fn expect(toks: &[&TokenWithSpan], i: &mut usize, want: &Token) -> Option<()> {
     }
 }
 
-/// Reads `a.b.c` and returns the last segment (the column name).
+// Returns the last segment of a dotted path (the column name).
 fn read_qualified(toks: &[&TokenWithSpan], i: &mut usize) -> Option<String> {
     let mut last = ident(toks.get(*i)?)?;
     *i += 1;
@@ -2207,8 +2071,7 @@ fn parse_pair(toks: &[&TokenWithSpan], i: &mut usize) -> Option<(String, String)
     Some((l, r))
 }
 
-// `0s` / `-5s` tokenize as Number + Word / Minus + Number + Word; Display
-// concatenation reassembles the literal for `parse_interval_to_ms`.
+// `0s` tokenizes as Number + Word; concatenate to reassemble for parse_interval_to_ms.
 fn token_text(toks: &[&TokenWithSpan], start: usize, end: usize) -> String {
     toks[start..end]
         .iter()
@@ -2302,15 +2165,9 @@ fn location_to_byte(sql: &str, loc: Location) -> usize {
     sql.len()
 }
 
-// ---------------------------------------------------------------------------
-// Top-K filtering
-// ---------------------------------------------------------------------------
-
-/// Apply a Top-K filter to batches, keeping at most `k` rows total.
+/// Apply a global Top-K limit across all batches.
 ///
-/// `DataFusion` applies `LIMIT N` per micro-batch, but streaming Top-K
-/// needs a global limit across the combined result. This function
-/// concatenates all batches and slices to the first `k` rows.
+/// `DataFusion`'s `LIMIT N` is per micro-batch; this slices the combined result to `k` rows.
 pub(crate) fn apply_topk_filter(batches: &[RecordBatch], k: usize) -> Vec<RecordBatch> {
     if batches.is_empty() || k == 0 {
         return Vec::new();
@@ -2321,7 +2178,6 @@ pub(crate) fn apply_topk_filter(batches: &[RecordBatch], k: usize) -> Vec<Record
         return batches.to_vec();
     }
 
-    // Slice across batches to keep exactly k rows
     let mut remaining = k;
     let mut result = Vec::new();
     for batch in batches {
@@ -2335,17 +2191,11 @@ pub(crate) fn apply_topk_filter(batches: &[RecordBatch], k: usize) -> Vec<Record
     result
 }
 
-// ---------------------------------------------------------------------------
-// Private: shared join-projection expression rewriter
-// ---------------------------------------------------------------------------
-
-/// Rewrite an expression to SQL text over a flattened join temp table.
+/// Rewrite an expression to SQL over a flattened join temp table.
 ///
-/// `leaf` resolves the per-join-type leaves (qualified column references),
-/// returning `None` to fall through to the generic recursion over the
-/// structural variants. This is the single recursion shared by the ASOF,
-/// temporal, stream-stream, and lookup rewriters, which differ only in how they
-/// resolve a `t.col` reference.
+/// `leaf` resolves qualified column references for the specific join type, returning `None`
+/// to fall through to the shared structural recursion. Shared by ASOF, temporal,
+/// stream-stream, and lookup rewriters.
 fn rewrite_join_expr<F: Fn(&Expr) -> Option<String>>(expr: &Expr, leaf: &F) -> String {
     if let Some(s) = leaf(expr) {
         return s;
@@ -2444,12 +2294,7 @@ fn rewrite_join_expr<F: Fn(&Expr) -> Option<String>>(expr: &Expr, leaf: &F) -> S
     }
 }
 
-// ---------------------------------------------------------------------------
-// Private: ASOF projection rewriting
-// ---------------------------------------------------------------------------
-
-/// Build a `SELECT ... FROM __asof_tmp` projection query from the original
-/// SELECT items, rewriting table-qualified references to plain column names.
+// Build `SELECT … FROM __asof_tmp` rewriting table-qualified refs to plain names.
 fn build_projection_sql(
     select: &sqlparser::ast::Select,
     analysis: &laminar_sql::parser::join_parser::JoinAnalysis,
@@ -2457,14 +2302,6 @@ fn build_projection_sql(
 ) -> String {
     let left_alias = analysis.left_alias.as_deref();
     let right_alias = analysis.right_alias.as_deref();
-
-    // Collect disambiguation mapping: right-side columns that collide with left
-    // get suffixed with _{right_table} in the output schema.
-    // We don't know the exact schemas here, but we know the key column is shared.
-    // For the right time column, it often collides (e.g., both sides have "ts").
-    // The actual renaming is done in build_output_schema; here we just need to
-    // handle the common case of right-qualified columns referencing their
-    // potentially-renamed counterparts.
 
     let items: Vec<String> = select
         .projection
@@ -2474,7 +2311,6 @@ fn build_projection_sql(
 
     let select_clause = items.join(", ");
 
-    // Rewrite WHERE clause if present
     let where_clause = select.selection.as_ref().map(|expr| {
         let rewritten = rewrite_expr(expr, left_alias, right_alias, config);
         format!(" WHERE {rewritten}")
@@ -2486,7 +2322,6 @@ fn build_projection_sql(
     )
 }
 
-/// Rewrite a single `SelectItem` to remove table qualifiers.
 fn rewrite_select_item(
     item: &SelectItem,
     left_alias: Option<&str>,
@@ -2502,7 +2337,6 @@ fn rewrite_select_item(
         SelectItem::Wildcard(WildcardAdditionalOptions { .. }) => "*".to_string(),
         SelectItem::QualifiedWildcard(name, _) => {
             let table = name.to_string();
-            // t.* or q.* — just use * since all columns are flattened
             if Some(table.as_str()) == left_alias || Some(table.as_str()) == right_alias {
                 "*".to_string()
             } else {
@@ -2512,8 +2346,6 @@ fn rewrite_select_item(
     }
 }
 
-/// Recursively rewrite an expression tree to remove table qualifiers
-/// and map right-side columns to their disambiguated names.
 fn rewrite_expr(
     expr: &Expr,
     left_alias: Option<&str>,
@@ -2534,8 +2366,7 @@ fn rewrite_expr(
         Some(if is_left {
             column.to_string()
         } else if is_right {
-            // Right-side columns keep their bare name, except a non-key time
-            // column that shares the left time column's name, which is suffixed.
+            // Suffix right time column if it shares the left time column name.
             if column == config.left_time_column
                 && column == config.right_time_column
                 && column != config.key_column
@@ -2550,12 +2381,6 @@ fn rewrite_expr(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Private: Temporal join projection rewriting
-// ---------------------------------------------------------------------------
-
-/// Build a `SELECT ... FROM __temporal_tmp` projection query from the original
-/// SELECT items, rewriting table-qualified references to plain column names.
 fn build_temporal_projection_sql(
     select: &sqlparser::ast::Select,
     analysis: &laminar_sql::parser::join_parser::JoinAnalysis,
@@ -2600,9 +2425,6 @@ fn build_temporal_projection_sql(
     )
 }
 
-/// Rewrite an expression tree to remove table qualifiers for temporal joins.
-/// Stream-side columns keep their names. Table-side columns keep their names
-/// (temporal join output is a flat concatenation of both sides).
 fn rewrite_temporal_expr(
     expr: &Expr,
     left_alias: Option<&str>,
@@ -2628,10 +2450,6 @@ fn rewrite_temporal_expr(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Private: Stream-stream join projection rewriting
-// ---------------------------------------------------------------------------
-
 #[allow(clippy::too_many_lines)]
 fn build_stream_join_projection_sql(
     select: &sqlparser::ast::Select,
@@ -2642,16 +2460,13 @@ fn build_stream_join_projection_sql(
     let left_alias = analysis.left_alias.as_deref();
     let right_alias = analysis.right_alias.as_deref();
 
-    // When the original SELECT chains more joins past the stream-stream step
-    // (`A JOIN B ... JOIN C ...`), they run as residual joins in the post-
-    // projection over `__interval_tmp` plus the live source catalog. Step-0
-    // column refs are then prefixed with `__interval_tmp.` so shared names
-    // (e.g. `ka` present in both `__interval_tmp` and `c`) don't collide.
+    // Extra joins beyond the step-0 stream-stream join run as residual joins in the
+    // post-projection over __interval_tmp. Step-0 refs are prefixed with __interval_tmp.
+    // to avoid collisions with downstream table names.
     let has_residual = select.from.len() == 1 && select.from[0].joins.len() > 1;
     let tmp_qual: Option<&str> = has_residual.then_some("__interval_tmp");
 
-    // Count natural-name occurrences so colliding projections (`p.type`,
-    // `a.type`) can be aliased as `{qual}_{col}` instead of duplicate `type`.
+    // Count natural names so colliding projections (p.type, a.type) get {qual}_{col} aliases.
     let mut natural_counts: FxHashMap<String, usize> = FxHashMap::default();
     if has_residual {
         for item in &select.projection {
@@ -2675,9 +2490,6 @@ fn build_stream_join_projection_sql(
             SelectItem::UnnamedExpr(expr) => {
                 let rewritten =
                     rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
-                // Alias back to the natural column name so projection labels
-                // stay user-visible. On self-join collisions, fall back to
-                // `{qual}_{col}` so output names stay unique.
                 if has_residual {
                     let (qual, natural) = match expr {
                         Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
@@ -2733,10 +2545,8 @@ fn build_stream_join_projection_sql(
         String::new()
     };
 
-    // IntervalJoin matches symmetrically (`|left_ts - right_ts| <= N`) but
-    // BETWEEN is directional (`right_ts >= left_ts AND right_ts <= left_ts +
-    // N`). The upper bound is already covered by the symmetric tolerance; we
-    // add `right_ts >= left_ts` here to enforce the lower bound.
+    // IntervalJoin is symmetric but BETWEEN is directional; add right_ts >= left_ts
+    // to enforce the lower bound (the upper is already covered by the tolerance).
     let directional_filter =
         if !config.left_time_column.is_empty() && !config.right_time_column.is_empty() {
             let left_ref = match tmp_qual {
@@ -2765,9 +2575,7 @@ fn build_stream_join_projection_sql(
     )
 }
 
-/// Append residual joins (steps 1..N) onto a projection that selects
-/// from `__interval_tmp`. Unsupported join shapes (CROSS, USING, etc.)
-/// pass through via sqlparser's Display — we only rewrite ON exprs.
+// Unsupported shapes (CROSS, USING, etc.) pass through sqlparser's Display unchanged.
 fn render_residual_joins(
     joins: &[sqlparser::ast::Join],
     config: &StreamJoinConfig,
@@ -2787,7 +2595,6 @@ fn render_residual_joins(
             JoinOperator::Right(JoinConstraint::On(e))
             | JoinOperator::RightOuter(JoinConstraint::On(e)) => ("RIGHT JOIN", e),
             JoinOperator::FullOuter(JoinConstraint::On(e)) => ("FULL JOIN", e),
-            // No ON expr to rewrite — let sqlparser format the whole join.
             _ => {
                 out.push(' ');
                 let _ = std::fmt::Write::write_fmt(&mut out, format_args!("{join}"));
@@ -2803,11 +2610,8 @@ fn render_residual_joins(
     out
 }
 
-/// Rewrite `t.col` references against the `__interval_tmp` schema:
-/// step-0 left columns become bare names, right columns get the
-/// `_<right_table>` suffix that `IntervalJoinState` adds. With
-/// `tmp_qual = Some("__interval_tmp")` the rewritten names are also
-/// prefixed to disambiguate from downstream tables in residual joins.
+// Left columns become bare names; right columns get the _<right_table> suffix from IntervalJoinState.
+// tmp_qual prefixes rewritten names to disambiguate from downstream tables in residual joins.
 fn rewrite_stream_join_expr(
     expr: &sqlparser::ast::Expr,
     left_alias: Option<&str>,
@@ -2842,12 +2646,7 @@ fn rewrite_stream_join_expr(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Private: Temporal probe join projection rewriting
-// ---------------------------------------------------------------------------
-
-/// Pre-process the temporal probe SQL into a standard JOIN that sqlparser
-/// can parse, then walk the AST to build the projection SQL.
+// Rewrites the probe clause to a standard JOIN so sqlparser can parse the rest of the query.
 fn build_probe_projection_via_ast(
     original_sql: &str,
     tpj_pos: usize,
@@ -2858,7 +2657,6 @@ fn build_probe_projection_via_ast(
 ) -> Option<String> {
     let probe = &config.probe_alias;
 
-    // Build standard JOIN to replace the probe clause
     let left_ref = left_alias.unwrap_or(&config.left_table);
     let right_ref = right_alias.unwrap_or(&config.right_table);
     let on_clause = config
@@ -2877,13 +2675,11 @@ fn build_probe_projection_via_ast(
     let after_probe = &original_sql[probe_clause_end..];
     let mut rewritten = format!("{before_probe}{join_clause}{after_probe}");
 
-    // Resolve probe pseudo-columns to plain identifiers before parsing
     rewritten = rewritten.replace(&format!("{probe}.offset_ms"), &format!("{probe}_offset_ms"));
     rewritten = rewritten.replace(&format!("{probe}.probe_ts"), &format!("{probe}_probe_ts"));
     rewritten = rewritten.replace(&format!("{probe}.offset_us"), &format!("{probe}_offset_ms"));
     rewritten = rewritten.replace(&format!("{probe}.timestamp"), &format!("{probe}_probe_ts"));
 
-    // Parse the rewritten SQL
     let stmts = laminar_sql::parse_streaming_sql(&rewritten).ok()?;
     let laminar_sql::parser::StreamingStatement::Standard(stmt) = stmts.first()? else {
         return None;
@@ -2895,7 +2691,6 @@ fn build_probe_projection_via_ast(
         return None;
     };
 
-    // Walk AST to build projection SQL
     let items: Vec<String> = select
         .projection
         .iter()
@@ -2954,10 +2749,6 @@ fn rewrite_probe_select_item(
     }
 }
 
-/// AST-level expression rewriter for temporal probe projection.
-/// Same recursive structure as ASOF `rewrite_expr`, parameterized for
-/// `TemporalProbeConfig` with composite key support and time-column
-/// disambiguation heuristic.
 fn rewrite_probe_expr(
     expr: &Expr,
     left_alias: Option<&str>,
@@ -3036,17 +2827,16 @@ fn rewrite_probe_expr(
     }
 }
 
-// --- Retracting temporal-filter recognition ---
-
-/// One side of `time_col CMP now()+off_ms`. `strict` ⇒ `>`/`<`.
+/// One bound of a `time_col CMP now() ± offset` predicate. `strict` means `>`/`<`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TemporalBound {
     pub(crate) off_ms: i64,
     pub(crate) strict: bool,
 }
 
-/// `SELECT cols FROM <t> WHERE time_col {>|>=|<|<=} now() ± INTERVAL`
-/// (or BETWEEN). Empty `proj_cols` ⇒ `SELECT *`.
+/// Config for a retracting temporal filter (`WHERE time_col CMP now() ± INTERVAL`).
+///
+/// Empty `proj_cols` means `SELECT *`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TemporalFilterConfig {
     pub(crate) source_table: String,
@@ -3059,7 +2849,7 @@ pub(crate) struct TemporalFilterConfig {
 pub(crate) enum TemporalFilterAnalysis {
     NotPresent,
     Recognized(Box<TemporalFilterConfig>),
-    /// `now()` used in some shape we don't support.
+    /// `now()` appears in a shape the retracting filter doesn't support.
     PresentUnrecognized,
 }
 
@@ -3068,8 +2858,7 @@ fn ident_is_wallclock(name: &str) -> bool {
 }
 
 fn expr_is_wallclock(expr: &Expr) -> bool {
-    // Only unquoted single-segment identifiers are the wallclock keyword;
-    // `"now"` is a column, and `events.now` is a column reference.
+    // `"now"` is a column; only unquoted bare `now` / `current_timestamp` is wallclock.
     fn ident(i: &sqlparser::ast::Ident) -> bool {
         i.quote_style.is_none() && ident_is_wallclock(&i.value)
     }
@@ -3167,7 +2956,6 @@ fn strip_nested(expr: &Expr) -> &Expr {
     e
 }
 
-/// `INTERVAL '<n>' <unit>` → magnitude in ms (sub-ms truncated).
 fn interval_to_ms(expr: &Expr) -> Option<i64> {
     let Expr::Interval(iv) = strip_nested(expr) else {
         return None;
@@ -3194,7 +2982,7 @@ fn interval_to_ms(expr: &Expr) -> Option<i64> {
     i64::try_from(value.checked_mul(us)? / 1_000).ok()
 }
 
-/// `now()` ⇒ 0, `now() ± I` ⇒ ±I (ms).
+// now() → 0, now() ± I → ±I (ms).
 fn now_offset_ms(expr: &Expr) -> Option<i64> {
     let expr = strip_nested(expr);
     if expr_is_wallclock(expr) {
@@ -3216,7 +3004,6 @@ fn now_offset_ms(expr: &Expr) -> Option<i64> {
     let mag = interval_to_ms(iv_side)?;
     match op {
         sqlparser::ast::BinaryOperator::Plus => Some(mag),
-        // `now() - I` only (subtraction is not commutative).
         sqlparser::ast::BinaryOperator::Minus if expr_is_wallclock(left) => Some(-mag),
         _ => None,
     }
@@ -3230,8 +3017,7 @@ fn column_name(expr: &Expr) -> Option<String> {
     }
 }
 
-/// Recognise `col CMP now()±I` or `col BETWEEN now()-X AND now()+Y`.
-/// Anything else (conjuncts, disjunctions, ...) ⇒ `None`.
+// Returns None for conjuncts, disjunctions, and other unsupported shapes.
 fn parse_temporal_predicate(
     expr: &Expr,
 ) -> Option<(String, Option<TemporalBound>, Option<TemporalBound>)> {
@@ -3259,7 +3045,7 @@ fn parse_temporal_predicate(
             ))
         }
         Expr::BinaryOp { left, op, right } => {
-            // Normalise to `col OP now()+off` (flip if column is on the right).
+            // Normalise to col OP now()+off (flip the operator when the column is on the right).
             let (col_e, now_e, op) = if column_name(left).is_some() {
                 (left.as_ref(), right.as_ref(), op.clone())
             } else {
@@ -3338,8 +3124,7 @@ pub(crate) fn analyze_temporal_filter(sql: &str) -> TemporalFilterAnalysis {
         return TemporalFilterAnalysis::NotPresent;
     }
 
-    // Canonical shape only — no DISTINCT/HAVING/TOP/ORDER/GROUP/JOIN/
-    // LIMIT/FETCH; row-limiting doesn't compose with retraction.
+    // Only the canonical shape is supported; row-limiting doesn't compose with retraction.
     let recognised = (|| {
         if query.order_by.is_some() || query.limit_clause.is_some() || query.fetch.is_some() {
             return None;

--- a/crates/laminar-db/src/sql_utils.rs
+++ b/crates/laminar-db/src/sql_utils.rs
@@ -1,4 +1,4 @@
-//! SQL utility functions for multi-statement parsing and config variable substitution.
+//! SQL parsing utilities: statement splitting and config variable substitution.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -8,10 +8,6 @@ use sqlparser::tokenizer::{Token, Tokenizer};
 
 use crate::error::DbError;
 
-/// Build a byte-offset index for each line in `sql`.
-///
-/// Returns a `Vec` where entry `i` is the byte offset of the start of
-/// 1-based line `i+1`. Line 1 always starts at byte 0.
 fn build_line_starts(sql: &str) -> Vec<usize> {
     let mut starts = vec![0usize];
     for (i, b) in sql.bytes().enumerate() {
@@ -22,17 +18,11 @@ fn build_line_starts(sql: &str) -> Vec<usize> {
     starts
 }
 
-/// Convert a 1-based `(line, column)` from sqlparser's `Location` to a byte
-/// offset in `sql`.
-///
-/// sqlparser's `column` counts *characters* (via `Peekable<Chars>`), not
-/// bytes, so we walk with `char_indices()` for multi-byte correctness.
+// sqlparser's column counts characters, not bytes — walk with char_indices for multi-byte safety.
 fn location_to_byte_offset(sql: &str, line_starts: &[usize], line: u64, column: u64) -> usize {
     let line_idx = usize::try_from(line).unwrap_or(1).saturating_sub(1);
     let line_start = line_starts.get(line_idx).copied().unwrap_or(0);
-    let col_chars = usize::try_from(column).unwrap_or(1).saturating_sub(1); // 1-based → 0-based
-
-    // Walk `col_chars` characters from `line_start` to find the byte offset.
+    let col_chars = usize::try_from(column).unwrap_or(1).saturating_sub(1);
     sql[line_start..]
         .char_indices()
         .nth(col_chars)
@@ -41,13 +31,11 @@ fn location_to_byte_offset(sql: &str, line_starts: &[usize], line: u64, column: 
 
 /// Split a SQL string into individual statements on unquoted semicolons.
 ///
-/// Uses the sqlparser tokenizer to correctly handle quoted strings,
-/// single-line comments (`--`), and block comments (`/* ... */`).
-/// Empty statements (whitespace/comments only) are skipped.
+/// Uses the sqlparser tokenizer to handle quoted strings, line comments, and block comments.
+/// Empty statements are skipped.
 pub fn split_statements(sql: &str) -> Vec<&str> {
     let dialect = GenericDialect {};
-    // On tokenizer failure, return the whole string as one statement
-    // so that the downstream parser can produce a proper error.
+    // On tokenizer failure, return the whole string so the parser can emit the real error.
     let Ok(tokens) = Tokenizer::new(&dialect, sql).tokenize_with_location() else {
         let trimmed = sql.trim();
         if trimmed.is_empty() {
@@ -84,7 +72,6 @@ pub fn split_statements(sql: &str) -> Vec<&str> {
         }
     }
 
-    // Trailing segment (no semicolon)
     if has_significant {
         let stmt = sql[seg_start..].trim();
         if !stmt.is_empty() {
@@ -95,13 +82,12 @@ pub fn split_statements(sql: &str) -> Vec<&str> {
     statements
 }
 
-/// Resolve `${VAR_NAME}` placeholders in a SQL string with values from the given map.
+/// Resolve `${VAR_NAME}` placeholders in `sql` from `vars`.
 ///
 /// # Errors
 ///
-/// Returns `DbError::InvalidOperation` if a referenced variable is not found
-/// and `strict` is true. In permissive mode (strict=false), unresolved
-/// variables are left as-is.
+/// Returns `DbError::InvalidOperation` for an unknown variable when `strict` is true.
+/// When `strict` is false, unresolved placeholders are left in place.
 pub fn resolve_config_vars(
     sql: &str,
     vars: &HashMap<String, String>,
@@ -114,20 +100,15 @@ pub fn resolve_config_vars(
 
     while i < len {
         if bytes[i] == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
-            // Found ${
             let start = i;
-            i += 2; // skip ${
+            i += 2;
             let var_start = i;
-
-            // Find closing }
             while i < len && bytes[i] != b'}' {
                 i += 1;
             }
-
             if i < len {
                 let var_name = &sql[var_start..i];
-                i += 1; // skip }
-
+                i += 1;
                 if let Some(value) = vars.get(var_name) {
                     result.push_str(value);
                 } else if strict {
@@ -135,11 +116,9 @@ pub fn resolve_config_vars(
                         "Unresolved config variable: ${{{var_name}}}"
                     )));
                 } else {
-                    // Permissive: leave as-is
                     result.push_str(&sql[start..i]);
                 }
             } else {
-                // No closing }, copy literal
                 result.push_str(&sql[start..]);
             }
         } else {
@@ -151,12 +130,9 @@ pub fn resolve_config_vars(
     Ok(result)
 }
 
-// -- SQL value extraction helpers ----------------------------------------
-
 /// Extract a string representation from a SQL expression.
 ///
-/// Handles literals, quoted strings, numbers, booleans, NULL, and
-/// unary minus (negative numbers).
+/// Handles literals, quoted strings, numbers, booleans, NULL, and unary minus.
 pub fn expr_to_string(expr: Option<&sqlparser::ast::Expr>) -> Option<String> {
     use sqlparser::ast::{Expr, UnaryOperator, Value};
 
@@ -177,7 +153,7 @@ pub fn expr_to_string(expr: Option<&sqlparser::ast::Expr>) -> Option<String> {
     }
 }
 
-/// Extract an `i64` from a SQL expression.
+/// Extract an `i64` from a SQL number literal or negated literal.
 pub fn expr_to_i64(expr: Option<&sqlparser::ast::Expr>) -> Option<i64> {
     use sqlparser::ast::{Expr, UnaryOperator, Value};
 
@@ -195,7 +171,7 @@ pub fn expr_to_i64(expr: Option<&sqlparser::ast::Expr>) -> Option<i64> {
     }
 }
 
-/// Extract an `f64` from a SQL expression.
+/// Extract an `f64` from a SQL number literal or negated literal.
 pub fn expr_to_f64(expr: Option<&sqlparser::ast::Expr>) -> Option<f64> {
     use sqlparser::ast::{Expr, UnaryOperator, Value};
 
@@ -213,7 +189,7 @@ pub fn expr_to_f64(expr: Option<&sqlparser::ast::Expr>) -> Option<f64> {
     }
 }
 
-/// Extract a `bool` from a SQL expression.
+/// Extract a `bool` from a SQL boolean literal.
 pub fn expr_to_bool(expr: Option<&sqlparser::ast::Expr>) -> Option<bool> {
     use sqlparser::ast::{Expr, Value};
 
@@ -227,8 +203,7 @@ pub fn expr_to_bool(expr: Option<&sqlparser::ast::Expr>) -> Option<bool> {
     }
 }
 
-/// Narrow `i64` SQL literals to a smaller signed Arrow integer type,
-/// erroring on out-of-range values rather than silently wrapping.
+/// Narrow `i64` SQL literals to a smaller signed Arrow type, erroring on overflow.
 fn narrow_i64_col<N: TryFrom<i64>>(
     values: &[Vec<sqlparser::ast::Expr>],
     col_idx: usize,
@@ -254,13 +229,11 @@ fn narrow_i64_col<N: TryFrom<i64>>(
 
 /// Convert SQL `VALUES (...)` rows into an Arrow `RecordBatch`.
 ///
-/// Each inner `Vec<Expr>` is one row. Columns are matched positionally
-/// against the provided `schema`.
+/// Columns are matched positionally against `schema`.
 ///
 /// # Errors
 ///
-/// Returns `DbError::InsertError` if the batch cannot be constructed
-/// (e.g. column count mismatch).
+/// Returns `DbError::InsertError` if the batch cannot be constructed.
 #[allow(clippy::cast_possible_truncation)] // SQL float literals widened to Arrow f32
 pub fn sql_values_to_record_batch(
     schema: &arrow::datatypes::SchemaRef,
@@ -320,7 +293,6 @@ pub fn sql_values_to_record_batch(
                 columns.push(std::sync::Arc::new(arr));
             }
             _ => {
-                // For Utf8 and any other type, convert to string
                 let strs: Vec<Option<String>> = values
                     .iter()
                     .map(|row| expr_to_string(row.get(col_idx)))

--- a/crates/laminar-db/src/state_tier/mod.rs
+++ b/crates/laminar-db/src/state_tier/mod.rs
@@ -22,33 +22,24 @@ use crate::error::DbError;
 /// fjall database subdirectory under the tier dir.
 const DB_DIR: &str = "db";
 
-/// The cold-tier store: one fjall database with a single KV-separated
-/// keyspace holding `(operator, vnode) → slice bytes`.
-///
-/// Synchronous API by design — call it from the worker / `spawn_blocking`,
-/// never from the compute thread.
+/// fjall-backed store for `(operator, vnode) → slice bytes`. Synchronous; call from
+/// the worker / `spawn_blocking`, never from the compute thread.
 pub(crate) struct StateTierStore {
-    /// Owns the fjall database. The `slices` keyspace only holds a sender to
-    /// this database's background flush/compaction workers, so the database
-    /// must outlive it — held, never read after construction.
+    // Must outlive `slices` (which only holds a sender to its background workers).
     #[allow(dead_code)]
     db: fjall::Database,
     slices: fjall::Keyspace,
-    /// Logical accounting (key + value bytes; slice count) for the gauges.
     logical_bytes: AtomicI64,
     logical_slices: AtomicI64,
     metrics: Option<Arc<EngineMetrics>>,
 }
 
 impl StateTierStore {
-    /// Open the tier under `dir`, wiping any leftover from a previous run —
-    /// the tier never survives a restart (demoted state rehydrates from
-    /// partials), so starting empty is the contract.
+    /// Open the tier under `dir`, wiping any leftover from a previous run.
     ///
     /// # Errors
     ///
-    /// Returns `DbError::Storage` when the directory cannot be (re)created or
-    /// the fjall database fails to open.
+    /// Returns `DbError::Storage` if the directory cannot be (re)created or fjall fails to open.
     pub(crate) fn open(
         dir: impl Into<std::path::PathBuf>,
         metrics: Option<Arc<EngineMetrics>>,
@@ -65,8 +56,7 @@ impl StateTierStore {
         let db = fjall::Database::builder(dir.join(DB_DIR))
             .open()
             .map_err(|e| DbError::Storage(format!("state tier open: {e}")))?;
-        // Slices are multi-KB..MB blobs — exactly what key-value separation
-        // is for (dev-box bench: 1.57x write amplification with it).
+        // KV-separation suits the multi-KB..MB blobs stored here (1.57x WA on dev-box bench).
         let ks = db
             .keyspace("slices", || {
                 fjall::KeyspaceCreateOptions::default()
@@ -84,8 +74,7 @@ impl StateTierStore {
     }
 
     fn key(operator: &str, vnode: u32) -> Vec<u8> {
-        // NUL separator between the operator name (a SQL identifier, never
-        // NUL) and the vnode — keeps keys unambiguous.
+        // NUL separator: operator names are SQL identifiers (never NUL), so keys stay unambiguous.
         let mut k = Vec::with_capacity(operator.len() + 5);
         k.extend_from_slice(operator.as_bytes());
         k.push(0);
@@ -93,8 +82,7 @@ impl StateTierStore {
         k
     }
 
-    /// Store a demoted slice (overwrites any previous demotion of the same
-    /// vnode). No fsync — the tier is rebuildable by contract.
+    /// Store a demoted slice. No fsync — the tier is rebuildable from checkpoint partials.
     pub(crate) fn put(&self, operator: &str, vnode: u32, bytes: &[u8]) -> Result<(), DbError> {
         let key = Self::key(operator, vnode);
         let old_len = self
@@ -115,14 +103,13 @@ impl StateTierStore {
             self.logical_bytes.fetch_add(new_total, Ordering::Relaxed);
             self.logical_slices.fetch_add(1, Ordering::Relaxed);
         }
-        // `state_tier_demote_total` counts *effective* demotions, incremented by
-        // the graph only when the operator actually drops the vnode — not here,
-        // where a write may still be rolled back if the vnode turns out dirty.
+        // `state_tier_demote_total` is incremented by the graph, not here — a write
+        // may still be rolled back if the vnode turns out dirty.
         self.publish_gauges();
         Ok(())
     }
 
-    /// Fetch a slice for promotion. `None` = not resident (e.g. wiped).
+    /// Fetch a slice for promotion. `None` if not resident.
     pub(crate) fn get(&self, operator: &str, vnode: u32) -> Result<Option<Bytes>, DbError> {
         let start = std::time::Instant::now();
         let v = self
@@ -137,7 +124,7 @@ impl StateTierStore {
         Ok(v.map(|v| Bytes::copy_from_slice(&v)))
     }
 
-    /// Drop a slice (after promotion, or when releasing a vnode).
+    /// Remove a slice after promotion or vnode release.
     pub(crate) fn remove(&self, operator: &str, vnode: u32) -> Result<(), DbError> {
         let key = Self::key(operator, vnode);
         let old = self
@@ -157,12 +144,10 @@ impl StateTierStore {
         Ok(())
     }
 
-    /// Logical bytes currently resident (keys + values).
     pub(crate) fn logical_bytes(&self) -> i64 {
         self.logical_bytes.load(Ordering::Relaxed)
     }
 
-    /// Slices currently resident.
     pub(crate) fn logical_slices(&self) -> i64 {
         self.logical_slices.load(Ordering::Relaxed)
     }

--- a/crates/laminar-db/src/state_tier/mod.rs
+++ b/crates/laminar-db/src/state_tier/mod.rs
@@ -339,7 +339,7 @@ impl StateTierStore {
 
 mod worker;
 #[allow(unused_imports)] // consumed by the demotion/promotion wiring (and tests)
-pub(crate) use worker::{spawn_worker, TierRequest};
+pub(crate) use worker::{spawn_worker, TierRequest, TierTx};
 
 #[cfg(test)]
 mod tests;

--- a/crates/laminar-db/src/state_tier/mod.rs
+++ b/crates/laminar-db/src/state_tier/mod.rs
@@ -1,28 +1,16 @@
 //! Disk cold tier for demoted operator state.
 //!
-//! Stores `(operator, vnode)` checkpoint slices that have been demoted out
-//! of memory: a slice may be demoted only when its bytes are already
-//! captured in a restorable checkpoint, so the tier holds **capacity, not
-//! durability** — truth stays in the object-store checkpoint artifacts, and
-//! the tier runs without per-write fsync. Losing it costs a rehydration
-//! from the last restorable epoch, never data.
+//! Stores `(operator, vnode)` checkpoint slices demoted out of memory. A
+//! slice may be demoted only once its bytes are captured in a restorable
+//! checkpoint, so the tier holds **capacity, not durability** — truth stays
+//! in the object-store checkpoint artifacts, the tier runs without per-write
+//! fsync, and it is wiped on restart (demoted vnodes rehydrate from their
+//! partials). Losing it costs a rehydration, never data.
 //!
-//! Lifecycle contract: a marker file records the engine version, a clean
-//! flag, and the logical counters. On open, anything other than a clean
-//! marker from the same engine version (unclean shutdown, version change,
-//! corruption) **wipes the directory** and starts empty — the demoted state
-//! rehydrates through the existing recovery path.
-//!
-//! Threading contract: the synchronous fjall handle is only ever touched
-//! from the worker (`spawn_worker`), which runs on the main tokio runtime
-//! and pushes each store call into `spawn_blocking`. The compute thread
-//! talks to the tier exclusively through the worker's bounded channel
-//! (`try_send` on submit, drain replies on later cycles), so a cold read
-//! can never stall it.
+//! The synchronous fjall handle is only ever touched from the worker
+//! (`spawn_worker`) via `spawn_blocking`; the compute thread talks to the
+//! tier through the worker's bounded channel, so a cold read never stalls it.
 
-#![allow(dead_code)] // dormant until the demotion/promotion wiring lands
-
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
@@ -31,65 +19,8 @@ use bytes::Bytes;
 use crate::engine_metrics::EngineMetrics;
 use crate::error::DbError;
 
-/// Bump when the marker format or the key encoding changes.
-const FORMAT_VERSION: u32 = 1;
-/// Marker file name, sibling of the fjall directory.
-const MARKER_FILE: &str = "marker";
-/// fjall database subdirectory.
+/// fjall database subdirectory under the tier dir.
 const DB_DIR: &str = "db";
-
-/// Why an existing tier directory was discarded at open.
-#[derive(Debug, PartialEq, Eq)]
-enum WipeReason {
-    UncleanShutdown,
-    FormatMismatch,
-    EngineVersionMismatch,
-    CorruptMarker,
-}
-
-/// Parsed contents of the marker file.
-struct Marker {
-    format: u32,
-    engine: String,
-    clean: bool,
-    slices: i64,
-    bytes: i64,
-}
-
-impl Marker {
-    fn parse(text: &str) -> Option<Self> {
-        let mut format = None;
-        let mut engine = None;
-        let mut clean = None;
-        let mut slices = None;
-        let mut bytes = None;
-        for line in text.lines() {
-            let (k, v) = line.split_once('=')?;
-            match k {
-                "format" => format = v.parse().ok(),
-                "engine" => engine = Some(v.to_string()),
-                "clean" => clean = v.parse().ok(),
-                "slices" => slices = v.parse().ok(),
-                "bytes" => bytes = v.parse().ok(),
-                _ => {}
-            }
-        }
-        Some(Self {
-            format: format?,
-            engine: engine?,
-            clean: clean?,
-            slices: slices?,
-            bytes: bytes?,
-        })
-    }
-
-    fn render(&self) -> String {
-        format!(
-            "format={}\nengine={}\nclean={}\nslices={}\nbytes={}\n",
-            self.format, self.engine, self.clean, self.slices, self.bytes
-        )
-    }
-}
 
 /// The cold-tier store: one fjall database with a single KV-separated
 /// keyspace holding `(operator, vnode) → slice bytes`.
@@ -97,61 +28,39 @@ impl Marker {
 /// Synchronous API by design — call it from the worker / `spawn_blocking`,
 /// never from the compute thread.
 pub(crate) struct StateTierStore {
+    /// Owns the fjall database. The `slices` keyspace only holds a sender to
+    /// this database's background flush/compaction workers, so the database
+    /// must outlive it — held, never read after construction.
+    #[allow(dead_code)]
     db: fjall::Database,
     slices: fjall::Keyspace,
-    dir: PathBuf,
-    /// Logical accounting (key + value bytes; slice count). Persisted into
-    /// the marker at clean shutdown so a reused tier reopens with correct
-    /// gauges without scanning blobs.
+    /// Logical accounting (key + value bytes; slice count) for the gauges.
     logical_bytes: AtomicI64,
     logical_slices: AtomicI64,
     metrics: Option<Arc<EngineMetrics>>,
 }
 
 impl StateTierStore {
-    /// Open (or wipe-and-create) the tier under `dir`.
+    /// Open the tier under `dir`, wiping any leftover from a previous run —
+    /// the tier never survives a restart (demoted state rehydrates from
+    /// partials), so starting empty is the contract.
     ///
     /// # Errors
     ///
-    /// Returns `DbError::Storage` when the directory cannot be created or
-    /// the fjall database fails to open. A bad *previous* state is not an
-    /// error — it wipes and starts empty by contract.
+    /// Returns `DbError::Storage` when the directory cannot be (re)created or
+    /// the fjall database fails to open.
     pub(crate) fn open(
-        dir: impl Into<PathBuf>,
+        dir: impl Into<std::path::PathBuf>,
         metrics: Option<Arc<EngineMetrics>>,
     ) -> Result<Self, DbError> {
         let dir = dir.into();
-        let mut slices: i64 = 0;
-        let mut bytes: i64 = 0;
-
         if dir.exists() {
-            match Self::validate_marker(&dir) {
-                Ok(marker) => {
-                    slices = marker.slices;
-                    bytes = marker.bytes;
-                }
-                Err(reason) => {
-                    tracing::warn!(
-                        dir = %dir.display(),
-                        reason = ?reason,
-                        "state tier not reusable — wiping (demoted state will \
-                         rehydrate from the last restorable checkpoint)"
-                    );
-                    if let Some(ref m) = metrics {
-                        m.state_tier_wipes_total.inc();
-                    }
-                    std::fs::remove_dir_all(&dir).map_err(|e| {
-                        DbError::Storage(format!("state tier wipe {}: {e}", dir.display()))
-                    })?;
-                }
-            }
+            tracing::info!(dir = %dir.display(), "wiping leftover cold tier on open");
+            std::fs::remove_dir_all(&dir)
+                .map_err(|e| DbError::Storage(format!("state tier wipe {}: {e}", dir.display())))?;
         }
         std::fs::create_dir_all(&dir)
             .map_err(|e| DbError::Storage(format!("state tier dir {}: {e}", dir.display())))?;
-
-        // Mark "running" before any writes: a crash from here on is an
-        // unclean shutdown and the next open wipes.
-        Self::write_marker(&dir, false, slices, bytes)?;
 
         let db = fjall::Database::builder(dir.join(DB_DIR))
             .open()
@@ -165,49 +74,18 @@ impl StateTierStore {
             })
             .map_err(|e| DbError::Storage(format!("state tier keyspace: {e}")))?;
 
-        let store = Self {
+        Ok(Self {
             db,
             slices: ks,
-            dir,
-            logical_bytes: AtomicI64::new(bytes),
-            logical_slices: AtomicI64::new(slices),
+            logical_bytes: AtomicI64::new(0),
+            logical_slices: AtomicI64::new(0),
             metrics,
-        };
-        store.publish_gauges();
-        Ok(store)
-    }
-
-    fn validate_marker(dir: &Path) -> Result<Marker, WipeReason> {
-        let text = std::fs::read_to_string(dir.join(MARKER_FILE))
-            .map_err(|_| WipeReason::CorruptMarker)?;
-        let marker = Marker::parse(&text).ok_or(WipeReason::CorruptMarker)?;
-        if marker.format != FORMAT_VERSION {
-            return Err(WipeReason::FormatMismatch);
-        }
-        if marker.engine != env!("CARGO_PKG_VERSION") {
-            return Err(WipeReason::EngineVersionMismatch);
-        }
-        if !marker.clean {
-            return Err(WipeReason::UncleanShutdown);
-        }
-        Ok(marker)
-    }
-
-    fn write_marker(dir: &Path, clean: bool, slices: i64, bytes: i64) -> Result<(), DbError> {
-        let marker = Marker {
-            format: FORMAT_VERSION,
-            engine: env!("CARGO_PKG_VERSION").to_string(),
-            clean,
-            slices,
-            bytes,
-        };
-        std::fs::write(dir.join(MARKER_FILE), marker.render())
-            .map_err(|e| DbError::Storage(format!("state tier marker: {e}")))
+        })
     }
 
     fn key(operator: &str, vnode: u32) -> Vec<u8> {
-        // Operator names are SQL identifiers and never contain NUL, so a
-        // NUL separator keeps (operator, vnode) prefixes unambiguous.
+        // NUL separator between the operator name (a SQL identifier, never
+        // NUL) and the vnode — keeps keys unambiguous.
         let mut k = Vec::with_capacity(operator.len() + 5);
         k.extend_from_slice(operator.as_bytes());
         k.push(0);
@@ -279,32 +157,6 @@ impl StateTierStore {
         Ok(())
     }
 
-    /// Drop every slice of one operator (operator removed from the graph).
-    pub(crate) fn remove_operator(&self, operator: &str) -> Result<usize, DbError> {
-        let mut prefix = Vec::with_capacity(operator.len() + 1);
-        prefix.extend_from_slice(operator.as_bytes());
-        prefix.push(0);
-        let keys: Vec<_> = self
-            .slices
-            .prefix(&prefix)
-            .map(|guard| guard.into_inner().map(|(k, v)| (k, v.len())))
-            .collect::<Result<_, _>>()
-            .map_err(|e| DbError::Storage(format!("state tier scan: {e}")))?;
-        let count = keys.len();
-        for (key, vlen) in keys {
-            let klen = key.len();
-            self.slices
-                .remove(key)
-                .map_err(|e| DbError::Storage(format!("state tier remove: {e}")))?;
-            #[allow(clippy::cast_possible_wrap)]
-            self.logical_bytes
-                .fetch_sub((klen + vlen) as i64, Ordering::Relaxed);
-            self.logical_slices.fetch_sub(1, Ordering::Relaxed);
-        }
-        self.publish_gauges();
-        Ok(count)
-    }
-
     /// Logical bytes currently resident (keys + values).
     pub(crate) fn logical_bytes(&self) -> i64 {
         self.logical_bytes.load(Ordering::Relaxed)
@@ -321,24 +173,9 @@ impl StateTierStore {
             m.state_tier_slices.set(self.logical_slices());
         }
     }
-
-    /// Clean shutdown: persist fjall, then write the clean marker so the
-    /// next open reuses the tier. Anything short of this wipes on reopen.
-    ///
-    /// # Errors
-    ///
-    /// Returns `DbError::Storage` if the persist or the marker write fails
-    /// (the tier then reopens empty — safe, just slower).
-    pub(crate) fn shutdown(&self) -> Result<(), DbError> {
-        self.db
-            .persist(fjall::PersistMode::SyncAll)
-            .map_err(|e| DbError::Storage(format!("state tier persist: {e}")))?;
-        Self::write_marker(&self.dir, true, self.logical_slices(), self.logical_bytes())
-    }
 }
 
 mod worker;
-#[allow(unused_imports)] // consumed by the demotion/promotion wiring (and tests)
 pub(crate) use worker::{spawn_worker, TierRequest, TierTx};
 
 #[cfg(test)]

--- a/crates/laminar-db/src/state_tier/mod.rs
+++ b/crates/laminar-db/src/state_tier/mod.rs
@@ -1,0 +1,345 @@
+//! Disk cold tier for demoted operator state.
+//!
+//! Stores `(operator, vnode)` checkpoint slices that have been demoted out
+//! of memory: a slice may be demoted only when its bytes are already
+//! captured in a restorable checkpoint, so the tier holds **capacity, not
+//! durability** — truth stays in the object-store checkpoint artifacts, and
+//! the tier runs without per-write fsync. Losing it costs a rehydration
+//! from the last restorable epoch, never data.
+//!
+//! Lifecycle contract: a marker file records the engine version, a clean
+//! flag, and the logical counters. On open, anything other than a clean
+//! marker from the same engine version (unclean shutdown, version change,
+//! corruption) **wipes the directory** and starts empty — the demoted state
+//! rehydrates through the existing recovery path.
+//!
+//! Threading contract: the synchronous fjall handle is only ever touched
+//! from the worker (`spawn_worker`), which runs on the main tokio runtime
+//! and pushes each store call into `spawn_blocking`. The compute thread
+//! talks to the tier exclusively through the worker's bounded channel
+//! (`try_send` on submit, drain replies on later cycles), so a cold read
+//! can never stall it.
+
+#![allow(dead_code)] // dormant until the demotion/promotion wiring lands
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::engine_metrics::EngineMetrics;
+use crate::error::DbError;
+
+/// Bump when the marker format or the key encoding changes.
+const FORMAT_VERSION: u32 = 1;
+/// Marker file name, sibling of the fjall directory.
+const MARKER_FILE: &str = "marker";
+/// fjall database subdirectory.
+const DB_DIR: &str = "db";
+
+/// Why an existing tier directory was discarded at open.
+#[derive(Debug, PartialEq, Eq)]
+enum WipeReason {
+    UncleanShutdown,
+    FormatMismatch,
+    EngineVersionMismatch,
+    CorruptMarker,
+}
+
+/// Parsed contents of the marker file.
+struct Marker {
+    format: u32,
+    engine: String,
+    clean: bool,
+    slices: i64,
+    bytes: i64,
+}
+
+impl Marker {
+    fn parse(text: &str) -> Option<Self> {
+        let mut format = None;
+        let mut engine = None;
+        let mut clean = None;
+        let mut slices = None;
+        let mut bytes = None;
+        for line in text.lines() {
+            let (k, v) = line.split_once('=')?;
+            match k {
+                "format" => format = v.parse().ok(),
+                "engine" => engine = Some(v.to_string()),
+                "clean" => clean = v.parse().ok(),
+                "slices" => slices = v.parse().ok(),
+                "bytes" => bytes = v.parse().ok(),
+                _ => {}
+            }
+        }
+        Some(Self {
+            format: format?,
+            engine: engine?,
+            clean: clean?,
+            slices: slices?,
+            bytes: bytes?,
+        })
+    }
+
+    fn render(&self) -> String {
+        format!(
+            "format={}\nengine={}\nclean={}\nslices={}\nbytes={}\n",
+            self.format, self.engine, self.clean, self.slices, self.bytes
+        )
+    }
+}
+
+/// The cold-tier store: one fjall database with a single KV-separated
+/// keyspace holding `(operator, vnode) → slice bytes`.
+///
+/// Synchronous API by design — call it from the worker / `spawn_blocking`,
+/// never from the compute thread.
+pub(crate) struct StateTierStore {
+    db: fjall::Database,
+    slices: fjall::Keyspace,
+    dir: PathBuf,
+    /// Logical accounting (key + value bytes; slice count). Persisted into
+    /// the marker at clean shutdown so a reused tier reopens with correct
+    /// gauges without scanning blobs.
+    logical_bytes: AtomicI64,
+    logical_slices: AtomicI64,
+    metrics: Option<Arc<EngineMetrics>>,
+}
+
+impl StateTierStore {
+    /// Open (or wipe-and-create) the tier under `dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DbError::Storage` when the directory cannot be created or
+    /// the fjall database fails to open. A bad *previous* state is not an
+    /// error — it wipes and starts empty by contract.
+    pub(crate) fn open(
+        dir: impl Into<PathBuf>,
+        metrics: Option<Arc<EngineMetrics>>,
+    ) -> Result<Self, DbError> {
+        let dir = dir.into();
+        let mut slices: i64 = 0;
+        let mut bytes: i64 = 0;
+
+        if dir.exists() {
+            match Self::validate_marker(&dir) {
+                Ok(marker) => {
+                    slices = marker.slices;
+                    bytes = marker.bytes;
+                }
+                Err(reason) => {
+                    tracing::warn!(
+                        dir = %dir.display(),
+                        reason = ?reason,
+                        "state tier not reusable — wiping (demoted state will \
+                         rehydrate from the last restorable checkpoint)"
+                    );
+                    if let Some(ref m) = metrics {
+                        m.state_tier_wipes_total.inc();
+                    }
+                    std::fs::remove_dir_all(&dir).map_err(|e| {
+                        DbError::Storage(format!("state tier wipe {}: {e}", dir.display()))
+                    })?;
+                }
+            }
+        }
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| DbError::Storage(format!("state tier dir {}: {e}", dir.display())))?;
+
+        // Mark "running" before any writes: a crash from here on is an
+        // unclean shutdown and the next open wipes.
+        Self::write_marker(&dir, false, slices, bytes)?;
+
+        let db = fjall::Database::builder(dir.join(DB_DIR))
+            .open()
+            .map_err(|e| DbError::Storage(format!("state tier open: {e}")))?;
+        // Slices are multi-KB..MB blobs — exactly what key-value separation
+        // is for (dev-box bench: 1.57x write amplification with it).
+        let ks = db
+            .keyspace("slices", || {
+                fjall::KeyspaceCreateOptions::default()
+                    .with_kv_separation(Some(fjall::KvSeparationOptions::default()))
+            })
+            .map_err(|e| DbError::Storage(format!("state tier keyspace: {e}")))?;
+
+        let store = Self {
+            db,
+            slices: ks,
+            dir,
+            logical_bytes: AtomicI64::new(bytes),
+            logical_slices: AtomicI64::new(slices),
+            metrics,
+        };
+        store.publish_gauges();
+        Ok(store)
+    }
+
+    fn validate_marker(dir: &Path) -> Result<Marker, WipeReason> {
+        let text = std::fs::read_to_string(dir.join(MARKER_FILE))
+            .map_err(|_| WipeReason::CorruptMarker)?;
+        let marker = Marker::parse(&text).ok_or(WipeReason::CorruptMarker)?;
+        if marker.format != FORMAT_VERSION {
+            return Err(WipeReason::FormatMismatch);
+        }
+        if marker.engine != env!("CARGO_PKG_VERSION") {
+            return Err(WipeReason::EngineVersionMismatch);
+        }
+        if !marker.clean {
+            return Err(WipeReason::UncleanShutdown);
+        }
+        Ok(marker)
+    }
+
+    fn write_marker(dir: &Path, clean: bool, slices: i64, bytes: i64) -> Result<(), DbError> {
+        let marker = Marker {
+            format: FORMAT_VERSION,
+            engine: env!("CARGO_PKG_VERSION").to_string(),
+            clean,
+            slices,
+            bytes,
+        };
+        std::fs::write(dir.join(MARKER_FILE), marker.render())
+            .map_err(|e| DbError::Storage(format!("state tier marker: {e}")))
+    }
+
+    fn key(operator: &str, vnode: u32) -> Vec<u8> {
+        // Operator names are SQL identifiers and never contain NUL, so a
+        // NUL separator keeps (operator, vnode) prefixes unambiguous.
+        let mut k = Vec::with_capacity(operator.len() + 5);
+        k.extend_from_slice(operator.as_bytes());
+        k.push(0);
+        k.extend_from_slice(&vnode.to_be_bytes());
+        k
+    }
+
+    /// Store a demoted slice (overwrites any previous demotion of the same
+    /// vnode). No fsync — the tier is rebuildable by contract.
+    pub(crate) fn put(&self, operator: &str, vnode: u32, bytes: &[u8]) -> Result<(), DbError> {
+        let key = Self::key(operator, vnode);
+        let old_len = self
+            .slices
+            .get(&key)
+            .map_err(|e| DbError::Storage(format!("state tier read-before-put: {e}")))?
+            .map(|o| o.len());
+        self.slices
+            .insert(&key, bytes)
+            .map_err(|e| DbError::Storage(format!("state tier put: {e}")))?;
+        #[allow(clippy::cast_possible_wrap)]
+        let new_total = (key.len() + bytes.len()) as i64;
+        if let Some(old_len) = old_len {
+            #[allow(clippy::cast_possible_wrap)]
+            self.logical_bytes
+                .fetch_add(new_total - (key.len() + old_len) as i64, Ordering::Relaxed);
+        } else {
+            self.logical_bytes.fetch_add(new_total, Ordering::Relaxed);
+            self.logical_slices.fetch_add(1, Ordering::Relaxed);
+        }
+        if let Some(ref m) = self.metrics {
+            m.state_tier_demote_total.inc();
+        }
+        self.publish_gauges();
+        Ok(())
+    }
+
+    /// Fetch a slice for promotion. `None` = not resident (e.g. wiped).
+    pub(crate) fn get(&self, operator: &str, vnode: u32) -> Result<Option<Bytes>, DbError> {
+        let start = std::time::Instant::now();
+        let v = self
+            .slices
+            .get(Self::key(operator, vnode))
+            .map_err(|e| DbError::Storage(format!("state tier get: {e}")))?;
+        if let Some(ref m) = self.metrics {
+            m.state_tier_fetch_total.inc();
+            m.state_tier_fetch_duration
+                .observe(start.elapsed().as_secs_f64());
+        }
+        Ok(v.map(|v| Bytes::copy_from_slice(&v)))
+    }
+
+    /// Drop a slice (after promotion, or when releasing a vnode).
+    pub(crate) fn remove(&self, operator: &str, vnode: u32) -> Result<(), DbError> {
+        let key = Self::key(operator, vnode);
+        let old = self
+            .slices
+            .get(&key)
+            .map_err(|e| DbError::Storage(format!("state tier read-before-remove: {e}")))?;
+        if let Some(old) = old {
+            self.slices
+                .remove(&key)
+                .map_err(|e| DbError::Storage(format!("state tier remove: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            self.logical_bytes
+                .fetch_sub((key.len() + old.len()) as i64, Ordering::Relaxed);
+            self.logical_slices.fetch_sub(1, Ordering::Relaxed);
+            self.publish_gauges();
+        }
+        Ok(())
+    }
+
+    /// Drop every slice of one operator (operator removed from the graph).
+    pub(crate) fn remove_operator(&self, operator: &str) -> Result<usize, DbError> {
+        let mut prefix = Vec::with_capacity(operator.len() + 1);
+        prefix.extend_from_slice(operator.as_bytes());
+        prefix.push(0);
+        let keys: Vec<_> = self
+            .slices
+            .prefix(&prefix)
+            .map(|guard| guard.into_inner().map(|(k, v)| (k, v.len())))
+            .collect::<Result<_, _>>()
+            .map_err(|e| DbError::Storage(format!("state tier scan: {e}")))?;
+        let count = keys.len();
+        for (key, vlen) in keys {
+            let klen = key.len();
+            self.slices
+                .remove(key)
+                .map_err(|e| DbError::Storage(format!("state tier remove: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            self.logical_bytes
+                .fetch_sub((klen + vlen) as i64, Ordering::Relaxed);
+            self.logical_slices.fetch_sub(1, Ordering::Relaxed);
+        }
+        self.publish_gauges();
+        Ok(count)
+    }
+
+    /// Logical bytes currently resident (keys + values).
+    pub(crate) fn logical_bytes(&self) -> i64 {
+        self.logical_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Slices currently resident.
+    pub(crate) fn logical_slices(&self) -> i64 {
+        self.logical_slices.load(Ordering::Relaxed)
+    }
+
+    fn publish_gauges(&self) {
+        if let Some(ref m) = self.metrics {
+            m.state_tier_bytes.set(self.logical_bytes());
+            m.state_tier_slices.set(self.logical_slices());
+        }
+    }
+
+    /// Clean shutdown: persist fjall, then write the clean marker so the
+    /// next open reuses the tier. Anything short of this wipes on reopen.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DbError::Storage` if the persist or the marker write fails
+    /// (the tier then reopens empty — safe, just slower).
+    pub(crate) fn shutdown(&self) -> Result<(), DbError> {
+        self.db
+            .persist(fjall::PersistMode::SyncAll)
+            .map_err(|e| DbError::Storage(format!("state tier persist: {e}")))?;
+        Self::write_marker(&self.dir, true, self.logical_slices(), self.logical_bytes())
+    }
+}
+
+mod worker;
+#[allow(unused_imports)] // consumed by the demotion/promotion wiring (and tests)
+pub(crate) use worker::{spawn_worker, TierRequest};
+
+#[cfg(test)]
+mod tests;

--- a/crates/laminar-db/src/state_tier/mod.rs
+++ b/crates/laminar-db/src/state_tier/mod.rs
@@ -115,9 +115,9 @@ impl StateTierStore {
             self.logical_bytes.fetch_add(new_total, Ordering::Relaxed);
             self.logical_slices.fetch_add(1, Ordering::Relaxed);
         }
-        if let Some(ref m) = self.metrics {
-            m.state_tier_demote_total.inc();
-        }
+        // `state_tier_demote_total` counts *effective* demotions, incremented by
+        // the graph only when the operator actually drops the vnode — not here,
+        // where a write may still be rolled back if the vnode turns out dirty.
         self.publish_gauges();
         Ok(())
     }

--- a/crates/laminar-db/src/state_tier/tests.rs
+++ b/crates/laminar-db/src/state_tier/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use tokio::sync::oneshot;
 
-use super::{spawn_worker, StateTierStore, TierRequest, MARKER_FILE};
+use super::{spawn_worker, StateTierStore, TierRequest};
 
 fn tier_dir() -> (tempfile::TempDir, std::path::PathBuf) {
     let tmp = tempfile::tempdir().unwrap();
@@ -43,86 +43,16 @@ fn round_trip_overwrite_and_remove() {
 }
 
 #[test]
-fn remove_operator_only_touches_that_prefix() {
-    let (_tmp, dir) = tier_dir();
-    let store = StateTierStore::open(&dir, None).unwrap();
-
-    store.put("agg_a", 1, b"a1").unwrap();
-    store.put("agg_a", 2, b"a2").unwrap();
-    // Prefix-collision probe: "agg_a" must not match "agg_ab".
-    store.put("agg_ab", 1, b"ab1").unwrap();
-
-    let removed = store.remove_operator("agg_a").unwrap();
-    assert_eq!(removed, 2);
-    assert_eq!(store.get("agg_a", 1).unwrap(), None);
-    assert_eq!(store.get("agg_a", 2).unwrap(), None);
-    assert_eq!(store.get("agg_ab", 1).unwrap().unwrap().as_ref(), b"ab1");
-    assert_eq!(store.logical_slices(), 1);
-}
-
-#[test]
-fn clean_shutdown_reuses_and_restores_counters() {
-    let (_tmp, dir) = tier_dir();
-    let (slices, bytes);
-    {
-        let store = StateTierStore::open(&dir, None).unwrap();
-        store.put("agg", 1, b"keep-me").unwrap();
-        store.put("agg", 2, b"and-me").unwrap();
-        slices = store.logical_slices();
-        bytes = store.logical_bytes();
-        store.shutdown().unwrap();
-    }
-    let store = StateTierStore::open(&dir, None).unwrap();
-    assert_eq!(store.get("agg", 1).unwrap().unwrap().as_ref(), b"keep-me");
-    assert_eq!(store.logical_slices(), slices);
-    assert_eq!(store.logical_bytes(), bytes);
-}
-
-#[test]
-fn unclean_shutdown_wipes() {
+fn open_wipes_leftover_dir() {
     let (_tmp, dir) = tier_dir();
     {
         let store = StateTierStore::open(&dir, None).unwrap();
         store.put("agg", 1, b"doomed").unwrap();
-        // No shutdown(): the marker still says clean=false.
     }
+    // The tier never survives a restart — reopening starts empty.
     let store = StateTierStore::open(&dir, None).unwrap();
-    assert_eq!(store.get("agg", 1).unwrap(), None, "unclean tier must wipe");
+    assert_eq!(store.get("agg", 1).unwrap(), None);
     assert_eq!(store.logical_slices(), 0);
-}
-
-#[test]
-fn engine_version_mismatch_wipes() {
-    let (_tmp, dir) = tier_dir();
-    {
-        let store = StateTierStore::open(&dir, None).unwrap();
-        store.put("agg", 1, b"old-engine").unwrap();
-        store.shutdown().unwrap();
-    }
-    // Forge a clean marker from a different engine version.
-    let text = std::fs::read_to_string(dir.join(MARKER_FILE)).unwrap();
-    let forged = text.replace(
-        &format!("engine={}", env!("CARGO_PKG_VERSION")),
-        "engine=0.0.0-other",
-    );
-    assert_ne!(text, forged, "test must actually change the version");
-    std::fs::write(dir.join(MARKER_FILE), forged).unwrap();
-
-    let store = StateTierStore::open(&dir, None).unwrap();
-    assert_eq!(store.get("agg", 1).unwrap(), None);
-}
-
-#[test]
-fn corrupt_marker_wipes() {
-    let (_tmp, dir) = tier_dir();
-    {
-        let store = StateTierStore::open(&dir, None).unwrap();
-        store.put("agg", 1, b"x").unwrap();
-        store.shutdown().unwrap();
-    }
-    std::fs::write(dir.join(MARKER_FILE), "not a marker").unwrap();
-    let store = StateTierStore::open(&dir, None).unwrap();
-    assert_eq!(store.get("agg", 1).unwrap(), None);
 }
 
 #[tokio::test]
@@ -168,72 +98,4 @@ async fn worker_demote_fetch_drop() {
     })
     .unwrap();
     assert_eq!(rx.await.unwrap().unwrap(), None);
-}
-
-#[tokio::test]
-async fn worker_fetches_under_concurrent_demotes() {
-    let (_tmp, dir) = tier_dir();
-    let store = Arc::new(StateTierStore::open(&dir, None).unwrap());
-    let tx = spawn_worker(&tokio::runtime::Handle::current(), store, 256);
-
-    let op: Arc<str> = Arc::from("agg");
-    // Seed 32 slices.
-    for v in 0..32u32 {
-        let (reply, rx) = oneshot::channel();
-        tx.send(TierRequest::Demote {
-            operator: Arc::clone(&op),
-            vnode: v,
-            bytes: Bytes::from(vec![u8::try_from(v).unwrap(); 64]),
-            reply,
-        })
-        .await
-        .unwrap();
-        rx.await.unwrap().unwrap();
-    }
-
-    // Interleave rewrites and fetches; every fetch must observe a complete
-    // value (one of the two versions, never torn or missing).
-    let writer = {
-        let tx = tx.clone();
-        let op = Arc::clone(&op);
-        tokio::spawn(async move {
-            for round in 0..4u8 {
-                for v in 0..32u32 {
-                    let (reply, rx) = oneshot::channel();
-                    tx.send(TierRequest::Demote {
-                        operator: Arc::clone(&op),
-                        vnode: v,
-                        bytes: Bytes::from(vec![round, 64]),
-                        reply,
-                    })
-                    .await
-                    .unwrap();
-                    rx.await.unwrap().unwrap();
-                }
-            }
-        })
-    };
-    let reader = {
-        let tx = tx.clone();
-        let op = Arc::clone(&op);
-        tokio::spawn(async move {
-            for _ in 0..4 {
-                for v in 0..32u32 {
-                    let (reply, rx) = oneshot::channel();
-                    tx.send(TierRequest::Fetch {
-                        operator: Arc::clone(&op),
-                        vnode: v,
-                        reply,
-                    })
-                    .await
-                    .unwrap();
-                    let got = rx.await.unwrap().unwrap();
-                    let got = got.expect("slice must stay resident under rewrites");
-                    assert!(got.len() == 64 || got.len() == 2, "torn value: {got:?}");
-                }
-            }
-        })
-    };
-    writer.await.unwrap();
-    reader.await.unwrap();
 }

--- a/crates/laminar-db/src/state_tier/tests.rs
+++ b/crates/laminar-db/src/state_tier/tests.rs
@@ -1,0 +1,239 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use tokio::sync::oneshot;
+
+use super::{spawn_worker, StateTierStore, TierRequest, MARKER_FILE};
+
+fn tier_dir() -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("state-tier");
+    (tmp, dir)
+}
+
+#[test]
+fn round_trip_overwrite_and_remove() {
+    let (_tmp, dir) = tier_dir();
+    let store = StateTierStore::open(&dir, None).unwrap();
+
+    assert_eq!(store.get("agg", 7).unwrap(), None);
+    store.put("agg", 7, b"slice-v1").unwrap();
+    assert_eq!(store.get("agg", 7).unwrap().unwrap().as_ref(), b"slice-v1");
+    assert_eq!(store.logical_slices(), 1);
+    let bytes_v1 = store.logical_bytes();
+    assert!(bytes_v1 > 0);
+
+    // Overwrite adjusts bytes, not the slice count.
+    store.put("agg", 7, b"slice-v2-longer").unwrap();
+    assert_eq!(
+        store.get("agg", 7).unwrap().unwrap().as_ref(),
+        b"slice-v2-longer"
+    );
+    assert_eq!(store.logical_slices(), 1);
+    assert!(store.logical_bytes() > bytes_v1);
+
+    store.remove("agg", 7).unwrap();
+    assert_eq!(store.get("agg", 7).unwrap(), None);
+    assert_eq!(store.logical_slices(), 0);
+    assert_eq!(store.logical_bytes(), 0);
+
+    // Removing an absent slice is a no-op, not an error or a negative count.
+    store.remove("agg", 7).unwrap();
+    assert_eq!(store.logical_slices(), 0);
+}
+
+#[test]
+fn remove_operator_only_touches_that_prefix() {
+    let (_tmp, dir) = tier_dir();
+    let store = StateTierStore::open(&dir, None).unwrap();
+
+    store.put("agg_a", 1, b"a1").unwrap();
+    store.put("agg_a", 2, b"a2").unwrap();
+    // Prefix-collision probe: "agg_a" must not match "agg_ab".
+    store.put("agg_ab", 1, b"ab1").unwrap();
+
+    let removed = store.remove_operator("agg_a").unwrap();
+    assert_eq!(removed, 2);
+    assert_eq!(store.get("agg_a", 1).unwrap(), None);
+    assert_eq!(store.get("agg_a", 2).unwrap(), None);
+    assert_eq!(store.get("agg_ab", 1).unwrap().unwrap().as_ref(), b"ab1");
+    assert_eq!(store.logical_slices(), 1);
+}
+
+#[test]
+fn clean_shutdown_reuses_and_restores_counters() {
+    let (_tmp, dir) = tier_dir();
+    let (slices, bytes);
+    {
+        let store = StateTierStore::open(&dir, None).unwrap();
+        store.put("agg", 1, b"keep-me").unwrap();
+        store.put("agg", 2, b"and-me").unwrap();
+        slices = store.logical_slices();
+        bytes = store.logical_bytes();
+        store.shutdown().unwrap();
+    }
+    let store = StateTierStore::open(&dir, None).unwrap();
+    assert_eq!(store.get("agg", 1).unwrap().unwrap().as_ref(), b"keep-me");
+    assert_eq!(store.logical_slices(), slices);
+    assert_eq!(store.logical_bytes(), bytes);
+}
+
+#[test]
+fn unclean_shutdown_wipes() {
+    let (_tmp, dir) = tier_dir();
+    {
+        let store = StateTierStore::open(&dir, None).unwrap();
+        store.put("agg", 1, b"doomed").unwrap();
+        // No shutdown(): the marker still says clean=false.
+    }
+    let store = StateTierStore::open(&dir, None).unwrap();
+    assert_eq!(store.get("agg", 1).unwrap(), None, "unclean tier must wipe");
+    assert_eq!(store.logical_slices(), 0);
+}
+
+#[test]
+fn engine_version_mismatch_wipes() {
+    let (_tmp, dir) = tier_dir();
+    {
+        let store = StateTierStore::open(&dir, None).unwrap();
+        store.put("agg", 1, b"old-engine").unwrap();
+        store.shutdown().unwrap();
+    }
+    // Forge a clean marker from a different engine version.
+    let text = std::fs::read_to_string(dir.join(MARKER_FILE)).unwrap();
+    let forged = text.replace(
+        &format!("engine={}", env!("CARGO_PKG_VERSION")),
+        "engine=0.0.0-other",
+    );
+    assert_ne!(text, forged, "test must actually change the version");
+    std::fs::write(dir.join(MARKER_FILE), forged).unwrap();
+
+    let store = StateTierStore::open(&dir, None).unwrap();
+    assert_eq!(store.get("agg", 1).unwrap(), None);
+}
+
+#[test]
+fn corrupt_marker_wipes() {
+    let (_tmp, dir) = tier_dir();
+    {
+        let store = StateTierStore::open(&dir, None).unwrap();
+        store.put("agg", 1, b"x").unwrap();
+        store.shutdown().unwrap();
+    }
+    std::fs::write(dir.join(MARKER_FILE), "not a marker").unwrap();
+    let store = StateTierStore::open(&dir, None).unwrap();
+    assert_eq!(store.get("agg", 1).unwrap(), None);
+}
+
+#[tokio::test]
+async fn worker_demote_fetch_drop() {
+    let (_tmp, dir) = tier_dir();
+    let store = Arc::new(StateTierStore::open(&dir, None).unwrap());
+    let tx = spawn_worker(&tokio::runtime::Handle::current(), store, 16);
+
+    let op: Arc<str> = Arc::from("agg");
+    let (reply, rx) = oneshot::channel();
+    tx.try_send(TierRequest::Demote {
+        operator: Arc::clone(&op),
+        vnode: 3,
+        bytes: Bytes::from_static(b"demoted"),
+        reply,
+    })
+    .unwrap();
+    rx.await.unwrap().unwrap();
+
+    let (reply, rx) = oneshot::channel();
+    tx.try_send(TierRequest::Fetch {
+        operator: Arc::clone(&op),
+        vnode: 3,
+        reply,
+    })
+    .unwrap();
+    assert_eq!(rx.await.unwrap().unwrap().unwrap().as_ref(), b"demoted");
+
+    let (reply, rx) = oneshot::channel();
+    tx.try_send(TierRequest::Drop {
+        operator: Arc::clone(&op),
+        vnode: 3,
+        reply,
+    })
+    .unwrap();
+    rx.await.unwrap().unwrap();
+
+    let (reply, rx) = oneshot::channel();
+    tx.try_send(TierRequest::Fetch {
+        operator: op,
+        vnode: 3,
+        reply,
+    })
+    .unwrap();
+    assert_eq!(rx.await.unwrap().unwrap(), None);
+}
+
+#[tokio::test]
+async fn worker_fetches_under_concurrent_demotes() {
+    let (_tmp, dir) = tier_dir();
+    let store = Arc::new(StateTierStore::open(&dir, None).unwrap());
+    let tx = spawn_worker(&tokio::runtime::Handle::current(), store, 256);
+
+    let op: Arc<str> = Arc::from("agg");
+    // Seed 32 slices.
+    for v in 0..32u32 {
+        let (reply, rx) = oneshot::channel();
+        tx.send(TierRequest::Demote {
+            operator: Arc::clone(&op),
+            vnode: v,
+            bytes: Bytes::from(vec![u8::try_from(v).unwrap(); 64]),
+            reply,
+        })
+        .await
+        .unwrap();
+        rx.await.unwrap().unwrap();
+    }
+
+    // Interleave rewrites and fetches; every fetch must observe a complete
+    // value (one of the two versions, never torn or missing).
+    let writer = {
+        let tx = tx.clone();
+        let op = Arc::clone(&op);
+        tokio::spawn(async move {
+            for round in 0..4u8 {
+                for v in 0..32u32 {
+                    let (reply, rx) = oneshot::channel();
+                    tx.send(TierRequest::Demote {
+                        operator: Arc::clone(&op),
+                        vnode: v,
+                        bytes: Bytes::from(vec![round, 64]),
+                        reply,
+                    })
+                    .await
+                    .unwrap();
+                    rx.await.unwrap().unwrap();
+                }
+            }
+        })
+    };
+    let reader = {
+        let tx = tx.clone();
+        let op = Arc::clone(&op);
+        tokio::spawn(async move {
+            for _ in 0..4 {
+                for v in 0..32u32 {
+                    let (reply, rx) = oneshot::channel();
+                    tx.send(TierRequest::Fetch {
+                        operator: Arc::clone(&op),
+                        vnode: v,
+                        reply,
+                    })
+                    .await
+                    .unwrap();
+                    let got = rx.await.unwrap().unwrap();
+                    let got = got.expect("slice must stay resident under rewrites");
+                    assert!(got.len() == 64 || got.len() == 2, "torn value: {got:?}");
+                }
+            }
+        })
+    };
+    writer.await.unwrap();
+    reader.await.unwrap();
+}

--- a/crates/laminar-db/src/state_tier/worker.rs
+++ b/crates/laminar-db/src/state_tier/worker.rs
@@ -18,15 +18,12 @@ use tokio::sync::oneshot;
 use super::StateTierStore;
 use crate::error::DbError;
 
-/// Multi-producer sender for cold-tier requests — the compute thread
-/// (promotion), the coordinator (forced-full re-uploads), and the pipeline
-/// callback (demotion) all submit through one channel.
+/// Multi-producer sender for cold-tier requests.
 pub(crate) type TierTx = crossfire::MAsyncTx<crossfire::mpsc::Array<TierRequest>>;
 type TierRx = crossfire::AsyncRx<crossfire::mpsc::Array<TierRequest>>;
 
-/// One request to the tier. Each carries a reply channel; demotion waits on
-/// it (groups must not leave memory until the slice is durably written),
-/// while `Drop` callers may ignore it (best-effort cleanup).
+/// One request to the cold tier. Demotion awaits the reply before releasing memory;
+/// Drop callers may ignore it for best-effort cleanup.
 pub(crate) enum TierRequest {
     Demote {
         operator: Arc<str>,
@@ -47,10 +44,7 @@ pub(crate) enum TierRequest {
 }
 
 /// Spawn the worker on `runtime` and return its request channel.
-///
-/// The channel is bounded; submitters on the compute thread must use
-/// `try_send` and treat a full channel as backpressure (defer and retry
-/// next cycle), never block.
+/// The channel is bounded; compute-thread submitters must use `try_send` and back off on full.
 pub(crate) fn spawn_worker(
     runtime: &tokio::runtime::Handle,
     store: Arc<StateTierStore>,
@@ -62,7 +56,6 @@ pub(crate) fn spawn_worker(
 }
 
 async fn run_worker(store: Arc<StateTierStore>, rx: TierRx) {
-    // `recv` errors once every sender has dropped (pipeline shutdown).
     while let Ok(req) = rx.recv().await {
         let store = Arc::clone(&store);
         match req {

--- a/crates/laminar-db/src/state_tier/worker.rs
+++ b/crates/laminar-db/src/state_tier/worker.rs
@@ -54,11 +54,6 @@ pub(crate) enum TierRequest {
         vnode: u32,
         reply: oneshot::Sender<Result<(), DbError>>,
     },
-    /// Drop every slice of an operator removed from the graph.
-    DropOperator {
-        operator: Arc<str>,
-        reply: oneshot::Sender<Result<usize, DbError>>,
-    },
 }
 
 /// Spawn the worker on `runtime` and return its request channel.
@@ -111,15 +106,6 @@ async fn run_worker(store: Arc<StateTierStore>, rx: TierRx) {
             } => {
                 let res =
                     tokio::task::spawn_blocking(move || store.remove(operator.as_ref(), vnode))
-                        .await
-                        .unwrap_or_else(|e| {
-                            Err(DbError::Storage(format!("state tier worker: {e}")))
-                        });
-                let _ = reply.send(res);
-            }
-            TierRequest::DropOperator { operator, reply } => {
-                let res =
-                    tokio::task::spawn_blocking(move || store.remove_operator(operator.as_ref()))
                         .await
                         .unwrap_or_else(|e| {
                             Err(DbError::Storage(format!("state tier worker: {e}")))

--- a/crates/laminar-db/src/state_tier/worker.rs
+++ b/crates/laminar-db/src/state_tier/worker.rs
@@ -1,20 +1,14 @@
 //! The cold tier's off-compute worker.
 //!
-//! Mirrors the lookup-enrich / AI-operator decoupling: the compute thread
-//! `try_send`s requests into a bounded channel and drains replies on later
-//! cycles; this worker (a task on the main tokio runtime, never the compute
-//! thread) services them one at a time, pushing each synchronous fjall call
-//! into `spawn_blocking`. Single-flight is deliberate — it serializes tier
-//! I/O the way the demotion/promotion protocol expects, and matches the
-//! dev-box finding that read tails degrade under concurrent write pressure.
+//! The compute thread `try_send`s requests onto a bounded channel; this
+//! worker (a task on the main runtime) services them one at a time via
+//! `spawn_blocking`, so a synchronous fjall call never stalls compute.
+//! Single-flight serializes tier I/O as the demotion/promotion protocol
+//! expects.
 //!
-//! The request channel is `crossfire` (a multi-producer mpsc, like the
-//! engine's other compute-thread/runtime plumbing). The per-request replies
-//! stay `tokio::oneshot`: the promotion operator stores its in-flight reply
-//! receivers in a field, and that operator must be `Sync` (its `process`
-//! future holds `&self` across an await), which crossfire's `!Sync`
-//! `RxOneshot` cannot satisfy — the same reason the lookup-enrich and AI
-//! workers store tokio receivers.
+//! Requests use a `crossfire` channel; replies stay `tokio::oneshot`
+//! because the promotion operator stores reply receivers in a field and so
+//! must be `Sync`, which crossfire's `!Sync` `RxOneshot` is not.
 
 use std::sync::Arc;
 
@@ -30,25 +24,21 @@ use crate::error::DbError;
 pub(crate) type TierTx = crossfire::MAsyncTx<crossfire::mpsc::Array<TierRequest>>;
 type TierRx = crossfire::AsyncRx<crossfire::mpsc::Array<TierRequest>>;
 
-/// One request to the tier. Every variant carries a reply channel: even
-/// fire-and-forget callers need the completion signal before they may act
-/// on it (a demotion must not drop groups from memory until the slice is
-/// confirmed written).
+/// One request to the tier. Each carries a reply channel; demotion waits on
+/// it (groups must not leave memory until the slice is durably written),
+/// while `Drop` callers may ignore it (best-effort cleanup).
 pub(crate) enum TierRequest {
-    /// Write a demoted slice.
     Demote {
         operator: Arc<str>,
         vnode: u32,
         bytes: Bytes,
         reply: oneshot::Sender<Result<(), DbError>>,
     },
-    /// Read a slice for promotion.
     Fetch {
         operator: Arc<str>,
         vnode: u32,
         reply: oneshot::Sender<Result<Option<Bytes>, DbError>>,
     },
-    /// Drop a promoted (or released) slice.
     Drop {
         operator: Arc<str>,
         vnode: u32,

--- a/crates/laminar-db/src/state_tier/worker.rs
+++ b/crates/laminar-db/src/state_tier/worker.rs
@@ -7,14 +7,28 @@
 //! into `spawn_blocking`. Single-flight is deliberate — it serializes tier
 //! I/O the way the demotion/promotion protocol expects, and matches the
 //! dev-box finding that read tails degrade under concurrent write pressure.
+//!
+//! The request channel is `crossfire` (a multi-producer mpsc, like the
+//! engine's other compute-thread/runtime plumbing). The per-request replies
+//! stay `tokio::oneshot`: the promotion operator stores its in-flight reply
+//! receivers in a field, and that operator must be `Sync` (its `process`
+//! future holds `&self` across an await), which crossfire's `!Sync`
+//! `RxOneshot` cannot satisfy — the same reason the lookup-enrich and AI
+//! workers store tokio receivers.
 
 use std::sync::Arc;
 
 use bytes::Bytes;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
 use super::StateTierStore;
 use crate::error::DbError;
+
+/// Multi-producer sender for cold-tier requests — the compute thread
+/// (promotion), the coordinator (forced-full re-uploads), and the pipeline
+/// callback (demotion) all submit through one channel.
+pub(crate) type TierTx = crossfire::MAsyncTx<crossfire::mpsc::Array<TierRequest>>;
+type TierRx = crossfire::AsyncRx<crossfire::mpsc::Array<TierRequest>>;
 
 /// One request to the tier. Every variant carries a reply channel: even
 /// fire-and-forget callers need the completion signal before they may act
@@ -56,14 +70,15 @@ pub(crate) fn spawn_worker(
     runtime: &tokio::runtime::Handle,
     store: Arc<StateTierStore>,
     queue_capacity: usize,
-) -> mpsc::Sender<TierRequest> {
-    let (tx, rx) = mpsc::channel(queue_capacity);
+) -> TierTx {
+    let (tx, rx) = crossfire::mpsc::bounded_async(queue_capacity);
     runtime.spawn(run_worker(store, rx));
     tx
 }
 
-async fn run_worker(store: Arc<StateTierStore>, mut rx: mpsc::Receiver<TierRequest>) {
-    while let Some(req) = rx.recv().await {
+async fn run_worker(store: Arc<StateTierStore>, rx: TierRx) {
+    // `recv` errors once every sender has dropped (pipeline shutdown).
+    while let Ok(req) = rx.recv().await {
         let store = Arc::clone(&store);
         match req {
             TierRequest::Demote {

--- a/crates/laminar-db/src/state_tier/worker.rs
+++ b/crates/laminar-db/src/state_tier/worker.rs
@@ -1,0 +1,116 @@
+//! The cold tier's off-compute worker.
+//!
+//! Mirrors the lookup-enrich / AI-operator decoupling: the compute thread
+//! `try_send`s requests into a bounded channel and drains replies on later
+//! cycles; this worker (a task on the main tokio runtime, never the compute
+//! thread) services them one at a time, pushing each synchronous fjall call
+//! into `spawn_blocking`. Single-flight is deliberate — it serializes tier
+//! I/O the way the demotion/promotion protocol expects, and matches the
+//! dev-box finding that read tails degrade under concurrent write pressure.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use tokio::sync::{mpsc, oneshot};
+
+use super::StateTierStore;
+use crate::error::DbError;
+
+/// One request to the tier. Every variant carries a reply channel: even
+/// fire-and-forget callers need the completion signal before they may act
+/// on it (a demotion must not drop groups from memory until the slice is
+/// confirmed written).
+pub(crate) enum TierRequest {
+    /// Write a demoted slice.
+    Demote {
+        operator: Arc<str>,
+        vnode: u32,
+        bytes: Bytes,
+        reply: oneshot::Sender<Result<(), DbError>>,
+    },
+    /// Read a slice for promotion.
+    Fetch {
+        operator: Arc<str>,
+        vnode: u32,
+        reply: oneshot::Sender<Result<Option<Bytes>, DbError>>,
+    },
+    /// Drop a promoted (or released) slice.
+    Drop {
+        operator: Arc<str>,
+        vnode: u32,
+        reply: oneshot::Sender<Result<(), DbError>>,
+    },
+    /// Drop every slice of an operator removed from the graph.
+    DropOperator {
+        operator: Arc<str>,
+        reply: oneshot::Sender<Result<usize, DbError>>,
+    },
+}
+
+/// Spawn the worker on `runtime` and return its request channel.
+///
+/// The channel is bounded; submitters on the compute thread must use
+/// `try_send` and treat a full channel as backpressure (defer and retry
+/// next cycle), never block.
+pub(crate) fn spawn_worker(
+    runtime: &tokio::runtime::Handle,
+    store: Arc<StateTierStore>,
+    queue_capacity: usize,
+) -> mpsc::Sender<TierRequest> {
+    let (tx, rx) = mpsc::channel(queue_capacity);
+    runtime.spawn(run_worker(store, rx));
+    tx
+}
+
+async fn run_worker(store: Arc<StateTierStore>, mut rx: mpsc::Receiver<TierRequest>) {
+    while let Some(req) = rx.recv().await {
+        let store = Arc::clone(&store);
+        match req {
+            TierRequest::Demote {
+                operator,
+                vnode,
+                bytes,
+                reply,
+            } => {
+                let res = tokio::task::spawn_blocking(move || {
+                    store.put(operator.as_ref(), vnode, &bytes)
+                })
+                .await
+                .unwrap_or_else(|e| Err(DbError::Storage(format!("state tier worker: {e}"))));
+                let _ = reply.send(res);
+            }
+            TierRequest::Fetch {
+                operator,
+                vnode,
+                reply,
+            } => {
+                let res = tokio::task::spawn_blocking(move || store.get(operator.as_ref(), vnode))
+                    .await
+                    .unwrap_or_else(|e| Err(DbError::Storage(format!("state tier worker: {e}"))));
+                let _ = reply.send(res);
+            }
+            TierRequest::Drop {
+                operator,
+                vnode,
+                reply,
+            } => {
+                let res =
+                    tokio::task::spawn_blocking(move || store.remove(operator.as_ref(), vnode))
+                        .await
+                        .unwrap_or_else(|e| {
+                            Err(DbError::Storage(format!("state tier worker: {e}")))
+                        });
+                let _ = reply.send(res);
+            }
+            TierRequest::DropOperator { operator, reply } => {
+                let res =
+                    tokio::task::spawn_blocking(move || store.remove_operator(operator.as_ref()))
+                        .await
+                        .unwrap_or_else(|e| {
+                            Err(DbError::Storage(format!("state tier worker: {e}")))
+                        });
+                let _ = reply.send(res);
+            }
+        }
+    }
+}

--- a/crates/laminar-db/src/subscription/registry.rs
+++ b/crates/laminar-db/src/subscription/registry.rs
@@ -30,7 +30,7 @@ pub enum SubscribeStart {
 
 #[derive(Debug)]
 pub(crate) struct ReplayPruned {
-    /// Earliest barrier epoch still in the log, or `0` if none retained.
+    /// Earliest barrier epoch still in the log; `0` if the log is empty.
     pub(crate) earliest_retained: u64,
 }
 
@@ -179,7 +179,6 @@ impl SubscriptionRegistry {
             .map_or(0, |log| log.subscriber_count())
     }
 
-    /// Only the cluster subscription router consults this.
     #[cfg(feature = "cluster")]
     pub(crate) fn active_subscription_names(&self) -> Vec<String> {
         self.streams

--- a/crates/laminar-db/src/table_backend.rs
+++ b/crates/laminar-db/src/table_backend.rs
@@ -1,6 +1,4 @@
-//! Backend storage for reference tables.
-//!
-//! Provides an in-memory backend for storing reference/dimension table rows.
+//! Backend storage for reference/dimension table rows.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -10,36 +8,26 @@ use arrow::datatypes::SchemaRef;
 
 use crate::error::DbError;
 
-/// Backend storage for a single reference table.
 pub(crate) enum TableBackend {
-    /// In-memory storage (default behavior).
-    InMemory {
-        /// Rows keyed by stringified primary key.
-        rows: HashMap<String, RecordBatch>,
-    },
+    InMemory { rows: HashMap<String, RecordBatch> },
 }
 
-// `get`/`remove` are used by `table_store` reference-table read paths that
-// aren't reachable in the minimal (no-default-features) lib build.
+// `get`/`remove` are used by table_store read paths not reachable in minimal builds.
 #[allow(dead_code, clippy::unnecessary_wraps)]
 impl TableBackend {
-    /// Create a new in-memory backend.
     pub fn in_memory() -> Self {
         Self::InMemory {
             rows: HashMap::new(),
         }
     }
 
-    /// Get a row by primary key.
     pub fn get(&self, key: &str) -> Result<Option<RecordBatch>, DbError> {
         match self {
             Self::InMemory { rows } => Ok(rows.get(key).cloned()),
         }
     }
 
-    /// Insert or update a row.
-    ///
-    /// Returns `true` if the key already existed (update), `false` if new.
+    /// Insert or update a row; returns `true` if the key existed.
     pub fn put(&mut self, key: &str, batch: RecordBatch) -> Result<bool, DbError> {
         match self {
             Self::InMemory { rows } => {
@@ -49,21 +37,18 @@ impl TableBackend {
         }
     }
 
-    /// Remove a row by primary key. Returns `true` if the key existed.
     pub fn remove(&mut self, key: &str) -> Result<bool, DbError> {
         match self {
             Self::InMemory { rows } => Ok(rows.remove(key).is_some()),
         }
     }
 
-    /// Collect all keys.
     pub fn keys(&self) -> Result<Vec<String>, DbError> {
         match self {
             Self::InMemory { rows } => Ok(rows.keys().cloned().collect()),
         }
     }
 
-    /// Concatenate all rows into a single `RecordBatch`.
     pub fn to_record_batch(&self, schema: &SchemaRef) -> Result<Option<RecordBatch>, DbError> {
         match self {
             Self::InMemory { rows } => {
@@ -78,7 +63,6 @@ impl TableBackend {
         }
     }
 
-    /// Whether this backend is persistent.
     #[allow(clippy::unused_self)]
     pub fn is_persistent(&self) -> bool {
         false

--- a/crates/laminar-db/src/table_cache_mode.rs
+++ b/crates/laminar-db/src/table_cache_mode.rs
@@ -1,24 +1,16 @@
-//! Cache mode configuration for reference tables.
-//!
-//! Controls how dimension table rows are cached in memory:
-//! - `Full`: all rows in memory (default, suitable for small tables)
-//! - `Partial`: LRU cache of hot keys with xor filter for negative lookups
-//! - `None`: no caching (direct backing store access)
+//! Cache mode for reference tables: Full (all rows), Partial (LRU), or None.
 
 use crate::error::DbError;
 
 /// How a reference table's rows are cached in memory.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum TableCacheMode {
-    /// All rows kept in memory (default). Best for tables < 10M rows.
+    /// All rows in memory (default).
     #[default]
     Full,
-    /// LRU cache of hot keys. Cold keys fall through to the backing store.
-    Partial {
-        /// Maximum number of entries in the LRU cache.
-        max_entries: usize,
-    },
-    /// No caching — every lookup goes to the backing store.
+    /// LRU cache; cold keys fall through to the backing store.
+    Partial { max_entries: usize },
+    /// No caching.
     None,
 }
 
@@ -26,8 +18,7 @@ pub enum TableCacheMode {
 const DEFAULT_PARTIAL_MAX_ENTRIES: usize = 500_000;
 
 impl TableCacheMode {
-    /// Return the max entries for partial mode, or `None` for other modes.
-    #[allow(dead_code)] // test verification API
+    #[allow(dead_code)] // test-only
     pub fn max_entries(&self) -> Option<usize> {
         match self {
             Self::Partial { max_entries } => Some(*max_entries),
@@ -35,7 +26,6 @@ impl TableCacheMode {
         }
     }
 
-    /// Create a `Partial` mode with the default max entries.
     pub fn partial_default() -> Self {
         Self::Partial {
             max_entries: DEFAULT_PARTIAL_MAX_ENTRIES,
@@ -43,12 +33,7 @@ impl TableCacheMode {
     }
 }
 
-/// Parse a cache mode string from DDL `WITH (cache_mode = '...')`.
-///
-/// Supported values:
-/// - `"full"` → `TableCacheMode::Full`
-/// - `"partial"` → `TableCacheMode::Partial { max_entries: 500_000 }`
-/// - `"none"` → `TableCacheMode::None`
+/// Parse a `cache_mode` DDL option; accepts `"full"`, `"partial"`, `"none"`.
 pub(crate) fn parse_cache_mode(s: &str) -> Result<TableCacheMode, DbError> {
     match s.to_lowercase().as_str() {
         "full" => Ok(TableCacheMode::Full),

--- a/crates/laminar-db/src/table_provider.rs
+++ b/crates/laminar-db/src/table_provider.rs
@@ -1,10 +1,4 @@
-//! Live `DataFusion` table providers for `TableStore` and streaming sources.
-//!
-//! [`ReferenceTableProvider`] reads directly from the `TableStore` on each
-//! `scan()` call, so queries always see the latest data without re-registration.
-//!
-//! [`SourceSnapshotProvider`] serves point-in-time snapshots of buffered
-//! source data, enabling `SELECT * FROM source` on streaming sources.
+//! `DataFusion` table providers for `TableStore`, streaming sources, and materialized views.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -21,10 +15,7 @@ use crate::catalog::SourceEntry;
 use crate::mv_store::MvStore;
 use crate::table_store::TableStore;
 
-/// A `DataFusion` table provider that reads live data from `TableStore`.
-///
-/// Registered once at CREATE TABLE time and never needs re-registration —
-/// each `scan()` fetches the current snapshot from the backing store.
+/// Live `DataFusion` table provider over `TableStore`; each `scan()` sees the current snapshot.
 pub(crate) struct ReferenceTableProvider {
     table_name: String,
     schema: SchemaRef,
@@ -32,7 +23,6 @@ pub(crate) struct ReferenceTableProvider {
 }
 
 impl ReferenceTableProvider {
-    /// Create a new provider for the given table.
     pub fn new(
         table_name: String,
         schema: SchemaRef,
@@ -94,25 +84,14 @@ impl std::fmt::Debug for ReferenceTableProvider {
     }
 }
 
-/// A `DataFusion` table provider that serves point-in-time snapshots of a
-/// streaming source's buffered data.
-///
-/// Registered at `CREATE SOURCE` time. Each `scan()` reads the current
-/// snapshot from `SourceEntry::snapshot()` and distributes batches
-/// round-robin across `num_partitions` partitions to enable parallel
-/// query execution.
+/// Point-in-time snapshot provider for a streaming source's buffered data.
 pub(crate) struct SourceSnapshotProvider {
     source_entry: Arc<SourceEntry>,
     num_partitions: usize,
 }
 
 impl SourceSnapshotProvider {
-    /// Create a new provider backed by the given source entry.
-    ///
-    /// # Arguments
-    ///
-    /// * `source_entry` - The source entry to snapshot
-    /// * `num_partitions` - Number of partitions for parallel scans (clamped to 1..=256)
+    /// `num_partitions` is clamped to `1..=256`.
     pub fn new(source_entry: Arc<SourceEntry>, num_partitions: usize) -> Self {
         Self {
             source_entry,
@@ -145,12 +124,9 @@ impl TableProvider for SourceSnapshotProvider {
         let batches = self.source_entry.snapshot();
         let schema = self.source_entry.schema.clone();
         let data = if batches.is_empty() {
-            // Produce the right number of (empty) partitions
             (0..self.num_partitions).map(|_| Vec::new()).collect()
         } else {
-            // Distribute batches round-robin across partitions.
-            // Assumes roughly uniform batch sizes; skew is acceptable
-            // for ad-hoc snapshot queries (not on the streaming hot path).
+            // Round-robin distribution; skew is fine for ad-hoc snapshot queries.
             let mut partitions: Vec<Vec<_>> =
                 (0..self.num_partitions).map(|_| Vec::new()).collect();
             for (i, batch) in batches.into_iter().enumerate() {
@@ -172,10 +148,7 @@ impl std::fmt::Debug for SourceSnapshotProvider {
     }
 }
 
-/// A `DataFusion` table provider for materialized view results.
-///
-/// Registered once at `CREATE MATERIALIZED VIEW` time. Each `scan()` reads
-/// the latest results from the shared `MvStore`.
+/// `DataFusion` table provider for materialized view results.
 pub(crate) struct MvTableProvider {
     mv_name: String,
     schema: SchemaRef,
@@ -183,7 +156,6 @@ pub(crate) struct MvTableProvider {
 }
 
 impl MvTableProvider {
-    /// Create a new provider for the given materialized view.
     pub fn new(
         mv_name: String,
         schema: SchemaRef,

--- a/crates/laminar-db/src/table_store.rs
+++ b/crates/laminar-db/src/table_store.rs
@@ -1,12 +1,4 @@
-//! Primary-key-based reference table store.
-//!
-//! Supports upsert, delete, and lookup by primary key for dimension/reference
-//! tables used in enrichment joins (e.g., `JOIN instruments ON t.symbol = i.symbol`).
-//!
-//! Tables can operate in different cache modes:
-//! - **Full**: all rows in memory (default, unchanged behavior)
-//! - **Partial**: LRU cache of hot keys with xor filter for negative lookups
-//! - **None**: no caching, direct backend access (same as Full for in-memory)
+//! Primary-key-based reference table store for dimension/enrichment tables.
 #![allow(clippy::disallowed_types)] // cold path
 
 use std::collections::HashMap;
@@ -18,37 +10,23 @@ use crate::error::DbError;
 use crate::table_backend::TableBackend;
 use crate::table_cache_mode::TableCacheMode;
 
-/// Internal state for a single reference table.
 struct TableState {
-    /// Arrow schema for this table.
     schema: SchemaRef,
-    /// Name of the primary key column.
     primary_key: String,
-    /// Index of the primary key column in the schema.
     pk_index: usize,
-    /// Backend storage for row data.
     backend: TableBackend,
-    /// Tracked row count (avoids expensive iteration for persistent backends).
     row_count: usize,
-    /// Whether the table has been fully populated (e.g., initial snapshot done).
     ready: bool,
-    /// Connector type backing this table, if any.
     connector: Option<String>,
-    /// Cache mode for this table.
     #[cfg_attr(not(test), allow(dead_code))]
     cache_mode: TableCacheMode,
 }
 
-/// Primary-key-based reference table store.
-///
-/// Manages dimension/reference tables with upsert/delete/lookup semantics.
-/// Each table has a designated primary key column used to key individual rows.
 pub(crate) struct TableStore {
     tables: HashMap<String, TableState>,
 }
 
 impl TableStore {
-    /// Create an empty table store.
     pub fn new() -> Self {
         Self {
             tables: HashMap::new(),
@@ -56,8 +34,6 @@ impl TableStore {
     }
 
     /// Register a new table with the given schema and primary key column.
-    ///
-    /// Uses the default `Full` cache mode.
     ///
     /// # Errors
     ///
@@ -110,17 +86,14 @@ impl TableStore {
         Ok(())
     }
 
-    /// Remove a table. Returns `true` if it existed.
     pub fn drop_table(&mut self, name: &str) -> bool {
         self.tables.remove(name).is_some()
     }
 
-    /// Check if a table exists.
     pub fn has_table(&self, name: &str) -> bool {
         self.tables.contains_key(name)
     }
 
-    /// List all table names.
     pub fn table_names(&self) -> Vec<String> {
         self.tables.keys().cloned().collect()
     }
@@ -158,20 +131,13 @@ impl TableStore {
         self.tables.get(name).and_then(|t| t.connector.as_deref())
     }
 
-    /// Whether a table uses persistent storage.
     pub fn is_persistent(&self, name: &str) -> bool {
         self.tables
             .get(name)
             .is_some_and(|t| t.backend.is_persistent())
     }
 
-    /// Upsert rows from a `RecordBatch` into a table.
-    ///
-    /// Extracts the primary key column, slices the batch into per-row batches,
-    /// and inserts/overwrites each row by its PK value.
-    /// Invalidates affected LRU cache entries on update.
-    ///
-    /// Returns the number of rows upserted.
+    /// Upsert rows from a `RecordBatch`, keyed by the primary key column.
     ///
     /// # Errors
     ///
@@ -220,9 +186,7 @@ impl TableStore {
         state.backend.get(key).ok().flatten()
     }
 
-    /// Upsert a batch in a single lock scope.
-    ///
-    /// Returns the upserted row count.
+    /// Upsert a batch; returns the row count.
     ///
     /// # Errors
     ///
@@ -235,33 +199,25 @@ impl TableStore {
         self.upsert(name, batch)
     }
 
-    /// Rebuild the cache/indices (no-op since removing hand-rolled caches).
+    // No-op since removing hand-rolled caches.
     #[allow(clippy::unused_self)]
     pub fn rebuild_xor_filter(&mut self, _name: &str) {}
 
-    /// Get the cache mode for a table.
     #[cfg(test)]
     pub fn cache_mode(&self, name: &str) -> Option<&TableCacheMode> {
         self.tables.get(name).map(|t| &t.cache_mode)
     }
 
-    /// Concatenate all rows into a single `RecordBatch`.
-    ///
-    /// Returns `None` if the table does not exist. Returns an empty batch
-    /// (with correct schema) if the table has no rows.
     pub fn to_record_batch(&self, name: &str) -> Option<RecordBatch> {
         let state = self.tables.get(name)?;
         state.backend.to_record_batch(&state.schema).ok().flatten()
     }
 }
 
-/// Extract the string representation of a primary key value at a given row.
 fn extract_pk_string(col: &dyn Array, row: usize) -> String {
-    // Try StringArray first (most common for PKs)
     if let Some(arr) = col.as_any().downcast_ref::<StringArray>() {
         return arr.value(row).to_string();
     }
-    // Fall back to generic display via arrow's array formatting
     if let Some(arr) = col.as_any().downcast_ref::<arrow::array::Int32Array>() {
         return arr.value(row).to_string();
     }
@@ -271,7 +227,6 @@ fn extract_pk_string(col: &dyn Array, row: usize) -> String {
     if let Some(arr) = col.as_any().downcast_ref::<arrow::array::UInt64Array>() {
         return arr.value(row).to_string();
     }
-    // Generic fallback using array_value_to_string
     arrow::util::display::array_value_to_string(col, row).unwrap_or_default()
 }
 

--- a/crates/laminar-db/src/temporal_probe.rs
+++ b/crates/laminar-db/src/temporal_probe.rs
@@ -1,21 +1,8 @@
 #![deny(clippy::disallowed_types)]
 
-//! Temporal probe join execution.
-//!
-//! For each left event, probes the right stream at multiple fixed time offsets.
-//! Each left row produces N output rows (one per offset) with the ASOF-matched
-//! right value at `event_time + offset_ms`.
-//!
-//! State is watermark-driven: probes with `probe_ts <= watermark` are emitted
-//! immediately. Remaining probes are buffered until the watermark advances.
-//!
-//! ## Known limitations
-//!
-//! - **Column disambiguation**: right-side columns that collide with left-side
-//!   names are suffixed `_{right_table}`. The projection SQL builder needs source
-//!   schemas (available in `add_query`) to detect collisions correctly.
-//! - **Sparse reference streams**: if the correct ASOF match predates the
-//!   eviction cutoff, the lookup returns NULL. Dense reference streams avoid this.
+//! Temporal probe join: each left row fans out N output rows (one per offset),
+//! ASOF-matched against the reference stream at `event_time + offset_ms`.
+//! Probes whose target timestamp exceeds the current watermark are carried until it advances.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -34,7 +21,6 @@ use crate::key_column::{extract_column_as_timestamps, take_with_nulls, Composite
 const COMPACTION_THRESHOLD: u32 = 32;
 const MAX_PENDING_PROBES: usize = 100_000;
 
-/// Per-key reference stream buffer with ASOF lookup and bounded memory.
 #[derive(Debug, Default)]
 struct RefBuffer {
     index: FxHashMap<u64, BTreeMap<i64, Vec<usize>>>,
@@ -100,7 +86,6 @@ impl RefBuffer {
         Ok(())
     }
 
-    /// ASOF lookup with key verification.
     fn asof_lookup(
         &self,
         key_hash: u64,
@@ -160,7 +145,6 @@ impl RefBuffer {
             idx_map.insert(old_idx, new_idx);
         }
 
-        // Use arrow::compute::take instead of per-row slice + concat
         #[allow(clippy::cast_possible_truncation)]
         let take_indices = arrow::array::UInt32Array::from(
             live_rows.iter().map(|&i| i as u32).collect::<Vec<_>>(),
@@ -529,7 +513,6 @@ pub(crate) fn execute_temporal_probe_cycle(
         }
     }
 
-    // Resolve carried probes from previous cycles
     if !state.carried_probes.is_empty() && watermark > state.last_watermark {
         let mut still_pending = Vec::new();
         #[allow(clippy::type_complexity)]
@@ -623,7 +606,7 @@ pub(crate) fn execute_temporal_probe_cycle(
         }
     }
 
-    // Evict — safe cutoff preserving data for carried probes
+    // Evict: cutoff clamped to the earliest pending probe's target timestamp.
     if watermark > state.last_watermark {
         let min_offset = config.min_offset_ms();
         let base_cutoff = if min_offset < 0 {

--- a/crates/laminar-db/src/vnode_partial.rs
+++ b/crates/laminar-db/src/vnode_partial.rs
@@ -1,35 +1,18 @@
-//! Per-vnode durable partial state.
+//! Per-vnode durable partial state (`epoch=N/vnode=V/partial.bin`).
 //!
-//! Replaces the old `ckpt:{id}` marker that `partial.bin` used to hold. A
-//! `VnodePartial` is the slice of operator state belonging to a single vnode
-//! at a single committed epoch: when a node acquires that vnode in a
-//! rebalance it reads this blob from the shared object store
-//! (`epoch=N/vnode=V/partial.bin`) and merges each operator's slice into the
-//! corresponding live operator.
-//!
-//! The presence of `partial.bin` still drives the durability gate
-//! (`StateBackend::epoch_complete`), so an empty `operators` map (a vnode this
-//! node owns but for which no operator carried state) is valid and seals the
-//! epoch exactly as the marker did.
+//! An empty `operators` map is valid — it seals the epoch without carrying state,
+//! which is correct for vnodes whose operators hold nothing.
 
 use crate::error::DbError;
 
 /// Operator-state slices for one vnode at one epoch.
 ///
-/// Each entry is `(operator_name, that operator's serialized vnode slice)`.
-/// The bytes are exactly what the operator's per-vnode checkpoint produced
-/// (e.g. an rkyv-encoded `AggStateCheckpoint` holding only this vnode's
-/// groups), so the apply path can hand them straight back to the operator.
-///
-/// `base_epoch = Some(N)` makes this a *reference* artifact: the
-/// vnode's state is byte-identical to the full partial it
-/// uploaded at epoch `N`, so `operators` is empty and the reader follows
-/// the reference (a single hop — references always point at a full
-/// artifact, never at another reference). The writer re-emits a full
-/// partial before the base can leave the prune retention window.
+/// `base_epoch = Some(N)` means the state is byte-identical to the full partial at epoch N;
+/// `operators` is empty and the reader follows this one-hop reference. The writer re-emits a full
+/// partial before the base leaves the prune window.
 #[derive(Debug, Default, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub(crate) struct VnodePartial {
-    /// Checkpoint id this partial was sealed under — for audit/logging.
+    /// Sealed epoch, for audit.
     pub checkpoint_id: u64,
     /// `(operator_name, vnode-slice bytes)`. Empty for references.
     pub operators: Vec<(String, Vec<u8>)>,
@@ -38,22 +21,13 @@ pub(crate) struct VnodePartial {
 }
 
 impl VnodePartial {
-    /// Serialize for `write_partial`.
     pub(crate) fn encode(&self) -> Result<Vec<u8>, DbError> {
         rkyv::to_bytes::<rkyv::rancor::Error>(self)
             .map(|v| v.to_vec())
             .map_err(|e| DbError::Checkpoint(format!("vnode partial serialization: {e}")))
     }
 
-    /// Deserialize a `partial.bin` blob.
-    ///
-    /// Best-effort by contract at the call site: a blob that isn't a
-    /// `VnodePartial` (a legacy `ckpt:{id}` marker, or hand-written test
-    /// bytes) returns `Err` and the caller skips it rather than aborting the
-    /// rebalance.
-    ///
-    /// Only the cluster rehydration path decodes partials; in a non-cluster
-    /// build this is exercised solely by unit tests.
+    /// Deserialize a `partial.bin` blob; returns `Err` for legacy markers so callers can skip them.
     #[cfg_attr(not(feature = "cluster"), allow(dead_code))]
     pub(crate) fn decode(bytes: &[u8]) -> Result<Self, DbError> {
         rkyv::from_bytes::<Self, rkyv::rancor::Error>(bytes)

--- a/crates/laminar-db/tests/single_node_tier.rs
+++ b/crates/laminar-db/tests/single_node_tier.rs
@@ -1,0 +1,135 @@
+#![cfg(feature = "state-tier")]
+//! Single-node cold-tier demotion + promotion, with no cluster controller.
+//!
+//! Exercises the path where a durable state backend and a single-owner vnode
+//! registry are configured but there is no controller or row shuffle. The tier
+//! takes its vnode count from the registry (not the shuffle config), so
+//! per-vnode capture and demotion run without a cluster. Before the vnode count
+//! was decoupled from the shuffle config, a node without a controller could
+//! never demote (the tier stayed disabled), so `demote_total` would never move.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use laminar_core::state::{NodeId, ObjectStoreBackend, VnodeRegistry};
+use laminar_core::streaming::StreamCheckpointConfig;
+use laminar_db::LaminarDB;
+use object_store::local::LocalFileSystem;
+
+const VNODES: u32 = 64;
+
+fn key_batch(keys: &[i64]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Int64, false)]));
+    RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(keys.to_vec()))]).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn single_node_demotes_and_promotes_without_a_controller() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    let tier_dir = dir.path().join("tier");
+    std::fs::create_dir_all(&state_dir).unwrap();
+
+    let store = Arc::new(LocalFileSystem::new_with_prefix(&state_dir).unwrap());
+    let backend = Arc::new(ObjectStoreBackend::new(store, "node-0", VNODES));
+
+    // Single-owner registry: all vnodes owned by this node, no controller. This
+    // is the documented single-instance path — the durability gate wires the
+    // coordinator from it, and the tier takes its vnode count from it.
+    let registry = Arc::new(VnodeRegistry::new(VNODES));
+    registry.set_assignment((0..VNODES).map(|_| NodeId(0)).collect::<Vec<_>>().into());
+
+    let db = LaminarDB::builder()
+        .storage_dir(dir.path().join("ckpt"))
+        .checkpoint(StreamCheckpointConfig {
+            interval_ms: None, // drive checkpoints manually below
+            ..StreamCheckpointConfig::default()
+        })
+        .state_backend(backend)
+        .vnode_registry(registry)
+        .state_tier_dir(&tier_dir)
+        .state_memory_budget_bytes(4096) // tiny — forces demotion under load
+        .build()
+        .await
+        .unwrap();
+
+    db.execute("CREATE SOURCE events (k BIGINT)").await.unwrap();
+    db.execute(
+        "CREATE STREAM counts AS SELECT k, COUNT(*) AS n FROM events GROUP BY k EMIT CHANGES",
+    )
+    .await
+    .unwrap();
+    db.start().await.unwrap();
+
+    // The tier opens its fjall dir only when the activation gate passes — so its
+    // presence proves the single-node tier was enabled without a controller.
+    assert!(
+        tier_dir.join("db").exists(),
+        "single-node tier should be enabled (no controller required)"
+    );
+
+    let source = db.source_untyped("events").unwrap();
+
+    // Build aggregate state over the 4 KiB budget: 1000 distinct keys.
+    for batch in 0..2i64 {
+        let start = batch * 500;
+        source
+            .push_arrow(key_batch(&(start..start + 500).collect::<Vec<_>>()))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Drain the ingest backlog so every vnode goes idle (demotion only sheds
+    // vnodes clean since the last capture — a still-draining backlog keeps them
+    // dirty), then checkpoint to set the clean baseline + per-vnode slices.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(db.checkpoint().await.unwrap().success);
+
+    // With no more input, the maintenance pass sees clean, over-budget vnodes
+    // and sheds them to the tier.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        if db.tier_metrics().demote_total > 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "demotion never fired on a single node: {:?}",
+            db.tier_metrics()
+        );
+    }
+    let demoted = db.tier_metrics();
+    assert!(demoted.demote_total > 0, "expected effective demotions");
+    assert!(
+        demoted.resident_bytes > 0 && demoted.resident_slices > 0,
+        "tier should hold demoted slices: {demoted:?}"
+    );
+
+    // Re-feed earlier keys — now demoted — so a row lands on a cold vnode and
+    // must promote it back (a fetch), not silently rebuild it (which would lose
+    // the prior count).
+    source
+        .push_arrow(key_batch(&(0..200).collect::<Vec<_>>()))
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        if db.tier_metrics().fetch_total > 0 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "promotion never fired on a single node: {:?}",
+            db.tier_metrics()
+        );
+    }
+    assert!(
+        db.tier_metrics().fetch_total > 0,
+        "expected promotion fetches"
+    );
+
+    db.shutdown().await.unwrap();
+}

--- a/crates/laminar-derive/Cargo.toml
+++ b/crates/laminar-derive/Cargo.toml
@@ -19,5 +19,5 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 arrow = { workspace = true }
-laminar-core = { path = "../laminar-core", version = "0.25.1" }
-laminar-connectors = { path = "../laminar-connectors", version = "0.25.1" }
+laminar-core = { path = "../laminar-core", version = "0.26.0" }
+laminar-connectors = { path = "../laminar-connectors", version = "0.26.0" }

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -23,9 +23,9 @@ required-features = ["cluster"]
 # LaminarDB crates. laminar-db re-exports the rest of the workspace; the
 # server only needs the unified facade plus laminar-core for things like
 # metrics types referenced directly.
-laminar-core = { path = "../laminar-core", version = "0.25.1" }
-laminar-db = { path = "../laminar-db", version = "0.25.1", features = ["api", "remote", "local"] }
-laminar-sql = { path = "../laminar-sql", version = "0.25.1" }
+laminar-core = { path = "../laminar-core", version = "0.26.0" }
+laminar-db = { path = "../laminar-db", version = "0.26.0", features = ["api", "remote", "local"] }
+laminar-sql = { path = "../laminar-sql", version = "0.26.0" }
 
 # For pgwire dispatch on parsed AST
 sqlparser = { workspace = true }
@@ -152,6 +152,7 @@ default = [
     "parquet-lookup",
     "otel",
     "cluster",
+    "state-tier",
     "aws",
     "gcs",
     "azure",

--- a/crates/laminar-server/Cargo.toml
+++ b/crates/laminar-server/Cargo.toml
@@ -193,4 +193,6 @@ cluster = [
     "dep:tokio-util",
     "dep:reqwest",
 ]
+# Disk cold tier for demoted operator state (experimental). Implies cluster.
+state-tier = ["cluster", "laminar-db/state-tier"]
 vendored-openssl = ["dep:openssl"]

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -58,6 +58,11 @@ mode = "embedded"           # "embedded" (single-node) or "cluster" (multi-node 
 bind = "0.0.0.0:8080"       # HTTP API bind address
 pgwire_bind = "127.0.0.1:5433"  # optional; enables Postgres wire protocol for SUBSCRIBE
 log_level = "info"
+# Optional node-level cap on total operator state held in memory, in bytes.
+# Crossing it pauses source intake (backpressure, not failure) until state
+# drains below the budget; watch `state_bytes` / `state_over_budget` in
+# /metrics. Unset = unlimited.
+# state_memory_budget_bytes = 8589934592
 # Optional MD5 password auth for the pgwire listener. When this map is set,
 # the listener requires MD5 auth and is allowed to bind to non-localhost
 # interfaces. When empty, auth is "trust" and the bind must be localhost.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -63,6 +63,11 @@ log_level = "info"
 # drains below the budget; watch `state_bytes` / `state_over_budget` in
 # /metrics. Unset = unlimited.
 # state_memory_budget_bytes = 8589934592
+# Optional disk cold tier (experimental; needs a `state-tier` build). With a
+# memory budget set, idle aggregate state approaching the budget is demoted
+# here (local NVMe) and fetched back on demand instead of backpressuring.
+# Watch `state_tier_bytes` / `state_tier_slices` / `state_tier_demote_total`.
+# state_tier_dir = "/var/lib/laminardb/state-tier"
 # Optional MD5 password auth for the pgwire listener. When this map is set,
 # the listener requires MD5 auth and is allowed to bind to non-localhost
 # interfaces. When empty, auth is "trust" and the bind must be localhost.

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -67,6 +67,10 @@ log_level = "info"
 # memory budget set, idle aggregate state approaching the budget is demoted
 # here (local NVMe) and fetched back on demand instead of backpressuring.
 # Watch `state_tier_bytes` / `state_tier_slices` / `state_tier_demote_total`.
+# Works single-node (no cluster) — the server derives the vnode topology from
+# [state]. Requires a durable [state] backend (`local`/`object_store`): the
+# tier's demoted state is replayed from it on restart, so an `in_process`
+# backend is rejected. Set a memory budget too, or nothing is demoted.
 # state_tier_dir = "/var/lib/laminardb/state-tier"
 # Optional MD5 password auth for the pgwire listener. When this map is set,
 # the listener requires MD5 auth and is allowed to bind to non-localhost

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -451,8 +451,28 @@ pub async fn start_cluster(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    #[cfg(feature = "state-tier")]
     if let Some(ref dir) = config.server.state_tier_dir {
+        // Demotion is budget-driven; with no budget the tier never demotes,
+        // so a dir alone is a silent no-op.
+        if config.server.state_memory_budget_bytes.is_none() {
+            return Err(ClusterStartupError::EngineConstruction(
+                "state_tier_dir requires state_memory_budget_bytes — demotion to \
+                 the cold tier is triggered by the memory budget, so a tier dir \
+                 without a budget would never demote"
+                    .to_string(),
+            ));
+        }
         builder = builder.state_tier_dir(dir);
+    }
+    #[cfg(not(feature = "state-tier"))]
+    if config.server.state_tier_dir.is_some() {
+        return Err(ClusterStartupError::EngineConstruction(
+            "state_tier_dir is set but this binary was built without the \
+             'state-tier' feature; rebuild with --features state-tier or remove \
+             state_tier_dir from the [server] config"
+                .to_string(),
+        ));
     }
 
     if let Some(path) = config.state.local_storage_dir() {

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -448,6 +448,9 @@ pub async fn start_cluster(
     if let Some(ref token) = config.server.console_token {
         builder = builder.http_auth_token(token.expose());
     }
+    if let Some(budget) = config.server.state_memory_budget_bytes {
+        builder = builder.state_memory_budget_bytes(budget);
+    }
 
     if let Some(path) = config.state.local_storage_dir() {
         builder = builder.storage_dir(path);

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -453,6 +453,16 @@ pub async fn start_cluster(
     }
     #[cfg(feature = "state-tier")]
     if let Some(ref dir) = config.server.state_tier_dir {
+        // The tier replays demoted state from [state] on restart, so a
+        // non-durable (in-process) backend would lose it.
+        if !config.state.is_durable() {
+            return Err(ClusterStartupError::EngineConstruction(
+                "state_tier_dir requires a durable [state] backend (a local path \
+                 or object store); an in-process backend would lose demoted state \
+                 on restart"
+                    .to_string(),
+            ));
+        }
         // Demotion is budget-driven; with no budget the tier never demotes,
         // so a dir alone is a silent no-op.
         if config.server.state_memory_budget_bytes.is_none() {

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -451,38 +451,11 @@ pub async fn start_cluster(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    // The state_tier_dir contract (durable backend + budget + feature) is
+    // enforced by config validation at load; here we only wire the dir.
     #[cfg(feature = "state-tier")]
     if let Some(ref dir) = config.server.state_tier_dir {
-        // The tier replays demoted state from [state] on restart, so a
-        // non-durable (in-process) backend would lose it.
-        if !config.state.is_durable() {
-            return Err(ClusterStartupError::EngineConstruction(
-                "state_tier_dir requires a durable [state] backend (a local path \
-                 or object store); an in-process backend would lose demoted state \
-                 on restart"
-                    .to_string(),
-            ));
-        }
-        // Demotion is budget-driven; with no budget the tier never demotes,
-        // so a dir alone is a silent no-op.
-        if config.server.state_memory_budget_bytes.is_none() {
-            return Err(ClusterStartupError::EngineConstruction(
-                "state_tier_dir requires state_memory_budget_bytes — demotion to \
-                 the cold tier is triggered by the memory budget, so a tier dir \
-                 without a budget would never demote"
-                    .to_string(),
-            ));
-        }
         builder = builder.state_tier_dir(dir);
-    }
-    #[cfg(not(feature = "state-tier"))]
-    if config.server.state_tier_dir.is_some() {
-        return Err(ClusterStartupError::EngineConstruction(
-            "state_tier_dir is set but this binary was built without the \
-             'state-tier' feature; rebuild with --features state-tier or remove \
-             state_tier_dir from the [server] config"
-                .to_string(),
-        ));
     }
 
     if let Some(path) = config.state.local_storage_dir() {

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -451,6 +451,9 @@ pub async fn start_cluster(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    if let Some(ref dir) = config.server.state_tier_dir {
+        builder = builder.state_tier_dir(dir);
+    }
 
     if let Some(path) = config.state.local_storage_dir() {
         builder = builder.storage_dir(path);

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -240,12 +240,48 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
 
     validate_ai(config, &mut errors);
     validate_cluster_tls(config, &mut errors);
+    validate_state_tier(config, &mut errors);
 
     if !errors.is_empty() {
         return Err(ConfigError::ValidationErrors { errors });
     }
 
     Ok(())
+}
+
+/// The `state_tier_dir` contract, validated once here so the embedded and
+/// cluster startup paths share it instead of each re-checking and drifting.
+fn validate_state_tier(config: &ServerConfig, errors: &mut Vec<String>) {
+    if config.server.state_tier_dir.is_none() {
+        return;
+    }
+    #[cfg(feature = "state-tier")]
+    {
+        // The tier replays demoted state from [state] on restart, so a
+        // non-durable backend would lose it; demotion is budget-driven, so a
+        // dir without a budget never demotes.
+        if !config.state.is_durable() {
+            errors.push(
+                "state_tier_dir requires a durable [state] backend (a local path or \
+                 object store); an in-process backend would lose demoted state on restart"
+                    .to_string(),
+            );
+        }
+        if config.server.state_memory_budget_bytes.is_none() {
+            errors.push(
+                "state_tier_dir requires state_memory_budget_bytes — demotion to the cold \
+                 tier is triggered by the memory budget, so a tier dir without a budget \
+                 would never demote"
+                    .to_string(),
+            );
+        }
+    }
+    #[cfg(not(feature = "state-tier"))]
+    errors.push(
+        "state_tier_dir is set but this binary was built without the 'state-tier' \
+         feature; rebuild with --features state-tier or remove state_tier_dir"
+            .to_string(),
+    );
 }
 
 /// Top-level server configuration deserialized from `laminardb.toml`.

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -329,6 +329,11 @@ pub struct ServerSection {
     /// state drains below the budget. `None` = unlimited.
     #[serde(default)]
     pub state_memory_budget_bytes: Option<usize>,
+    /// Local directory for the disk cold tier. With a memory budget set,
+    /// operator state approaching the budget is demoted here instead of
+    /// backpressuring. Requires a `state-tier` build. `None` = no tier.
+    #[serde(default)]
+    pub state_tier_dir: Option<std::path::PathBuf>,
 }
 
 fn default_pgwire_max_connections() -> usize {
@@ -360,6 +365,7 @@ impl Default for ServerSection {
             console_token: None,
             console_cors_allowed_origins: None,
             state_memory_budget_bytes: None,
+            state_tier_dir: None,
         }
     }
 }
@@ -1123,6 +1129,17 @@ state_memory_budget_bytes = 1073741824
 
         let config: ServerConfig = toml::from_str("[server]\nmode = \"embedded\"\n").unwrap();
         assert_eq!(config.server.state_memory_budget_bytes, None);
+        assert_eq!(config.server.state_tier_dir, None);
+    }
+
+    #[test]
+    fn test_state_tier_dir_parses() {
+        let toml = "[server]\nmode = \"embedded\"\nstate_tier_dir = \"/data/tier\"\n";
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.server.state_tier_dir,
+            Some(std::path::PathBuf::from("/data/tier"))
+        );
     }
 
     #[test]

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -324,6 +324,11 @@ pub struct ServerSection {
     /// permissive policy (dev only); set this before exposing the console.
     #[serde(default)]
     pub console_cors_allowed_origins: Option<Vec<String>>,
+    /// Node-level cap on total operator state held in memory, in bytes.
+    /// Crossing it pauses source intake (backpressure, not failure) until
+    /// state drains below the budget. `None` = unlimited.
+    #[serde(default)]
+    pub state_memory_budget_bytes: Option<usize>,
 }
 
 fn default_pgwire_max_connections() -> usize {
@@ -354,6 +359,7 @@ impl Default for ServerSection {
             pgwire_tls_min_version: default_pgwire_tls_min_version(),
             console_token: None,
             console_cors_allowed_origins: None,
+            state_memory_budget_bytes: None,
         }
     }
 }
@@ -1103,6 +1109,23 @@ delivery = "exactly_once"
         assert_eq!(coord.heartbeat_interval, Duration::from_millis(300));
 
         validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn test_state_memory_budget_parses_and_defaults_off() {
+        let toml = r#"
+[server]
+mode = "embedded"
+state_memory_budget_bytes = 1073741824
+"#;
+        let config: ServerConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.server.state_memory_budget_bytes,
+            Some(1_073_741_824)
+        );
+
+        let config: ServerConfig = toml::from_str("[server]\nmode = \"embedded\"\n").unwrap();
+        assert_eq!(config.server.state_memory_budget_bytes, None);
     }
 
     #[test]

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -1119,10 +1119,7 @@ mode = "embedded"
 state_memory_budget_bytes = 1073741824
 "#;
         let config: ServerConfig = toml::from_str(toml).unwrap();
-        assert_eq!(
-            config.server.state_memory_budget_bytes,
-            Some(1_073_741_824)
-        );
+        assert_eq!(config.server.state_memory_budget_bytes, Some(1_073_741_824));
 
         let config: ServerConfig = toml::from_str("[server]\nmode = \"embedded\"\n").unwrap();
         assert_eq!(config.server.state_memory_budget_bytes, None);

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -125,6 +125,9 @@ pub async fn run_server(
     if let Some(ref token) = config.server.console_token {
         builder = builder.http_auth_token(token.expose());
     }
+    if let Some(budget) = config.server.state_memory_budget_bytes {
+        builder = builder.state_memory_budget_bytes(budget);
+    }
 
     let storage_dir = config.state.local_storage_dir();
     let has_storage = config.state.is_durable();

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -128,6 +128,9 @@ pub async fn run_server(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    if let Some(ref dir) = config.server.state_tier_dir {
+        builder = builder.state_tier_dir(dir);
+    }
 
     let storage_dir = config.state.local_storage_dir();
     let has_storage = config.state.is_durable();

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -128,6 +128,7 @@ pub async fn run_server(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    #[cfg(feature = "state-tier")]
     if let Some(ref dir) = config.server.state_tier_dir {
         // The cold tier holds demoted state whose truth lives in the [state]
         // backend (restart wipes the tier and replays from it). An in-process
@@ -141,7 +142,26 @@ pub async fn run_server(
                     .to_string(),
             ));
         }
+        // Demotion is budget-driven; with no budget the tier never demotes,
+        // so a dir alone is a silent no-op.
+        if config.server.state_memory_budget_bytes.is_none() {
+            return Err(ServerError::Build(
+                "state_tier_dir requires state_memory_budget_bytes — demotion to \
+                 the cold tier is triggered by the memory budget, so a tier dir \
+                 without a budget would never demote"
+                    .to_string(),
+            ));
+        }
         builder = builder.state_tier_dir(dir);
+    }
+    #[cfg(not(feature = "state-tier"))]
+    if config.server.state_tier_dir.is_some() {
+        return Err(ServerError::Build(
+            "state_tier_dir is set but this binary was built without the \
+             'state-tier' feature; rebuild with --features state-tier or remove \
+             state_tier_dir from the [server] config"
+                .to_string(),
+        ));
     }
 
     let storage_dir = config.state.local_storage_dir();

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -128,40 +128,11 @@ pub async fn run_server(
     if let Some(budget) = config.server.state_memory_budget_bytes {
         builder = builder.state_memory_budget_bytes(budget);
     }
+    // The state_tier_dir contract (durable backend + budget + feature) is
+    // enforced by config validation at load; here we only wire the dir.
     #[cfg(feature = "state-tier")]
     if let Some(ref dir) = config.server.state_tier_dir {
-        // The cold tier holds demoted state whose truth lives in the [state]
-        // backend (restart wipes the tier and replays from it). An in-process
-        // backend would lose that on restart, so refuse rather than tier into
-        // the void — single-node tiering needs a durable [state] backend.
-        if !config.state.is_durable() {
-            return Err(ServerError::Build(
-                "state_tier_dir requires a durable [state] backend (a local path \
-                 or object store); an in-process backend would lose demoted state \
-                 on restart"
-                    .to_string(),
-            ));
-        }
-        // Demotion is budget-driven; with no budget the tier never demotes,
-        // so a dir alone is a silent no-op.
-        if config.server.state_memory_budget_bytes.is_none() {
-            return Err(ServerError::Build(
-                "state_tier_dir requires state_memory_budget_bytes — demotion to \
-                 the cold tier is triggered by the memory budget, so a tier dir \
-                 without a budget would never demote"
-                    .to_string(),
-            ));
-        }
         builder = builder.state_tier_dir(dir);
-    }
-    #[cfg(not(feature = "state-tier"))]
-    if config.server.state_tier_dir.is_some() {
-        return Err(ServerError::Build(
-            "state_tier_dir is set but this binary was built without the \
-             'state-tier' feature; rebuild with --features state-tier or remove \
-             state_tier_dir from the [server] config"
-                .to_string(),
-        ));
     }
 
     let storage_dir = config.state.local_storage_dir();

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -129,6 +129,18 @@ pub async fn run_server(
         builder = builder.state_memory_budget_bytes(budget);
     }
     if let Some(ref dir) = config.server.state_tier_dir {
+        // The cold tier holds demoted state whose truth lives in the [state]
+        // backend (restart wipes the tier and replays from it). An in-process
+        // backend would lose that on restart, so refuse rather than tier into
+        // the void — single-node tiering needs a durable [state] backend.
+        if !config.state.is_durable() {
+            return Err(ServerError::Build(
+                "state_tier_dir requires a durable [state] backend (a local path \
+                 or object store); an in-process backend would lose demoted state \
+                 on restart"
+                    .to_string(),
+            ));
+        }
         builder = builder.state_tier_dir(dir);
     }
 

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -39,7 +39,8 @@
 //!   then asserts demotion AND promotion counters moved across the
 //!   kill -9 rounds. Knobs (tier mode only): `LAMINAR_SOAK_BUDGET_BYTES`
 //!   (default 256 KiB), `LAMINAR_SOAK_VNODES` (256), `LAMINAR_SOAK_RPS`
-//!   (400), `LAMINAR_SOAK_GROUPS` (2000 — the agg key-space size).
+//!   (400), `LAMINAR_SOAK_GROUPS` (2000 — the agg key-space size),
+//!   `LAMINAR_SOAK_SPAN` (12 — consecutive rows per agg key).
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -39,7 +39,7 @@
 //!   then asserts demotion AND promotion counters moved across the
 //!   kill -9 rounds. Knobs (tier mode only): `LAMINAR_SOAK_BUDGET_BYTES`
 //!   (default 256 KiB), `LAMINAR_SOAK_VNODES` (256), `LAMINAR_SOAK_RPS`
-//!   (400), `LAMINAR_SOAK_GROUPS` (4000 — the agg key-space size).
+//!   (400), `LAMINAR_SOAK_GROUPS` (2000 — the agg key-space size).
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -33,6 +33,13 @@
 //!   (read_committed) against the generator's deterministic output:
 //!   every seq must appear exactly once, no gaps, no duplicates —
 //!   the exactly-once proof under kill -9.
+//! - `LAMINAR_SOAK_STATE_TIER`  any value: enable the disk cold tier
+//!   (build with `--features state-tier`). Adds a small memory budget
+//!   and an `EMIT CHANGES` aggregation so state is demoted under load,
+//!   then asserts demotion AND promotion counters moved across the
+//!   kill -9 rounds. Knobs (tier mode only): `LAMINAR_SOAK_BUDGET_BYTES`
+//!   (default 256 KiB), `LAMINAR_SOAK_VNODES` (256), `LAMINAR_SOAK_RPS`
+//!   (400), `LAMINAR_SOAK_GROUPS` (4000 — the agg key-space size).
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;
@@ -150,6 +157,28 @@ fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -
     let data_dir = dir.join(format!("node{id}-data"));
     std::fs::create_dir_all(&data_dir).unwrap();
 
+    // Optional disk cold tier (Phase 5 soak). A tiny budget forces
+    // demotion under load, a larger vnode ring keeps most vnodes clean
+    // each capture interval (only clean vnodes are demotable), and the
+    // `soak_agg` pipeline below gives the tier demotable per-vnode state
+    // (the pass-through `soak_stream` has none). Bounded key space (mod
+    // GROUPS) means demoted keys are revisited, driving promotion too.
+    // Gated on the env var so default runs are byte-identical.
+    let tier = std::env::var("LAMINAR_SOAK_STATE_TIER").is_ok();
+    let rps = env_u64("LAMINAR_SOAK_RPS", if tier { 400 } else { 200 });
+    let vnodes = env_u64("LAMINAR_SOAK_VNODES", if tier { 256 } else { 64 });
+    let mut server_extra = String::new();
+    if tier {
+        let budget = env_u64("LAMINAR_SOAK_BUDGET_BYTES", 256 * 1024);
+        let tier_dir = data_dir
+            .join("tier")
+            .display()
+            .to_string()
+            .replace('\\', "/");
+        server_extra =
+            format!("state_tier_dir = \"{tier_dir}\"\nstate_memory_budget_bytes = {budget}\n");
+    }
+
     let mut storage = String::new();
     for (env, key) in [
         ("LAMINAR_SOAK_S3_ENDPOINT", "endpoint"),
@@ -173,7 +202,7 @@ storage_dir = "{data}"
 [server]
 mode = "cluster"
 bind = "127.0.0.1:{http}"
-
+{server_extra}
 [discovery]
 strategy = "static"
 seeds = [{seeds}]
@@ -187,7 +216,7 @@ strategy = "raft"
 backend = "object_store"
 url = "{state_url}"
 instance_id = "n{id}"
-vnode_capacity = 64
+vnode_capacity = {vnodes}
 
 [state.storage]
 {storage}
@@ -205,7 +234,7 @@ max_in_flight_epochs = {depth}
 [[source]]
 name = "gen"
 connector = "generator"
-properties = {{ "rows.per.second" = "200", "batch.max.size" = "256" }}
+properties = {{ "rows.per.second" = "{rps}", "batch.max.size" = "256" }}
 
 [[pipeline]]
 name = "soak_stream"
@@ -215,6 +244,28 @@ sql = "SELECT seq, ts_ms, value FROM gen"
         seeds = seeds.join(", "),
         url = checkpoint_url,
     );
+
+    // Demotable per-vnode aggregate state for the cold tier: an EMIT
+    // CHANGES agg over a SLOW-CYCLING bounded key space. Only changelog
+    // aggs are demotable, and demotion only sheds vnodes that are CLEAN
+    // (untouched since the last capture) — so the key must idle long
+    // enough for whole vnodes to fall quiet. `(seq / SPAN) % GROUPS`
+    // writes each key in a burst of SPAN consecutive rows, then moves
+    // on; a key (and its vnode) is then idle for a full GROUPS*SPAN-row
+    // cycle (→ demotable) before the cycle returns to it (→ promotable).
+    // A plain `seq % GROUPS` instead scatters every key across the ring
+    // every cycle, so no vnode is ever idle and demotion just thrashes.
+    if tier {
+        let groups = env_u64("LAMINAR_SOAK_GROUPS", 2000);
+        let span = env_u64("LAMINAR_SOAK_SPAN", 12);
+        toml.push_str(&format!(
+            r#"
+[[pipeline]]
+name = "soak_agg"
+sql = "SELECT (seq / {span}) % {groups} AS k, COUNT(*) AS n FROM gen GROUP BY (seq / {span}) % {groups} EMIT CHANGES"
+"#,
+        ));
+    }
 
     // Optional exactly-once Kafka sink: each node writes its own topic
     // (its generator is an independent seq stream), so each topic must
@@ -451,39 +502,103 @@ fn three_node_kill9_soak() {
     let mut floor = assert_progress(&nodes, 0.0, Duration::from_secs(90), "startup");
     eprintln!("soak: cluster up, epoch {floor}");
 
+    // Cap on kill rounds. `LAMINAR_SOAK_KILLS=0` runs a steady, no-fault
+    // soak — the right vehicle to observe *effective* demotion/promotion,
+    // since rebalance rehydration (every kill) sets `dirty_all` and refuses
+    // demotion until the next capture. Default: kill for the whole window.
+    let max_kills = env_u64("LAMINAR_SOAK_KILLS", u64::MAX);
     let deadline = Instant::now() + Duration::from_secs(soak_secs);
     let mut round = 0u32;
+    let mut kills = 0u64;
     while Instant::now() < deadline {
-        // kill -9 a node mid-epoch (no drain, no final checkpoint —
-        // the cadence guarantees an epoch is in flight). Round-robin:
-        // over the soak this hits the leader and every follower.
-        let victim = (round as usize) % NODES;
         round += 1;
-        eprintln!("soak round {round}: kill -9 node {victim}");
-        nodes[victim].kill9();
-        floor = assert_progress(
-            &nodes,
-            floor,
-            Duration::from_secs(90),
-            "progress after kill",
-        );
+        if kills < max_kills {
+            // kill -9 a node mid-epoch (no drain, no final checkpoint —
+            // the cadence guarantees an epoch is in flight). Round-robin:
+            // over the soak this hits the leader and every follower.
+            let victim = (kills as usize) % NODES;
+            kills += 1;
+            eprintln!("soak round {round}: kill -9 node {victim}");
+            nodes[victim].kill9();
+            floor = assert_progress(
+                &nodes,
+                floor,
+                Duration::from_secs(90),
+                "progress after kill",
+            );
 
-        // Restart it; it must rejoin and the cluster keeps committing.
-        nodes[victim].spawn();
-        wait_for(
-            "killed node serving /metrics again",
-            Duration::from_secs(60),
-            || nodes[victim].epoch().is_some(),
-        );
-        floor = assert_progress(
-            &nodes,
-            floor,
-            Duration::from_secs(90),
-            "progress after rejoin",
-        );
+            // Restart it; it must rejoin and the cluster keeps committing.
+            nodes[victim].spawn();
+            wait_for(
+                "killed node serving /metrics again",
+                Duration::from_secs(60),
+                || nodes[victim].epoch().is_some(),
+            );
+            floor = assert_progress(
+                &nodes,
+                floor,
+                Duration::from_secs(90),
+                "progress after rejoin",
+            );
+        } else {
+            // No-fault steady state: just confirm the cluster keeps
+            // committing, then pace the loop so demotion has clean windows.
+            floor = assert_progress(&nodes, floor, Duration::from_secs(90), "steady progress");
+            std::thread::sleep(Duration::from_secs(5));
+        }
+
+        // Per-round tier snapshot: demotion/promotion evolve across the
+        // run, and the final scrape can land just after a rebalance wiped
+        // a node's tier — logging each round captures the peak.
+        if std::env::var("LAMINAR_SOAK_STATE_TIER").is_ok() {
+            let s = |m: &str| -> f64 { nodes.iter().filter_map(|n| n.metric(m)).sum() };
+            eprintln!(
+                "soak round {round} tier: demotes={} fetches={} resident_bytes={} \
+                 slices={} in_memory_state={}",
+                s("laminardb_state_tier_demote_total"),
+                s("laminardb_state_tier_fetch_total"),
+                s("laminardb_state_tier_bytes"),
+                s("laminardb_state_tier_slices"),
+                s("laminardb_state_bytes"),
+            );
+        }
     }
 
-    eprintln!("soak: completed {round} fault rounds, final epoch {floor}");
+    eprintln!("soak: completed {round} rounds ({kills} kills), final epoch {floor}");
+
+    // Tier validation: scrape while every node is still live (the Kafka
+    // diff below kills them all). Demotions prove the budget→demote
+    // trigger fired on clean vnodes after a committed capture; fetches
+    // prove a row hit a cold vnode and promotion read it back. Both must
+    // survive the kill -9 rounds (restart rehydrates demoted vnodes from
+    // durable partials, not from the wiped tier).
+    if std::env::var("LAMINAR_SOAK_STATE_TIER").is_ok() {
+        let sum = |name: &str| -> f64 { nodes.iter().filter_map(|n| n.metric(name)).sum() };
+        let demotes = sum("laminardb_state_tier_demote_total");
+        let fetches = sum("laminardb_state_tier_fetch_total");
+        let resident = sum("laminardb_state_tier_bytes");
+        let slices = sum("laminardb_state_tier_slices");
+        let state = sum("laminardb_state_bytes");
+        eprintln!(
+            "soak: tier demotes={demotes} fetches={fetches} resident_bytes={resident} \
+             slices={slices} in_memory_state_bytes={state}"
+        );
+        // `demotes` (state_tier_demote_total) counts *effective* demotions —
+        // slices that actually left memory — and resident_bytes/slices show
+        // what the cold tier still holds. Both >0 with fetches >0 proves the
+        // demote→promote cycle ran end-to-end.
+        assert!(
+            demotes > 0.0,
+            "tier enabled but no demotions — set LAMINAR_SOAK_BUDGET_BYTES below \
+             the per-node state (and LAMINAR_SOAK_KILLS=0 to avoid rebalance churn \
+             holding state dirty)",
+        );
+        assert!(
+            fetches > 0.0,
+            "tier demoted but never promoted — lower LAMINAR_SOAK_GROUPS so demoted keys \
+             are revisited (a row must hit a cold vnode to trigger a fetch)",
+        );
+    }
 
     if let Ok(brokers) = std::env::var("LAMINAR_SOAK_KAFKA_BROKERS") {
         // Let in-flight epochs commit, then stop every writer so the

--- a/crates/laminar-sql/Cargo.toml
+++ b/crates/laminar-sql/Cargo.toml
@@ -17,7 +17,7 @@ cluster = ["laminar-core/cluster"]
 
 [dependencies]
 # Core dependency
-laminar-core = { path = "../laminar-core", version = "0.25.1" }
+laminar-core = { path = "../laminar-core", version = "0.26.0" }
 
 # Runtime glue for ClusterRepartitionExec's per-partition channels.
 tokio-stream = { workspace = true }

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -50,8 +50,8 @@ data:
     {{- with $pg.users }}
 
     [server.pgwire_users]
-    {{- range $user, $pass := . }}
-    {{ $user }} = "{{ $pass }}"
+    {{- range $user, $env := . }}
+    {{ $user }} = {{ printf "${%s}" $env | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/deploy/helm/laminardb/templates/configmap.yaml
+++ b/deploy/helm/laminardb/templates/configmap.yaml
@@ -27,6 +27,34 @@ data:
     {{- with .Values.laminardb.consoleCorsAllowedOrigins }}
     console_cors_allowed_origins = [{{ range $i, $o := . }}{{ if $i }}, {{ end }}"{{ $o }}"{{ end }}]
     {{- end }}
+    {{- if gt (.Values.laminardb.state.memoryBudgetBytes | int64) 0 }}
+    state_memory_budget_bytes = {{ .Values.laminardb.state.memoryBudgetBytes }}
+    {{- end }}
+    {{- if .Values.laminardb.state.tier.enabled }}
+    state_tier_dir = "{{ .Values.laminardb.state.tier.path }}"
+    {{- end }}
+    {{- if .Values.laminardb.pgwire.enabled }}
+    {{- $pg := .Values.laminardb.pgwire }}
+    pgwire_bind = "{{ $pg.bind }}"
+    pgwire_allow_remote = {{ $pg.allowRemote }}
+    pgwire_max_connections = {{ $pg.maxConnections }}
+    pgwire_max_auth_failures_per_min = {{ $pg.maxAuthFailuresPerMin }}
+    pgwire_tls_min_version = "{{ $pg.tls.minVersion }}"
+    {{- if $pg.tls.existingSecret }}
+    pgwire_tls_cert = "/etc/laminardb/pgwire-tls/tls.crt"
+    pgwire_tls_key = "/etc/laminardb/pgwire-tls/tls.key"
+    {{- if $pg.tls.mtls }}
+    pgwire_tls_client_ca = "/etc/laminardb/pgwire-tls/ca.crt"
+    {{- end }}
+    {{- end }}
+    {{- with $pg.users }}
+
+    [server.pgwire_users]
+    {{- range $user, $pass := . }}
+    {{ $user }} = "{{ $pass }}"
+    {{- end }}
+    {{- end }}
+    {{- end }}
 
     [state]
     backend = "{{ .Values.laminardb.state.backend }}"

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -142,7 +142,7 @@ spec:
               mountPath: /var/lib/laminardb/checkpoints
             {{- if .Values.laminardb.state.tier.enabled }}
             - name: state-tier
-              mountPath: {{ .Values.laminardb.state.tier.path }}
+              mountPath: "{{ .Values.laminardb.state.tier.path }}"
             {{- end }}
             {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
             - name: pgwire-tls

--- a/deploy/helm/laminardb/templates/deployment.yaml
+++ b/deploy/helm/laminardb/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "laminardb.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.initContainers }}
@@ -51,7 +54,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            {{- if .Values.service.pgEnabled }}
+            {{- if .Values.laminardb.pgwire.enabled }}
             - name: pg
               containerPort: 5432
               protocol: TCP
@@ -137,6 +140,15 @@ spec:
             {{- end }}
             - name: checkpoints
               mountPath: /var/lib/laminardb/checkpoints
+            {{- if .Values.laminardb.state.tier.enabled }}
+            - name: state-tier
+              mountPath: {{ .Values.laminardb.state.tier.path }}
+            {{- end }}
+            {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
+            - name: pgwire-tls
+              mountPath: /etc/laminardb/pgwire-tls
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -160,6 +172,19 @@ spec:
         # Volatile; durable checkpoints need the StatefulSet PVC or an object store.
         - name: checkpoints
           emptyDir: {}
+        {{- if .Values.laminardb.state.tier.enabled }}
+        # Cold-tier scratch; rebuilt from checkpoints on restart, so ephemeral.
+        - name: state-tier
+          emptyDir:
+            {{- if .Values.laminardb.state.tier.emptyDirMedium }}
+            medium: {{ .Values.laminardb.state.tier.emptyDirMedium }}
+            {{- end }}
+        {{- end }}
+        {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
+        - name: pgwire-tls
+          secret:
+            secretName: {{ .Values.laminardb.pgwire.tls.existingSecret }}
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/laminardb/templates/service.yaml
+++ b/deploy/helm/laminardb/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.service.pgEnabled }}
+    {{- if .Values.laminardb.pgwire.enabled }}
     - port: {{ .Values.service.pgPort }}
       targetPort: pg
       protocol: TCP

--- a/deploy/helm/laminardb/templates/serviceaccount.yaml
+++ b/deploy/helm/laminardb/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "laminardb.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.initContainers }}
@@ -53,7 +56,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            {{- if .Values.service.pgEnabled }}
+            {{- if .Values.laminardb.pgwire.enabled }}
             - name: pg
               containerPort: 5432
               protocol: TCP
@@ -137,6 +140,15 @@ spec:
             {{- end }}
             - name: checkpoints
               mountPath: /var/lib/laminardb/checkpoints
+            {{- if .Values.laminardb.state.tier.enabled }}
+            - name: state-tier
+              mountPath: {{ .Values.laminardb.state.tier.path }}
+            {{- end }}
+            {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
+            - name: pgwire-tls
+              mountPath: /etc/laminardb/pgwire-tls
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -146,10 +158,32 @@ spec:
             name: {{ include "laminardb.fullname" . }}
         - name: tmp
           emptyDir: {}
+        {{- if and .Values.persistence.state.enabled .Values.persistence.state.useEmptyDir }}
+        # PVC mode supplies `state` via volumeClaimTemplates; the ephemeral
+        # path needs an explicit emptyDir here instead.
+        - name: state
+          emptyDir:
+            {{- if .Values.persistence.state.emptyDirMedium }}
+            medium: {{ .Values.persistence.state.emptyDirMedium }}
+            {{- end }}
+        {{- end }}
         {{- if not .Values.persistence.checkpoints.enabled }}
         # Volatile fallback so the file:// checkpoint path stays writable.
         - name: checkpoints
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.laminardb.state.tier.enabled }}
+        # Cold-tier scratch; rebuilt from checkpoints on restart, so ephemeral.
+        - name: state-tier
+          emptyDir:
+            {{- if .Values.laminardb.state.tier.emptyDirMedium }}
+            medium: {{ .Values.laminardb.state.tier.emptyDirMedium }}
+            {{- end }}
+        {{- end }}
+        {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
+        - name: pgwire-tls
+          secret:
+            secretName: {{ .Values.laminardb.pgwire.tls.existingSecret }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/laminardb/templates/statefulset.yaml
+++ b/deploy/helm/laminardb/templates/statefulset.yaml
@@ -142,7 +142,7 @@ spec:
               mountPath: /var/lib/laminardb/checkpoints
             {{- if .Values.laminardb.state.tier.enabled }}
             - name: state-tier
-              mountPath: {{ .Values.laminardb.state.tier.path }}
+              mountPath: "{{ .Values.laminardb.state.tier.path }}"
             {{- end }}
             {{- if and .Values.laminardb.pgwire.enabled .Values.laminardb.pgwire.tls.existingSecret }}
             - name: pgwire-tls

--- a/deploy/helm/laminardb/templates/tests/test-connection.yaml
+++ b/deploy/helm/laminardb/templates/tests/test-connection.yaml
@@ -7,9 +7,26 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  serviceAccountName: {{ include "laminardb.serviceAccountName" . }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: wget
-      image: busybox:1.36
+      image: "{{ .Values.testConnection.image.repository }}:{{ .Values.testConnection.image.tag }}"
       command: ['wget']
       args: ['--spider', '--timeout=5', 'http://{{ include "laminardb.fullname" . }}:{{ .Values.service.httpPort }}/health']
   restartPolicy: Never

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -91,9 +91,11 @@ laminardb:
     bind: "0.0.0.0:5432"
     # -- Required to bind on a non-loopback address (always true in K8s).
     allowRemote: true
-    # -- MD5 auth users. Empty = trust auth (loopback only). Values land in the
-    # -- ConfigMap, so use pre-hashed "md5<hex>" passwords (pg_authid style).
+    # -- MD5 auth users, mapping username -> env var holding the pre-hashed
+    # -- "md5<hex>" password. Supply the env vars from a Secret via extraEnv /
+    # -- extraEnvFrom; only the env reference (not the hash) enters the ConfigMap.
     users: {}
+    #   alice: PGWIRE_ALICE   # then set PGWIRE_ALICE=md5<hex> from a Secret
     # -- Concurrent session cap.
     maxConnections: 256
     # -- Per-IP auth failures per 60s window (0 disables).

--- a/deploy/helm/laminardb/values.yaml
+++ b/deploy/helm/laminardb/values.yaml
@@ -23,6 +23,12 @@ nameOverride: ""
 # -- Override the full release name
 fullnameOverride: ""
 
+# -- Image for the `helm test` connection-check hook (override for air-gapped registries).
+testConnection:
+  image:
+    repository: busybox
+    tag: "1.36"
+
 # -- LaminarDB server configuration
 laminardb:
   # -- Server mode: "embedded" (single-node) or "cluster" (multi-node clustering)
@@ -52,6 +58,16 @@ laminardb:
     vnodeCapacity: 256
     # -- Optional static vnode list (only for object_store backend)
     vnodes: []
+    # -- Node-level memory budget for operator state, in bytes (0 = unlimited).
+    # -- Crossing it backpressures intake, or demotes to the cold tier below.
+    memoryBudgetBytes: 0
+    # -- Disk cold tier for demoted state. Needs memoryBudgetBytes > 0 and a
+    # -- durable backend. Scratch only: wiped on restart, rebuilt from checkpoints.
+    tier:
+      enabled: false
+      path: /var/lib/laminardb/tier
+      # -- emptyDir medium for tier scratch ("Memory" for tmpfs).
+      emptyDirMedium: ""
 
   # -- Checkpoint configuration
   checkpoint:
@@ -66,6 +82,29 @@ laminardb:
     mode: aligned
     # -- Snapshot strategy: "full", "incremental", or "fork_cow"
     snapshotStrategy: full
+
+  # -- PostgreSQL wire protocol (SUBSCRIBE + queries via psql/JDBC/psycopg).
+  pgwire:
+    # -- Enable the pgwire listener and expose its port.
+    enabled: false
+    # -- Bind address. Non-loopback requires allowRemote: true.
+    bind: "0.0.0.0:5432"
+    # -- Required to bind on a non-loopback address (always true in K8s).
+    allowRemote: true
+    # -- MD5 auth users. Empty = trust auth (loopback only). Values land in the
+    # -- ConfigMap, so use pre-hashed "md5<hex>" passwords (pg_authid style).
+    users: {}
+    # -- Concurrent session cap.
+    maxConnections: 256
+    # -- Per-IP auth failures per 60s window (0 disables).
+    maxAuthFailuresPerMin: 10
+    tls:
+      # -- Secret with tls.crt + tls.key (+ ca.crt when mtls). Empty = no TLS.
+      existingSecret: ""
+      # -- Require client certs chained to the Secret's ca.crt (mTLS).
+      mtls: false
+      # -- Minimum TLS version: "1.2" or "1.3".
+      minVersion: "1.2"
 
   # -- Bearer token for the control-plane (console) HTTP API, read from an
   # -- existing Secret. Empty existingSecret = unauthenticated API (dev only).
@@ -197,10 +236,8 @@ service:
   type: ClusterIP
   # -- HTTP API port
   httpPort: 8080
-  # -- PostgreSQL wire protocol port (future)
+  # -- PostgreSQL wire protocol port (exposed when laminardb.pgwire.enabled)
   pgPort: 5432
-  # -- Enable PostgreSQL wire protocol port
-  pgEnabled: false
   # -- Gossip port for cluster mode discovery
   gossipPort: 7946
   # -- Raft port for cluster mode coordination
@@ -268,6 +305,10 @@ nodeSelector: {}
 tolerations: []
 # -- Affinity rules
 affinity: {}
+
+# -- Shutdown grace period. Cluster mode drains owned vnodes on SIGTERM (<=30s);
+# -- keep this above that so Kubernetes does not SIGKILL mid-drain.
+terminationGracePeriodSeconds: 60
 
 # -- For thread-per-core: request guaranteed CPU.
 # -- Set to true to use Guaranteed QoS class (requests == limits).

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -249,13 +249,22 @@ wipe), round-trip, concurrent fetch-under-write.
 >   its whole result from memory, so dropping groups would shrink query
 >   output (same restriction as idle-TTL eviction).
 >
-> Open items carried to the next phases: (1) the whole-state manifest blob
-> (`checkpoint()`) does not contain demoted groups — the recovery path for
-> tier-enabled operators must restore from vnode partials, audit before
-> enabling the trigger; (2) per-vnode capture currently requires the
-> cluster shuffle config — single-node tiering needs `snapshot_state_by_vnode`
-> to take a vnode count from the single-owner registry (and accept the
-> capture-cost regression only when the tier is enabled).
+> Open items carried to the next phases — **(1) is a hard precondition for
+> the trigger**:
+>
+> 1. **Restart recovery must learn to read vnode partials.** Audited
+>    2026-06-12: plain restart restores operator state from the manifest's
+>    whole-state blob only; per-vnode partials are consulted exclusively by
+>    the cluster rebalance/acquisition path. The manifest blob does not
+>    contain demoted groups, so enabling demotion today would lose them on
+>    any restart. Phase 4 must extend restart recovery for tier-capable
+>    operators to also replay their owned vnodes' partial chains (the
+>    decode + reference-resolution + `apply_vnode_state` machinery already
+>    exists on the acquisition path).
+> 2. Per-vnode capture currently requires the cluster shuffle config —
+>    single-node tiering needs `snapshot_state_by_vnode` to take a vnode
+>    count from the single-owner registry (and accept the capture-cost
+>    regression only when the tier is enabled).
 
 1. **Restorable-epoch visibility.** Coordinator publishes the latest
    restorable epoch into a shared atomic readable by the pipeline callback /

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -193,6 +193,15 @@ visible in `/metrics`; soak with a tiny budget shows stable RSS.
 
 ### Phase 2 — Cold-tier service (no operator wiring yet)
 
+> **Status: implemented 2026-06-12** on `feat/state-memory-budget`
+> (`1159df64`). Deviation from the sketch below: a **single KV-separated
+> keyspace** keyed `operator \0 vnode_be32` instead of a keyspace per
+> operator — avoids keyspace-name sanitization, gives prefix-scoped
+> operator drop, and KV separation is the right layout for slice blobs
+> (1.57× WA in the bench). Marker persists logical counters so a clean
+> reuse restores gauges without scanning blobs. Worker is single-flight
+> by design (bench: read tails degrade under concurrent write pressure).
+
 New module `crates/laminar-db/src/state_tier/` behind a new `state-tier`
 feature (implies `cluster`); fjall is the only new dependency, major version
 pinned.
@@ -215,6 +224,38 @@ Exit: unit tests for lifecycle (clean reuse, unclean wipe, version-mismatch
 wipe), round-trip, concurrent fetch-under-write.
 
 ### Phase 3 — Demotion (agg operator + coordinator)
+
+> **Status: substrate implemented 2026-06-12** on `feat/state-memory-budget`
+> (mechanism only — the budget→demote trigger ships with promotion, since a
+> cold vnode receiving rows needs the promotion path first). Design changes
+> vs. the sketch below, all simplifications found during implementation:
+>
+> - **Demotion is coordinator-driven, not operator-serialized**: the
+>   coordinator's `last_vnode_uploads` already retains each slice's exact
+>   uploaded bytes for the reference-partial comparison, so demotion hands
+>   *those* bytes to the tier (truth-identical by construction) and then
+>   swaps the entry to a `Cold` marker — releasing the RAM pin. No
+>   restorable-epoch atomic is needed: candidates carry their base epoch
+>   and the caller (the pipeline callback, which observes epoch
+>   completions) filters against it.
+> - Staged slices are now `StagedSlice::{Bytes, Cold}` end-to-end (operator
+>   → graph → callback → coordinator). `Cold` counts as unchanged in the
+>   reference comparison; a forced full re-upload fetches the bytes back
+>   from the tier, and **a tier miss fails the epoch** rather than writing
+>   a partial that silently drops the slice from recovery truth.
+> - The operator keeps a per-vnode dirty set (re-baselined at each capture)
+>   and `demote_vnode` refuses dirty vnodes, bulk-restored/merged state,
+>   and — load-bearing — **non-changelog aggs**: a full-emit agg rebuilds
+>   its whole result from memory, so dropping groups would shrink query
+>   output (same restriction as idle-TTL eviction).
+>
+> Open items carried to the next phases: (1) the whole-state manifest blob
+> (`checkpoint()`) does not contain demoted groups — the recovery path for
+> tier-enabled operators must restore from vnode partials, audit before
+> enabling the trigger; (2) per-vnode capture currently requires the
+> cluster shuffle config — single-node tiering needs `snapshot_state_by_vnode`
+> to take a vnode count from the single-owner registry (and accept the
+> capture-cost regression only when the tier is enabled).
 
 1. **Restorable-epoch visibility.** Coordinator publishes the latest
    restorable epoch into a shared atomic readable by the pipeline callback /

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -99,9 +99,48 @@ own merits. ADR-005 should get a short amendment recording this v1/v2 split.
 
 > **Status: harness built 2026-06-12** (`tools/state-tier-bench`, standalone
 > crate with its own lockfile — fjall stays out of the main workspace until
-> the gate passes). Both modes smoke-tested on Windows; **gate numbers still
-> owed from target-class Linux NVMe with a beyond-RAM dataset** — see the
-> tool's README for the exact invocations.
+> the gate passes). **Formal gate numbers still owed from target-class Linux
+> NVMe** — see the tool's README for the exact invocations.
+>
+> **Dev-box results 2026-06-12** (Windows 11, 31 GB RAM, Crucial P3 Plus 2 TB
+> — consumer DRAM-less QLC; indicative only). Group mode, 300M keys × 240 B
+> (74 GB logical, 2.4× RAM), uniform cold reads from a dedicated thread,
+> fjall 3.1.5 with a 2 GiB block cache unless noted:
+>
+> | sustained writes | p50 | p90 | p99 | p999 | 1ms gate |
+> |---|---|---|---|---|---|
+> | ~88k/s (ingest-saturated, default cache) | 532µs | 1.4ms | 7.7ms | 33ms | FAIL |
+> | ~88k/s (ingest-saturated) | 386µs | 909µs | 6.9ms | 29ms | FAIL |
+> | 10k/s | 307µs | 443µs | 1.43ms | 7.9ms | FAIL (marginal) |
+> | 100/s | 332µs | 428µs | 554µs | 2.0ms | PASS |
+>
+> Slice mode (the v1 demotion unit): 15,360 slices × 4 MiB (60 GB logical),
+> KV separation on, slice rewrites targeted at 10/s, uniform slice fetches:
+>
+> | metric | result |
+> |---|---|
+> | cold slice fetch (4 MiB) | p90 11ms, p99 18.4ms, p999 80ms (p50 4µs cached) |
+> | fetch throughput | 273/s ≈ 1.1 GB/s sustained |
+> | write amplification | **1.57×** (KV separation) |
+> | space amp / CPU | 1.35× / 28% of one core |
+> | achieved rewrite rate | **4/s of the 10/s target** (~17 MB/s logical single-writer blob ingest; bulk load averaged 34 MB/s) |
+>
+> The 1ms gate line doesn't apply to 4 MiB fetches (transfer alone is
+> ms-scale); the relevant comparison is the ~100ms object-store GET this
+> replaces. The slice-ingest throughput ceiling (~17–34 MB/s here) bounds
+> demotion speed (~100 MB of operator state ≈ 3–6 s) — fine for background
+> demotion, but a sizing input for budget-pressure response time.
+>
+> Findings: the cold-read tail is **write-pressure-coupled, not an intrinsic
+> floor** — sub-ms p99 at light write rates, ~7ms at ingest saturation.
+> Sizing the block cache (filters+indexes resident) improves the body of the
+> distribution ~30% but not the tail. Single-keyspace ingest ceiling on this
+> box ≈ 88k upserts/s; write amplification 5.1× at saturation, 6.8–9.2× at
+> low rates (flush/journal floor); compaction CPU bounded (≤123% of one
+> core); space amplification 1.10×. Read for the design: v1's slice-demotion
+> write rates sit near the passing end; sustained group-granularity churn
+> (v2) is the case that pressures the gate. The deciding run must happen on
+> datacenter-class Linux NVMe — this drive is the pessimistic case.
 
 Build a standalone harness (e.g. `tools/state-tier-bench`, not in the default
 workspace build) that exercises fjall with our workload shape:

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -1,0 +1,283 @@
+# Tiered Operator State — Implementation Plan
+
+Implements ADR-005 (in-memory hot tier, fjall cold tier, object-store truth).
+Plan written 2026-06-12 against `main` @ `6a397a13` (sub-second checkpointing
+landed, PR #428).
+
+Convention note: **no ADR references in code**. Source, comments, config keys,
+metric names, and log messages describe behavior in their own terms
+(`state tier`, `cold tier`, `memory budget`, `demote`/`promote`). ADR citations
+live only in `docs/`.
+
+---
+
+## 1. Where the codebase actually is (survey results)
+
+| ADR-005 assumption | What landed | Consequence |
+|---|---|---|
+| ADR-003 phases 1–3 (restorable epochs, delta artifacts, staging window) | Landed in PR #428 — but "incremental snapshots" are **vnode-level byte-identity reference partials**, not group-level deltas | See §2 — this changes the safe demotion granularity for v1 |
+| `estimated_state_bytes` hook exists | Yes — `GraphOperator::estimated_state_bytes` (`operator_graph.rs:41`), implemented by agg (`sql_query.rs:713`), joins, lookup-enrich, AI op | Budget precursor builds on it |
+| Budget → backpressure | Only a per-operator **hard-fail** limit exists: `max_state_bytes_per_operator` → `DbError::Pipeline` at 100%, warn at 80% (`operator_graph.rs:1675-1691`) | Precursor must add node-level budget + backpressure instead of error |
+| Async-decoupling pattern reusable | Yes — `LookupEnrichOperator` (`operator/lookup_enrich.rs`): `PendingBatch` slots, bounded `mpsc::channel(256)`, worker on the main runtime handle, `try_recv` drain per cycle, `watermark_hold()` + `wants_input()` backpressure, pending-row checkpoint/replay | Promotion path copies this wholesale |
+| Rebalance hand-off needs no new mechanism | Confirmed — `merge_groups` is additive (`aggregate_state.rs:1376`), `apply_vnode_state` (`sql_query.rs:767`) handles live + pending-restore | Holds for the chosen v1 granularity |
+
+Other load-bearing facts found:
+
+- **Per-epoch capture serializes ALL groups.** Every barrier,
+  `capture_vnode_states` (`pipeline_callback.rs:1054`) →
+  `checkpoint_by_vnode` (`sql_query.rs:740`) →
+  `checkpoint_groups_by_vnode` (`aggregate_state.rs:1308`) rkyv-encodes every
+  group, every vnode. Dedup happens later in the coordinator by byte
+  comparison. At 100 ms cadence this is O(total state) CPU per epoch — an
+  independent scaling ceiling that the v1 design happens to improve (demoted
+  vnodes are no longer serialized each epoch).
+- **The coordinator pins last-upload bytes in RAM.**
+  `last_vnode_uploads: HashMap<vnode, (epoch, HashMap<op, Bytes>)>`
+  (`checkpoint_coordinator.rs:771-829`) retains the full serialized slice per
+  vnode to do the byte-identity comparison. For large state this is a second
+  full copy of state in memory; tiering must remove this pin for cold vnodes.
+- **References are forced back to full before their base leaves the
+  `max_retained` prune window** (`checkpoint_coordinator.rs:742-747`,
+  `max_ref_age` check at `:767,:781`). Any demotion design must be able to
+  produce full bytes on demand for that re-upload.
+- **`estimated_state_bytes` for agg is O(groups) per call**
+  (`aggregate_state.rs:1181-1190` walks every group summing `acc.size()`).
+  Fine as an occasional probe; too expensive to evaluate per cycle as a
+  budget. Needs an incrementally-maintained estimate.
+- **Per-vnode partials are `cluster`-feature code** (`sql_query.rs:740` is
+  `#[cfg(feature = "cluster")]`), and `cluster` is in the server's default
+  feature set. v1 tiering rides the per-vnode path and is therefore gated the
+  same way; non-cluster lib builds simply never tier.
+- The aggregation state shape: `AHashMap<arrow::row::OwnedRow, GroupEntry>`
+  (`aggregate_state.rs:241`), `GroupEntry { accs, last_updated_ms }`
+  (`:316`). `last_updated_ms` already gives an idle signal per group; per-vnode
+  idle is derivable.
+- Restorable-epoch knowledge lives in the checkpoint coordinator / barrier
+  path; nothing currently publishes "epoch N is restorable" toward the
+  operator graph. Small plumbing needed (an atomic/watch is enough).
+
+## 2. The one real design decision: demotion granularity
+
+ADR-005 says "demote clean **groups**" and claims delta epochs are unaffected
+because "demoted groups are clean, so deltas never include them". That
+reasoning assumed group-level delta artifacts. What actually landed is
+different: each epoch re-serializes the **whole vnode slice** from the
+in-memory map and the coordinator emits a reference partial only if the bytes
+are identical to the last full upload.
+
+Under that format, group-granularity demotion is **unsafe as-is**: dropping
+cold groups from the map changes the serialized vnode bytes, so the next full
+upload for that vnode would silently omit the demoted groups — truth (the
+object store) loses state. Making group granularity safe requires group-level
+delta artifacts (base + changed-group chains), which is exactly the "artifact
+format change" the ADR promised to avoid.
+
+Decision for v1: **demote at (operator, vnode)-slice granularity** — the unit
+at which byte-identity already proves cleanliness.
+
+- A slice that the coordinator has been emitting reference partials for is, by
+  construction, byte-identical to a durable full upload at a restorable epoch.
+  That is precisely the ADR's "clean" condition, proven by machinery that
+  already exists.
+- The cold tier stores the exact uploaded bytes, so the forced full re-upload
+  (base aging out of `max_retained`) streams those bytes from fjall on Ring 1
+  without promoting anything.
+- No artifact format change, no recovery-path change, no prune-logic change.
+- Bonus wins: demoted vnodes drop out of the per-epoch O(state) serialization,
+  and their `last_vnode_uploads` byte pin moves to disk.
+
+Cost: granularity is coarse — one hot key keeps its whole vnode slice
+resident. For skewed/idle-heavy workloads (the realistic huge-cardinality
+case) this captures most of the win. True group granularity is deferred to a
+v2 that introduces group-level delta artifacts — which is also the fix for the
+per-epoch O(state) serialization ceiling, so it will likely be wanted on its
+own merits. ADR-005 should get a short amendment recording this v1/v2 split.
+
+## 3. Phases
+
+### Phase 0 — Benchmark gate (ADR precondition; no engine changes)
+
+Build a standalone harness (e.g. `tools/state-tier-bench`, not in the default
+workspace build) that exercises fjall with our workload shape:
+
+- Keys: Zipfian-distributed `(operator, vnode, group-key)` byte strings.
+- Values: rkyv-encoded accumulator states, 100 B – 4 KiB.
+- Two access patterns: (a) slice-granularity (one value per (op, vnode), tens
+  of KB – tens of MB, matching v1) and (b) group-granularity point upserts
+  (matching v2) — measure both so the v2 decision is informed now.
+- Measure on target NVMe: cold-read p99 from a non-compute thread under
+  sustained write load (gate: ≤ 1 ms), compaction CPU and whether fjall's
+  background threads can be pinned/limited away from compute cores, write
+  amplification at sustained upsert rates.
+
+Exit: numbers recorded in the ADR (flip to Accepted, or pivot to the named
+hash-log fallback). Also verify here: fjall's sync API behaves from
+`spawn_blocking`, keyspace-per-operator works, point-in-time snapshot/iterator
+semantics, crash-recovery behavior without per-write fsync.
+
+### Phase 1 — State memory budget (independently shippable, ships first)
+
+> **Status: implemented 2026-06-12** on `feat/state-memory-budget`. Notes vs.
+> the plan below: the agg estimate is a generation-counter + min-2s-rewalk
+> cache (not a running counter — fewer mutation-path hooks, same O(1) read);
+> the budget gate reuses the coordinator's existing skip-drain backpressure
+> (intake throttles to one message per cycle so checkpoint barriers keep
+> flowing — a full intake halt would starve them) and additionally skips
+> `tick_idle_watermark()` while paused so a budget-paused source is not
+> idle-demoted (which would late-drop its queued rows on resume). Config:
+> `state_memory_budget_bytes` (builder + `[server]`). Metrics: `state_bytes`,
+> `operator_state_bytes{operator}`, `state_memory_budget_bytes`,
+> `state_over_budget`, `state_budget_paused_cycles_total`.
+
+1. **Cheap state-size accounting.** Make the agg estimate incrementally
+   maintained (running byte counter updated on group insert/remove plus a
+   periodic accumulator resample), so reading it per cycle is O(1). Keep the
+   trait hook signature unchanged.
+2. **Node-level budget.** New config: `DbConfig::state_memory_budget_bytes`
+   (server: `[state] memory_budget_bytes`). The graph sums
+   `estimated_state_bytes` across nodes once per cycle.
+3. **Backpressure, not failure.** Over budget → stop ingesting source input
+   (the graph stops offering new batches; sources pause naturally), hold
+   watermarks at the gate, raise `state_over_budget` gauge + rate-limited
+   error log. Existing per-operator hard limit stays as the kill switch.
+4. **Metrics**: `state_bytes{operator}`, `state_memory_budget_bytes`,
+   `state_over_budget`, time-over-budget counter.
+
+Exit: a workload exceeding budget throttles instead of OOM-killing; metrics
+visible in `/metrics`; soak with a tiny budget shows stable RSS.
+
+### Phase 2 — Cold-tier service (no operator wiring yet)
+
+New module `crates/laminar-db/src/state_tier/` behind a new `state-tier`
+feature (implies `cluster`); fjall is the only new dependency, major version
+pinned.
+
+- `StateTierStore`: owns the fjall `Keyspace` under
+  `<data_dir>/state-tier/`, one fjall partition per operator. Sync API only,
+  called exclusively from Ring 1 (`spawn_blocking` / worker task).
+- **Lifecycle**: on open, validate a marker file (engine version + clean-flag
+  + per-instance nonce). Missing/mismatched/unclean → wipe directory and start
+  empty (state rehydrates from checkpoints exactly like today's recovery).
+  Clean shutdown writes the marker; runtime operation never fsyncs per write.
+- `StateTierWorker`: Ring-1 task (spawned on the main runtime handle, the
+  `set_runtime_handle` pattern at `operator_graph.rs:355`), bounded mpsc
+  request/response channels, request types: `Demote{key, bytes}`,
+  `Fetch{key}`, `Drop{key}`, `SnapshotRead{...}`.
+- Metrics: tier size bytes, keys, demote/promote counters, fetch latency
+  histogram, wipe events.
+
+Exit: unit tests for lifecycle (clean reuse, unclean wipe, version-mismatch
+wipe), round-trip, concurrent fetch-under-write.
+
+### Phase 3 — Demotion (agg operator + coordinator)
+
+1. **Restorable-epoch visibility.** Coordinator publishes the latest
+   restorable epoch into a shared atomic readable by the pipeline callback /
+   graph (one `Arc<AtomicU64>`, no new channels).
+2. **Cold-slice tracking in the coordinator.** Extend the pending-state
+   contract so a vnode-operator slice can be staged as `Unchanged` (no bytes)
+   instead of full bytes; the coordinator emits the reference partial from its
+   recorded base as it does today. When `max_ref_age` forces a full re-upload
+   of a cold slice, the coordinator requests the bytes from the tier worker
+   (Ring 1, during the existing staging window) instead of from memory.
+   `last_vnode_uploads` keeps `(epoch, hash)` for cold slices — exact bytes
+   live in fjall; full bytes are retained in RAM only for hot slices.
+3. **Demotion trigger.** When the Phase-1 budget crosses a demote watermark
+   (default 80%), the graph asks tier-capable operators for demotion
+   candidates: vnode slices ranked by idle time (max `last_updated_ms` in the
+   slice), eligible only if the coordinator's records show the slice is
+   currently in reference state (byte-identical to a durable upload at a
+   restorable epoch ≤ the published atomic).
+4. **Demotion execution** (two-step, crash-safe in either order because the
+   object store stays truth): Ring 1 writes the slice bytes to fjall →
+   confirms → next cycle the operator drops those groups from the map and
+   marks the vnode cold. New `GraphOperator` default-method hooks:
+   `demotion_candidates()`, `demote_vnode(vnode)`, `cold_vnodes()` — only the
+   agg operator implements them in v1.
+5. **Capture-path change.** `checkpoint_groups_by_vnode` skips cold vnodes;
+   `capture_vnode_states` stages them as `Unchanged`.
+
+Exit: unit tests — demoted slice keeps emitting references; forced full
+re-upload streams from fjall and matches byte-for-byte; recovery from a
+checkpoint taken while slices were cold restores all groups; budget falls
+after demotion.
+
+### Phase 4 — Promotion (async, never blocking)
+
+Copy the lookup-enrich pattern into the agg path:
+
+1. On `process_batch`, partition input rows by vnode (`key_hash % vnode_count`,
+   `state/vnode.rs:302`). Rows hitting cold vnodes go into a `PendingBatch`
+   (slots + `ingest_watermark`); a `Fetch` is submitted for each cold vnode
+   (deduped while in flight).
+2. Worker fetches slice bytes from fjall, returns them; next cycle the
+   operator decodes `AggStateCheckpoint` and `merge_groups` it back in
+   (`aggregate_state.rs:1376` — additive, but the slice was dropped from
+   memory so the merge is into an empty key range; assert no overlap), marks
+   the vnode hot, notifies the coordinator the slice is hot again (bytes
+   retained in RAM resume; fjall entry dropped), and replays deferred rows.
+3. Backpressure identical to lookup-enrich: `watermark_hold()` = min pending
+   ingest watermark; `wants_input()` caps in-flight deferred rows.
+4. Checkpoint while promotion is in flight: serialize pending batches +
+   replay queue with their ingest watermark, exactly as lookup-enrich does
+   (`lookup_enrich.rs:740-779`). A barrier does not wait for promotion.
+5. Promotion storms: cap concurrent in-flight promotions; over cap defers via
+   `wants_input()`.
+
+Exit: unit tests — deferred rows produce identical results to never-demoted
+baseline (golden diff); checkpoint/restore mid-promotion; watermark held while
+rows pending; thrash test (alternating hot/cold access) stays correct.
+
+### Phase 5 — Recovery, rebalance, soaks
+
+- **Unclean restart**: tier wiped, vnode set rehydrates from last restorable
+  epoch via the existing path — verify with the kill -9 exactly-once diff soak
+  extended to run with `state-tier` on and a small budget (forces demotion
+  under load).
+- **Rebalance**: releasing a vnode drops its fjall entries; acquiring one goes
+  through the existing object-store rehydration into memory (it arrives hot,
+  may demote later). Extend `cluster_integration` with a rebalance while
+  slices are cold on the donor.
+- **Bounded-RAM soak**: open-key-space workload (high-cardinality GROUP BY)
+  with state ≫ budget; assert stable RSS, no OOM, correct final answers, and
+  demotion/promotion counters moving.
+- Grafana: panel set for tier size, promotions/sec, fetch p99, over-budget.
+
+### Deferred v2 — group granularity (separate ADR amendment + plan)
+
+Group-level delta artifacts (`VnodePartial` gains a delta form: base epoch +
+changed groups), dirty-group tracking in `AggregateState`, chain-resolving
+recovery and prune, compaction epochs streaming the cold portion from a fjall
+snapshot. Unlocks: per-group demotion (skew-proof), per-epoch capture cost
+O(dirty) instead of O(state). Do not start until v1 telemetry shows vnode
+granularity leaving real memory on the table, and price it against the ADR's
+stated evolution path (point-readable artifacts + cache-over-truth) before
+committing — group-level deltas are a step toward SST-like artifacts anyway.
+
+## 4. Risks / open items
+
+- **fjall behavior under our shape is unproven** — that's what Phase 0 is
+  for; the fallback (purpose-built hash-log) is named in the ADR.
+- **Compaction CPU on a pinned engine**: verify thread-count/affinity control
+  in Phase 0; if fjall can't bound it, that's a gate failure.
+- **Uniform-access workloads don't demote at vnode granularity**: accepted v1
+  limitation; budget backpressure (Phase 1) is the safety net; v2 fixes it.
+- **Coordinator/operator cold-state handshake** (who believes a slice is
+  cold) must be single-writer: the graph cycle drives all transitions;
+  coordinator only reads staged markers. Keep the state machine in one place
+  (operator side) to avoid split-brain between `pending_vnode_states` and the
+  map.
+- **Dirty-set pinning** (ADR negative): a workload touching every vnode every
+  epoch never has clean slices → nothing demotes → backpressure. Surfaced by
+  the over-budget metric; correct by design but worth a docs note.
+- **Windows dev environment**: fjall is pure Rust (no perl/openssl issues),
+  but Phase-0 numbers must come from target-like Linux NVMe, not the dev box.
+
+## 5. Suggested PR slicing
+
+1. PR-1: Phase 1 (budget + accounting + metrics) — no fjall, no feature flag.
+2. PR-2: Phase 0 harness + recorded results + ADR status flip/amendment.
+3. PR-3: Phase 2 tier service (feature-gated, dormant).
+4. PR-4: Phase 3 demotion + coordinator `Unchanged` staging.
+5. PR-5: Phase 4 promotion + correctness tests.
+6. PR-6: Phase 5 soaks/integration + Grafana + docs.

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -320,18 +320,32 @@ after demotion.
 > data-loss gap. Open item 2 (single-node capture without cluster shuffle)
 > still stands — tiering rides the cluster path for now.
 >
-> **NOT done — the budget→demote trigger (Phase 3 item 3/4, the enablement).**
-> Demotion machinery, promotion, and recovery are all in place and tested,
-> but nothing wires the budget pressure to actually demote in production:
-> still needed are (a) creating the `StateTierStore` + worker at pipeline
-> build and sharing the sender with both the graph (`set_state_tier`) and
-> the coordinator (`set_state_tier`), (b) a config surface to enable the
-> tier + its directory, (c) the trigger pass (over the demote watermark →
-> `demotion_candidates` → write slices to tier → `graph.demote_vnode` →
-> `coordinator.mark_vnode_demoted`), driven from the callback's maintenance
-> phase, and (d) publishing the restorable epoch the candidates filter on.
-> This is the live-fire step and is paired with the Phase 5 soaks below —
-> do them together.
+> **DONE — the budget→demote trigger (Phase 3 item 3/4, the enablement),
+> 2026-06-13.** The pipeline build opens a `StateTierStore` + worker when
+> `state_tier_dir` is configured AND the per-vnode path is live (cluster
+> shuffle + state backend), sharing one request channel with the graph
+> (promotion), the coordinator (forced-full re-uploads), and the callback
+> (demotion). `maybe_demote_state` runs in the cycle's maintenance phase:
+> over the 80%-of-budget watermark it plans idle candidates
+> (`demotion_candidates`) and drains down to 65%, writing each slice to the
+> tier then dropping it from memory (`graph.demote_vnode`, which refuses if
+> the vnode was touched since its capture → tier write rolled back) and
+> marking it cold per operator (`mark_slice_demoted`). **Load-bearing safety
+> gate: demotion runs only when `checkpoint_in_flight == 0`**, so the latest
+> per-vnode capture is committed and a clean vnode's resident state equals
+> the durable upload bytes handed to the tier (no half-staged newer epoch to
+> disagree with); `restorable_epoch` (tracked from `publish_barrier`) bounds
+> candidates further. Config: `state_tier_dir` (builder + `[server]`, behind
+> the `state-tier` feature). Tested end-to-end (`demotion_pass_sheds_idle_slices`:
+> agg state → checkpoint → pass → slices in tier, dropped from memory,
+> marked cold). The tier wipes on every restart — recovery replays demoted
+> vnodes from durable partials (Phase 4a), so the tier never needs to
+> survive a restart, and `StateTierStore::shutdown`'s clean-reuse path is
+> intentionally unused in the lifecycle.
+>
+> Still owed (Phase 5): the live soaks — kill-9 exactly-once with the tier
+> enabled, and a bounded-RSS run on a high-cardinality workload — plus the
+> formal fjall benchmark gate on Linux NVMe.
 
 Copy the lookup-enrich pattern into the agg path:
 

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -299,6 +299,40 @@ after demotion.
 
 ### Phase 4 — Promotion (async, never blocking)
 
+> **Status: implemented 2026-06-13** on `feat/state-memory-budget`
+> (`0eb26a33` promotion, `88ad6a13` restart recovery). Promotion mirrors
+> the lookup-enrich decoupling exactly as sketched below: cold-vnode rows
+> defer, a Ring-1 fetch runs off the compute thread, and rows replay after
+> the slice merges via `apply_vnode_state` + `mark_vnode_hot`;
+> `watermark_hold`/`wants_input` were added to the agg operator. Cold
+> detection reuses the cluster shuffle hashing (`row_vnodes`). The operator
+> checkpoint became `AggOpCheckpoint { agg, deferred, cold_vnodes }` —
+> deferred promotion batches are carried across restart, and the manifest
+> blob omits demoted vnodes' groups (listed in `cold_vnodes`).
+>
+> **Restart recovery (the audited precondition, item 1 below): DONE.** A
+> tier operator's demoted vnodes are replayed from their durable partials
+> on restart — `take_tier_cold_vnodes` collects each operator's cold list,
+> `VnodeRehydrator` reads those vnodes (resolving reference partials), and
+> `apply_vnode_slice` applies **only the demoting operator's slice** of each
+> vnode (the partial bundles every operator; the rest already restored from
+> the manifest, so a blanket apply would double-count). Closes the
+> data-loss gap. Open item 2 (single-node capture without cluster shuffle)
+> still stands — tiering rides the cluster path for now.
+>
+> **NOT done — the budget→demote trigger (Phase 3 item 3/4, the enablement).**
+> Demotion machinery, promotion, and recovery are all in place and tested,
+> but nothing wires the budget pressure to actually demote in production:
+> still needed are (a) creating the `StateTierStore` + worker at pipeline
+> build and sharing the sender with both the graph (`set_state_tier`) and
+> the coordinator (`set_state_tier`), (b) a config surface to enable the
+> tier + its directory, (c) the trigger pass (over the demote watermark →
+> `demotion_candidates` → write slices to tier → `graph.demote_vnode` →
+> `coordinator.mark_vnode_demoted`), driven from the callback's maintenance
+> phase, and (d) publishing the restorable epoch the candidates filter on.
+> This is the live-fire step and is paired with the Phase 5 soaks below —
+> do them together.
+
 Copy the lookup-enrich pattern into the agg path:
 
 1. On `process_batch`, partition input rows by vnode (`key_hash % vnode_count`,

--- a/docs/plans/tiered-operator-state.md
+++ b/docs/plans/tiered-operator-state.md
@@ -97,6 +97,12 @@ own merits. ADR-005 should get a short amendment recording this v1/v2 split.
 
 ### Phase 0 — Benchmark gate (ADR precondition; no engine changes)
 
+> **Status: harness built 2026-06-12** (`tools/state-tier-bench`, standalone
+> crate with its own lockfile — fjall stays out of the main workspace until
+> the gate passes). Both modes smoke-tested on Windows; **gate numbers still
+> owed from target-class Linux NVMe with a beyond-RAM dataset** — see the
+> tool's README for the exact invocations.
+
 Build a standalone harness (e.g. `tools/state-tier-bench`, not in the default
 workspace build) that exercises fjall with our workload shape:
 

--- a/tools/state-tier-bench/Cargo.toml
+++ b/tools/state-tier-bench/Cargo.toml
@@ -11,6 +11,12 @@ rand = "0.9"
 rand_distr = "0.5"
 hdrhistogram = "7"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+] }
+
 # Standalone on purpose: fjall must not enter the main workspace lockfile
 # until the benchmark gate passes.
 [workspace]

--- a/tools/state-tier-bench/Cargo.toml
+++ b/tools/state-tier-bench/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "state-tier-bench"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Benchmark gate for the state cold tier: fjall under streaming-state-shaped workloads"
+
+[dependencies]
+fjall = "3.1"
+rand = "0.9"
+rand_distr = "0.5"
+hdrhistogram = "7"
+
+# Standalone on purpose: fjall must not enter the main workspace lockfile
+# until the benchmark gate passes.
+[workspace]

--- a/tools/state-tier-bench/README.md
+++ b/tools/state-tier-bench/README.md
@@ -1,0 +1,60 @@
+# state-tier-bench
+
+Benchmark gate for the state cold tier (`docs/plans/tiered-operator-state.md`,
+Phase 0). Exercises [fjall](https://github.com/fjall-rs/fjall) with workloads
+shaped like demoted operator state and reports the numbers the go/no-go
+decision needs. Deliberately a standalone crate (own lockfile): fjall must not
+enter the main workspace until the gate passes.
+
+## Modes
+
+- `--mode group` — point upserts/reads of `(operator, vnode, group-key) →
+  accumulator-state` records (default 2M keys × 256 B). Models the v2
+  group-granularity design.
+- `--mode slice` — whole `(operator, vnode) → serialized-slice` blobs
+  (default 256 × 4 MiB), with fjall key-value separation enabled. Models the
+  v1 slice-granularity design.
+
+Writes are Zipfian-skewed (`--zipf-s`, default 0.99) and paced to
+`--write-rate` ops/s; reads sample keys uniformly from a dedicated thread —
+i.e. dominated by keys the writer rarely touches, mirroring cold promotion
+fetches running off the compute thread.
+
+## Gate criteria
+
+Run on target-class **Linux NVMe** (write amplification and CPU come from
+`/proc`; they print `n/a` elsewhere):
+
+1. cold-read p99 ≤ 1 ms under sustained write load,
+2. background (compaction) CPU bounded,
+3. write amplification acceptable at the sustained upsert rate.
+
+## Running the gate
+
+The dataset must be **well beyond RAM**, or the OS page cache makes every
+read warm and the p99 is fiction. On a 64 GB box:
+
+```bash
+# group mode: ~96 GB logical (400M × 240B values + keys), 30 min steady state
+cargo run --release -- --path /nvme/stb --keys 400000000 --value-bytes 240 \
+  --duration-secs 1800 --write-rate 200000
+
+# slice mode: ~96 GB logical (24576 × 4 MiB), slice rewrites at 50/s
+cargo run --release -- --path /nvme/stb --mode slice --keys 24576 \
+  --duration-secs 1800 --write-rate 50
+```
+
+Record the output of both modes in the tiered-state plan / ADR when flipping
+its status. If the LSM fails the gate, the named fallback is a purpose-built
+Bitcask/FASTER-style hash-log.
+
+## Caveats
+
+- Short, small runs (like CI smoke) are cache-resident and always "pass" —
+  they only prove the harness works.
+- `write amplification` counts all process writes (journal + flush +
+  compaction) during the steady window via `/proc/self/io`, divided by the
+  logical bytes the writer produced. Run long enough for compaction to reach
+  steady state or it underestimates.
+- The process CPU figure includes the writer/reader threads; subtract the
+  load you'd expect from the op rates to estimate the background share.

--- a/tools/state-tier-bench/src/main.rs
+++ b/tools/state-tier-bench/src/main.rs
@@ -122,10 +122,11 @@ fn parse_args() -> Args {
     args
 }
 
+const VNODES: u64 = 256;
+
 /// Key layout mirrors the engine's: operator name, vnode, then (group mode
 /// only) the group key — so prefix locality matches what the tier will see.
 fn make_key(mode: Mode, i: u64, buf: &mut Vec<u8>) {
-    const VNODES: u64 = 256;
     buf.clear();
     buf.extend_from_slice(b"agg-0/");
     match mode {
@@ -170,7 +171,50 @@ mod sys {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(windows)]
+mod sys {
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcess, GetProcessIoCounters, GetProcessTimes, IO_COUNTERS,
+    };
+
+    /// Bytes this process has written (buffered-write transfer count — a
+    /// fair write-amplification proxy, counted at the write call).
+    pub fn write_bytes() -> Option<u64> {
+        unsafe {
+            let mut io: IO_COUNTERS = std::mem::zeroed();
+            (GetProcessIoCounters(GetCurrentProcess(), &mut io) != 0)
+                .then_some(io.WriteTransferCount)
+        }
+    }
+
+    /// Total process CPU time (user + kernel).
+    pub fn cpu_time() -> Option<std::time::Duration> {
+        unsafe {
+            let mut creation: FILETIME = std::mem::zeroed();
+            let mut exit: FILETIME = std::mem::zeroed();
+            let mut kernel: FILETIME = std::mem::zeroed();
+            let mut user: FILETIME = std::mem::zeroed();
+            if GetProcessTimes(
+                GetCurrentProcess(),
+                &mut creation,
+                &mut exit,
+                &mut kernel,
+                &mut user,
+            ) == 0
+            {
+                return None;
+            }
+            let ft = |t: FILETIME| (u64::from(t.dwHighDateTime) << 32) | u64::from(t.dwLowDateTime);
+            // FILETIME ticks are 100 ns.
+            Some(std::time::Duration::from_nanos(
+                (ft(kernel) + ft(user)) * 100,
+            ))
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", windows)))]
 mod sys {
     pub fn write_bytes() -> Option<u64> {
         None
@@ -230,16 +274,44 @@ fn main() {
         .expect("open keyspace");
 
     // ---- Phase A: bulk load every key once (the demoted working set). ----
+    // Loaded in key-sorted order (vnode-major in group mode) so the bulk
+    // load doesn't pay full compaction churn before measurement starts.
     let load_start = Instant::now();
     let mut rng = SmallRng::seed_from_u64(42);
     let mut key = Vec::with_capacity(64);
     let mut value = vec![0u8; args.value_bytes];
     let mut logical_bytes: u64 = 0;
-    for i in 0..args.keys {
+    let mut loaded: u64 = 0;
+    let progress_every = (args.keys / 10).max(1);
+    let mut load_one = |i: u64| {
         make_key(args.mode, i, &mut key);
         fill_value(&mut rng, &mut value);
         ks.insert(&key, &value).expect("load insert");
         logical_bytes += (key.len() + value.len()) as u64;
+        loaded += 1;
+        if loaded.is_multiple_of(progress_every) {
+            println!(
+                "  load: {loaded}/{} ({:.0}s)",
+                args.keys,
+                load_start.elapsed().as_secs_f64()
+            );
+        }
+    };
+    match args.mode {
+        Mode::Group => {
+            for v in 0..VNODES.min(args.keys) {
+                let mut i = v;
+                while i < args.keys {
+                    load_one(i);
+                    i += VNODES;
+                }
+            }
+        }
+        Mode::Slice => {
+            for i in 0..args.keys {
+                load_one(i);
+            }
+        }
     }
     db.persist(fjall::PersistMode::SyncAll).expect("persist");
     println!(
@@ -369,7 +441,7 @@ fn main() {
                 logical as f64 / (1 << 20) as f64
             );
         }
-        _ => println!("write amplification: n/a (needs /proc, run on Linux)"),
+        _ => println!("write amplification: n/a (unsupported platform)"),
     }
     match (cpu_before, sys::cpu_time()) {
         (Some(before), Some(after)) => {
@@ -380,7 +452,7 @@ fn main() {
                 100.0 * cpu.as_secs_f64() / steady_wall.as_secs_f64()
             );
         }
-        _ => println!("process CPU: n/a (needs /proc, run on Linux)"),
+        _ => println!("process CPU: n/a (unsupported platform)"),
     }
     println!(
         "on-disk size: {:.1} MiB ({:.2}x of logical loaded)",

--- a/tools/state-tier-bench/src/main.rs
+++ b/tools/state-tier-bench/src/main.rs
@@ -1,0 +1,403 @@
+//! Benchmark gate for the state cold tier.
+//!
+//! Exercises fjall with workloads shaped like demoted operator state and
+//! reports the numbers the go/no-go decision needs:
+//!
+//! - **group mode**: point upserts/reads of `(operator, vnode, group-key) →
+//!   accumulator-state` records, Zipfian-skewed writes, uniform cold reads.
+//! - **slice mode**: whole `(operator, vnode) → serialized-slice` blobs
+//!   (tens of KB to MB), Zipfian-skewed slice rewrites, uniform slice reads.
+//!
+//! Gate criteria (run on target-class Linux NVMe, not a dev laptop):
+//! cold-read p99 ≤ 1 ms from a non-writer thread under sustained write load;
+//! background CPU bounded; write amplification acceptable at the sustained
+//! upsert rate. Reads run on their own thread, mirroring how promotion
+//! fetches run off the compute thread.
+//!
+//! Write amplification and CPU are sampled from `/proc` and reported as
+//! n/a elsewhere.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use hdrhistogram::Histogram;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use rand_distr::{Distribution, Zipf};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Group,
+    Slice,
+}
+
+struct Args {
+    path: PathBuf,
+    mode: Mode,
+    /// group mode: number of distinct group keys. slice mode: number of slices.
+    keys: u64,
+    /// group mode: value size. slice mode: slice blob size.
+    value_bytes: usize,
+    /// Steady-state measurement window.
+    duration_secs: u64,
+    /// Zipf exponent for the write key distribution.
+    zipf_s: f64,
+    /// Target sustained upsert rate (ops/s); 0 = unthrottled.
+    write_rate: u64,
+    keep: bool,
+}
+
+fn usage() -> ! {
+    eprintln!(
+        "state-tier-bench --path <dir> [--mode group|slice] [--keys N] \
+         [--value-bytes N] [--duration-secs N] [--zipf-s F] \
+         [--write-rate OPS] [--keep]\n\
+         defaults: group mode, 2,000,000 keys x 256 B (group) / \
+         256 slices x 4 MiB (slice), 60 s, zipf 0.99, 100,000 ops/s"
+    );
+    std::process::exit(2);
+}
+
+fn parse_args() -> Args {
+    let mut args = Args {
+        path: PathBuf::new(),
+        mode: Mode::Group,
+        keys: 0,
+        value_bytes: 0,
+        duration_secs: 60,
+        zipf_s: 0.99,
+        write_rate: 100_000,
+        keep: false,
+    };
+    let mut keys_set = false;
+    let mut value_set = false;
+    let mut it = std::env::args().skip(1);
+    while let Some(flag) = it.next() {
+        let val = |it: &mut dyn Iterator<Item = String>| -> String {
+            it.next().unwrap_or_else(|| usage())
+        };
+        match flag.as_str() {
+            "--path" => args.path = PathBuf::from(val(&mut it)),
+            "--mode" => {
+                args.mode = match val(&mut it).as_str() {
+                    "group" => Mode::Group,
+                    "slice" => Mode::Slice,
+                    _ => usage(),
+                }
+            }
+            "--keys" => {
+                args.keys = val(&mut it).parse().unwrap_or_else(|_| usage());
+                keys_set = true;
+            }
+            "--value-bytes" => {
+                args.value_bytes = val(&mut it).parse().unwrap_or_else(|_| usage());
+                value_set = true;
+            }
+            "--duration-secs" => {
+                args.duration_secs = val(&mut it).parse().unwrap_or_else(|_| usage());
+            }
+            "--zipf-s" => args.zipf_s = val(&mut it).parse().unwrap_or_else(|_| usage()),
+            "--write-rate" => args.write_rate = val(&mut it).parse().unwrap_or_else(|_| usage()),
+            "--keep" => args.keep = true,
+            _ => usage(),
+        }
+    }
+    if args.path.as_os_str().is_empty() {
+        usage();
+    }
+    if !keys_set {
+        args.keys = match args.mode {
+            Mode::Group => 2_000_000,
+            Mode::Slice => 256,
+        };
+    }
+    if !value_set {
+        args.value_bytes = match args.mode {
+            Mode::Group => 256,
+            Mode::Slice => 4 << 20,
+        };
+    }
+    args
+}
+
+/// Key layout mirrors the engine's: operator name, vnode, then (group mode
+/// only) the group key — so prefix locality matches what the tier will see.
+fn make_key(mode: Mode, i: u64, buf: &mut Vec<u8>) {
+    const VNODES: u64 = 256;
+    buf.clear();
+    buf.extend_from_slice(b"agg-0/");
+    match mode {
+        Mode::Group => {
+            buf.extend_from_slice(&u32::try_from(i % VNODES).unwrap().to_be_bytes());
+            buf.push(b'/');
+            buf.extend_from_slice(&i.to_be_bytes());
+        }
+        Mode::Slice => {
+            buf.extend_from_slice(&u32::try_from(i).unwrap_or(u32::MAX).to_be_bytes());
+        }
+    }
+}
+
+fn fill_value(rng: &mut SmallRng, buf: &mut [u8]) {
+    rng.fill(buf);
+}
+
+#[cfg(target_os = "linux")]
+mod sys {
+    /// Bytes this process has caused to be written to storage.
+    pub fn write_bytes() -> Option<u64> {
+        let io = std::fs::read_to_string("/proc/self/io").ok()?;
+        io.lines()
+            .find_map(|l| l.strip_prefix("write_bytes: "))
+            .and_then(|v| v.trim().parse().ok())
+    }
+
+    /// Total process CPU time (user + system).
+    pub fn cpu_time() -> Option<std::time::Duration> {
+        let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+        // Fields 14/15 (utime/stime) counted after the parenthesized comm,
+        // which may itself contain spaces.
+        let rest = stat.rsplit_once(')')?.1;
+        let fields: Vec<&str> = rest.split_whitespace().collect();
+        let utime: u64 = fields.get(11)?.parse().ok()?;
+        let stime: u64 = fields.get(12)?.parse().ok()?;
+        let tick = 100u64; // CLK_TCK on every Linux that matters here
+        Some(std::time::Duration::from_millis(
+            (utime + stime) * 1000 / tick,
+        ))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod sys {
+    pub fn write_bytes() -> Option<u64> {
+        None
+    }
+    pub fn cpu_time() -> Option<std::time::Duration> {
+        None
+    }
+}
+
+fn dir_size(path: &std::path::Path) -> u64 {
+    let mut total = 0;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                total += dir_size(&p);
+            } else {
+                total += e.metadata().map(|m| m.len()).unwrap_or(0);
+            }
+        }
+    }
+    total
+}
+
+#[allow(clippy::too_many_lines)]
+fn main() {
+    let args = parse_args();
+    let mode_name = match args.mode {
+        Mode::Group => "group",
+        Mode::Slice => "slice",
+    };
+    println!(
+        "mode={mode_name} keys={} value_bytes={} duration={}s zipf_s={} write_rate={}/s",
+        args.keys, args.value_bytes, args.duration_secs, args.zipf_s, args.write_rate
+    );
+
+    if args.path.exists() {
+        std::fs::remove_dir_all(&args.path).expect("clear bench dir");
+    }
+    std::fs::create_dir_all(&args.path).expect("create bench dir");
+
+    let db = fjall::Database::builder(&args.path)
+        .open()
+        .expect("open database");
+    // Slice blobs are exactly what key-value separation is for; without it
+    // every compaction rewrites the multi-MB values and the write
+    // amplification number is meaningless.
+    let kv_separation = args.mode == Mode::Slice;
+    let ks = db
+        .keyspace("state", move || {
+            fjall::KeyspaceCreateOptions::default().with_kv_separation(if kv_separation {
+                Some(fjall::KvSeparationOptions::default())
+            } else {
+                None
+            })
+        })
+        .expect("open keyspace");
+
+    // ---- Phase A: bulk load every key once (the demoted working set). ----
+    let load_start = Instant::now();
+    let mut rng = SmallRng::seed_from_u64(42);
+    let mut key = Vec::with_capacity(64);
+    let mut value = vec![0u8; args.value_bytes];
+    let mut logical_bytes: u64 = 0;
+    for i in 0..args.keys {
+        make_key(args.mode, i, &mut key);
+        fill_value(&mut rng, &mut value);
+        ks.insert(&key, &value).expect("load insert");
+        logical_bytes += (key.len() + value.len()) as u64;
+    }
+    db.persist(fjall::PersistMode::SyncAll).expect("persist");
+    println!(
+        "loaded {} keys ({:.1} MiB logical) in {:.1}s",
+        args.keys,
+        logical_bytes as f64 / (1 << 20) as f64,
+        load_start.elapsed().as_secs_f64()
+    );
+
+    // ---- Phase B: steady state — Zipfian writer + uniform cold reader. ----
+    let stop = Arc::new(AtomicBool::new(false));
+    let writes_done = Arc::new(AtomicU64::new(0));
+    let write_logical = Arc::new(AtomicU64::new(0));
+
+    let disk_before = sys::write_bytes();
+    let cpu_before = sys::cpu_time();
+    let steady_start = Instant::now();
+
+    let writer = {
+        let ks = ks.clone();
+        let stop = Arc::clone(&stop);
+        let writes_done = Arc::clone(&writes_done);
+        let write_logical = Arc::clone(&write_logical);
+        let mode = args.mode;
+        let keys = args.keys;
+        let value_bytes = args.value_bytes;
+        let zipf_s = args.zipf_s;
+        let write_rate = args.write_rate;
+        std::thread::spawn(move || {
+            let mut rng = SmallRng::seed_from_u64(7);
+            let zipf = Zipf::new(keys as f64, zipf_s).expect("zipf");
+            let mut key = Vec::with_capacity(64);
+            let mut value = vec![0u8; value_bytes];
+            let start = Instant::now();
+            let mut done: u64 = 0;
+            while !stop.load(Ordering::Relaxed) {
+                // Zipf yields ranks in [1, keys]; spread the hot ranks over
+                // the id space so skew isn't aligned with insertion order.
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let rank = zipf.sample(&mut rng) as u64;
+                let i = rank.wrapping_mul(0x9E37_79B9_7F4A_7C15) % keys;
+                make_key(mode, i, &mut key);
+                fill_value(&mut rng, &mut value);
+                ks.insert(&key, &value).expect("steady insert");
+                write_logical.fetch_add((key.len() + value.len()) as u64, Ordering::Relaxed);
+                done += 1;
+                writes_done.store(done, Ordering::Relaxed);
+                if write_rate > 0 {
+                    // Pace precisely: sleep off the deficit to the target rate.
+                    let target_elapsed = done as f64 / write_rate as f64;
+                    let actual = start.elapsed().as_secs_f64();
+                    if target_elapsed > actual {
+                        std::thread::sleep(Duration::from_secs_f64(target_elapsed - actual));
+                    }
+                }
+            }
+        })
+    };
+
+    let reader = {
+        let ks = ks.clone();
+        let stop = Arc::clone(&stop);
+        let mode = args.mode;
+        let keys = args.keys;
+        std::thread::spawn(move || {
+            let mut rng = SmallRng::seed_from_u64(13);
+            let mut key = Vec::with_capacity(64);
+            let mut hist = Histogram::<u64>::new_with_bounds(1, 60_000_000, 3).expect("hist");
+            let mut read_bytes: u64 = 0;
+            while !stop.load(Ordering::Relaxed) {
+                // Uniform over the whole key space: dominated by keys the
+                // Zipfian writer rarely touches, i.e. genuinely cold reads.
+                let i = rng.random_range(0..keys);
+                make_key(mode, i, &mut key);
+                let t = Instant::now();
+                let v = ks.get(&key).expect("read");
+                let us = u64::try_from(t.elapsed().as_micros()).unwrap_or(u64::MAX);
+                hist.record(us.max(1)).ok();
+                read_bytes += v.map(|v| v.len() as u64).unwrap_or(0);
+            }
+            (hist, read_bytes)
+        })
+    };
+
+    std::thread::sleep(Duration::from_secs(args.duration_secs));
+    stop.store(true, Ordering::Relaxed);
+    writer.join().expect("writer join");
+    let (hist, read_bytes) = reader.join().expect("reader join");
+    let steady_wall = steady_start.elapsed();
+
+    // Let queued background work land before sampling disk/CPU deltas.
+    db.persist(fjall::PersistMode::SyncAll).expect("persist");
+    std::thread::sleep(Duration::from_secs(2));
+
+    // ---- Report. ----
+    let writes = writes_done.load(Ordering::Relaxed);
+    let logical = write_logical.load(Ordering::Relaxed);
+    println!("\n== steady state ({:.1}s wall) ==", steady_wall.as_secs_f64());
+    println!(
+        "writes: {} ({:.0}/s, {:.1} MiB logical)",
+        writes,
+        writes as f64 / steady_wall.as_secs_f64(),
+        logical as f64 / (1 << 20) as f64
+    );
+    println!(
+        "reads:  {} ({:.0}/s, {:.1} MiB returned)",
+        hist.len(),
+        hist.len() as f64 / steady_wall.as_secs_f64(),
+        read_bytes as f64 / (1 << 20) as f64
+    );
+    println!(
+        "read latency (us): p50={} p90={} p99={} p999={} max={}",
+        hist.value_at_quantile(0.50),
+        hist.value_at_quantile(0.90),
+        hist.value_at_quantile(0.99),
+        hist.value_at_quantile(0.999),
+        hist.max()
+    );
+
+    match (disk_before, sys::write_bytes()) {
+        (Some(before), Some(after)) if logical > 0 => {
+            let physical = after.saturating_sub(before);
+            println!(
+                "write amplification: {:.2}x ({:.1} MiB physical / {:.1} MiB logical)",
+                physical as f64 / logical as f64,
+                physical as f64 / (1 << 20) as f64,
+                logical as f64 / (1 << 20) as f64
+            );
+        }
+        _ => println!("write amplification: n/a (needs /proc, run on Linux)"),
+    }
+    match (cpu_before, sys::cpu_time()) {
+        (Some(before), Some(after)) => {
+            let cpu = after.saturating_sub(before);
+            println!(
+                "process CPU during steady state: {:.1}s ({:.0}% of one core)",
+                cpu.as_secs_f64(),
+                100.0 * cpu.as_secs_f64() / steady_wall.as_secs_f64()
+            );
+        }
+        _ => println!("process CPU: n/a (needs /proc, run on Linux)"),
+    }
+    println!(
+        "on-disk size: {:.1} MiB ({:.2}x of logical loaded)",
+        dir_size(&args.path) as f64 / (1 << 20) as f64,
+        dir_size(&args.path) as f64 / logical_bytes.max(1) as f64
+    );
+
+    let p99_us = hist.value_at_quantile(0.99);
+    println!(
+        "\nGATE: cold-read p99 {} 1ms -> {}",
+        if p99_us <= 1000 { "<=" } else { ">" },
+        if p99_us <= 1000 { "PASS" } else { "FAIL" }
+    );
+
+    drop(ks);
+    drop(db);
+    if !args.keep {
+        std::fs::remove_dir_all(&args.path).ok();
+    }
+}

--- a/tools/state-tier-bench/src/main.rs
+++ b/tools/state-tier-bench/src/main.rs
@@ -132,6 +132,17 @@ fn parse_args() -> Args {
             Mode::Slice => 4 << 20,
         };
     }
+    // Slice keys index a u32 space (see `make_key`); a larger count would
+    // alias every overflowing key onto the same slice and silently
+    // deduplicate the workload. Reject it instead of skewing the benchmark.
+    if matches!(args.mode, Mode::Slice) && args.keys > u64::from(u32::MAX) {
+        eprintln!(
+            "--keys {} exceeds u32::MAX ({}) in slice mode",
+            args.keys,
+            u32::MAX
+        );
+        usage();
+    }
     args
 }
 
@@ -149,7 +160,9 @@ fn make_key(mode: Mode, i: u64, buf: &mut Vec<u8>) {
             buf.extend_from_slice(&i.to_be_bytes());
         }
         Mode::Slice => {
-            buf.extend_from_slice(&u32::try_from(i).unwrap_or(u32::MAX).to_be_bytes());
+            // `parse_args` rejects slice-mode key counts above u32::MAX, so
+            // every `i` fits — no silent aliasing onto a saturated index.
+            buf.extend_from_slice(&u32::try_from(i).unwrap().to_be_bytes());
         }
     }
 }

--- a/tools/state-tier-bench/src/main.rs
+++ b/tools/state-tier-bench/src/main.rs
@@ -46,14 +46,20 @@ struct Args {
     zipf_s: f64,
     /// Target sustained upsert rate (ops/s); 0 = unthrottled.
     write_rate: u64,
+    /// fjall block/blob cache size; 0 = fjall default. Size it like a
+    /// deployment would (filters + indexes resident), or every get pays
+    /// extra I/Os and the p99 measures cache sizing, not the LSM.
+    cache_bytes: u64,
     keep: bool,
+    /// Reuse an existing data dir: skip the bulk load (implies --keep).
+    reuse: bool,
 }
 
 fn usage() -> ! {
     eprintln!(
         "state-tier-bench --path <dir> [--mode group|slice] [--keys N] \
          [--value-bytes N] [--duration-secs N] [--zipf-s F] \
-         [--write-rate OPS] [--keep]\n\
+         [--write-rate OPS] [--cache-bytes N] [--keep] [--reuse]\n\
          defaults: group mode, 2,000,000 keys x 256 B (group) / \
          256 slices x 4 MiB (slice), 60 s, zipf 0.99, 100,000 ops/s"
     );
@@ -69,7 +75,9 @@ fn parse_args() -> Args {
         duration_secs: 60,
         zipf_s: 0.99,
         write_rate: 100_000,
+        cache_bytes: 0,
         keep: false,
+        reuse: false,
     };
     let mut keys_set = false;
     let mut value_set = false;
@@ -100,7 +108,12 @@ fn parse_args() -> Args {
             }
             "--zipf-s" => args.zipf_s = val(&mut it).parse().unwrap_or_else(|_| usage()),
             "--write-rate" => args.write_rate = val(&mut it).parse().unwrap_or_else(|_| usage()),
+            "--cache-bytes" => args.cache_bytes = val(&mut it).parse().unwrap_or_else(|_| usage()),
             "--keep" => args.keep = true,
+            "--reuse" => {
+                args.reuse = true;
+                args.keep = true;
+            }
             _ => usage(),
         }
     }
@@ -251,14 +264,19 @@ fn main() {
         args.keys, args.value_bytes, args.duration_secs, args.zipf_s, args.write_rate
     );
 
-    if args.path.exists() {
-        std::fs::remove_dir_all(&args.path).expect("clear bench dir");
+    let reuse = args.reuse && args.path.exists();
+    if !reuse {
+        if args.path.exists() {
+            std::fs::remove_dir_all(&args.path).expect("clear bench dir");
+        }
+        std::fs::create_dir_all(&args.path).expect("create bench dir");
     }
-    std::fs::create_dir_all(&args.path).expect("create bench dir");
 
-    let db = fjall::Database::builder(&args.path)
-        .open()
-        .expect("open database");
+    let mut builder = fjall::Database::builder(&args.path);
+    if args.cache_bytes > 0 {
+        builder = builder.cache_size(args.cache_bytes);
+    }
+    let db = builder.open().expect("open database");
     // Slice blobs are exactly what key-value separation is for; without it
     // every compaction rewrites the multi-MB values and the write
     // amplification number is meaningless.
@@ -280,46 +298,53 @@ fn main() {
     let mut rng = SmallRng::seed_from_u64(42);
     let mut key = Vec::with_capacity(64);
     let mut value = vec![0u8; args.value_bytes];
-    let mut logical_bytes: u64 = 0;
+    make_key(args.mode, 0, &mut key);
+    let logical_bytes: u64 = args.keys * (key.len() + args.value_bytes) as u64;
     let mut loaded: u64 = 0;
     let progress_every = (args.keys / 10).max(1);
-    let mut load_one = |i: u64| {
-        make_key(args.mode, i, &mut key);
-        fill_value(&mut rng, &mut value);
-        ks.insert(&key, &value).expect("load insert");
-        logical_bytes += (key.len() + value.len()) as u64;
-        loaded += 1;
-        if loaded.is_multiple_of(progress_every) {
-            println!(
-                "  load: {loaded}/{} ({:.0}s)",
-                args.keys,
-                load_start.elapsed().as_secs_f64()
-            );
-        }
-    };
-    match args.mode {
-        Mode::Group => {
-            for v in 0..VNODES.min(args.keys) {
-                let mut i = v;
-                while i < args.keys {
+    if reuse {
+        println!(
+            "reusing existing data dir ({:.1} MiB logical assumed)",
+            logical_bytes as f64 / (1 << 20) as f64
+        );
+    } else {
+        let mut load_one = |i: u64| {
+            make_key(args.mode, i, &mut key);
+            fill_value(&mut rng, &mut value);
+            ks.insert(&key, &value).expect("load insert");
+            loaded += 1;
+            if loaded.is_multiple_of(progress_every) {
+                println!(
+                    "  load: {loaded}/{} ({:.0}s)",
+                    args.keys,
+                    load_start.elapsed().as_secs_f64()
+                );
+            }
+        };
+        match args.mode {
+            Mode::Group => {
+                for v in 0..VNODES.min(args.keys) {
+                    let mut i = v;
+                    while i < args.keys {
+                        load_one(i);
+                        i += VNODES;
+                    }
+                }
+            }
+            Mode::Slice => {
+                for i in 0..args.keys {
                     load_one(i);
-                    i += VNODES;
                 }
             }
         }
-        Mode::Slice => {
-            for i in 0..args.keys {
-                load_one(i);
-            }
-        }
+        db.persist(fjall::PersistMode::SyncAll).expect("persist");
+        println!(
+            "loaded {} keys ({:.1} MiB logical) in {:.1}s",
+            args.keys,
+            logical_bytes as f64 / (1 << 20) as f64,
+            load_start.elapsed().as_secs_f64()
+        );
     }
-    db.persist(fjall::PersistMode::SyncAll).expect("persist");
-    println!(
-        "loaded {} keys ({:.1} MiB logical) in {:.1}s",
-        args.keys,
-        logical_bytes as f64 / (1 << 20) as f64,
-        load_start.elapsed().as_secs_f64()
-    );
 
     // ---- Phase B: steady state — Zipfian writer + uniform cold reader. ----
     let stop = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
Implements ADR-005 **tiered operator state**: a hot in-memory tier backed by a local [fjall](https://github.com/fjall-rs/fjall) (pure-Rust LSM) cold tier, with the object-store checkpoint artifacts as the source of truth. When operator state nears a configured memory budget, idle per-vnode aggregate slices are **demoted** to the cold tier and **promoted** back on demand instead of backpressuring ingest.

Gated behind the experimental `state-tier` feature (implies `cluster`).

## What's here (Phases 1–5 + single-node)

- **Memory budget** — node-level `state_memory_budget_bytes` with ingest backpressure when over budget; O(1) incremental size accounting.
- **Benchmark gate** — `state-tier-bench` harness for the fjall cold-read p99 gate (Zipfian, slice/group shapes); dev-box results recorded in the plan.
- **Cold-tier store + worker** — `state_tier/` module: fjall, single KV-separated keyspace keyed `op\0vnode`, single-flight Ring-1 worker that keeps synchronous fjall I/O off the compute thread.
- **Demotion** — coordinator-driven; byte-identity reference partials; budget→demote trigger that only sheds *clean* (non-dirty) changelog-aggregate vnodes with no checkpoint in flight (writes the slice durably before dropping it from memory).
- **Promotion + restart recovery** — rows hitting a demoted vnode are deferred, fetched off-thread, and replayed; on restart the tier is wiped and demoted vnodes rehydrate from their durable partials.
- **Single-node demotion (no controller)** — the per-vnode capture only needs a vnode count, now decoupled from the cluster shuffle config, so a single node tiers via a single-owner registry. The embedded server synthesizes that registry from `[state]`, so it needs only `state_tier_dir` + a durable `[state]` backend (rejected if the backend is in-process, since demoted state replays from it on restart).
- Compute↔runtime channels moved to crossfire for consistency; a subtraction pass + self-review cleanup removed dead scaffolding and tightened docs.

## Validation

- **kill-9 exactly-once soak with the tier on**: 3 real-binary nodes under fault injection — ~180k records dense across per-node topics (0 dups, 0 gaps) *while* the tier demoted/promoted; restart rehydrates demoted vnodes from partials.
- Steady demote/promote with bounded in-memory state; new embedded single-node integration test (`single_node_tier.rs`) asserts demote + promote fire and the tier holds resident slices.
- clippy across `state-tier` / `cluster` / `no-default` (`-D warnings`) + full lib suite green.

## Not production-ready yet

Still owed before enabling on real workloads, tracked in `docs/plans/tiered-operator-state.md`:
- the **formal fjall cold-read p99 gate on Linux NVMe** (so far only measured on a consumer Windows/QLC box — pessimistic but not the target);
- a **multi-hour / large-state endurance soak**.

Until then the feature stays behind the `state-tier` flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tiered operator state: a hot in‑memory tier with a disk cold tier backed by `fjall`, demoting idle per‑vnode slices as a node memory budget is approached and promoting them on demand. Also fixes temporal join startup by rebuilding versioned lookup state from loaded snapshots so pre‑snapshot rows are visible before CDC.

- **New Features**
  - Node-level state memory budget with ingest backpressure; O(1) probes and gauges for state bytes and budget status.
  - Cold tier store + off-thread worker using `crossfire`; `(operator, vnode) → slice` blobs with gauges for tier bytes/slices and demote/fetch totals.
  - Coordinator-driven demotion of clean slices only (no checkpoint in flight); writes the exact uploaded bytes, then drops in-memory state.
  - On-demand promotion: rows hitting a cold vnode are deferred; slice fetched off the compute thread, applied, watermark held while pending; stale tier copies dropped after promotion.
  - Restart recovery rehydrates demoted vnodes from durable per‑vnode partials; the tier itself wipes on restart (capacity only).
  - Single-node support without a controller: vnode topology derived from the registry; embedded mode exposes `Connection::tier_metrics()`.
  - Correctness: accurate demote counting, narrower dirty tracking, pre-checks avoid futile tier writes, promotion cleans up tier copies; intake pause also holds on idle cycles; rehydration failures fail fast.

- **Migration**
  - `laminar-server` now ships `state-tier` in its default feature set; workspace bumped to `0.26.0`. `laminar-db` keeps it behind `--features state-tier` (implies `cluster`); adds optional `fjall = "3.1"`.
  - Configure a budget and tier dir: builder `.state_memory_budget_bytes(..)` and `.state_tier_dir(..)`, or `[server] state_memory_budget_bytes` and `state_tier_dir`. `state_tier_dir` requires a memory budget and a durable `[state]` backend (local/object-store); errors otherwise. Single-node tiering derives vnodes from `[state]`.
  - Monitor `laminardb_state_*` and `laminardb_state_tier_*` gauges, or use `Connection::tier_metrics()` in embedded mode.
  - Helm: new values under `laminardb.state.memoryBudgetBytes` and `laminardb.state.tier.*` (scratch emptyDir supported); pgwire config surfaced with MD5 hashes supplied via environment variables; add `terminationGracePeriodSeconds` for clean drain.

<sup>Written for commit df00cbbec6c3231a1bb3f81ad13bd0e69b9ea32a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional in-memory operator state budget (`state_memory_budget_bytes`) that throttles intake and enables cold-tier demotion.
  * Added experimental disk cold tier (“state-tier”) with on-demand promotion and restart rehydration for durable state backends.

* **Observability**
  * Added Prometheus cold-tier/state-budget metrics plus an embedded `tier_metrics()` accessor.

* **Configuration**
  * Added `state_tier_dir` (state-tier feature-gated), with server + Helm wiring.

* **Benchmarks**
  * Added a standalone cold-tier benchmark tool.

* **Deployment**
  * Improved Helm pgwire/TLS rendering and state-tier-related mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->