### PR TITLE
fix(laminar-db): bound pipeline shutdown so stop_pipeline can't wedge

### DIFF
--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -105,6 +105,9 @@ pub struct LaminarDB {
     /// Panic message when the compute thread exits unexpectedly (`Faulted`);
     /// cleared on a clean start. Surfaced via `pipeline_status`/`/ready`.
     pub(crate) last_fault: Arc<parking_lot::Mutex<Option<String>>>,
+    /// Set when a `stop_pipeline` times out so the watcher finalizes ShuttingDown→Created;
+    /// keeps it from racing a normal stop/shutdown, which finalize themselves.
+    pub(crate) stop_timed_out: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) runtime_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Decoupled coordinated-commit committer task; aborted on shutdown.
     pub(crate) committer_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -361,6 +364,7 @@ impl LaminarDB {
             )),
             state: Arc::new(std::sync::atomic::AtomicU8::new(DbState::Created as u8)),
             last_fault: Arc::new(parking_lot::Mutex::new(None)),
+            stop_timed_out: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             runtime_handle: parking_lot::Mutex::new(None),
             committer_handle: parking_lot::Mutex::new(None),
             shutdown_signal: Arc::new(tokio::sync::Notify::new()),

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -337,23 +337,25 @@ impl StreamingCoordinator {
                     }
                 }
 
-                // Best-effort flush before close(): time-boxed poll, non-blocking send.
-                // Unflushed rows resume from the committed offset on restart.
+                // Bounded best-effort flush before close(). The `while` deadline (not the
+                // inner timeout) bounds an always-ready poll — timeout() polls the future
+                // first. Non-blocking send; unflushed rows resume from the committed offset.
                 let deadline = Instant::now() + SHUTDOWN_DRAIN_BUDGET;
