### PR TITLE
refactor(laminar-db): improve maintainability — decompose oversized functions + dedup agg compile

### DIFF
--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -32,7 +32,7 @@ pub(crate) use checkpoints::{
 };
 pub(crate) use compile::{
     apply_compiled_having, compile_having_filter, expr_to_sql, extract_clauses, find_aggregate,
-    resolve_expr_type, CompiledProjection,
+    CompiledProjection, PreAggBuilder,
 };
 pub(crate) use keys::{
     global_aggregate_key, row_to_scalar_key_with_types, scalar_key_to_owned_row,
@@ -398,208 +398,35 @@ impl IncrementalAggState {
         let state = ctx.state();
         let props = state.execution_props();
         let input_df_schema = &agg_info.input_df_schema;
-        let mut compiled_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
-        let mut proj_fields: Vec<Field> = Vec::new();
-        let mut compile_ok = compile_source.is_some();
-
-        let mut agg_specs = Vec::new();
-        let mut pre_agg_select_items: Vec<String> = Vec::new();
+        let compile =
+            |e: &datafusion_expr::Expr| create_physical_expr(e, input_df_schema, props).ok();
+        let mut builder =
+            PreAggBuilder::new(&input_schema, num_group_cols, compile_source.is_some());
 
         for (i, group_expr) in group_exprs.iter().enumerate() {
-            if let datafusion_expr::Expr::Column(col) = group_expr {
-                pre_agg_select_items.push(format!("\"{}\"", col.name));
-            } else {
-                let group_sql = expr_to_sql(group_expr);
-                pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
-            }
-
-            if compile_ok {
-                match create_physical_expr(group_expr, input_df_schema, props) {
-                    Ok(phys) => {
-                        let dt = phys
-                            .data_type(input_df_schema.as_arrow())
-                            .unwrap_or(DataType::Utf8);
-                        let name = match group_expr {
-                            datafusion_expr::Expr::Column(col) => col.name.clone(),
-                            _ => format!("__group_{i}"),
-                        };
-                        proj_fields.push(Field::new(name, dt, true));
-                        compiled_exprs.push(phys);
-                    }
-                    Err(_) => compile_ok = false,
-                }
-            }
+            builder.push_group_expr(i, group_expr, &compile);
         }
-
-        let mut next_col_idx = num_group_cols;
 
         for (i, expr) in aggr_exprs.iter().enumerate() {
             let agg_schema_idx = num_group_cols + i;
             let agg_field = agg_schema.field(agg_schema_idx);
-            // Use the top-level schema for the output name (has user alias)
+            // Top-level schema carries the user alias (e.g. `SUM(x) AS total`).
             let output_name = if agg_schema_idx < top_schema.fields().len() {
                 top_schema.field(agg_schema_idx).name().clone()
             } else {
                 agg_field.name().clone()
             };
-
-            if let datafusion_expr::Expr::AggregateFunction(agg_func) = expr {
-                let udf = Arc::clone(&agg_func.func);
-                let is_distinct = agg_func.params.distinct;
-
-                let mut input_col_indices = Vec::new();
-                let mut input_types = Vec::new();
-
-                if agg_func.params.args.is_empty() {
-                    // COUNT(*): no input column needed; pass a dummy boolean.
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    pre_agg_select_items.push(format!("TRUE AS \"__agg_input_{col_idx}\""));
-                    input_col_indices.push(col_idx);
-                    input_types.push(DataType::Boolean);
-
-                    if compile_ok {
-                        match create_physical_expr(
-                            &datafusion_expr::lit(true),
-                            input_df_schema,
-                            props,
-                        ) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_input_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-                } else {
-                    for arg_expr in &agg_func.params.args {
-                        let col_idx = next_col_idx;
-                        next_col_idx += 1;
-                        let expr_sql = expr_to_sql(arg_expr);
-
-                        // FILTER: wrap with CASE WHEN so filtered rows become NULL.
-                        if let Some(filter_expr) = &agg_func.params.filter {
-                            let filter_sql = expr_to_sql(filter_expr);
-                            pre_agg_select_items.push(format!(
-                                "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
-                            ));
-
-                            if compile_ok {
-                                let case_expr =
-                                    datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                                        expr: None,
-                                        when_then_expr: vec![(
-                                            Box::new(filter_expr.as_ref().clone()),
-                                            Box::new(arg_expr.clone()),
-                                        )],
-                                        else_expr: Some(Box::new(datafusion_expr::lit(
-                                            ScalarValue::Null,
-                                        ))),
-                                    });
-                                match create_physical_expr(&case_expr, input_df_schema, props) {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        } else {
-                            pre_agg_select_items
-                                .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
-
-                            if compile_ok {
-                                match create_physical_expr(arg_expr, input_df_schema, props) {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        }
-
-                        input_col_indices.push(col_idx);
-                        let dt = resolve_expr_type(arg_expr, &input_schema, agg_field.data_type());
-                        input_types.push(dt);
-                    }
-                }
-
-                let filter_col_index = if let Some(filter_expr) = &agg_func.params.filter {
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    let filter_sql = expr_to_sql(filter_expr);
-                    pre_agg_select_items.push(format!(
-                            "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
-                        ));
-
-                    if compile_ok {
-                        let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                            expr: None,
-                            when_then_expr: vec![(
-                                Box::new(filter_expr.as_ref().clone()),
-                                Box::new(datafusion_expr::lit(true)),
-                            )],
-                            else_expr: Some(Box::new(datafusion_expr::lit(false))),
-                        });
-                        match create_physical_expr(&case_expr, input_df_schema, props) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_filter_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-
-                    Some(col_idx)
-                } else {
-                    None
-                };
-
-                let return_type = udf
-                    .return_type(&input_types)
-                    .unwrap_or_else(|_| agg_field.data_type().clone());
-
-                agg_specs.push(AggFuncSpec {
-                    udf,
-                    input_types,
-                    input_col_indices,
-                    output_name,
-                    return_type,
-                    distinct: is_distinct,
-                    is_count_star: agg_func.params.args.is_empty(),
-                    filter_col_index,
-                });
-            } else {
+            if !builder.push_aggregate(expr, output_name, agg_field, &compile) {
                 return Ok(None);
             }
         }
+
+        let mut compile_ok = builder.compile_ok;
+        let next_col_idx = builder.next_col_idx;
+        let mut pre_agg_select_items = builder.pre_agg_select_items;
+        let agg_specs = builder.agg_specs;
+        let compiled_exprs = builder.compiled_exprs;
+        let proj_fields = builder.proj_fields;
 
         let clauses = extract_clauses(sql);
 

--- a/crates/laminar-db/src/aggregate_state/compile.rs
+++ b/crates/laminar-db/src/aggregate_state/compile.rs
@@ -22,16 +22,12 @@ pub(crate) struct AggregateInfo {
     pub(crate) where_predicate: Option<datafusion_expr::Expr>,
 }
 
-/// A function that compiles a logical expr to a physical one, or `None` on
-/// failure. Constructed by the caller capturing the input schema + props so the
-/// builder needn't name `DFSchema`/`ExecutionProps`.
+/// Supplied by the caller so the builder needn't name `DFSchema`/`ExecutionProps`.
 pub(crate) type ExprCompiler<'a> =
     dyn Fn(&datafusion_expr::Expr) -> Option<Arc<dyn PhysicalExpr>> + 'a;
 
-/// Accumulates a query's pre-aggregate projection — the `SELECT` items, the
-/// optional compiled physical projection (skipped once compilation fails), and
-/// one [`AggFuncSpec`] per aggregate — while walking GROUP BY / aggregate exprs.
-/// Shared by the plain, windowed, and EOWC aggregate-state builders.
+/// Builds a query's pre-aggregate projection; shared by the plain, windowed, and
+/// EOWC aggregate-state builders.
 pub(crate) struct PreAggBuilder<'a> {
     input_schema: &'a Schema,
     pub(crate) compile_ok: bool,
@@ -55,9 +51,8 @@ impl<'a> PreAggBuilder<'a> {
         }
     }
 
-    /// Compile `expr` and add it as projected column `name`. When `from_phys`,
-    /// the column type is the compiled expr's type (falling back to `fallback`),
-    /// otherwise `fallback` is used directly. No-op once compilation has failed.
+    /// `from_phys` takes the column type from the compiled expr; no-op once
+    /// compilation has failed.
     pub(crate) fn push_compiled_column(
         &mut self,
         name: &str,
@@ -83,7 +78,6 @@ impl<'a> PreAggBuilder<'a> {
         }
     }
 
-    /// Add a GROUP BY column to the pre-agg projection.
     pub(crate) fn push_group_expr(
         &mut self,
         i: usize,
@@ -102,9 +96,8 @@ impl<'a> PreAggBuilder<'a> {
         self.push_compiled_column(&name, group_expr, DataType::Utf8, true, compile);
     }
 
-    /// Add an aggregate's input column(s), optional FILTER column, and its
-    /// [`AggFuncSpec`]. Returns `false` if `expr` is not an aggregate function
-    /// (the caller should bail to the interpreted path).
+    /// `false` if `expr` is not an aggregate function (caller bails to the
+    /// interpreted path).
     pub(crate) fn push_aggregate(
         &mut self,
         expr: &datafusion_expr::Expr,
@@ -203,8 +196,6 @@ impl<'a> PreAggBuilder<'a> {
         true
     }
 
-    /// Add the `__agg_filter_*` column for an aggregate's `FILTER (WHERE ...)`
-    /// clause and return its pre-agg column index.
     fn push_filter_column(
         &mut self,
         filter_expr: &datafusion_expr::Expr,

--- a/crates/laminar-db/src/aggregate_state/compile.rs
+++ b/crates/laminar-db/src/aggregate_state/compile.rs
@@ -3,12 +3,13 @@
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::{DataType, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DFSchema, ScalarValue};
 use datafusion_expr::LogicalPlan;
 
+use super::AggFuncSpec;
 use crate::error::DbError;
 
 pub(crate) struct AggregateInfo {
@@ -19,6 +20,219 @@ pub(crate) struct AggregateInfo {
     pub(crate) having_predicate: Option<datafusion_expr::Expr>,
     pub(crate) input_df_schema: Arc<DFSchema>,
     pub(crate) where_predicate: Option<datafusion_expr::Expr>,
+}
+
+/// A function that compiles a logical expr to a physical one, or `None` on
+/// failure. Constructed by the caller capturing the input schema + props so the
+/// builder needn't name `DFSchema`/`ExecutionProps`.
+pub(crate) type ExprCompiler<'a> =
+    dyn Fn(&datafusion_expr::Expr) -> Option<Arc<dyn PhysicalExpr>> + 'a;
+
+/// Accumulates a query's pre-aggregate projection — the `SELECT` items, the
+/// optional compiled physical projection (skipped once compilation fails), and
+/// one [`AggFuncSpec`] per aggregate — while walking GROUP BY / aggregate exprs.
+/// Shared by the plain, windowed, and EOWC aggregate-state builders.
+pub(crate) struct PreAggBuilder<'a> {
+    input_schema: &'a Schema,
+    pub(crate) compile_ok: bool,
+    pub(crate) next_col_idx: usize,
+    pub(crate) compiled_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    pub(crate) proj_fields: Vec<Field>,
+    pub(crate) pre_agg_select_items: Vec<String>,
+    pub(crate) agg_specs: Vec<AggFuncSpec>,
+}
+
+impl<'a> PreAggBuilder<'a> {
+    pub(crate) fn new(input_schema: &'a Schema, num_group_cols: usize, compile_ok: bool) -> Self {
+        Self {
+            input_schema,
+            compile_ok,
+            next_col_idx: num_group_cols,
+            compiled_exprs: Vec::new(),
+            proj_fields: Vec::new(),
+            pre_agg_select_items: Vec::new(),
+            agg_specs: Vec::new(),
+        }
+    }
+
+    /// Compile `expr` and add it as projected column `name`. When `from_phys`,
+    /// the column type is the compiled expr's type (falling back to `fallback`),
+    /// otherwise `fallback` is used directly. No-op once compilation has failed.
+    pub(crate) fn push_compiled_column(
+        &mut self,
+        name: &str,
+        expr: &datafusion_expr::Expr,
+        fallback: DataType,
+        from_phys: bool,
+        compile: &ExprCompiler<'_>,
+    ) {
+        if !self.compile_ok {
+            return;
+        }
+        match compile(expr) {
+            Some(phys) => {
+                let dt = if from_phys {
+                    phys.data_type(self.input_schema).unwrap_or(fallback)
+                } else {
+                    fallback
+                };
+                self.proj_fields.push(Field::new(name, dt, true));
+                self.compiled_exprs.push(phys);
+            }
+            None => self.compile_ok = false,
+        }
+    }
+
+    /// Add a GROUP BY column to the pre-agg projection.
+    pub(crate) fn push_group_expr(
+        &mut self,
+        i: usize,
+        group_expr: &datafusion_expr::Expr,
+        compile: &ExprCompiler<'_>,
+    ) {
+        let name = if let datafusion_expr::Expr::Column(col) = group_expr {
+            self.pre_agg_select_items.push(format!("\"{}\"", col.name));
+            col.name.clone()
+        } else {
+            let group_sql = expr_to_sql(group_expr);
+            self.pre_agg_select_items
+                .push(format!("{group_sql} AS \"__group_{i}\""));
+            format!("__group_{i}")
+        };
+        self.push_compiled_column(&name, group_expr, DataType::Utf8, true, compile);
+    }
+
+    /// Add an aggregate's input column(s), optional FILTER column, and its
+    /// [`AggFuncSpec`]. Returns `false` if `expr` is not an aggregate function
+    /// (the caller should bail to the interpreted path).
+    pub(crate) fn push_aggregate(
+        &mut self,
+        expr: &datafusion_expr::Expr,
+        output_name: String,
+        agg_field: &Field,
+        compile: &ExprCompiler<'_>,
+    ) -> bool {
+        let datafusion_expr::Expr::AggregateFunction(agg_func) = expr else {
+            return false;
+        };
+        let udf = Arc::clone(&agg_func.func);
+        let is_distinct = agg_func.params.distinct;
+
+        let mut input_col_indices = Vec::new();
+        let mut input_types = Vec::new();
+
+        if agg_func.params.args.is_empty() {
+            let col_idx = self.next_col_idx;
+            self.next_col_idx += 1;
+            self.pre_agg_select_items
+                .push(format!("TRUE AS \"__agg_input_{col_idx}\""));
+            input_col_indices.push(col_idx);
+            input_types.push(DataType::Boolean);
+            self.push_compiled_column(
+                &format!("__agg_input_{col_idx}"),
+                &datafusion_expr::lit(true),
+                DataType::Boolean,
+                false,
+                compile,
+            );
+        } else {
+            for arg_expr in &agg_func.params.args {
+                let col_idx = self.next_col_idx;
+                self.next_col_idx += 1;
+                let expr_sql = expr_to_sql(arg_expr);
+                let dt = resolve_expr_type(arg_expr, self.input_schema, agg_field.data_type());
+
+                // FILTER: wrap with CASE WHEN so filtered rows become NULL.
+                if let Some(filter_expr) = &agg_func.params.filter {
+                    let filter_sql = expr_to_sql(filter_expr);
+                    self.pre_agg_select_items.push(format!(
+                        "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
+                    ));
+                    let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
+                        expr: None,
+                        when_then_expr: vec![(
+                            Box::new(filter_expr.as_ref().clone()),
+                            Box::new(arg_expr.clone()),
+                        )],
+                        else_expr: Some(Box::new(datafusion_expr::lit(ScalarValue::Null))),
+                    });
+                    self.push_compiled_column(
+                        &format!("__agg_input_{col_idx}"),
+                        &case_expr,
+                        dt.clone(),
+                        false,
+                        compile,
+                    );
+                } else {
+                    self.pre_agg_select_items
+                        .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
+                    self.push_compiled_column(
+                        &format!("__agg_input_{col_idx}"),
+                        arg_expr,
+                        dt.clone(),
+                        false,
+                        compile,
+                    );
+                }
+
+                input_col_indices.push(col_idx);
+                input_types.push(dt);
+            }
+        }
+
+        let filter_col_index = agg_func
+            .params
+            .filter
+            .as_ref()
+            .map(|filter_expr| self.push_filter_column(filter_expr, compile));
+
+        let return_type = udf
+            .return_type(&input_types)
+            .unwrap_or_else(|_| agg_field.data_type().clone());
+
+        self.agg_specs.push(AggFuncSpec {
+            udf,
+            input_types,
+            input_col_indices,
+            output_name,
+            return_type,
+            distinct: is_distinct,
+            is_count_star: agg_func.params.args.is_empty(),
+            filter_col_index,
+        });
+        true
+    }
+
+    /// Add the `__agg_filter_*` column for an aggregate's `FILTER (WHERE ...)`
+    /// clause and return its pre-agg column index.
+    fn push_filter_column(
+        &mut self,
+        filter_expr: &datafusion_expr::Expr,
+        compile: &ExprCompiler<'_>,
+    ) -> usize {
+        let col_idx = self.next_col_idx;
+        self.next_col_idx += 1;
+        let filter_sql = expr_to_sql(filter_expr);
+        self.pre_agg_select_items.push(format!(
+            "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
+        ));
+        let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
+            expr: None,
+            when_then_expr: vec![(
+                Box::new(filter_expr.clone()),
+                Box::new(datafusion_expr::lit(true)),
+            )],
+            else_expr: Some(Box::new(datafusion_expr::lit(false))),
+        });
+        self.push_compiled_column(
+            &format!("__agg_filter_{col_idx}"),
+            &case_expr,
+            DataType::Boolean,
+            false,
+            compile,
+        );
+        col_idx
+    }
 }
 
 pub(crate) fn find_aggregate(plan: &LogicalPlan) -> Option<AggregateInfo> {

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -860,7 +860,6 @@ impl CoreWindowState {
         Ok(())
     }
 
-    /// Merge several overlapping sessions into one, folding their accumulators.
     fn merge_overlapping_sessions(
         &mut self,
         key: &arrow::row::OwnedRow,
@@ -870,46 +869,46 @@ impl CoreWindowState {
         batch: &RecordBatch,
         index_array: &arrow::array::UInt32Array,
     ) -> Result<(), DbError> {
+        // Stage the merge into a fresh survivor before mutating the group: fold in
+        // every overlapping session's state (a non-destructive read) plus the new
+        // row, and only remove + insert once all fallible steps succeed — so a
+        // mid-merge failure leaves the existing sessions intact.
+        let mut accs = self.create_fresh_accumulators()?;
+
         let group = self
             .session_groups
             .get_mut(key)
             .expect("invariant: key present (overlapping derived from same group)");
         let mut merged_start = new_start;
         let mut merged_end = new_end;
-        let mut survivor_accs: Option<Vec<Box<dyn datafusion_expr::Accumulator>>> = None;
-
         for &sess_key in overlapping {
             let sess = group
                 .sessions
-                .remove(&sess_key)
+                .get_mut(&sess_key)
                 .expect("invariant: overlapping keys are unique BTreeMap entries");
             merged_start = merged_start.min(sess.start);
             merged_end = merged_end.max(sess.end);
-
-            if let Some(ref mut surv) = survivor_accs {
-                for (i, mut acc) in sess.accs.into_iter().enumerate() {
-                    let state = acc
-                        .state()
-                        .map_err(|e| DbError::Pipeline(format!("session merge state: {e}")))?;
-                    let arrays: Vec<ArrayRef> = state
-                        .iter()
-                        .map(|sv| {
-                            sv.to_array()
-                                .map_err(|e| DbError::Pipeline(format!("session merge array: {e}")))
-                        })
-                        .collect::<Result<_, _>>()?;
-                    surv[i]
-                        .merge_batch(&arrays)
-                        .map_err(|e| DbError::Pipeline(format!("session merge: {e}")))?;
-                }
-            } else {
-                survivor_accs = Some(sess.accs);
+            for (i, acc) in sess.accs.iter_mut().enumerate() {
+                let state = acc
+                    .state()
+                    .map_err(|e| DbError::Pipeline(format!("session merge state: {e}")))?;
+                let arrays: Vec<ArrayRef> = state
+                    .iter()
+                    .map(|sv| {
+                        sv.to_array()
+                            .map_err(|e| DbError::Pipeline(format!("session merge array: {e}")))
+                    })
+                    .collect::<Result<_, _>>()?;
+                accs[i]
+                    .merge_batch(&arrays)
+                    .map_err(|e| DbError::Pipeline(format!("session merge: {e}")))?;
             }
         }
-
-        let mut accs =
-            survivor_accs.expect("invariant: overlapping non-empty, survivor set on first iter");
         Self::update_accumulators(&mut accs, &self.agg_specs, batch, index_array)?;
+
+        for &sess_key in overlapping {
+            group.sessions.remove(&sess_key);
+        }
         group.sessions.insert(
             merged_start,
             SessionAccState {

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -713,7 +713,6 @@ impl CoreWindowState {
     /// Update per-window accumulators with a new pre-aggregation batch.
     ///
     /// Session windows use per-row processing because merge depends on insertion order.
-    #[allow(clippy::too_many_lines)]
     pub fn update_batch(&mut self, batch: &RecordBatch) -> Result<(), DbError> {
         if batch.num_rows() == 0 {
             return Ok(());
@@ -725,83 +724,92 @@ impl CoreWindowState {
             return self.update_batch_session(batch, &ts_array);
         }
 
-        let rows = if self.num_group_cols > 0 {
-            let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
-                .map(|i| Arc::clone(batch.column(i)))
-                .collect();
-            let rows = self
-                .row_converter
-                .convert_columns(&group_cols)
-                .map_err(|e| DbError::Pipeline(format!("row conversion: {e}")))?;
-            Some(rows)
+        if self.num_group_cols == 0 {
+            self.update_batch_nogroup(batch, &ts_array)
         } else {
-            None
-        };
+            self.update_batch_grouped(batch, &ts_array)
+        }
+    }
 
-        let has_groups = self.num_group_cols > 0;
-        if !has_groups {
-            let empty_key = crate::aggregate_state::global_aggregate_key();
-            let mut grouped = std::mem::take(&mut self.scratch_nogroup);
-            grouped.clear();
-            for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
-                if ts_ms == NULL_TIMESTAMP {
-                    continue;
+    fn update_batch_nogroup(
+        &mut self,
+        batch: &RecordBatch,
+        ts_array: &[i64],
+    ) -> Result<(), DbError> {
+        let empty_key = crate::aggregate_state::global_aggregate_key();
+        let mut grouped = std::mem::take(&mut self.scratch_nogroup);
+        grouped.clear();
+        for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
+            if ts_ms == NULL_TIMESTAMP {
+                continue;
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let idx = row_idx as u32;
+            match &self.assigner {
+                CoreWindowAssigner::Tumbling(a) => {
+                    let ws = a.assign(ts_ms).start;
+                    if self.is_window_closed(ws) {
+                        self.record_late_drop(1);
+                        continue;
+                    }
+                    grouped.entry(ws).or_default().push(idx);
                 }
-                #[allow(clippy::cast_possible_truncation)]
-                let idx = row_idx as u32;
-                match &self.assigner {
-                    CoreWindowAssigner::Tumbling(a) => {
-                        let ws = a.assign(ts_ms).start;
-                        if self.is_window_closed(ws) {
+                CoreWindowAssigner::Hopping(a) => {
+                    for wid in a.assign_windows(ts_ms) {
+                        if self.is_window_closed(wid.start) {
                             self.record_late_drop(1);
                             continue;
                         }
-                        grouped.entry(ws).or_default().push(idx);
+                        grouped.entry(wid.start).or_default().push(idx);
                     }
-                    CoreWindowAssigner::Hopping(a) => {
-                        for wid in a.assign_windows(ts_ms) {
-                            if self.is_window_closed(wid.start) {
-                                self.record_late_drop(1);
-                                continue;
-                            }
-                            grouped.entry(wid.start).or_default().push(idx);
-                        }
-                    }
-                    CoreWindowAssigner::Session { .. } => unreachable!("handled above"),
                 }
+                CoreWindowAssigner::Session { .. } => unreachable!("handled above"),
             }
-            for (window_start, indices) in &grouped {
-                let needs_insert = {
-                    let wg = self.windows.entry(*window_start).or_default();
-                    !wg.contains_key(&empty_key)
-                };
-                if needs_insert {
-                    let accs = self.create_fresh_accumulators()?;
-                    self.windows
-                        .entry(*window_start)
-                        .or_default()
-                        .insert(empty_key.clone(), accs);
-                }
-                let Some(accs) = self
-                    .windows
-                    .get_mut(window_start)
-                    .and_then(|g| g.get_mut(&empty_key))
-                else {
-                    continue;
-                };
-                crate::aggregate_state::IncrementalAggState::update_group_accumulators(
-                    accs,
-                    batch,
-                    indices,
-                    &self.agg_specs,
-                    None,
-                )?;
-            }
-            self.scratch_nogroup = grouped;
-            return Ok(());
         }
+        for (window_start, indices) in &grouped {
+            let needs_insert = {
+                let wg = self.windows.entry(*window_start).or_default();
+                !wg.contains_key(&empty_key)
+            };
+            if needs_insert {
+                let accs = self.create_fresh_accumulators()?;
+                self.windows
+                    .entry(*window_start)
+                    .or_default()
+                    .insert(empty_key.clone(), accs);
+            }
+            let Some(accs) = self
+                .windows
+                .get_mut(window_start)
+                .and_then(|g| g.get_mut(&empty_key))
+            else {
+                continue;
+            };
+            crate::aggregate_state::IncrementalAggState::update_group_accumulators(
+                accs,
+                batch,
+                indices,
+                &self.agg_specs,
+                None,
+            )?;
+        }
+        self.scratch_nogroup = grouped;
+        Ok(())
+    }
 
-        let rows_ref = rows.as_ref().expect("rows set when has_groups");
+    fn update_batch_grouped(
+        &mut self,
+        batch: &RecordBatch,
+        ts_array: &[i64],
+    ) -> Result<(), DbError> {
+        let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
+            .map(|i| Arc::clone(batch.column(i)))
+            .collect();
+        let rows = self
+            .row_converter
+            .convert_columns(&group_cols)
+            .map_err(|e| DbError::Pipeline(format!("row conversion: {e}")))?;
+
         let mut grouped = std::mem::take(&mut self.scratch_grouped);
         let mut group_keys = std::mem::take(&mut self.scratch_group_keys);
         grouped.clear();
@@ -811,7 +819,7 @@ impl CoreWindowState {
             if ts_ms == NULL_TIMESTAMP {
                 continue;
             }
-            let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
+            let (gid, _) = group_keys.insert_full(rows.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
             let (gid, idx) = (gid as u32, row_idx as u32);
             match &self.assigner {
@@ -938,7 +946,6 @@ impl CoreWindowState {
     }
 
     /// Update accumulators for a session window, merging overlapping sessions.
-    #[allow(clippy::too_many_lines)]
     fn update_session_window(
         &mut self,
         ts_ms: i64,
@@ -1013,58 +1020,78 @@ impl CoreWindowState {
                 }
             }
             _ => {
-                let group = self
-                    .session_groups
-                    .get_mut(key)
-                    .expect("invariant: key present (overlapping derived from same group)");
-                let mut merged_start = new_start;
-                let mut merged_end = new_end;
-                let mut survivor_accs: Option<Vec<Box<dyn datafusion_expr::Accumulator>>> = None;
-
-                for &sess_key in &overlapping {
-                    let sess = group
-                        .sessions
-                        .remove(&sess_key)
-                        .expect("invariant: overlapping keys are unique BTreeMap entries");
-                    merged_start = merged_start.min(sess.start);
-                    merged_end = merged_end.max(sess.end);
-
-                    if let Some(ref mut surv) = survivor_accs {
-                        for (i, mut acc) in sess.accs.into_iter().enumerate() {
-                            let state = acc.state().map_err(|e| {
-                                DbError::Pipeline(format!("session merge state: {e}"))
-                            })?;
-                            let arrays: Vec<ArrayRef> = state
-                                .iter()
-                                .map(|sv| {
-                                    sv.to_array().map_err(|e| {
-                                        DbError::Pipeline(format!("session merge array: {e}"))
-                                    })
-                                })
-                                .collect::<Result<_, _>>()?;
-                            surv[i]
-                                .merge_batch(&arrays)
-                                .map_err(|e| DbError::Pipeline(format!("session merge: {e}")))?;
-                        }
-                    } else {
-                        survivor_accs = Some(sess.accs);
-                    }
-                }
-
-                let mut accs = survivor_accs
-                    .expect("invariant: overlapping non-empty, survivor set on first iter");
-                Self::update_accumulators(&mut accs, &self.agg_specs, batch, index_array)?;
-                group.sessions.insert(
-                    merged_start,
-                    SessionAccState {
-                        start: merged_start,
-                        end: merged_end,
-                        accs,
-                    },
-                );
+                self.merge_overlapping_sessions(
+                    key,
+                    &overlapping,
+                    new_start,
+                    new_end,
+                    batch,
+                    index_array,
+                )?;
             }
         }
 
+        Ok(())
+    }
+
+    /// Merge several overlapping sessions into one, folding their accumulators.
+    fn merge_overlapping_sessions(
+        &mut self,
+        key: &arrow::row::OwnedRow,
+        overlapping: &[i64],
+        new_start: i64,
+        new_end: i64,
+        batch: &RecordBatch,
+        index_array: &arrow::array::UInt32Array,
+    ) -> Result<(), DbError> {
+        let group = self
+            .session_groups
+            .get_mut(key)
+            .expect("invariant: key present (overlapping derived from same group)");
+        let mut merged_start = new_start;
+        let mut merged_end = new_end;
+        let mut survivor_accs: Option<Vec<Box<dyn datafusion_expr::Accumulator>>> = None;
+
+        for &sess_key in overlapping {
+            let sess = group
+                .sessions
+                .remove(&sess_key)
+                .expect("invariant: overlapping keys are unique BTreeMap entries");
+            merged_start = merged_start.min(sess.start);
+            merged_end = merged_end.max(sess.end);
+
+            if let Some(ref mut surv) = survivor_accs {
+                for (i, mut acc) in sess.accs.into_iter().enumerate() {
+                    let state = acc
+                        .state()
+                        .map_err(|e| DbError::Pipeline(format!("session merge state: {e}")))?;
+                    let arrays: Vec<ArrayRef> = state
+                        .iter()
+                        .map(|sv| {
+                            sv.to_array()
+                                .map_err(|e| DbError::Pipeline(format!("session merge array: {e}")))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    surv[i]
+                        .merge_batch(&arrays)
+                        .map_err(|e| DbError::Pipeline(format!("session merge: {e}")))?;
+                }
+            } else {
+                survivor_accs = Some(sess.accs);
+            }
+        }
+
+        let mut accs =
+            survivor_accs.expect("invariant: overlapping non-empty, survivor set on first iter");
+        Self::update_accumulators(&mut accs, &self.agg_specs, batch, index_array)?;
+        group.sessions.insert(
+            merged_start,
+            SessionAccState {
+                start: merged_start,
+                end: merged_end,
+                accs,
+            },
+        );
         Ok(())
     }
 

--- a/crates/laminar-db/src/core_window_state.rs
+++ b/crates/laminar-db/src/core_window_state.rs
@@ -22,8 +22,8 @@ use laminar_sql::parser::EmitClause;
 use laminar_sql::translator::{WindowOperatorConfig, WindowType};
 
 use crate::aggregate_state::{
-    compile_having_filter, expr_to_sql, extract_clauses, find_aggregate, resolve_expr_type,
-    AggFuncSpec, CompiledProjection, GroupCheckpoint, WindowCheckpoint,
+    compile_having_filter, expr_to_sql, extract_clauses, find_aggregate, AggFuncSpec,
+    CompiledProjection, GroupCheckpoint, PreAggBuilder, WindowCheckpoint,
 };
 use crate::eowc_state::{extract_i64_timestamps, NULL_TIMESTAMP};
 use crate::error::DbError;
@@ -260,9 +260,6 @@ impl CoreWindowState {
         let state_ref = ctx.state();
         let compile_props = state_ref.execution_props();
         let input_df_schema = &agg_info.input_df_schema;
-        let mut compiled_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
-        let mut proj_fields: Vec<Field> = Vec::new();
-        let mut compile_ok = compile_source.is_some();
 
         // A Projection above the Aggregate makes the top schema differ.
         let has_projection = {
@@ -330,36 +327,15 @@ impl CoreWindowState {
             group_types.push(agg_field.data_type().clone());
         }
 
-        let mut agg_specs = Vec::new();
-        let mut pre_agg_select_items: Vec<String> = Vec::new();
+        let compile = |e: &datafusion_expr::Expr| {
+            create_physical_expr(e, input_df_schema, compile_props).ok()
+        };
+        let mut builder =
+            PreAggBuilder::new(&input_schema, num_group_cols, compile_source.is_some());
 
         for (i, group_expr) in group_exprs.iter().enumerate() {
-            if let datafusion_expr::Expr::Column(col) = group_expr {
-                pre_agg_select_items.push(format!("\"{}\"", col.name));
-            } else {
-                let group_sql = expr_to_sql(group_expr);
-                pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
-            }
-
-            if compile_ok {
-                match create_physical_expr(group_expr, input_df_schema, compile_props) {
-                    Ok(phys) => {
-                        let dt = phys
-                            .data_type(input_df_schema.as_arrow())
-                            .unwrap_or(DataType::Utf8);
-                        let name = match group_expr {
-                            datafusion_expr::Expr::Column(col) => col.name.clone(),
-                            _ => format!("__group_{i}"),
-                        };
-                        proj_fields.push(Field::new(name, dt, true));
-                        compiled_exprs.push(phys);
-                    }
-                    Err(_) => compile_ok = false,
-                }
-            }
+            builder.push_group_expr(i, group_expr, &compile);
         }
-
-        let mut next_col_idx = num_group_cols;
 
         for (i, expr) in aggr_exprs.iter().enumerate() {
             let agg_schema_idx = num_group_cols + i;
@@ -371,167 +347,17 @@ impl CoreWindowState {
             } else {
                 agg_field.name().clone()
             };
-
-            if let datafusion_expr::Expr::AggregateFunction(agg_func) = expr {
-                let udf = Arc::clone(&agg_func.func);
-                let is_distinct = agg_func.params.distinct;
-
-                let mut input_col_indices = Vec::new();
-                let mut input_types = Vec::new();
-
-                if agg_func.params.args.is_empty() {
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    pre_agg_select_items.push(format!("TRUE AS \"__agg_input_{col_idx}\""));
-                    input_col_indices.push(col_idx);
-                    input_types.push(DataType::Boolean);
-
-                    if compile_ok {
-                        match create_physical_expr(
-                            &datafusion_expr::lit(true),
-                            input_df_schema,
-                            compile_props,
-                        ) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_input_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-                } else {
-                    for arg_expr in &agg_func.params.args {
-                        let col_idx = next_col_idx;
-                        next_col_idx += 1;
-                        let expr_sql = expr_to_sql(arg_expr);
-
-                        if let Some(filter_expr) = &agg_func.params.filter {
-                            let filter_sql = expr_to_sql(filter_expr);
-                            pre_agg_select_items.push(format!(
-                                "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
-                            ));
-
-                            if compile_ok {
-                                let case_expr =
-                                    datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                                        expr: None,
-                                        when_then_expr: vec![(
-                                            Box::new(filter_expr.as_ref().clone()),
-                                            Box::new(arg_expr.clone()),
-                                        )],
-                                        else_expr: Some(Box::new(datafusion_expr::lit(
-                                            ScalarValue::Null,
-                                        ))),
-                                    });
-                                match create_physical_expr(
-                                    &case_expr,
-                                    input_df_schema,
-                                    compile_props,
-                                ) {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        } else {
-                            pre_agg_select_items
-                                .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
-
-                            if compile_ok {
-                                match create_physical_expr(arg_expr, input_df_schema, compile_props)
-                                {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        }
-
-                        input_col_indices.push(col_idx);
-                        let dt = resolve_expr_type(arg_expr, &input_schema, agg_field.data_type());
-                        input_types.push(dt);
-                    }
-                }
-
-                let filter_col_index = if let Some(filter_expr) = &agg_func.params.filter {
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    let filter_sql = expr_to_sql(filter_expr);
-                    pre_agg_select_items.push(format!(
-                        "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
-                    ));
-
-                    if compile_ok {
-                        let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                            expr: None,
-                            when_then_expr: vec![(
-                                Box::new(filter_expr.as_ref().clone()),
-                                Box::new(datafusion_expr::lit(true)),
-                            )],
-                            else_expr: Some(Box::new(datafusion_expr::lit(false))),
-                        });
-                        match create_physical_expr(&case_expr, input_df_schema, compile_props) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_filter_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-
-                    Some(col_idx)
-                } else {
-                    None
-                };
-
-                let return_type = udf
-                    .return_type(&input_types)
-                    .unwrap_or_else(|_| agg_field.data_type().clone());
-
-                agg_specs.push(AggFuncSpec {
-                    udf,
-                    input_types,
-                    input_col_indices,
-                    output_name,
-                    return_type,
-                    distinct: is_distinct,
-                    is_count_star: agg_func.params.args.is_empty(),
-                    filter_col_index,
-                });
-            } else {
+            if !builder.push_aggregate(expr, output_name, agg_field, &compile) {
                 return Ok(None);
             }
         }
+
+        let mut compile_ok = builder.compile_ok;
+        let next_col_idx = builder.next_col_idx;
+        let mut pre_agg_select_items = builder.pre_agg_select_items;
+        let agg_specs = builder.agg_specs;
+        let mut compiled_exprs = builder.compiled_exprs;
+        let mut proj_fields = builder.proj_fields;
 
         let time_col_index = next_col_idx;
         pre_agg_select_items.push(format!("\"{}\" AS \"__cw_ts\"", window_config.time_column));

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -972,7 +972,6 @@ impl LaminarDB {
     }
 
     /// Register a materialized view and wire it into the running pipeline.
-    #[allow(clippy::too_many_lines)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn handle_create_materialized_view(
         &self,
@@ -987,54 +986,16 @@ impl LaminarDB {
         let name_str = name.to_string();
         reject_reserved_namespace(&name_str)?;
 
-        {
-            let registry = self.mv_registry.lock();
-            if registry.get(&name_str).is_some() {
-                if if_not_exists {
-                    return Ok(ExecuteResult::Ddl(DdlInfo {
-                        statement_type: "CREATE MATERIALIZED VIEW".to_string(),
-                        object_name: name_str,
-                    }));
-                }
-                if !or_replace {
-                    return Err(DbError::MaterializedView(format!(
-                        "Materialized view '{name_str}' already exists"
-                    )));
-                }
-            }
+        if self.mv_exists_guard(&name_str, if_not_exists, or_replace)? {
+            return Ok(ExecuteResult::Ddl(DdlInfo {
+                statement_type: "CREATE MATERIALIZED VIEW".to_string(),
+                object_name: name_str,
+            }));
         }
 
         let query_sql = query_sql.to_string();
-
-        // Planning is cheaper than execution; fall back for ASOF and other joins DataFusion can't lower.
-        let schema =
-            match crate::pipeline_lifecycle::plan_output_schema(&self.ctx, &query_sql).await {
-                Some(s) => s,
-                None => match self.handle_query(&query_sql).await? {
-                    ExecuteResult::Query(qh) => qh.schema().clone(),
-                    _ => Arc::new(Schema::new(vec![Field::new(
-                        "result",
-                        DataType::Utf8,
-                        true,
-                    )])),
-                },
-            };
-
-        let table_refs = crate::sql_analysis::extract_table_references(&query_sql);
-        let catalog_sources = self.catalog.list_sources();
-        let mut sources: Vec<String> = catalog_sources
-            .into_iter()
-            .filter(|s| table_refs.contains(s.as_str()))
-            .collect();
-
-        {
-            let registry = self.mv_registry.lock();
-            for view in registry.views() {
-                if view.name != name_str && table_refs.contains(view.name.as_str()) {
-                    sources.push(view.name.clone());
-                }
-            }
-        }
+        let schema = self.resolve_mv_schema(&query_sql).await?;
+        let sources = self.collect_mv_sources(&query_sql, &name_str);
 
         {
             let mv =
@@ -1086,53 +1047,8 @@ impl LaminarDB {
             });
         }
 
-        {
-            use crate::mv_store::MvStorageMode;
-
-            // Non-windowed aggs emit all groups every cycle (replace-all); windowed aggs emit
-            // only closing windows (append) so previous windows aren't overwritten.
-            let has_aggregate = self.ctx.sql(&query_sql).await.ok().is_some_and(|df| {
-                crate::aggregate_state::find_aggregate(df.logical_plan()).is_some()
-            });
-            let mode = if has_aggregate && plan_window.is_none() {
-                MvStorageMode::Aggregate
-            } else {
-                MvStorageMode::append_default()
-            };
-
-            self.mv_store
-                .write()
-                .create_mv(&name_str, schema.clone(), mode);
-
-            let mv_provider = crate::table_provider::MvTableProvider::new(
-                name_str.clone(),
-                schema.clone(),
-                self.mv_store.clone(),
-            );
-
-            // In cluster mode each node owns a vnode slice; wrap to union peers on read.
-            #[cfg(feature = "cluster")]
-            let provider: Arc<dyn datafusion::datasource::TableProvider> =
-                if let Some(controller) = self.cluster_controller.lock().clone() {
-                    Arc::new(
-                        laminar_sql::datafusion::distributed_scan::DistributedTableProvider::new(
-                            name_str.clone(),
-                            schema,
-                            Arc::new(mv_provider),
-                            controller,
-                        ),
-                    )
-                } else {
-                    Arc::new(mv_provider)
-                };
-            #[cfg(not(feature = "cluster"))]
-            let provider: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(mv_provider);
-
-            let _ = self.ctx.deregister_table(&name_str);
-            self.ctx.register_table(&name_str, provider).map_err(|e| {
-                DbError::MaterializedView(format!("Failed to register MV table provider: {e}"))
-            })?;
-        }
+        self.register_mv_provider(&name_str, schema, &query_sql, plan_window.is_some())
+            .await?;
 
         // Hot-add to running pipeline; roll back on a saturated channel so retry is clean.
         if let Some(ref tx) = *self.control_tx.lock() {
@@ -1159,6 +1075,119 @@ impl LaminarDB {
             statement_type: "CREATE MATERIALIZED VIEW".to_string(),
             object_name: name_str,
         }))
+    }
+
+    /// Returns `true` when an existing MV means the caller should no-op
+    /// (`IF NOT EXISTS`). Errors when it exists without `OR REPLACE`.
+    fn mv_exists_guard(
+        &self,
+        name_str: &str,
+        if_not_exists: bool,
+        or_replace: bool,
+    ) -> Result<bool, DbError> {
+        let registry = self.mv_registry.lock();
+        if registry.get(name_str).is_some() {
+            if if_not_exists {
+                return Ok(true);
+            }
+            if !or_replace {
+                return Err(DbError::MaterializedView(format!(
+                    "Materialized view '{name_str}' already exists"
+                )));
+            }
+        }
+        Ok(false)
+    }
+
+    /// Resolve the MV output schema by planning the query, falling back to
+    /// execution for shapes `DataFusion` can't lower (ASOF and other joins).
+    async fn resolve_mv_schema(&self, query_sql: &str) -> Result<Arc<Schema>, DbError> {
+        if let Some(s) = crate::pipeline_lifecycle::plan_output_schema(&self.ctx, query_sql).await {
+            return Ok(s);
+        }
+        Ok(match self.handle_query(query_sql).await? {
+            ExecuteResult::Query(qh) => qh.schema().clone(),
+            _ => Arc::new(Schema::new(vec![Field::new(
+                "result",
+                DataType::Utf8,
+                true,
+            )])),
+        })
+    }
+
+    /// Collect the base sources and upstream MVs this view reads from.
+    fn collect_mv_sources(&self, query_sql: &str, name_str: &str) -> Vec<String> {
+        let table_refs = crate::sql_analysis::extract_table_references(query_sql);
+        let mut sources: Vec<String> = self
+            .catalog
+            .list_sources()
+            .into_iter()
+            .filter(|s| table_refs.contains(s.as_str()))
+            .collect();
+        let registry = self.mv_registry.lock();
+        for view in registry.views() {
+            if view.name != name_str && table_refs.contains(view.name.as_str()) {
+                sources.push(view.name.clone());
+            }
+        }
+        sources
+    }
+
+    /// Create MV storage and register its `DataFusion` table provider. In cluster
+    /// mode the provider is wrapped to union peer vnode slices on read.
+    async fn register_mv_provider(
+        &self,
+        name_str: &str,
+        schema: Arc<Schema>,
+        query_sql: &str,
+        has_window: bool,
+    ) -> Result<(), DbError> {
+        use crate::mv_store::MvStorageMode;
+
+        // Non-windowed aggs emit all groups every cycle (replace-all); windowed aggs emit
+        // only closing windows (append) so previous windows aren't overwritten.
+        let has_aggregate =
+            self.ctx.sql(query_sql).await.ok().is_some_and(|df| {
+                crate::aggregate_state::find_aggregate(df.logical_plan()).is_some()
+            });
+        let mode = if has_aggregate && !has_window {
+            MvStorageMode::Aggregate
+        } else {
+            MvStorageMode::append_default()
+        };
+
+        self.mv_store
+            .write()
+            .create_mv(name_str, schema.clone(), mode);
+
+        let mv_provider = crate::table_provider::MvTableProvider::new(
+            name_str.to_string(),
+            schema.clone(),
+            self.mv_store.clone(),
+        );
+
+        #[cfg(feature = "cluster")]
+        let provider: Arc<dyn datafusion::datasource::TableProvider> =
+            if let Some(controller) = self.cluster_controller.lock().clone() {
+                Arc::new(
+                    laminar_sql::datafusion::distributed_scan::DistributedTableProvider::new(
+                        name_str.to_string(),
+                        schema,
+                        Arc::new(mv_provider),
+                        controller,
+                    ),
+                )
+            } else {
+                Arc::new(mv_provider)
+            };
+        #[cfg(not(feature = "cluster"))]
+        let provider: Arc<dyn datafusion::datasource::TableProvider> = Arc::new(mv_provider);
+
+        let _ = self.ctx.deregister_table(name_str);
+        self.ctx.register_table(name_str, provider).map_err(|e| {
+            DbError::MaterializedView(format!("Failed to register MV table provider: {e}"))
+        })?;
+        Ok(())
     }
 
     /// Handle DROP MATERIALIZED VIEW statement.

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -32,6 +32,137 @@ fn reject_reserved_namespace(name: &str) -> Result<(), DbError> {
     Ok(())
 }
 
+/// Parsed `WITH (...)` clause of a `CREATE TABLE`.
+#[derive(Default)]
+struct CreateTableWith {
+    connector_type: Option<String>,
+    connector_options: HashMap<String, String>,
+    format: Option<String>,
+    format_options: HashMap<String, String>,
+    refresh_mode: Option<laminar_connectors::reference::RefreshMode>,
+    cache_mode: Option<crate::table_cache_mode::TableCacheMode>,
+    cache_max_entries: Option<usize>,
+    cache_max_bytes: Option<usize>,
+    cache_ttl: Option<std::time::Duration>,
+    storage: Option<String>,
+}
+
+fn build_table_fields(create: &sqlparser::ast::CreateTable) -> Result<Vec<Field>, DbError> {
+    create
+        .columns
+        .iter()
+        .map(|col| {
+            let data_type = streaming_ddl::sql_type_to_arrow(&col.data_type).map_err(|e| {
+                DbError::InvalidOperation(format!(
+                    "unsupported column type for '{}': {e}",
+                    col.name
+                ))
+            })?;
+            let nullable = !col
+                .options
+                .iter()
+                .any(|opt| matches!(opt.option, sqlparser::ast::ColumnOption::NotNull));
+            Ok(Field::new(col.name.value.clone(), data_type, nullable))
+        })
+        .collect()
+}
+
+fn extract_primary_key(create: &sqlparser::ast::CreateTable) -> Option<String> {
+    for col in &create.columns {
+        for opt in &col.options {
+            if matches!(
+                opt.option,
+                sqlparser::ast::ColumnOption::Unique {
+                    is_primary: true,
+                    ..
+                }
+            ) {
+                return Some(col.name.value.clone());
+            }
+        }
+    }
+    for constraint in &create.constraints {
+        if let sqlparser::ast::TableConstraint::PrimaryKey { columns, .. } = constraint {
+            if let Some(first) = columns.first() {
+                return Some(match &first.column.expr {
+                    sqlparser::ast::Expr::Identifier(ident) => ident.value.clone(),
+                    other => other.to_string(),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn parse_create_table_with(
+    with_options: &[sqlparser::ast::SqlOption],
+) -> Result<CreateTableWith, DbError> {
+    let mut out = CreateTableWith {
+        connector_options: HashMap::with_capacity(8),
+        format_options: HashMap::with_capacity(4),
+        ..Default::default()
+    };
+    for opt in with_options {
+        let sqlparser::ast::SqlOption::KeyValue { key, value } = opt else {
+            continue;
+        };
+        let k = key.to_string().to_lowercase();
+        let val = value.to_string().trim_matches('\'').to_string();
+        match k.as_str() {
+            "connector" => out.connector_type = Some(val),
+            "format" => out.format = Some(val),
+            "refresh" => {
+                out.refresh_mode = Some(crate::connector_manager::parse_refresh_mode(&val)?);
+            }
+            "cache_mode" | "cache.mode" => {
+                out.cache_mode = Some(crate::table_cache_mode::parse_cache_mode(&val)?);
+            }
+            "cache_max_entries" | "cache.max_entries" => {
+                out.cache_max_entries = Some(val.parse::<usize>().map_err(|_| {
+                    DbError::InvalidOperation(format!(
+                        "Invalid cache_max_entries '{val}': expected positive integer"
+                    ))
+                })?);
+            }
+            "cache_max_bytes" | "cache.max_bytes" | "cache.memory" => {
+                let bytes = val.parse::<usize>().map_err(|_| {
+                    DbError::InvalidOperation(format!(
+                        "Invalid cache_max_bytes '{val}': expected positive integer"
+                    ))
+                })?;
+                if bytes == 0 {
+                    return Err(DbError::InvalidOperation(format!(
+                        "Invalid cache_max_bytes '{val}': expected positive integer"
+                    )));
+                }
+                out.cache_max_bytes = Some(bytes);
+            }
+            "cache_ttl" | "cache.ttl" => {
+                let secs = val.parse::<u64>().map_err(|_| {
+                    DbError::InvalidOperation(format!(
+                        "Invalid cache_ttl '{val}': expected positive integer seconds"
+                    ))
+                })?;
+                if secs == 0 {
+                    return Err(DbError::InvalidOperation(format!(
+                        "Invalid cache_ttl '{val}': expected positive integer seconds"
+                    )));
+                }
+                out.cache_ttl = Some(std::time::Duration::from_secs(secs));
+            }
+            "storage" => out.storage = Some(val),
+            kk if kk.starts_with("format.") => {
+                out.format_options
+                    .insert(kk.strip_prefix("format.").unwrap().to_string(), val);
+            }
+            _ => {
+                out.connector_options.insert(k, val);
+            }
+        }
+    }
+    Ok(out)
+}
+
 impl LaminarDB {
     /// Resolve `${VAR}` in connector + format options (config vars, then env) and
     /// verify the type is registered + format known — up front, before any
@@ -82,7 +213,6 @@ impl LaminarDB {
         Ok(Some(resolved))
     }
 
-    #[allow(clippy::too_many_lines)]
     pub(crate) async fn handle_create_source(
         &self,
         create: &laminar_sql::parser::CreateSourceStatement,
@@ -117,59 +247,126 @@ impl LaminarDB {
             ConnectorKind::Source,
         )?;
 
-        let source_def = if create.columns.is_empty() && has_connector {
-            let resolved = resolved.as_ref().expect("has_connector ⇒ Some");
-            let connector_type = resolved.connector_type.as_deref().ok_or_else(|| {
-                DbError::Config(format!(
-                    "source '{source_name}': no columns declared and no connector type resolved"
-                ))
-            })?;
-            let normalized = normalize_connector_type(connector_type);
+        let source_def = self
+            .build_source_definition(create, resolved.as_ref(), has_connector, &source_name)
+            .await?;
 
-            let mut props = resolved.connector_options.clone();
-            if let Some(fmt) = resolved.format.clone() {
-                props.insert("format".into(), fmt);
+        let entry = self.register_source_entry(create, &source_def)?;
+        let name = &source_def.name;
+
+        if let Some(ref entry) = entry {
+            if create.or_replace {
+                let _ = self.ctx.deregister_table(name);
             }
-            props.extend(resolved.format_options.clone());
+            let num_partitions = self.ctx.state().config().target_partitions();
+            let provider = crate::table_provider::SourceSnapshotProvider::new(
+                Arc::clone(entry),
+                num_partitions,
+            );
+            if let Err(e) = self.ctx.register_table(name, Arc::new(provider)) {
+                tracing::warn!(table = %name, error = %e, "failed to register source table in DataFusion");
+            }
+        }
 
-            let discovered = match self
-                .connector_registry
-                .default_source_schema(&normalized, &props)
-                .await
-            {
-                Ok(Some(s)) => s,
-                Ok(None) => {
-                    return Err(DbError::Config(format!(
-                        "source '{source_name}': no columns declared and connector \
-                         '{normalized}' could not auto-discover a schema (declare \
-                         columns explicitly or check that the format supports \
-                         schema discovery)"
-                    )));
-                }
-                Err(e) => {
-                    return Err(DbError::Config(format!(
-                        "source '{source_name}': schema auto-discovery failed: {e}"
-                    )));
-                }
-            };
+        self.mv_registry.lock().register_base_table(name);
 
-            let columns: Vec<ColumnDefinition> = discovered
-                .fields()
-                .iter()
-                .map(|f| ColumnDefinition {
-                    name: f.name().clone(),
-                    data_type: f.data_type().clone(),
-                    nullable: f.is_nullable(),
-                })
-                .collect();
+        {
+            let mut planner = self.planner.lock();
+            let stmt = StreamingStatement::CreateSource(Box::new(create.clone()));
+            if let Err(e) = planner.plan(&stmt) {
+                tracing::warn!(source = %name, error = %e, "failed to register source in planner");
+            }
+        }
 
-            streaming_ddl::translate_create_source_with_columns(create.clone(), columns)
-                .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)))?
-        } else {
-            streaming_ddl::translate_create_source(create.clone())
-                .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)))?
+        if let Some(resolved) = resolved {
+            if let Some(ct) = resolved.connector_type {
+                let mut mgr = self.connector_manager.lock();
+                mgr.register_source(crate::connector_manager::SourceRegistration {
+                    name: name.clone(),
+                    connector_type: Some(ct),
+                    connector_options: resolved.connector_options,
+                    format: resolved.format,
+                    format_options: resolved.format_options,
+                });
+            }
+        }
+
+        Ok(ExecuteResult::Ddl(DdlInfo {
+            statement_type: "CREATE SOURCE".to_string(),
+            object_name: name.clone(),
+        }))
+    }
+
+    /// Translate a `CREATE SOURCE` to a `SourceDefinition`, auto-discovering the
+    /// schema from the connector when no columns are declared.
+    async fn build_source_definition(
+        &self,
+        create: &laminar_sql::parser::CreateSourceStatement,
+        resolved: Option<&ResolvedConnector>,
+        has_connector: bool,
+        source_name: &str,
+    ) -> Result<streaming_ddl::SourceDefinition, DbError> {
+        if !(create.columns.is_empty() && has_connector) {
+            return streaming_ddl::translate_create_source(create.clone())
+                .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)));
+        }
+
+        let resolved = resolved.expect("has_connector ⇒ Some");
+        let connector_type = resolved.connector_type.as_deref().ok_or_else(|| {
+            DbError::Config(format!(
+                "source '{source_name}': no columns declared and no connector type resolved"
+            ))
+        })?;
+        let normalized = normalize_connector_type(connector_type);
+
+        let mut props = resolved.connector_options.clone();
+        if let Some(fmt) = resolved.format.clone() {
+            props.insert("format".into(), fmt);
+        }
+        props.extend(resolved.format_options.clone());
+
+        let discovered = match self
+            .connector_registry
+            .default_source_schema(&normalized, &props)
+            .await
+        {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                return Err(DbError::Config(format!(
+                    "source '{source_name}': no columns declared and connector \
+                     '{normalized}' could not auto-discover a schema (declare \
+                     columns explicitly or check that the format supports \
+                     schema discovery)"
+                )));
+            }
+            Err(e) => {
+                return Err(DbError::Config(format!(
+                    "source '{source_name}': schema auto-discovery failed: {e}"
+                )));
+            }
         };
 
+        let columns: Vec<ColumnDefinition> = discovered
+            .fields()
+            .iter()
+            .map(|f| ColumnDefinition {
+                name: f.name().clone(),
+                data_type: f.data_type().clone(),
+                nullable: f.is_nullable(),
+            })
+            .collect();
+
+        streaming_ddl::translate_create_source_with_columns(create.clone(), columns)
+            .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)))
+    }
+
+    /// Register a source in the catalog per the `OR REPLACE` / `IF NOT EXISTS`
+    /// semantics, returning the entry (`None` when an existing one was kept).
+    fn register_source_entry(
+        &self,
+        create: &laminar_sql::parser::CreateSourceStatement,
+        source_def: &streaming_ddl::SourceDefinition,
+    ) -> Result<Option<Arc<crate::catalog::SourceEntry>>, DbError> {
         let name = &source_def.name;
         let schema = source_def.schema.clone();
         let watermark_col = source_def.watermark.as_ref().map(|w| w.column.clone());
@@ -227,47 +424,7 @@ impl LaminarDB {
             }
         }
 
-        if let Some(ref entry) = entry {
-            if create.or_replace {
-                let _ = self.ctx.deregister_table(name);
-            }
-            let num_partitions = self.ctx.state().config().target_partitions();
-            let provider = crate::table_provider::SourceSnapshotProvider::new(
-                Arc::clone(entry),
-                num_partitions,
-            );
-            if let Err(e) = self.ctx.register_table(name, Arc::new(provider)) {
-                tracing::warn!(table = %name, error = %e, "failed to register source table in DataFusion");
-            }
-        }
-
-        self.mv_registry.lock().register_base_table(name);
-
-        {
-            let mut planner = self.planner.lock();
-            let stmt = StreamingStatement::CreateSource(Box::new(create.clone()));
-            if let Err(e) = planner.plan(&stmt) {
-                tracing::warn!(source = %name, error = %e, "failed to register source in planner");
-            }
-        }
-
-        if let Some(resolved) = resolved {
-            if let Some(ct) = resolved.connector_type {
-                let mut mgr = self.connector_manager.lock();
-                mgr.register_source(crate::connector_manager::SourceRegistration {
-                    name: name.clone(),
-                    connector_type: Some(ct),
-                    connector_options: resolved.connector_options,
-                    format: resolved.format,
-                    format_options: resolved.format_options,
-                });
-            }
-        }
-
-        Ok(ExecuteResult::Ddl(DdlInfo {
-            statement_type: "CREATE SOURCE".to_string(),
-            object_name: name.clone(),
-        }))
+        Ok(entry)
     }
 
     pub(crate) fn handle_create_sink(
@@ -337,7 +494,6 @@ impl LaminarDB {
         }))
     }
 
-    #[allow(clippy::too_many_lines)]
     pub(crate) fn handle_create_table(
         &self,
         create: &sqlparser::ast::CreateTable,
@@ -345,144 +501,23 @@ impl LaminarDB {
         let name = create.name.to_string();
         reject_reserved_namespace(&name)?;
 
-        let fields: Vec<arrow::datatypes::Field> = create
-            .columns
-            .iter()
-            .map(|col| {
-                let data_type = streaming_ddl::sql_type_to_arrow(&col.data_type).map_err(|e| {
-                    DbError::InvalidOperation(format!(
-                        "unsupported column type for '{}': {e}",
-                        col.name
-                    ))
-                })?;
-                let nullable = !col
-                    .options
-                    .iter()
-                    .any(|opt| matches!(opt.option, sqlparser::ast::ColumnOption::NotNull));
-                Ok(arrow::datatypes::Field::new(
-                    col.name.value.clone(),
-                    data_type,
-                    nullable,
-                ))
-            })
-            .collect::<Result<Vec<_>, DbError>>()?;
-
-        let schema = Arc::new(arrow::datatypes::Schema::new(fields));
-
-        let mut primary_key: Option<String> = None;
-
-        for col in &create.columns {
-            for opt in &col.options {
-                if matches!(
-                    opt.option,
-                    sqlparser::ast::ColumnOption::Unique {
-                        is_primary: true,
-                        ..
-                    }
-                ) {
-                    primary_key = Some(col.name.value.clone());
-                    break;
-                }
-            }
-            if primary_key.is_some() {
-                break;
-            }
-        }
-
-        if primary_key.is_none() {
-            for constraint in &create.constraints {
-                if let sqlparser::ast::TableConstraint::PrimaryKey { columns, .. } = constraint {
-                    if let Some(first) = columns.first() {
-                        primary_key = match &first.column.expr {
-                            sqlparser::ast::Expr::Identifier(ident) => Some(ident.value.clone()),
-                            other => Some(other.to_string()),
-                        };
-                    }
-                }
-            }
-        }
-
-        let mut connector_type: Option<String> = None;
-        let mut connector_options: HashMap<String, String> = HashMap::with_capacity(8);
-        let mut format: Option<String> = None;
-        let mut format_options: HashMap<String, String> = HashMap::with_capacity(4);
-        let mut refresh_mode: Option<laminar_connectors::reference::RefreshMode> = None;
-        let mut cache_mode: Option<crate::table_cache_mode::TableCacheMode> = None;
-        let mut cache_max_entries: Option<usize> = None;
-        let mut cache_max_bytes: Option<usize> = None;
-        let mut cache_ttl: Option<std::time::Duration> = None;
-        let mut storage: Option<String> = None;
+        let schema = Arc::new(Schema::new(build_table_fields(create)?));
+        let primary_key = extract_primary_key(create);
 
         let with_options = match &create.table_options {
             sqlparser::ast::CreateTableOptions::With(opts) => opts.as_slice(),
             _ => &[],
         };
+        let opts = parse_create_table_with(with_options)?;
 
-        for opt in with_options {
-            if let sqlparser::ast::SqlOption::KeyValue { key, value } = opt {
-                let k = key.to_string().to_lowercase();
-                let val = value.to_string().trim_matches('\'').to_string();
-                match k.as_str() {
-                    "connector" => connector_type = Some(val),
-                    "format" => format = Some(val),
-                    "refresh" => {
-                        refresh_mode = Some(crate::connector_manager::parse_refresh_mode(&val)?);
-                    }
-                    "cache_mode" | "cache.mode" => {
-                        cache_mode = Some(crate::table_cache_mode::parse_cache_mode(&val)?);
-                    }
-                    "cache_max_entries" | "cache.max_entries" => {
-                        cache_max_entries = Some(val.parse::<usize>().map_err(|_| {
-                            DbError::InvalidOperation(format!(
-                                "Invalid cache_max_entries '{val}': expected positive integer"
-                            ))
-                        })?);
-                    }
-                    "cache_max_bytes" | "cache.max_bytes" | "cache.memory" => {
-                        let bytes = val.parse::<usize>().map_err(|_| {
-                            DbError::InvalidOperation(format!(
-                                "Invalid cache_max_bytes '{val}': expected positive integer"
-                            ))
-                        })?;
-                        if bytes == 0 {
-                            return Err(DbError::InvalidOperation(format!(
-                                "Invalid cache_max_bytes '{val}': expected positive integer"
-                            )));
-                        }
-                        cache_max_bytes = Some(bytes);
-                    }
-                    "cache_ttl" | "cache.ttl" => {
-                        let secs = val.parse::<u64>().map_err(|_| {
-                            DbError::InvalidOperation(format!(
-                                "Invalid cache_ttl '{val}': expected positive integer seconds"
-                            ))
-                        })?;
-                        if secs == 0 {
-                            return Err(DbError::InvalidOperation(format!(
-                                "Invalid cache_ttl '{val}': expected positive integer seconds"
-                            )));
-                        }
-                        cache_ttl = Some(std::time::Duration::from_secs(secs));
-                    }
-                    "storage" => storage = Some(val),
-                    kk if kk.starts_with("format.") => {
-                        format_options.insert(kk.strip_prefix("format.").unwrap().to_string(), val);
-                    }
-                    _ => {
-                        connector_options.insert(k, val);
-                    }
-                }
-            }
-        }
-
-        let resolved_cache_mode = match (&cache_mode, cache_max_entries) {
+        let resolved_cache_mode = match (&opts.cache_mode, opts.cache_max_entries) {
             (Some(crate::table_cache_mode::TableCacheMode::Partial { .. }), Some(max)) => {
                 Some(crate::table_cache_mode::TableCacheMode::Partial { max_entries: max })
             }
-            _ => cache_mode.clone(),
+            _ => opts.cache_mode.clone(),
         };
 
-        let is_persistent = storage.as_deref() == Some("persistent");
+        let is_persistent = opts.storage.as_deref() == Some("persistent");
 
         if let Some(ref pk) = primary_key {
             let cache = resolved_cache_mode
@@ -502,9 +537,9 @@ impl LaminarDB {
             }
         }
 
-        if connector_type.is_some() || !connector_options.is_empty() {
+        if opts.connector_type.is_some() || !opts.connector_options.is_empty() {
             if let Some(ref pk) = primary_key {
-                if let Some(ref ct) = connector_type {
+                if let Some(ref ct) = opts.connector_type {
                     let mut ts = self.table_store.write();
                     ts.set_connector(&name, ct);
                 }
@@ -513,13 +548,13 @@ impl LaminarDB {
                 mgr.register_table(crate::connector_manager::TableRegistration {
                     name: name.clone(),
                     primary_key: pk.clone(),
-                    connector_type: connector_type.clone(),
-                    connector_options,
-                    format,
-                    format_options,
-                    refresh: refresh_mode,
-                    cache_max_bytes,
-                    cache_ttl,
+                    connector_type: opts.connector_type.clone(),
+                    connector_options: opts.connector_options,
+                    format: opts.format,
+                    format_options: opts.format_options,
+                    refresh: opts.refresh_mode,
+                    cache_max_bytes: opts.cache_max_bytes,
+                    cache_ttl: opts.cache_ttl,
                 });
             }
         }

--- a/crates/laminar-db/src/ddl.rs
+++ b/crates/laminar-db/src/ddl.rs
@@ -118,11 +118,17 @@ fn parse_create_table_with(
                 out.cache_mode = Some(crate::table_cache_mode::parse_cache_mode(&val)?);
             }
             "cache_max_entries" | "cache.max_entries" => {
-                out.cache_max_entries = Some(val.parse::<usize>().map_err(|_| {
+                let entries = val.parse::<usize>().map_err(|_| {
                     DbError::InvalidOperation(format!(
                         "Invalid cache_max_entries '{val}': expected positive integer"
                     ))
-                })?);
+                })?;
+                if entries == 0 {
+                    return Err(DbError::InvalidOperation(format!(
+                        "Invalid cache_max_entries '{val}': expected positive integer"
+                    )));
+                }
+                out.cache_max_entries = Some(entries);
             }
             "cache_max_bytes" | "cache.max_bytes" | "cache.memory" => {
                 let bytes = val.parse::<usize>().map_err(|_| {
@@ -297,8 +303,7 @@ impl LaminarDB {
         }))
     }
 
-    /// Translate a `CREATE SOURCE` to a `SourceDefinition`, auto-discovering the
-    /// schema from the connector when no columns are declared.
+    /// Auto-discovers the schema from the connector when no columns are declared.
     async fn build_source_definition(
         &self,
         create: &laminar_sql::parser::CreateSourceStatement,
@@ -360,8 +365,7 @@ impl LaminarDB {
             .map_err(|e| DbError::Sql(laminar_sql::Error::ParseError(e)))
     }
 
-    /// Register a source in the catalog per the `OR REPLACE` / `IF NOT EXISTS`
-    /// semantics, returning the entry (`None` when an existing one was kept).
+    /// `None` when an existing source was kept (`IF NOT EXISTS`).
     fn register_source_entry(
         &self,
         create: &laminar_sql::parser::CreateSourceStatement,
@@ -1077,8 +1081,7 @@ impl LaminarDB {
         }))
     }
 
-    /// Returns `true` when an existing MV means the caller should no-op
-    /// (`IF NOT EXISTS`). Errors when it exists without `OR REPLACE`.
+    /// `true` ⇒ an existing MV should make the caller no-op (`IF NOT EXISTS`).
     fn mv_exists_guard(
         &self,
         name_str: &str,
@@ -1099,8 +1102,7 @@ impl LaminarDB {
         Ok(false)
     }
 
-    /// Resolve the MV output schema by planning the query, falling back to
-    /// execution for shapes `DataFusion` can't lower (ASOF and other joins).
+    /// Falls back to executing the query for shapes `DataFusion` can't plan (e.g. ASOF).
     async fn resolve_mv_schema(&self, query_sql: &str) -> Result<Arc<Schema>, DbError> {
         if let Some(s) = crate::pipeline_lifecycle::plan_output_schema(&self.ctx, query_sql).await {
             return Ok(s);
@@ -1115,7 +1117,6 @@ impl LaminarDB {
         })
     }
 
-    /// Collect the base sources and upstream MVs this view reads from.
     fn collect_mv_sources(&self, query_sql: &str, name_str: &str) -> Vec<String> {
         let table_refs = crate::sql_analysis::extract_table_references(query_sql);
         let mut sources: Vec<String> = self
@@ -1133,8 +1134,7 @@ impl LaminarDB {
         sources
     }
 
-    /// Create MV storage and register its `DataFusion` table provider. In cluster
-    /// mode the provider is wrapped to union peer vnode slices on read.
+    /// Cluster mode wraps the provider to union peer vnode slices on read.
     async fn register_mv_provider(
         &self,
         name_str: &str,

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -525,81 +525,89 @@ impl IncrementalEowcState {
     }
 
     /// Update per-window accumulators with a new pre-aggregation batch.
-    #[allow(clippy::too_many_lines)]
     pub fn update_batch(&mut self, batch: &RecordBatch) -> Result<(), DbError> {
         if batch.num_rows() == 0 {
             return Ok(());
         }
 
         let ts_array = extract_i64_timestamps(batch, self.time_col_index)?;
-        let has_groups = self.num_group_cols > 0;
 
-        let rows = if has_groups {
-            let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
-                .map(|i| Arc::clone(batch.column(i)))
-                .collect();
-            let rows = self
-                .row_converter
-                .convert_columns(&group_cols)
-                .map_err(|e| DbError::Pipeline(format!("row conversion: {e}")))?;
-            Some(rows)
+        if self.num_group_cols == 0 {
+            self.update_batch_nogroup(batch, &ts_array)
         } else {
-            None
-        };
-
-        if !has_groups {
-            let empty_key = crate::aggregate_state::global_aggregate_key();
-            let mut grouped: AHashMap<i64, Vec<u32>> = AHashMap::new();
-            for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
-                if ts_ms == NULL_TIMESTAMP {
-                    continue;
-                }
-                #[allow(clippy::cast_possible_truncation)]
-                let idx = row_idx as u32;
-                for ws in assign_windows(ts_ms, &self.window_type) {
-                    if self.is_window_closed(ws) {
-                        self.record_late_drop(1);
-                        continue;
-                    }
-                    grouped.entry(ws).or_default().push(idx);
-                }
-            }
-            for (window_start, indices) in &grouped {
-                let needs_insert = {
-                    let wg = self.windows.entry(*window_start).or_default();
-                    !wg.contains_key(&empty_key)
-                };
-                if needs_insert {
-                    let mut accs = Vec::with_capacity(self.agg_specs.len());
-                    for spec in &self.agg_specs {
-                        accs.push(spec.create_accumulator()?);
-                    }
-                    self.windows
-                        .entry(*window_start)
-                        .or_default()
-                        .insert(empty_key.clone(), accs);
-                }
-                let Some(accs) = self
-                    .windows
-                    .get_mut(window_start)
-                    .and_then(|g| g.get_mut(&empty_key))
-                else {
-                    continue;
-                };
-                crate::aggregate_state::IncrementalAggState::update_group_accumulators(
-                    accs,
-                    batch,
-                    indices,
-                    &self.agg_specs,
-                    None,
-                )?;
-            }
-            return Ok(());
+            self.update_batch_grouped(batch, &ts_array)
         }
+    }
+
+    fn update_batch_nogroup(
+        &mut self,
+        batch: &RecordBatch,
+        ts_array: &[i64],
+    ) -> Result<(), DbError> {
+        let empty_key = crate::aggregate_state::global_aggregate_key();
+        let mut grouped: AHashMap<i64, Vec<u32>> = AHashMap::new();
+        for (row_idx, &ts_ms) in ts_array.iter().enumerate() {
+            if ts_ms == NULL_TIMESTAMP {
+                continue;
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let idx = row_idx as u32;
+            for ws in assign_windows(ts_ms, &self.window_type) {
+                if self.is_window_closed(ws) {
+                    self.record_late_drop(1);
+                    continue;
+                }
+                grouped.entry(ws).or_default().push(idx);
+            }
+        }
+        for (window_start, indices) in &grouped {
+            let needs_insert = {
+                let wg = self.windows.entry(*window_start).or_default();
+                !wg.contains_key(&empty_key)
+            };
+            if needs_insert {
+                let mut accs = Vec::with_capacity(self.agg_specs.len());
+                for spec in &self.agg_specs {
+                    accs.push(spec.create_accumulator()?);
+                }
+                self.windows
+                    .entry(*window_start)
+                    .or_default()
+                    .insert(empty_key.clone(), accs);
+            }
+            let Some(accs) = self
+                .windows
+                .get_mut(window_start)
+                .and_then(|g| g.get_mut(&empty_key))
+            else {
+                continue;
+            };
+            crate::aggregate_state::IncrementalAggState::update_group_accumulators(
+                accs,
+                batch,
+                indices,
+                &self.agg_specs,
+                None,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn update_batch_grouped(
+        &mut self,
+        batch: &RecordBatch,
+        ts_array: &[i64],
+    ) -> Result<(), DbError> {
+        let group_cols: Vec<ArrayRef> = (0..self.num_group_cols)
+            .map(|i| Arc::clone(batch.column(i)))
+            .collect();
+        let rows = self
+            .row_converter
+            .convert_columns(&group_cols)
+            .map_err(|e| DbError::Pipeline(format!("row conversion: {e}")))?;
 
         // Dedup group keys per batch; bucket by (window, group_id) to avoid cloning OwnedRow
         // for each overlapping window (hopping).
-        let rows_ref = rows.as_ref().expect("rows set when has_groups");
         let mut group_keys: indexmap::IndexSet<arrow::row::OwnedRow, ahash::RandomState> =
             indexmap::IndexSet::default();
         let mut grouped: AHashMap<(i64, u32), Vec<u32>> = AHashMap::new();
@@ -608,7 +616,7 @@ impl IncrementalEowcState {
             if ts_ms == NULL_TIMESTAMP {
                 continue;
             }
-            let (gid, _) = group_keys.insert_full(rows_ref.row(row_idx).owned());
+            let (gid, _) = group_keys.insert_full(rows.row(row_idx).owned());
             #[allow(clippy::cast_possible_truncation)]
             let (gid, idx) = (gid as u32, row_idx as u32);
             for ws in assign_windows(ts_ms, &self.window_type) {

--- a/crates/laminar-db/src/eowc_state.rs
+++ b/crates/laminar-db/src/eowc_state.rs
@@ -10,14 +10,13 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion::physical_expr::{create_physical_expr, PhysicalExpr};
 use datafusion::prelude::SessionContext;
-use datafusion_common::ScalarValue;
 
 use laminar_sql::parser::EmitClause;
 use laminar_sql::translator::{WindowOperatorConfig, WindowType};
 
 use crate::aggregate_state::{
-    compile_having_filter, expr_to_sql, extract_clauses, find_aggregate, resolve_expr_type,
-    AggFuncSpec, CompiledProjection, EowcStateCheckpoint,
+    compile_having_filter, expr_to_sql, extract_clauses, find_aggregate, AggFuncSpec,
+    CompiledProjection, EowcStateCheckpoint, PreAggBuilder,
 };
 use crate::error::DbError;
 
@@ -159,9 +158,6 @@ impl IncrementalEowcState {
         let state = ctx.state();
         let props = state.execution_props();
         let input_df_schema = &agg_info.input_df_schema;
-        let mut compiled_exprs: Vec<Arc<dyn PhysicalExpr>> = Vec::new();
-        let mut proj_fields: Vec<Field> = Vec::new();
-        let mut compile_ok = compile_source.is_some();
 
         // Bail if there's a post-aggregate projection (e.g. SUM(a)/SUM(b)); fall through
         // to raw-batch EOWC. Check types too — count match alone can hide remaps.
@@ -185,36 +181,14 @@ impl IncrementalEowcState {
             group_types.push(agg_field.data_type().clone());
         }
 
-        let mut agg_specs = Vec::new();
-        let mut pre_agg_select_items: Vec<String> = Vec::new();
+        let compile =
+            |e: &datafusion_expr::Expr| create_physical_expr(e, input_df_schema, props).ok();
+        let mut builder =
+            PreAggBuilder::new(&input_schema, num_group_cols, compile_source.is_some());
 
         for (i, group_expr) in group_exprs.iter().enumerate() {
-            if let datafusion_expr::Expr::Column(col) = group_expr {
-                pre_agg_select_items.push(format!("\"{}\"", col.name));
-            } else {
-                let group_sql = expr_to_sql(group_expr);
-                pre_agg_select_items.push(format!("{group_sql} AS \"__group_{i}\""));
-            }
-
-            if compile_ok {
-                match create_physical_expr(group_expr, input_df_schema, props) {
-                    Ok(phys) => {
-                        let dt = phys
-                            .data_type(input_df_schema.as_arrow())
-                            .unwrap_or(DataType::Utf8);
-                        let name = match group_expr {
-                            datafusion_expr::Expr::Column(col) => col.name.clone(),
-                            _ => format!("__group_{i}"),
-                        };
-                        proj_fields.push(Field::new(name, dt, true));
-                        compiled_exprs.push(phys);
-                    }
-                    Err(_) => compile_ok = false,
-                }
-            }
+            builder.push_group_expr(i, group_expr, &compile);
         }
-
-        let mut next_col_idx = num_group_cols;
 
         for (i, expr) in aggr_exprs.iter().enumerate() {
             let agg_schema_idx = num_group_cols + i;
@@ -224,162 +198,17 @@ impl IncrementalEowcState {
             } else {
                 agg_field.name().clone()
             };
-
-            if let datafusion_expr::Expr::AggregateFunction(agg_func) = expr {
-                let udf = Arc::clone(&agg_func.func);
-                let is_distinct = agg_func.params.distinct;
-
-                let mut input_col_indices = Vec::new();
-                let mut input_types = Vec::new();
-
-                if agg_func.params.args.is_empty() {
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    pre_agg_select_items.push(format!("TRUE AS \"__agg_input_{col_idx}\""));
-                    input_col_indices.push(col_idx);
-                    input_types.push(DataType::Boolean);
-
-                    if compile_ok {
-                        match create_physical_expr(
-                            &datafusion_expr::lit(true),
-                            input_df_schema,
-                            props,
-                        ) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_input_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-                } else {
-                    for arg_expr in &agg_func.params.args {
-                        let col_idx = next_col_idx;
-                        next_col_idx += 1;
-                        let expr_sql = expr_to_sql(arg_expr);
-
-                        if let Some(filter_expr) = &agg_func.params.filter {
-                            let filter_sql = expr_to_sql(filter_expr);
-                            pre_agg_select_items.push(format!(
-                                "CASE WHEN {filter_sql} THEN {expr_sql} ELSE NULL END AS \"__agg_input_{col_idx}\""
-                            ));
-
-                            if compile_ok {
-                                let case_expr =
-                                    datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                                        expr: None,
-                                        when_then_expr: vec![(
-                                            Box::new(filter_expr.as_ref().clone()),
-                                            Box::new(arg_expr.clone()),
-                                        )],
-                                        else_expr: Some(Box::new(datafusion_expr::lit(
-                                            ScalarValue::Null,
-                                        ))),
-                                    });
-                                match create_physical_expr(&case_expr, input_df_schema, props) {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        } else {
-                            pre_agg_select_items
-                                .push(format!("{expr_sql} AS \"__agg_input_{col_idx}\""));
-
-                            if compile_ok {
-                                match create_physical_expr(arg_expr, input_df_schema, props) {
-                                    Ok(phys) => {
-                                        let dt = resolve_expr_type(
-                                            arg_expr,
-                                            &input_schema,
-                                            agg_field.data_type(),
-                                        );
-                                        proj_fields.push(Field::new(
-                                            format!("__agg_input_{col_idx}"),
-                                            dt,
-                                            true,
-                                        ));
-                                        compiled_exprs.push(phys);
-                                    }
-                                    Err(_) => compile_ok = false,
-                                }
-                            }
-                        }
-
-                        input_col_indices.push(col_idx);
-                        let dt = resolve_expr_type(arg_expr, &input_schema, agg_field.data_type());
-                        input_types.push(dt);
-                    }
-                }
-
-                let filter_col_index = if let Some(filter_expr) = &agg_func.params.filter {
-                    let col_idx = next_col_idx;
-                    next_col_idx += 1;
-                    let filter_sql = expr_to_sql(filter_expr);
-                    pre_agg_select_items.push(format!(
-                            "CASE WHEN {filter_sql} THEN TRUE ELSE FALSE END AS \"__agg_filter_{col_idx}\""
-                        ));
-
-                    if compile_ok {
-                        let case_expr = datafusion_expr::Expr::Case(datafusion_expr::expr::Case {
-                            expr: None,
-                            when_then_expr: vec![(
-                                Box::new(filter_expr.as_ref().clone()),
-                                Box::new(datafusion_expr::lit(true)),
-                            )],
-                            else_expr: Some(Box::new(datafusion_expr::lit(false))),
-                        });
-                        match create_physical_expr(&case_expr, input_df_schema, props) {
-                            Ok(phys) => {
-                                proj_fields.push(Field::new(
-                                    format!("__agg_filter_{col_idx}"),
-                                    DataType::Boolean,
-                                    true,
-                                ));
-                                compiled_exprs.push(phys);
-                            }
-                            Err(_) => compile_ok = false,
-                        }
-                    }
-
-                    Some(col_idx)
-                } else {
-                    None
-                };
-
-                let return_type = udf
-                    .return_type(&input_types)
-                    .unwrap_or_else(|_| agg_field.data_type().clone());
-
-                agg_specs.push(AggFuncSpec {
-                    udf,
-                    input_types,
-                    input_col_indices,
-                    output_name,
-                    return_type,
-                    distinct: is_distinct,
-                    is_count_star: agg_func.params.args.is_empty(),
-                    filter_col_index,
-                });
-            } else {
+            if !builder.push_aggregate(expr, output_name, agg_field, &compile) {
                 return Ok(None);
             }
         }
+
+        let mut compile_ok = builder.compile_ok;
+        let next_col_idx = builder.next_col_idx;
+        let mut pre_agg_select_items = builder.pre_agg_select_items;
+        let agg_specs = builder.agg_specs;
+        let mut compiled_exprs = builder.compiled_exprs;
+        let mut proj_fields = builder.proj_fields;
 
         let time_col_index = next_col_idx;
         pre_agg_select_items.push(format!(

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -1626,8 +1626,7 @@ impl OperatorGraph {
         Ok(())
     }
 
-    /// Update a node's output watermark to the min of its input watermarks (and any
-    /// operator hold). Source nodes are pre-seeded in `execute_cycle` and skipped.
+    /// Source nodes are pre-seeded in `execute_cycle`, so skip them here.
     fn propagate_operator_watermark(
         &mut self,
         node_id: usize,
@@ -1675,7 +1674,6 @@ impl OperatorGraph {
         Ok(())
     }
 
-    /// Fan a node's output to its live provider, the results map, and downstream ports.
     fn route_output(
         &mut self,
         node_id: usize,
@@ -1824,8 +1822,7 @@ impl OperatorGraph {
         }
     }
 
-    /// Run one deferred operator (round-robin) so a per-cycle budget overrun can't
-    /// starve the tail of the topo order.
+    /// Round-robin one deferred operator so a budget overrun can't starve the tail.
     async fn run_one_deferred_operator(
         &mut self,
         i: usize,

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -1533,7 +1533,6 @@ impl OperatorGraph {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     async fn execute_single_operator(
         &mut self,
         node_id: usize,
@@ -1570,23 +1569,7 @@ impl OperatorGraph {
             )
             .await;
 
-        // Source nodes have output_watermarks pre-seeded in execute_cycle; don't overwrite.
-        if !self.source_node_ids.contains(&node_id) {
-            let mut wm = watermarks
-                .iter()
-                .copied()
-                .min()
-                .unwrap_or(current_watermark);
-            if let Some(hold) = self.nodes[node_id].operator.watermark_hold() {
-                wm = wm.min(hold);
-            }
-            self.output_watermarks[node_id] = wm;
-            if let Some(ref prom) = self.prom {
-                prom.stream_watermark_ms
-                    .with_label_values(&[&self.nodes[node_id].name])
-                    .set(wm);
-            }
-        }
+        self.propagate_operator_watermark(node_id, &watermarks, current_watermark);
 
         let batches = match output_result {
             Ok(b) => {
@@ -1626,23 +1609,7 @@ impl OperatorGraph {
             }
         };
 
-        if let Some(limit) = self.max_state_bytes {
-            let size = self.nodes[node_id].operator.estimated_state_bytes();
-            if size >= limit {
-                return Err(DbError::Pipeline(format!(
-                    "state size limit exceeded for query '{}' ({size} bytes >= {limit} limit)",
-                    self.nodes[node_id].name
-                )));
-            }
-            if size >= limit * 4 / 5 {
-                tracing::warn!(
-                    query = %self.nodes[node_id].name,
-                    size_bytes = size,
-                    limit_bytes = limit,
-                    "state size at 80% of limit"
-                );
-            }
-        }
+        self.enforce_state_limit(node_id)?;
 
         let batches = if let Some(oc) = self.order_configs.get(&node_id) {
             match oc {
@@ -1654,46 +1621,105 @@ impl OperatorGraph {
             batches
         };
 
-        if !batches.is_empty() {
-            let node_name = Arc::clone(&self.nodes[node_id].name);
-            let has_routes = !self.nodes[node_id].output_routes.is_empty();
-            let is_output = self.output_map.values().any(|&id| id == node_id);
-
-            if has_routes {
-                let name_ref = node_name.as_ref();
-                if !self.live_handles.contains_key(name_ref) {
-                    let schema = batches[0].schema();
-                    self.ensure_live_provider(name_ref, &schema);
-                }
-                if let Some(handle) = self.live_handles.get(name_ref) {
-                    handle.swap(batches.clone());
-                }
-            }
-
-            if is_output {
-                results.insert(node_name, batches.clone());
-            }
-
-            let bytes: usize = batches.iter().map(RecordBatch::get_array_memory_size).sum();
-            let route_count = self.nodes[node_id].output_routes.len();
-            if route_count == 1 {
-                let (target, port) = self.nodes[node_id].output_routes[0];
-                self.push_to_port(target, port, batches, bytes);
-            } else if route_count > 1 {
-                // Clone batches N-1 times; the last route takes ownership.
-                for i in 0..route_count - 1 {
-                    let (target, port) = self.nodes[node_id].output_routes[i];
-                    self.push_to_port(target, port, batches.clone(), bytes);
-                }
-                let (target, port) = self.nodes[node_id].output_routes[route_count - 1];
-                self.push_to_port(target, port, batches, bytes);
-            }
-        }
+        self.route_output(node_id, batches, results);
 
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines)]
+    /// Update a node's output watermark to the min of its input watermarks (and any
+    /// operator hold). Source nodes are pre-seeded in `execute_cycle` and skipped.
+    fn propagate_operator_watermark(
+        &mut self,
+        node_id: usize,
+        watermarks: &[i64],
+        current_watermark: i64,
+    ) {
+        if self.source_node_ids.contains(&node_id) {
+            return;
+        }
+        let mut wm = watermarks
+            .iter()
+            .copied()
+            .min()
+            .unwrap_or(current_watermark);
+        if let Some(hold) = self.nodes[node_id].operator.watermark_hold() {
+            wm = wm.min(hold);
+        }
+        self.output_watermarks[node_id] = wm;
+        if let Some(ref prom) = self.prom {
+            prom.stream_watermark_ms
+                .with_label_values(&[&self.nodes[node_id].name])
+                .set(wm);
+        }
+    }
+
+    fn enforce_state_limit(&self, node_id: usize) -> Result<(), DbError> {
+        let Some(limit) = self.max_state_bytes else {
+            return Ok(());
+        };
+        let size = self.nodes[node_id].operator.estimated_state_bytes();
+        if size >= limit {
+            return Err(DbError::Pipeline(format!(
+                "state size limit exceeded for query '{}' ({size} bytes >= {limit} limit)",
+                self.nodes[node_id].name
+            )));
+        }
+        if size >= limit * 4 / 5 {
+            tracing::warn!(
+                query = %self.nodes[node_id].name,
+                size_bytes = size,
+                limit_bytes = limit,
+                "state size at 80% of limit"
+            );
+        }
+        Ok(())
+    }
+
+    /// Fan a node's output to its live provider, the results map, and downstream ports.
+    fn route_output(
+        &mut self,
+        node_id: usize,
+        batches: Vec<RecordBatch>,
+        results: &mut FxHashMap<Arc<str>, Vec<RecordBatch>>,
+    ) {
+        if batches.is_empty() {
+            return;
+        }
+        let node_name = Arc::clone(&self.nodes[node_id].name);
+        let has_routes = !self.nodes[node_id].output_routes.is_empty();
+        let is_output = self.output_map.values().any(|&id| id == node_id);
+
+        if has_routes {
+            let name_ref = node_name.as_ref();
+            if !self.live_handles.contains_key(name_ref) {
+                let schema = batches[0].schema();
+                self.ensure_live_provider(name_ref, &schema);
+            }
+            if let Some(handle) = self.live_handles.get(name_ref) {
+                handle.swap(batches.clone());
+            }
+        }
+
+        if is_output {
+            results.insert(node_name, batches.clone());
+        }
+
+        let bytes: usize = batches.iter().map(RecordBatch::get_array_memory_size).sum();
+        let route_count = self.nodes[node_id].output_routes.len();
+        if route_count == 1 {
+            let (target, port) = self.nodes[node_id].output_routes[0];
+            self.push_to_port(target, port, batches, bytes);
+        } else if route_count > 1 {
+            // Clone batches N-1 times; the last route takes ownership.
+            for i in 0..route_count - 1 {
+                let (target, port) = self.nodes[node_id].output_routes[i];
+                self.push_to_port(target, port, batches.clone(), bytes);
+            }
+            let (target, port) = self.nodes[node_id].output_routes[route_count - 1];
+            self.push_to_port(target, port, batches, bytes);
+        }
+    }
+
     pub async fn execute_cycle(
         &mut self,
         source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
@@ -1708,23 +1734,7 @@ impl OperatorGraph {
         }
 
         self.register_source_tables(source_batches);
-
-        for &(ref name, node_id) in &self.source_list {
-            if let Some(batches) = source_batches.get(name) {
-                if !batches.is_empty() {
-                    let bytes: usize = batches.iter().map(RecordBatch::get_array_memory_size).sum();
-                    self.input_bufs[node_id][0].extend(batches.iter().cloned());
-                    self.input_buf_bytes[node_id][0] += bytes;
-                }
-            }
-            let wm = source_watermarks
-                .and_then(|m| m.get(name).copied())
-                .unwrap_or(current_watermark);
-            self.output_watermarks[node_id] = wm;
-            if let Some(ref prom) = self.prom {
-                prom.stream_watermark_ms.with_label_values(&[name]).set(wm);
-            }
-        }
+        self.prime_sources(source_batches, current_watermark, source_watermarks);
 
         let mut results = FxHashMap::default();
         let cycle_start = std::time::Instant::now();
@@ -1759,41 +1769,12 @@ impl OperatorGraph {
                         "per-query budget exceeded — deferring remaining operators"
                     );
 
-                    // Run one deferred operator (round-robin) to prevent tail starvation.
-                    let deferred_count = topo_len - i;
-                    let start = self.deferred_scan_offset % deferred_count;
-                    for offset in 0..deferred_count {
-                        let j = i + (start + offset) % deferred_count;
-                        let deferred_id = self.topo_order[j];
-                        if self.nodes[deferred_id].removed {
-                            continue;
-                        }
-                        let has_input = self.input_bufs[deferred_id]
-                            .iter()
-                            .any(|port| !port.is_empty());
-                        if !has_input {
-                            continue;
-                        }
-                        match self.gate_decision(deferred_id) {
-                            GateDecision::Skip => continue,
-                            GateDecision::Fail => {
-                                self.finish_cycle();
-                                return Err(DbError::BackpressureFail(format!(
-                                    "input buffer at capacity downstream of '{}'",
-                                    self.nodes[deferred_id].name
-                                )));
-                            }
-                            GateDecision::Run => {}
-                        }
-                        if let Err(e) = self
-                            .execute_single_operator(deferred_id, current_watermark, &mut results)
-                            .await
-                        {
-                            self.finish_cycle();
-                            return Err(e);
-                        }
-                        self.deferred_scan_offset = self.deferred_scan_offset.wrapping_add(1);
-                        break;
+                    if let Err(e) = self
+                        .run_one_deferred_operator(i, topo_len, current_watermark, &mut results)
+                        .await
+                    {
+                        self.finish_cycle();
+                        return Err(e);
                     }
 
                     break;
@@ -1814,22 +1795,92 @@ impl OperatorGraph {
         #[cfg(debug_assertions)]
         self.debug_assert_byte_sums();
 
-        self.stats_tick = self.stats_tick.wrapping_add(1);
-        if self.stats_tick.is_multiple_of(STATS_SAMPLE_INTERVAL) {
-            if let Some(ref prom) = self.prom {
-                for (id, ports) in self.input_buf_bytes.iter().enumerate() {
-                    if self.nodes[id].removed {
-                        continue;
-                    }
-                    let total: usize = ports.iter().sum();
-                    prom.input_buf_bytes
-                        .with_label_values(&[&self.nodes[id].name])
-                        .set(i64::try_from(total).unwrap_or(i64::MAX));
-                }
-            }
-        }
+        self.sample_buffer_stats();
 
         Ok(results)
+    }
+
+    fn prime_sources(
+        &mut self,
+        source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
+        current_watermark: i64,
+        source_watermarks: Option<&FxHashMap<Arc<str>, i64>>,
+    ) {
+        for &(ref name, node_id) in &self.source_list {
+            if let Some(batches) = source_batches.get(name) {
+                if !batches.is_empty() {
+                    let bytes: usize = batches.iter().map(RecordBatch::get_array_memory_size).sum();
+                    self.input_bufs[node_id][0].extend(batches.iter().cloned());
+                    self.input_buf_bytes[node_id][0] += bytes;
+                }
+            }
+            let wm = source_watermarks
+                .and_then(|m| m.get(name).copied())
+                .unwrap_or(current_watermark);
+            self.output_watermarks[node_id] = wm;
+            if let Some(ref prom) = self.prom {
+                prom.stream_watermark_ms.with_label_values(&[name]).set(wm);
+            }
+        }
+    }
+
+    /// Run one deferred operator (round-robin) so a per-cycle budget overrun can't
+    /// starve the tail of the topo order.
+    async fn run_one_deferred_operator(
+        &mut self,
+        i: usize,
+        topo_len: usize,
+        current_watermark: i64,
+        results: &mut FxHashMap<Arc<str>, Vec<RecordBatch>>,
+    ) -> Result<(), DbError> {
+        let deferred_count = topo_len - i;
+        let start = self.deferred_scan_offset % deferred_count;
+        for offset in 0..deferred_count {
+            let j = i + (start + offset) % deferred_count;
+            let deferred_id = self.topo_order[j];
+            if self.nodes[deferred_id].removed {
+                continue;
+            }
+            let has_input = self.input_bufs[deferred_id]
+                .iter()
+                .any(|port| !port.is_empty());
+            if !has_input {
+                continue;
+            }
+            match self.gate_decision(deferred_id) {
+                GateDecision::Skip => continue,
+                GateDecision::Fail => {
+                    return Err(DbError::BackpressureFail(format!(
+                        "input buffer at capacity downstream of '{}'",
+                        self.nodes[deferred_id].name
+                    )));
+                }
+                GateDecision::Run => {}
+            }
+            self.execute_single_operator(deferred_id, current_watermark, results)
+                .await?;
+            self.deferred_scan_offset = self.deferred_scan_offset.wrapping_add(1);
+            break;
+        }
+        Ok(())
+    }
+
+    fn sample_buffer_stats(&mut self) {
+        self.stats_tick = self.stats_tick.wrapping_add(1);
+        if !self.stats_tick.is_multiple_of(STATS_SAMPLE_INTERVAL) {
+            return;
+        }
+        if let Some(ref prom) = self.prom {
+            for (id, ports) in self.input_buf_bytes.iter().enumerate() {
+                if self.nodes[id].removed {
+                    continue;
+                }
+                let total: usize = ports.iter().sum();
+                prom.input_buf_bytes
+                    .with_label_values(&[&self.nodes[id].name])
+                    .set(i64::try_from(total).unwrap_or(i64::MAX));
+            }
+        }
     }
 
     // Unknown stage (no live operator for it) is silently dropped.

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -552,7 +552,6 @@ impl<'a> RecoveryManager<'a> {
         result
     }
 
-    /// Warn about sources/sinks added or removed since the checkpoint was taken.
     fn warn_topology_changes(
         manifest: &CheckpointManifest,
         sources: &[RegisteredSource],
@@ -600,8 +599,6 @@ impl<'a> RecoveryManager<'a> {
         }
     }
 
-    /// Restore replayable sources from their saved offsets, retrying transient
-    /// failures up to three times. Records per-source failures in `result`.
     async fn restore_replayable_sources(
         sources: &[RegisteredSource],
         manifest: &CheckpointManifest,
@@ -650,7 +647,6 @@ impl<'a> RecoveryManager<'a> {
         }
     }
 
-    /// Roll back exactly-once sinks that did not commit; committed sinks are left alone.
     async fn rollback_uncommitted_sinks(
         sinks: &[RegisteredSink],
         manifest: &CheckpointManifest,

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -459,7 +459,6 @@ impl<'a> RecoveryManager<'a> {
     }
 
     /// Inner restore logic shared by the fast path and the fallback loop.
-    #[allow(clippy::too_many_lines)]
     async fn restore_from(
         &self,
         mut manifest: CheckpointManifest,
@@ -490,59 +489,7 @@ impl<'a> RecoveryManager<'a> {
             }
         }
 
-        // Warn about topology changes since the checkpoint.
-        if !manifest.source_names.is_empty() {
-            let mut current_sources: Vec<&str> = sources.iter().map(|s| s.name.as_str()).collect();
-            current_sources.sort_unstable();
-            let checkpoint_sources: Vec<&str> =
-                manifest.source_names.iter().map(String::as_str).collect();
-            let added: Vec<&&str> = current_sources
-                .iter()
-                .filter(|n| !checkpoint_sources.contains(n))
-                .collect();
-            let removed: Vec<&&str> = checkpoint_sources
-                .iter()
-                .filter(|n| !current_sources.contains(n))
-                .collect();
-            if !added.is_empty() {
-                warn!(
-                    sources = ?added,
-                    "new sources added since checkpoint — no saved offsets"
-                );
-            }
-            if !removed.is_empty() {
-                warn!(
-                    sources = ?removed,
-                    "sources removed since checkpoint — orphaned offsets"
-                );
-            }
-        }
-        if !manifest.sink_names.is_empty() {
-            let mut current_sinks: Vec<&str> = sinks.iter().map(|s| s.name.as_str()).collect();
-            current_sinks.sort_unstable();
-            let checkpoint_sinks: Vec<&str> =
-                manifest.sink_names.iter().map(String::as_str).collect();
-            let added: Vec<&&str> = current_sinks
-                .iter()
-                .filter(|n| !checkpoint_sinks.contains(n))
-                .collect();
-            let removed: Vec<&&str> = checkpoint_sinks
-                .iter()
-                .filter(|n| !current_sinks.contains(n))
-                .collect();
-            if !added.is_empty() {
-                warn!(
-                    sinks = ?added,
-                    "new sinks added since checkpoint — no saved epoch"
-                );
-            }
-            if !removed.is_empty() {
-                warn!(
-                    sinks = ?removed,
-                    "sinks removed since checkpoint — orphaned epochs"
-                );
-            }
-        }
+        Self::warn_topology_changes(&manifest, sources, sinks);
 
         info!(
             checkpoint_id = manifest.checkpoint_id,
@@ -569,46 +516,7 @@ impl<'a> RecoveryManager<'a> {
             );
         }
 
-        for source in sources {
-            if !source.supports_replay {
-                info!(
-                    source = %source.name,
-                    "skipping restore for non-replayable source (at-most-once)"
-                );
-                continue;
-            }
-            if let Some(cp) = manifest.source_offsets.get(&source.name) {
-                let source_cp = connector_to_source_checkpoint(cp);
-                let mut last_err = None;
-                for attempt in 0..3u32 {
-                    let mut connector = source.connector.lock().await;
-                    match connector.restore(&source_cp).await {
-                        Ok(()) => {
-                            last_err = None;
-                            break;
-                        }
-                        Err(e) => {
-                            warn!(
-                                source = %source.name, attempt,
-                                error = %e, "source restore failed, retrying"
-                            );
-                            last_err = Some(e);
-                            drop(connector);
-                            if attempt < 2 {
-                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                            }
-                        }
-                    }
-                }
-                if let Some(e) = last_err {
-                    let msg = format!("source restore failed after 3 attempts: {e}");
-                    result.source_errors.insert(source.name.clone(), msg);
-                } else {
-                    result.sources_restored += 1;
-                    debug!(source = %source.name, epoch = cp.epoch, "source restored");
-                }
-            }
-        }
+        Self::restore_replayable_sources(sources, &manifest, &mut result).await;
 
         for table_source in table_sources {
             if let Some(cp) = manifest.table_offsets.get(&table_source.name) {
@@ -629,41 +537,7 @@ impl<'a> RecoveryManager<'a> {
         }
 
         // Roll back exactly-once sinks that did not commit. Committed sinks are left alone.
-        for sink in sinks {
-            if sink.exactly_once {
-                let already_committed = manifest
-                    .sink_commit_statuses
-                    .get(&sink.name)
-                    .is_some_and(|s| matches!(s, SinkCommitStatus::Committed));
-
-                if already_committed {
-                    debug!(
-                        sink = %sink.name,
-                        epoch = manifest.epoch,
-                        "sink already committed, skipping rollback"
-                    );
-                    continue;
-                }
-
-                match sink.handle.rollback_epoch(manifest.epoch).await {
-                    Ok(()) => {
-                        result.sinks_rolled_back += 1;
-                        debug!(sink = %sink.name, epoch = manifest.epoch, "sink rolled back");
-                    }
-                    Err(e) => {
-                        result
-                            .sink_errors
-                            .insert(sink.name.clone(), format!("rollback failed: {e}"));
-                        warn!(
-                            sink = %sink.name,
-                            epoch = manifest.epoch,
-                            error = %e,
-                            "[LDB-6016] sink rollback failed during recovery"
-                        );
-                    }
-                }
-            }
-        }
+        Self::rollback_uncommitted_sinks(sinks, &manifest, &mut result).await;
 
         info!(
             checkpoint_id = manifest.checkpoint_id,
@@ -676,6 +550,146 @@ impl<'a> RecoveryManager<'a> {
         );
 
         result
+    }
+
+    /// Warn about sources/sinks added or removed since the checkpoint was taken.
+    fn warn_topology_changes(
+        manifest: &CheckpointManifest,
+        sources: &[RegisteredSource],
+        sinks: &[RegisteredSink],
+    ) {
+        if !manifest.source_names.is_empty() {
+            let mut current_sources: Vec<&str> = sources.iter().map(|s| s.name.as_str()).collect();
+            current_sources.sort_unstable();
+            let checkpoint_sources: Vec<&str> =
+                manifest.source_names.iter().map(String::as_str).collect();
+            let added: Vec<&&str> = current_sources
+                .iter()
+                .filter(|n| !checkpoint_sources.contains(n))
+                .collect();
+            let removed: Vec<&&str> = checkpoint_sources
+                .iter()
+                .filter(|n| !current_sources.contains(n))
+                .collect();
+            if !added.is_empty() {
+                warn!(sources = ?added, "new sources added since checkpoint — no saved offsets");
+            }
+            if !removed.is_empty() {
+                warn!(sources = ?removed, "sources removed since checkpoint — orphaned offsets");
+            }
+        }
+        if !manifest.sink_names.is_empty() {
+            let mut current_sinks: Vec<&str> = sinks.iter().map(|s| s.name.as_str()).collect();
+            current_sinks.sort_unstable();
+            let checkpoint_sinks: Vec<&str> =
+                manifest.sink_names.iter().map(String::as_str).collect();
+            let added: Vec<&&str> = current_sinks
+                .iter()
+                .filter(|n| !checkpoint_sinks.contains(n))
+                .collect();
+            let removed: Vec<&&str> = checkpoint_sinks
+                .iter()
+                .filter(|n| !current_sinks.contains(n))
+                .collect();
+            if !added.is_empty() {
+                warn!(sinks = ?added, "new sinks added since checkpoint — no saved epoch");
+            }
+            if !removed.is_empty() {
+                warn!(sinks = ?removed, "sinks removed since checkpoint — orphaned epochs");
+            }
+        }
+    }
+
+    /// Restore replayable sources from their saved offsets, retrying transient
+    /// failures up to three times. Records per-source failures in `result`.
+    async fn restore_replayable_sources(
+        sources: &[RegisteredSource],
+        manifest: &CheckpointManifest,
+        result: &mut RecoveredState,
+    ) {
+        for source in sources {
+            if !source.supports_replay {
+                info!(
+                    source = %source.name,
+                    "skipping restore for non-replayable source (at-most-once)"
+                );
+                continue;
+            }
+            let Some(cp) = manifest.source_offsets.get(&source.name) else {
+                continue;
+            };
+            let source_cp = connector_to_source_checkpoint(cp);
+            let mut last_err = None;
+            for attempt in 0..3u32 {
+                let mut connector = source.connector.lock().await;
+                match connector.restore(&source_cp).await {
+                    Ok(()) => {
+                        last_err = None;
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            source = %source.name, attempt,
+                            error = %e, "source restore failed, retrying"
+                        );
+                        last_err = Some(e);
+                        drop(connector);
+                        if attempt < 2 {
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            }
+            if let Some(e) = last_err {
+                let msg = format!("source restore failed after 3 attempts: {e}");
+                result.source_errors.insert(source.name.clone(), msg);
+            } else {
+                result.sources_restored += 1;
+                debug!(source = %source.name, epoch = cp.epoch, "source restored");
+            }
+        }
+    }
+
+    /// Roll back exactly-once sinks that did not commit; committed sinks are left alone.
+    async fn rollback_uncommitted_sinks(
+        sinks: &[RegisteredSink],
+        manifest: &CheckpointManifest,
+        result: &mut RecoveredState,
+    ) {
+        for sink in sinks {
+            if !sink.exactly_once {
+                continue;
+            }
+            let already_committed = manifest
+                .sink_commit_statuses
+                .get(&sink.name)
+                .is_some_and(|s| matches!(s, SinkCommitStatus::Committed));
+            if already_committed {
+                debug!(
+                    sink = %sink.name,
+                    epoch = manifest.epoch,
+                    "sink already committed, skipping rollback"
+                );
+                continue;
+            }
+            match sink.handle.rollback_epoch(manifest.epoch).await {
+                Ok(()) => {
+                    result.sinks_rolled_back += 1;
+                    debug!(sink = %sink.name, epoch = manifest.epoch, "sink rolled back");
+                }
+                Err(e) => {
+                    result
+                        .sink_errors
+                        .insert(sink.name.clone(), format!("rollback failed: {e}"));
+                    warn!(
+                        sink = %sink.name,
+                        epoch = manifest.epoch,
+                        error = %e,
+                        "[LDB-6016] sink rollback failed during recovery"
+                    );
+                }
+            }
+        }
     }
 
     /// Returns `true` if the checkpoint fails integrity validation.

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -377,7 +377,7 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
     }
 }
 
-/// Dispatch a single sink command. Returns `true` when the task should stop.
+/// Returns `true` when the task should stop.
 async fn handle_sink_command(
     inner: &mut SinkTaskInner,
     cmd: SinkCommand,

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -332,7 +332,6 @@ struct SinkTaskInner {
 }
 
 // `epoch_poisoned` causes `pre_commit`/`commit_epoch` to fail so the coordinator rolls back.
-#[allow(clippy::too_many_lines)]
 async fn run_sink_task(mut inner: SinkTaskInner) {
     let mut flush_timer = tokio::time::interval(inner.flush_interval);
     flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -357,138 +356,16 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
                     }
                     break;
                 };
-                match cmd {
-                    SinkCommand::WriteBatch { batch } => {
-                        let rows = batch.num_rows();
-                        match tokio::time::timeout(
-                            inner.write_timeout,
-                            inner.sink.write_batch(&batch),
-                        )
-                        .await
-                        {
-                            Ok(Ok(_)) => {}
-                            Ok(Err(e)) => {
-                                epoch_poisoned.store(true, Ordering::Release);
-                                tracing::warn!(
-                                    sink = %inner.name, error = %e, rows,
-                                    "Sink write error — epoch poisoned"
-                                );
-                                let _ = inner.event_tx.try_push(SinkEvent::WriteError {
-                                    sink_id: Arc::clone(&inner.sink_id),
-                                    epoch: current_epoch,
-                                    rows,
-                                    error: e.to_string(),
-                                });
-                            }
-                            Err(_elapsed) => {
-                                epoch_poisoned.store(true, Ordering::Release);
-                                tracing::error!(
-                                    sink = %inner.name,
-                                    timeout_secs = inner.write_timeout.as_secs(),
-                                    rows,
-                                    "Sink write I/O timed out — epoch poisoned"
-                                );
-                                let _ = inner.event_tx.try_push(SinkEvent::WriteTimeout {
-                                    sink_id: Arc::clone(&inner.sink_id),
-                                    epoch: current_epoch,
-                                    rows,
-                                    timeout: inner.write_timeout,
-                                });
-                            }
-                        }
-                    }
-                    SinkCommand::BeginEpoch { epoch, ack } => {
-                        let result = inner.sink.begin_epoch(epoch).await;
-                        if result.is_ok() {
-                            current_epoch = epoch;
-                            epoch_poisoned.store(false, Ordering::Release);
-                        }
-                        ack.send(result);
-                    }
-                    #[cfg(test)]
-                    SinkCommand::Flush { ack } => {
-                        let result = inner.sink.flush().await;
-                        ack.send(result);
-                    }
-                    SinkCommand::PreCommit { epoch, ack } => {
-                        let result = if epoch_poisoned.load(Ordering::Acquire) {
-                            Err(ConnectorError::WriteError(
-                                "epoch poisoned by prior write failure".into(),
-                            ))
-                        } else {
-                            inner.sink.pre_commit(epoch).await
-                        };
-                        ack.send(result);
-                    }
-                    SinkCommand::CommitEpoch { epoch, ack } => {
-                        let result = if epoch_poisoned.load(Ordering::Acquire) {
-                            Err(ConnectorError::WriteError(
-                                "epoch poisoned by prior write failure".into(),
-                            ))
-                        } else {
-                            inner.sink.commit_epoch(epoch).await
-                        };
-                        ack.send(result);
-                    }
-                    SinkCommand::CommitAggregated {
-                        epoch,
-                        descriptors,
-                        ack,
-                    } => {
-                        let result = match inner.sink.as_coordinated_committer() {
-                            Some(committer) => committer.commit_aggregated(epoch, descriptors).await,
-                            None => Err(ConnectorError::InvalidState {
-                                expected: "coordinated committer".into(),
-                                actual: format!("sink '{}' is not coordinated", inner.name),
-                            }),
-                        };
-                        ack.send(result);
-                    }
-                    SinkCommand::CommittedThrough { ack } => {
-                        let result = match inner.sink.as_coordinated_committer() {
-                            Some(committer) => committer.committed_through().await,
-                            None => Ok(None),
-                        };
-                        ack.send(result);
-                    }
-                    SinkCommand::RollbackEpoch { epoch, force, ack } => {
-                        let result = if force
-                            || !preserves_pending_on_abandon
-                            || epoch_poisoned.load(Ordering::Acquire)
-                        {
-                            inner.sink.rollback_epoch(epoch).await
-                        } else {
-                            tracing::debug!(
-                                sink = %inner.name, epoch,
-                                "coordination rollback — keeping pending sink \
-                                 output for the next epoch's commit"
-                            );
-                            Ok(())
-                        };
-                        if let Err(ref e) = result {
-                            tracing::warn!(
-                                sink = %inner.name, epoch, error = %e,
-                                "[LDB-6004] Sink rollback failed"
-                            );
-                        }
-                        ack.send(result);
-                    }
-                    SinkCommand::Sync { ack } => {
-                        ack.send(());
-                    }
-                    #[cfg(test)]
-                    SinkCommand::Close => {
-                        if let Err(e) = inner.sink.flush().await {
-                            tracing::warn!(sink = %inner.name, error = %e,
-                                "Sink flush failed during close");
-                        }
-                        if let Err(e) = inner.sink.close().await {
-                            tracing::warn!(sink = %inner.name, error = %e,
-                                "Sink close failed");
-                        }
-                        tracing::debug!(sink = %inner.name, "Sink task closed");
-                        break;
-                    }
+                let stop = handle_sink_command(
+                    &mut inner,
+                    cmd,
+                    &mut current_epoch,
+                    &epoch_poisoned,
+                    preserves_pending_on_abandon,
+                )
+                .await;
+                if stop {
+                    break;
                 }
             }
             _ = flush_timer.tick() => {
@@ -498,6 +375,170 @@ async fn run_sink_task(mut inner: SinkTaskInner) {
             }
         }
     }
+}
+
+/// Dispatch a single sink command. Returns `true` when the task should stop.
+async fn handle_sink_command(
+    inner: &mut SinkTaskInner,
+    cmd: SinkCommand,
+    current_epoch: &mut u64,
+    epoch_poisoned: &AtomicBool,
+    preserves_pending_on_abandon: bool,
+) -> bool {
+    match cmd {
+        SinkCommand::WriteBatch { batch } => {
+            handle_write_batch(inner, batch, *current_epoch, epoch_poisoned).await;
+        }
+        SinkCommand::BeginEpoch { epoch, ack } => {
+            let result = inner.sink.begin_epoch(epoch).await;
+            if result.is_ok() {
+                *current_epoch = epoch;
+                epoch_poisoned.store(false, Ordering::Release);
+            }
+            ack.send(result);
+        }
+        #[cfg(test)]
+        SinkCommand::Flush { ack } => {
+            let result = inner.sink.flush().await;
+            ack.send(result);
+        }
+        SinkCommand::PreCommit { epoch, ack } => {
+            let result = if epoch_poisoned.load(Ordering::Acquire) {
+                Err(ConnectorError::WriteError(
+                    "epoch poisoned by prior write failure".into(),
+                ))
+            } else {
+                inner.sink.pre_commit(epoch).await
+            };
+            ack.send(result);
+        }
+        SinkCommand::CommitEpoch { epoch, ack } => {
+            let result = if epoch_poisoned.load(Ordering::Acquire) {
+                Err(ConnectorError::WriteError(
+                    "epoch poisoned by prior write failure".into(),
+                ))
+            } else {
+                inner.sink.commit_epoch(epoch).await
+            };
+            ack.send(result);
+        }
+        SinkCommand::CommitAggregated {
+            epoch,
+            descriptors,
+            ack,
+        } => {
+            let result = match inner.sink.as_coordinated_committer() {
+                Some(committer) => committer.commit_aggregated(epoch, descriptors).await,
+                None => Err(ConnectorError::InvalidState {
+                    expected: "coordinated committer".into(),
+                    actual: format!("sink '{}' is not coordinated", inner.name),
+                }),
+            };
+            ack.send(result);
+        }
+        SinkCommand::CommittedThrough { ack } => {
+            let result = match inner.sink.as_coordinated_committer() {
+                Some(committer) => committer.committed_through().await,
+                None => Ok(None),
+            };
+            ack.send(result);
+        }
+        SinkCommand::RollbackEpoch { epoch, force, ack } => {
+            let result = handle_rollback_epoch(
+                inner,
+                epoch,
+                force,
+                preserves_pending_on_abandon,
+                epoch_poisoned,
+            )
+            .await;
+            ack.send(result);
+        }
+        SinkCommand::Sync { ack } => {
+            ack.send(());
+        }
+        #[cfg(test)]
+        SinkCommand::Close => {
+            if let Err(e) = inner.sink.flush().await {
+                tracing::warn!(sink = %inner.name, error = %e,
+                    "Sink flush failed during close");
+            }
+            if let Err(e) = inner.sink.close().await {
+                tracing::warn!(sink = %inner.name, error = %e,
+                    "Sink close failed");
+            }
+            tracing::debug!(sink = %inner.name, "Sink task closed");
+            return true;
+        }
+    }
+    false
+}
+
+/// Write a batch under the configured timeout; poisons the epoch on error.
+async fn handle_write_batch(
+    inner: &mut SinkTaskInner,
+    batch: RecordBatch,
+    current_epoch: u64,
+    epoch_poisoned: &AtomicBool,
+) {
+    let rows = batch.num_rows();
+    match tokio::time::timeout(inner.write_timeout, inner.sink.write_batch(&batch)).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            epoch_poisoned.store(true, Ordering::Release);
+            tracing::warn!(
+                sink = %inner.name, error = %e, rows,
+                "Sink write error — epoch poisoned"
+            );
+            let _ = inner.event_tx.try_push(SinkEvent::WriteError {
+                sink_id: Arc::clone(&inner.sink_id),
+                epoch: current_epoch,
+                rows,
+                error: e.to_string(),
+            });
+        }
+        Err(_elapsed) => {
+            epoch_poisoned.store(true, Ordering::Release);
+            tracing::error!(
+                sink = %inner.name,
+                timeout_secs = inner.write_timeout.as_secs(),
+                rows,
+                "Sink write I/O timed out — epoch poisoned"
+            );
+            let _ = inner.event_tx.try_push(SinkEvent::WriteTimeout {
+                sink_id: Arc::clone(&inner.sink_id),
+                epoch: current_epoch,
+                rows,
+                timeout: inner.write_timeout,
+            });
+        }
+    }
+}
+
+/// Roll back (or intentionally keep) a coordinated epoch's pending output.
+async fn handle_rollback_epoch(
+    inner: &mut SinkTaskInner,
+    epoch: u64,
+    force: bool,
+    preserves_pending_on_abandon: bool,
+    epoch_poisoned: &AtomicBool,
+) -> Result<(), ConnectorError> {
+    if !(force || !preserves_pending_on_abandon || epoch_poisoned.load(Ordering::Acquire)) {
+        tracing::debug!(
+            sink = %inner.name, epoch,
+            "coordination rollback — keeping pending sink \
+             output for the next epoch's commit"
+        );
+        return Ok(());
+    }
+    let result = inner.sink.rollback_epoch(epoch).await;
+    if let Err(ref e) = result {
+        tracing::warn!(
+            sink = %inner.name, epoch, error = %e,
+            "[LDB-6004] Sink rollback failed"
+        );
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/laminar-db/src/sql_analysis.rs
+++ b/crates/laminar-db/src/sql_analysis.rs
@@ -2450,7 +2450,6 @@ fn rewrite_temporal_expr(
     })
 }
 
-#[allow(clippy::too_many_lines)]
 fn build_stream_join_projection_sql(
     select: &sqlparser::ast::Select,
     analysis: &laminar_sql::parser::join_parser::JoinAnalysis,
@@ -2466,70 +2465,25 @@ fn build_stream_join_projection_sql(
     let has_residual = select.from.len() == 1 && select.from[0].joins.len() > 1;
     let tmp_qual: Option<&str> = has_residual.then_some("__interval_tmp");
 
-    // Count natural names so colliding projections (p.type, a.type) get {qual}_{col} aliases.
-    let mut natural_counts: FxHashMap<String, usize> = FxHashMap::default();
-    if has_residual {
-        for item in &select.projection {
-            if let SelectItem::UnnamedExpr(expr) = item {
-                let n = match expr {
-                    Expr::CompoundIdentifier(parts) => parts.last().map(|p| p.value.clone()),
-                    Expr::Identifier(ident) => Some(ident.value.clone()),
-                    _ => None,
-                };
-                if let Some(n) = n {
-                    *natural_counts.entry(n).or_insert(0) += 1;
-                }
-            }
-        }
-    }
+    let natural_counts = if has_residual {
+        count_natural_projection_names(select)
+    } else {
+        FxHashMap::default()
+    };
 
     let items: Vec<String> = select
         .projection
         .iter()
-        .map(|item| match item {
-            SelectItem::UnnamedExpr(expr) => {
-                let rewritten =
-                    rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
-                if has_residual {
-                    let (qual, natural) = match expr {
-                        Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
-                            (Some(parts[0].value.clone()), Some(parts[1].value.clone()))
-                        }
-                        Expr::Identifier(ident) => (None, Some(ident.value.clone())),
-                        _ => (None, None),
-                    };
-                    if let Some(n) = natural {
-                        let collides = natural_counts.get(&n).copied().unwrap_or(0) > 1;
-                        if collides {
-                            if let Some(q) = qual {
-                                return format!("{rewritten} AS {q}_{n}");
-                            }
-                        }
-                        if rewritten != n {
-                            return format!("{rewritten} AS {n}");
-                        }
-                    }
-                }
-                rewritten
-            }
-            SelectItem::ExprWithAlias { expr, alias } => {
-                let rewritten =
-                    rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
-                format!("{rewritten} AS {alias}")
-            }
-            SelectItem::Wildcard(_) => "*".to_string(),
-            SelectItem::QualifiedWildcard(name, _) => {
-                let table = name.to_string();
-                if table == config.left_table
-                    || left_alias.is_some_and(|a| a == table)
-                    || table == config.right_table
-                    || right_alias.is_some_and(|a| a == table)
-                {
-                    "*".to_string()
-                } else {
-                    format!("{table}.*")
-                }
-            }
+        .map(|item| {
+            render_join_projection_item(
+                item,
+                left_alias,
+                right_alias,
+                config,
+                tmp_qual,
+                has_residual,
+                &natural_counts,
+            )
         })
         .collect();
 
@@ -2545,22 +2499,7 @@ fn build_stream_join_projection_sql(
         String::new()
     };
 
-    // IntervalJoin is symmetric but BETWEEN is directional; add right_ts >= left_ts
-    // to enforce the lower bound (the upper is already covered by the tolerance).
-    let directional_filter =
-        if !config.left_time_column.is_empty() && !config.right_time_column.is_empty() {
-            let left_ref = match tmp_qual {
-                Some(q) => format!("{q}.{}", config.left_time_column),
-                None => config.left_time_column.clone(),
-            };
-            let right_ref = match tmp_qual {
-                Some(q) => format!("{q}.{}_{}", config.right_time_column, config.right_table),
-                None => format!("{}_{}", config.right_time_column, config.right_table),
-            };
-            format!("{right_ref} >= {left_ref}")
-        } else {
-            String::new()
-        };
+    let directional_filter = join_directional_filter(config, tmp_qual);
 
     let combined_where = match (where_clause.is_empty(), directional_filter.is_empty()) {
         (true, true) => String::new(),
@@ -2573,6 +2512,97 @@ fn build_stream_join_projection_sql(
         "SELECT {} FROM __interval_tmp{residual}{combined_where}",
         items.join(", ")
     )
+}
+
+// Count natural names so colliding projections (p.type, a.type) get {qual}_{col} aliases.
+fn count_natural_projection_names(select: &sqlparser::ast::Select) -> FxHashMap<String, usize> {
+    let mut counts: FxHashMap<String, usize> = FxHashMap::default();
+    for item in &select.projection {
+        if let SelectItem::UnnamedExpr(expr) = item {
+            let n = match expr {
+                Expr::CompoundIdentifier(parts) => parts.last().map(|p| p.value.clone()),
+                Expr::Identifier(ident) => Some(ident.value.clone()),
+                _ => None,
+            };
+            if let Some(n) = n {
+                *counts.entry(n).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+}
+
+fn render_join_projection_item(
+    item: &SelectItem,
+    left_alias: Option<&str>,
+    right_alias: Option<&str>,
+    config: &StreamJoinConfig,
+    tmp_qual: Option<&str>,
+    has_residual: bool,
+    natural_counts: &FxHashMap<String, usize>,
+) -> String {
+    match item {
+        SelectItem::UnnamedExpr(expr) => {
+            let rewritten =
+                rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
+            if has_residual {
+                let (qual, natural) = match expr {
+                    Expr::CompoundIdentifier(parts) if parts.len() == 2 => {
+                        (Some(parts[0].value.clone()), Some(parts[1].value.clone()))
+                    }
+                    Expr::Identifier(ident) => (None, Some(ident.value.clone())),
+                    _ => (None, None),
+                };
+                if let Some(n) = natural {
+                    let collides = natural_counts.get(&n).copied().unwrap_or(0) > 1;
+                    if collides {
+                        if let Some(q) = qual {
+                            return format!("{rewritten} AS {q}_{n}");
+                        }
+                    }
+                    if rewritten != n {
+                        return format!("{rewritten} AS {n}");
+                    }
+                }
+            }
+            rewritten
+        }
+        SelectItem::ExprWithAlias { expr, alias } => {
+            let rewritten =
+                rewrite_stream_join_expr(expr, left_alias, right_alias, config, tmp_qual);
+            format!("{rewritten} AS {alias}")
+        }
+        SelectItem::Wildcard(_) => "*".to_string(),
+        SelectItem::QualifiedWildcard(name, _) => {
+            let table = name.to_string();
+            if table == config.left_table
+                || left_alias.is_some_and(|a| a == table)
+                || table == config.right_table
+                || right_alias.is_some_and(|a| a == table)
+            {
+                "*".to_string()
+            } else {
+                format!("{table}.*")
+            }
+        }
+    }
+}
+
+// IntervalJoin is symmetric but BETWEEN is directional; add right_ts >= left_ts
+// to enforce the lower bound (the upper is already covered by the tolerance).
+fn join_directional_filter(config: &StreamJoinConfig, tmp_qual: Option<&str>) -> String {
+    if config.left_time_column.is_empty() || config.right_time_column.is_empty() {
+        return String::new();
+    }
+    let left_ref = match tmp_qual {
+        Some(q) => format!("{q}.{}", config.left_time_column),
+        None => config.left_time_column.clone(),
+    };
+    let right_ref = match tmp_qual {
+        Some(q) => format!("{q}.{}_{}", config.right_time_column, config.right_table),
+        None => format!("{}_{}", config.right_time_column, config.right_table),
+    };
+    format!("{right_ref} >= {left_ref}")
 }
 
 // Unsupported shapes (CROSS, USING, etc.) pass through sqlparser's Display unchanged.


### PR DESCRIPTION
## Why

GitHub Code Quality rates this repo's **maintainability** as *Fair*. That rating is driven by actual function length, complexity, and duplication (it does not read `#[allow]` attributes). This PR targets the worst offenders in `laminar-db` — the crate with the highest density of oversized functions.

## What

Behavior-preserving extract-method refactors plus one shared-builder dedup. **14 functions decomposed, 11 `too_many_lines` suppressions removed, ~450 lines of duplicated compile logic eliminated.**

| Area | Change |
|------|--------|
| `operator_graph.rs` | Split the hot-path executor's `execute_single_operator` / `execute_cycle` into focused helpers (`propagate_operator_watermark`, `enforce_state_limit`, `route_output`, `prime_sources`, `run_one_deferred_operator`, `sample_buffer_stats`) |
| `ddl.rs` | Decompose `handle_create_table`, `handle_create_source`, `handle_create_materialized_view` into schema/options/registration helpers |
| `sink_task.rs` | `run_sink_task` → thin driver + `handle_sink_command` / `handle_write_batch` / `handle_rollback_epoch` |
| `recovery_manager.rs` | `restore_from` → `warn_topology_changes` / `restore_replayable_sources` / `rollback_uncommitted_sinks` (also dedups the source/sink topology-diff blocks) |
| `sql_analysis.rs` | `build_stream_join_projection_sql` → `count_natural_projection_names` / `render_join_projection_item` / `join_directional_filter` |
| `core_window_state.rs`, `eowc_state.rs` | `update_batch` → no-group/grouped branch helpers; extract the multi-session merge |
| `aggregate_state` (+ `compile.rs`, window/EOWC) | **Shared `PreAggBuilder`** replacing the byte-identical ~150-line GROUP BY + aggregate compilation loop in all three `try_from_sql` paths |

The `PreAggBuilder` compiles via a caller-supplied closure so it needn't name `DFSchema`/`ExecutionProps`; each caller keeps only its module-specific output-name rule and projection tail.

## Verification

Every commit passed, on Windows with system OpenSSL:
- `cargo clippy --no-default-features -p laminar-db --lib -- -D warnings` — clean
- `cargo test --no-default-features -p laminar-db --lib` — **758 passed, 0 failed**
- `cargo fmt` applied

Net diff: 9 files, 1454 insertions / 1523 deletions.

## Not included (deliberate)

`db::open_with_config` (flat struct init) and `engine_metrics::new` (macro registration) keep their allows legitimately. Remaining flagged functions are cfg-heavy (`pipeline_lifecycle`, `streaming_coordinator`, `align_shuffle_barriers` — need a `--features cluster` build to verify), `checkpoint_coordinator::checkpoint_inner`, and the hot-path joins (`interval_join`/`temporal_*`); these warrant their own follow-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `laminar-db` to improve maintainability by splitting oversized functions and consolidating aggregate compilation into a shared `PreAggBuilder`. Removes ~450 lines of duplicate logic and 11 `too_many_lines` suppressions; also includes two correctness fixes.

- **Refactors**
  - Introduces a shared `PreAggBuilder` to compile GROUP BY + aggregates once across plain/windowed/EOWC paths.
  - Decomposes long functions into focused helpers across operator execution, sink task, recovery restore, SQL join-projection builder, DDL handlers, and window-state updates; tests (758) pass and `clippy -Dwarnings` is clean.

- **Bug Fixes**
  - Session window merge is now transactional to prevent partial state if a merge fails.
  - `CREATE TABLE`: reject `cache_max_entries = 0` (must be positive), matching `cache_max_bytes`/`cache_ttl` checks.

<sup>Written for commit 257413ae1ddb0bb9bd4f1e9e3c6eceb407261c1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored aggregation and query state compilation workflows for improved code organization.
  * Streamlined operator graph execution and recovery manager checkpoint handling.
  * Simplified sink task command processing and stream join projection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->