-                while let Ok(Ok(Some(batch))) = tokio::time::timeout(
-                    deadline.saturating_duration_since(Instant::now()),
-                    connector.poll_batch(max_poll),
-                )
-                .await
-                {
-                    let cp = connector.checkpoint();
-                    let msg = SourceMsg::Batch {
-                        source_idx: idx,
-                        batch: batch.records,
-                        checkpoint: cp,
-                    };
-                    if task_tx.try_send(msg).is_err() {
-                        break;
+                while Instant::now() < deadline {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    match tokio::time::timeout(remaining, connector.poll_batch(max_poll)).await {
+                        Ok(Ok(Some(batch))) => {
+                            let cp = connector.checkpoint();
+                            let msg = SourceMsg::Batch {
+                                source_idx: idx,
+                                batch: batch.records,
+                                checkpoint: cp,
+                            };
+                            if task_tx.try_send(msg).is_err() {
+                                break;
+                            }
+                        }
+                        _ => break,
                     }
                 }
 

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -128,6 +128,12 @@ impl PendingBarrier {
 /// Fallback timeout for idle wake.
 const IDLE_TIMEOUT: Duration = Duration::from_millis(100);
 
+/// Cap on a source task's post-shutdown flush so a hot source can't stall shutdown.
+const SHUTDOWN_DRAIN_BUDGET: Duration = Duration::from_secs(2);
+
+/// Cap on awaiting a source task at shutdown before aborting it.
+const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(3);
+
 /// Throttled (~once/10s) WARN while barrier admission is paused at the
 /// staged-state cap — this check runs every coordinator tick, so an
 /// unthrottled warn would spam under a sustained upload backlog.
@@ -331,15 +337,22 @@ impl StreamingCoordinator {
                     }
                 }
 
-                // Drain before close() so buffered data isn't lost.
-                while let Ok(Some(batch)) = connector.poll_batch(max_poll).await {
+                // Best-effort flush before close(): time-boxed poll, non-blocking send.
+                // Unflushed rows resume from the committed offset on restart.
+                let deadline = Instant::now() + SHUTDOWN_DRAIN_BUDGET;
+                while let Ok(Ok(Some(batch))) = tokio::time::timeout(
+                    deadline.saturating_duration_since(Instant::now()),
+                    connector.poll_batch(max_poll),
+                )
+                .await
+                {
                     let cp = connector.checkpoint();
                     let msg = SourceMsg::Batch {
                         source_idx: idx,
                         batch: batch.records,
                         checkpoint: cp,
                     };
-                    if task_tx.send(msg).await.is_err() {
+                    if task_tx.try_send(msg).is_err() {
                         break;
                     }
                 }
@@ -707,14 +720,22 @@ impl StreamingCoordinator {
         for handle in std::mem::take(&mut self.source_handles) {
             let SourceHandle {
                 name,
-                shutdown: _,
-                join,
-                barrier_injector: _,
+                mut join,
                 epoch_committed_tx,
+                ..
             } = handle;
             drop(epoch_committed_tx);
-            if let Err(e) = join.await {
-                tracing::warn!(source = %name, error = ?e, "source task panicked");
+            // Abort a source task that didn't exit in time so run() can return.
+            match tokio::time::timeout(SHUTDOWN_JOIN_TIMEOUT, &mut join).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(source = %name, error = ?e, "source task panicked"),
+                Err(_) => {
+                    tracing::warn!(
+                        source = %name,
+                        "source task did not exit within shutdown budget; aborting"
+                    );
+                    join.abort();
+                }
             }
         }
     }
@@ -1103,6 +1124,77 @@ mod tests {
 
         // The callback was consumed by run(), so we can't inspect it directly.
         // But the test proves: no panics, no deadlocks, clean shutdown.
+    }
+
+    /// A wedged source task must not stall shutdown: `run()` still returns.
+    #[tokio::test(start_paused = true)]
+    async fn test_shutdown_aborts_wedged_source_task() {
+        let shutdown = Arc::new(tokio::sync::Notify::new());
+        let (_tx, rx) = mpsc::bounded_async::<SourceMsg>(64);
+        let (_control_tx, control_rx) = mpsc::bounded_async::<crate::pipeline::ControlMsg>(64);
+
+        // No timer: under paused time only the join timeout can unblock run().
+        let wedged = tokio::spawn(std::future::pending::<()>());
+        let (epoch_tx, _epoch_rx) = tokio::sync::watch::channel(None);
+        let handle = SourceHandle {
+            name: Arc::from("wedged"),
+            shutdown: Arc::new(tokio::sync::Notify::new()),
+            join: wedged,
+            barrier_injector: CheckpointBarrierInjector::new(),
+            epoch_committed_tx: epoch_tx,
+        };
+
+        let coordinator = StreamingCoordinator {
+            config: PipelineConfig {
+                batch_window: Duration::ZERO,
+                max_poll_records: 1000,
+                channel_capacity: 64,
+                fallback_poll_interval: Duration::from_millis(10),
+                checkpoint_interval: None,
+                delivery_guarantee: DeliveryGuarantee::AtLeastOnce,
+                barrier_alignment_timeout: Duration::from_secs(30),
+                cycle_budget_ns: 10_000_000,
+                drain_budget_ns: 1_000_000,
+                query_budget_ns: 8_000_000,
+                background_budget_ns: 5_000_000,
+                max_input_buf_batches: 256,
+                max_input_buf_bytes: None,
+                backpressure_policy: crate::config::BackpressurePolicy::Backpressure,
+            },
+            rx,
+            source_handles: vec![handle],
+            source_names: vec![Arc::from("wedged")],
+            shutdown: Arc::clone(&shutdown),
+            pending_barrier: PendingBarrier::new(),
+            next_checkpoint_id: 1,
+            last_checkpoint: Instant::now(),
+            checkpoint_request_flags: Vec::new(),
+            source_batches_buf: FxHashMap::default(),
+            post_barrier_buf: Vec::new(),
+            pending_watermark_batches: Vec::new(),
+            barrier_seen: FxHashSet::default(),
+            committed_offsets: vec![None],
+            pending_offsets: vec![None],
+            control_rx,
+            checkpoint_complete_rx: None,
+            checkpoint_in_flight: Arc::new(AtomicU64::new(0)),
+            max_in_flight_epochs: 1,
+            staged_bytes: Arc::new(AtomicU64::new(0)),
+            max_staged_bytes: u64::MAX,
+        };
+
+        shutdown.notify_one();
+
+        // Outer bound gives a timer so a regression fails cleanly, not hangs.
+        let result = tokio::time::timeout(
+            Duration::from_secs(60),
+            coordinator.run(MockCallback::new()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "coordinator.run() must return after shutdown even with a wedged source task"
+        );
     }
 
     /// Test that a final checkpoint is triggered on shutdown when checkpointing

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1884,6 +1884,9 @@ impl LaminarDB {
         }
 
         *self.force_ckpt_tx.lock() = None;
+        // Clear up front so DDL during/after shutdown registers for the next start()
+        // instead of hot-adding into the dying coordinator's channel.
+        *self.control_tx.lock() = None;
 
         self.shutdown_signal.notify_one();
         if let Some(h) = self.committer_handle.lock().take() {
@@ -1896,9 +1899,8 @@ impl LaminarDB {
                 Ok(Ok(())) => tracing::info!("Pipeline stopped cleanly"),
                 Ok(Err(e)) => tracing::warn!(error = %e, "Pipeline task panicked during stop"),
                 Err(_) => {
-                    // Still draining. Re-store the watcher; it finalizes
-                    // ShuttingDown→Created once the thread exits. start() refuses
-                    // meanwhile, so nothing double-spawns over the draining coordinator.
+                    // Still draining. Re-store the watcher; it finalizes ShuttingDown→Created
+                    // once the thread exits. start() refuses meanwhile, so nothing double-spawns.
                     tracing::warn!(
                         "Pipeline stop still draining after 10s; will finalize when the coordinator exits"
                     );
@@ -1912,7 +1914,6 @@ impl LaminarDB {
             }
         }
 
-        *self.control_tx.lock() = None;
         DbState::Created.store(&self.state);
         Ok(())
     }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1806,7 +1806,15 @@ impl LaminarDB {
             let watcher_shutdown = Arc::clone(&self.shutdown_signal);
             let watcher_fault = Arc::clone(&self.last_fault);
             let handle = tokio::spawn(async move {
-                if done_rx.await.is_err() {
+                if done_rx.await.is_ok() {
+                    // Finalize a stop that out-waited its caller (ShuttingDown→Created);
+                    // a no-op if stop_pipeline already did.
+                    let _ = DbState::compare_exchange(
+                        DbState::ShuttingDown,
+                        DbState::Created,
+                        &watcher_state,
+                    );
+                } else {
                     tracing::error!("laminar-compute thread exited unexpectedly");
                     watcher_fault
                         .lock()
@@ -1883,14 +1891,22 @@ impl LaminarDB {
         }
 
         let handle = self.runtime_handle.lock().take();
-        if let Some(handle) = handle {
-            match tokio::time::timeout(std::time::Duration::from_secs(10), handle).await {
+        if let Some(mut handle) = handle {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
                 Ok(Ok(())) => tracing::info!("Pipeline stopped cleanly"),
                 Ok(Err(e)) => tracing::warn!(error = %e, "Pipeline task panicked during stop"),
                 Err(_) => {
-                    tracing::error!("Pipeline stop timed out after 10s; coordinator still running");
+                    // Still draining. Re-store the watcher; it finalizes
+                    // ShuttingDown→Created once the thread exits. start() refuses
+                    // meanwhile, so nothing double-spawns over the draining coordinator.
+                    tracing::warn!(
+                        "Pipeline stop still draining after 10s; will finalize when the coordinator exits"
+                    );
+                    *self.runtime_handle.lock() = Some(handle);
                     return Err(DbError::InvalidOperation(
-                        "pipeline stop timed out; coordinator did not exit".into(),
+                        "pipeline stop is taking longer than expected; coordinator still \
+                         draining, retry shortly"
+                            .into(),
                     ));
                 }
             }

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -214,6 +214,9 @@ impl LaminarDB {
         // Clear on entry, not after start_inner — otherwise a panic during this
         // startup (watcher → Faulted + reason) would be immediately overwritten.
         *self.last_fault.lock() = None;
+        // Drop any stale flag from a prior run so this run's watcher doesn't finalize spuriously.
+        self.stop_timed_out
+            .store(false, std::sync::atomic::Ordering::SeqCst);
 
         {
             let mut guard = self.engine_metrics.lock();
@@ -1805,15 +1808,18 @@ impl LaminarDB {
             let watcher_state = Arc::clone(&self.state);
             let watcher_shutdown = Arc::clone(&self.shutdown_signal);
             let watcher_fault = Arc::clone(&self.last_fault);
+            let watcher_stop_timed_out = Arc::clone(&self.stop_timed_out);
             let handle = tokio::spawn(async move {
                 if done_rx.await.is_ok() {
-                    // Finalize a stop that out-waited its caller (ShuttingDown→Created);
-                    // a no-op if stop_pipeline already did.
-                    let _ = DbState::compare_exchange(
-                        DbState::ShuttingDown,
-                        DbState::Created,
-                        &watcher_state,
-                    );
+                    // Only finalize for a timed-out stop. A normal stop/shutdown caller is
+                    // still awaiting this handle and sets the terminal state itself.
+                    if watcher_stop_timed_out.swap(false, std::sync::atomic::Ordering::SeqCst) {
+                        let _ = DbState::compare_exchange(
+                            DbState::ShuttingDown,
+                            DbState::Created,
+                            &watcher_state,
+                        );
+                    }
                 } else {
                     tracing::error!("laminar-compute thread exited unexpectedly");
                     watcher_fault
@@ -1895,12 +1901,16 @@ impl LaminarDB {
 
         let handle = self.runtime_handle.lock().take();
         if let Some(mut handle) = handle {
+            // Set before awaiting: the watcher can wake on another thread the instant the
+            // coordinator exits, so it must already see the flag if we time out.
+            self.stop_timed_out
+                .store(true, std::sync::atomic::Ordering::SeqCst);
             match tokio::time::timeout(std::time::Duration::from_secs(10), &mut handle).await {
                 Ok(Ok(())) => tracing::info!("Pipeline stopped cleanly"),
                 Ok(Err(e)) => tracing::warn!(error = %e, "Pipeline task panicked during stop"),
                 Err(_) => {
-                    // Still draining. Re-store the watcher; it finalizes ShuttingDown→Created
-                    // once the thread exits. start() refuses meanwhile, so nothing double-spawns.
+                    // Still draining; the watcher finalizes ShuttingDown→Created when the
+                    // coordinator exits. Re-store its handle; start() refuses meanwhile.
                     tracing::warn!(
                         "Pipeline stop still draining after 10s; will finalize when the coordinator exits"
                     );


### PR DESCRIPTION
## Problem

Editing a pipeline from the console (which drives `POST /api/v1/pipeline/stop`) intermittently failed with `pipeline stop timed out after 10s; coordinator still running`, after which the DB was permanently stuck — `start()` and `stop_pipeline()` both refused, recoverable only by restarting the process.

It reproduces whenever a source is actively producing at stop time (datagen, a busy Kafka topic, CDC). An idle source stops cleanly; a live one hangs.

## Root cause

Two stacked bugs:

1. **Shutdown deadlock in the coordinator.** After the run loop breaks on shutdown, each source task runs a "drain before close()" loop — `while let Ok(Some(b)) = poll_batch().await { task_tx.send(b).await }`. On a continuously producing source this never sees `None`, and once the coordinator stops receiving (it's now sitting in `join.await`) the bounded `send().await` blocks. The coordinator's `join.await` had no timeout, so `run()` never returned and the compute thread never signalled completion.

2. **Wedged state machine.** `stop_pipeline()` waits up to 10s for that completion. On timeout it returned early, *before* resetting `control_tx` and the DB state, leaving the instance in `ShuttingDown` forever with no transition out.

## Fix

- **Source drain** (`streaming_coordinator.rs`): time-box the post-shutdown flush (`SHUTDOWN_DRAIN_BUDGET`) and use a non-blocking `try_send`, so neither a hot source nor a non-receiving coordinator can stall it. Unflushed rows resume from the last committed offset on restart, so the bound is lossless.
- **Source join** (`streaming_coordinator.rs`): time-box each join (`SHUTDOWN_JOIN_TIMEOUT`) and `abort()` on expiry, so `run()` always returns even if a task ignores its shutdown signal.
- **State machine** (`pipeline_lifecycle.rs`): the watcher task now finalizes `ShuttingDown → Created` on a clean coordinator exit. If `stop_pipeline()` still times out, it re-stores the watcher and returns a retryable error instead of wedging. Because `start()` refuses while `ShuttingDown` and the watcher only flips to `Created` after the thread is dead, no second coordinator can spawn over a draining one.

## Notes

The engine already supports zero-downtime live editing (`CREATE`/`DROP` hot-applied via `ControlMsg`), so the console should add/edit queries via `/api/v1/sql` rather than stop+recreate. This PR fixes the engine so that even when `stop` is used, it can't hang or wedge — but a console-side follow-up to stop calling `/pipeline/stop` for edits is the real ergonomic win.

## Testing

- New regression test `test_shutdown_aborts_wedged_source_task`: a source task that never exits must not stall shutdown; `run()` still returns (uses paused time, so it's fast and deterministic).
- `cargo test --no-default-features -p laminar-db --lib pipeline::streaming_coordinator` — 6 passed.
- `cargo clippy --no-default-features -p laminar-db --lib --tests -- -D warnings` — clean.
- `cargo check --no-default-features --features cluster -p laminar-db` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound pipeline shutdown in `laminar-db` so `stop_pipeline` can’t wedge. Hot sources can’t block coordinator exit, and timeout paths are safe and recoverable without a shutdown state race.

- **Bug Fixes**
  - Wall-clock-bounded post-shutdown source drain (`SHUTDOWN_DRAIN_BUDGET`) with non-blocking `try_send`, so always-ready polls can’t spin; unflushed rows resume from the last committed offset.
  - Time-boxed source joins (`SHUTDOWN_JOIN_TIMEOUT`) with abort on expiry so `run()` always returns (covers wedged source tasks).
  - Hardened stop lifecycle: clear `control_tx` up front; on timeout set `stop_timed_out`, re-store the coordinator handle, and return a retryable error while `start()` still refuses. The watcher now finalizes `ShuttingDown → Created` only when a stop timed out; `start()` resets the flag to avoid races.

<sup>Written for commit 77f73fc0cefb310d428439f31c2f102d5bd508ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling to prevent the coordinator from hanging when source tasks become unresponsive during shutdown.
  * Enhanced pipeline stop timeout behavior with improved error recovery semantics and clearer retry guidance.
  * Strengthened shutdown operations with explicit time budgets and task abort mechanisms to ensure clean process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->