### PR TITLE
perf(db): cache per-operator TaskContext instead of rebuilding it per cycle

### DIFF
--- a/crates/laminar-db/src/operator/eowc_query.rs
+++ b/crates/laminar-db/src/operator/eowc_query.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
+use datafusion::execution::TaskContext;
 use datafusion::prelude::SessionContext;
 
 use crate::aggregate_state::{apply_compiled_having, EowcStateCheckpoint};
@@ -78,11 +79,10 @@ impl RawSqlCache {
 
     async fn apply(
         &self,
-        ctx: &SessionContext,
         op_name: &str,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        self.0.apply(ctx, op_name, batches).await
+        self.0.apply(op_name, batches).await
     }
 }
 
@@ -177,6 +177,7 @@ pub(crate) struct EowcQueryOperator {
     emit_clause: Option<EmitClause>,
     window_config: Option<WindowOperatorConfig>,
     ctx: SessionContext,
+    task_ctx: Arc<TaskContext>,
     state: EowcInnerState,
     pending_restore: Option<EowcCheckpointEnvelope>,
     prom: Option<Arc<EngineMetrics>>,
@@ -191,12 +192,14 @@ impl EowcQueryOperator {
         ctx: SessionContext,
         prom: Option<Arc<EngineMetrics>>,
     ) -> Self {
+        let task_ctx = ctx.task_ctx();
         Self {
             op_name: Arc::from(name),
             sql: Arc::from(sql),
             emit_clause,
             window_config,
             ctx,
+            task_ctx,
             state: EowcInnerState::Uninit,
             pending_restore: None,
             prom,
@@ -358,6 +361,7 @@ impl EowcQueryOperator {
         watermark: i64,
         op_name: &str,
         ctx: &SessionContext,
+        task_ctx: &Arc<TaskContext>,
     ) -> Result<Vec<RecordBatch>, DbError> {
         let now_filtered = cw.apply_dynamic_now_filter(ctx, inputs, watermark)?;
         let inputs: &[RecordBatch] = now_filtered.as_deref().unwrap_or(inputs);
@@ -372,7 +376,7 @@ impl EowcQueryOperator {
                         "EOWC compiled pre-agg failed, falling back to cached plan"
                     );
                     if let Some(physical) = cw.cached_pre_agg_physical() {
-                        super::execute_cached_physical(ctx, op_name, physical).await?
+                        super::execute_cached_physical(task_ctx.clone(), op_name, physical).await?
                     } else {
                         return Err(DbError::Pipeline(format!(
                             "[LDB-8051] EOWC query '{op_name}': compiled pre-agg failed and no cached plan: {e}"
@@ -381,7 +385,7 @@ impl EowcQueryOperator {
                 }
             }
         } else if let Some(physical) = cw.cached_pre_agg_physical() {
-            super::execute_cached_physical(ctx, op_name, physical).await?
+            super::execute_cached_physical(task_ctx.clone(), op_name, physical).await?
         } else {
             return Err(DbError::Pipeline(format!(
                 "[LDB-8050] EOWC query '{op_name}': no compiled projection or cached plan"
@@ -412,6 +416,7 @@ impl EowcQueryOperator {
         watermark: i64,
         op_name: &str,
         ctx: &SessionContext,
+        task_ctx: &Arc<TaskContext>,
     ) -> Result<Vec<RecordBatch>, DbError> {
         let pre_agg_batches = if let Some(proj) = eowc.compiled_projection() {
             match try_evaluate_compiled(proj, inputs) {
@@ -423,7 +428,7 @@ impl EowcQueryOperator {
                         "EOWC-agg compiled pre-agg failed, falling back to cached plan"
                     );
                     if let Some(physical) = eowc.cached_pre_agg_physical() {
-                        super::execute_cached_physical(ctx, op_name, physical).await?
+                        super::execute_cached_physical(task_ctx.clone(), op_name, physical).await?
                     } else {
                         return Err(DbError::Pipeline(format!(
                             "[LDB-8051] EOWC query '{op_name}': compiled pre-agg failed and no cached plan: {e}"
@@ -432,7 +437,7 @@ impl EowcQueryOperator {
                 }
             }
         } else if let Some(physical) = eowc.cached_pre_agg_physical() {
-            super::execute_cached_physical(ctx, op_name, physical).await?
+            super::execute_cached_physical(task_ctx.clone(), op_name, physical).await?
         } else {
             return Err(DbError::Pipeline(format!(
                 "[LDB-8050] EOWC query '{op_name}': no compiled projection or cached plan"
@@ -529,7 +534,7 @@ impl EowcQueryOperator {
         sql_cache
             .as_ref()
             .expect("just initialized")
-            .apply(ctx, op_name, query_batches)
+            .apply(op_name, query_batches)
             .await
     }
 }
@@ -555,12 +560,26 @@ impl GraphOperator for EowcQueryOperator {
                 self.op_name
             ))),
             EowcInnerState::CoreWindow(ref mut cw) => {
-                Self::process_core_window(cw, &input_batches, watermark, &self.op_name, &self.ctx)
-                    .await
+                Self::process_core_window(
+                    cw,
+                    &input_batches,
+                    watermark,
+                    &self.op_name,
+                    &self.ctx,
+                    &self.task_ctx,
+                )
+                .await
             }
             EowcInnerState::EowcAgg(ref mut eowc) => {
-                Self::process_eowc_agg(eowc, &input_batches, watermark, &self.op_name, &self.ctx)
-                    .await
+                Self::process_eowc_agg(
+                    eowc,
+                    &input_batches,
+                    watermark,
+                    &self.op_name,
+                    &self.ctx,
+                    &self.task_ctx,
+                )
+                .await
             }
             EowcInnerState::Raw {
                 ref mut accumulated,
@@ -709,7 +728,7 @@ async fn apply_having_via_sql(
     cache
         .as_ref()
         .expect("just initialized")
-        .apply(ctx, query_name, batches.to_vec())
+        .apply(query_name, batches.to_vec())
         .await
 }
 

--- a/crates/laminar-db/src/operator/mod.rs
+++ b/crates/laminar-db/src/operator/mod.rs
@@ -4,18 +4,19 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
+use datafusion::execution::TaskContext;
 use datafusion::prelude::SessionContext;
 
 use crate::error::DbError;
 use crate::sql_analysis::{extract_projection_exprs, CompiledPostProjection};
 
 /// Re-execute a cached physical plan without re-planning; source leaves are swapped per cycle.
+/// Takes a cached `task_ctx` — `SessionContext::task_ctx()` clones the function registries.
 pub(crate) async fn execute_cached_physical(
-    ctx: &SessionContext,
+    task_ctx: Arc<TaskContext>,
     op_name: &str,
     physical: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
 ) -> Result<Vec<RecordBatch>, DbError> {
-    let task_ctx = ctx.task_ctx();
     datafusion::physical_plan::collect(Arc::clone(physical), task_ctx)
         .await
         .map_err(|e| DbError::query_pipeline(op_name, &e))
@@ -25,6 +26,7 @@ pub(crate) async fn execute_cached_physical(
 pub(crate) struct LiveSqlCache {
     handle: laminar_sql::datafusion::LiveSourceHandle,
     physical: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
 }
 
 impl LiveSqlCache {
@@ -52,17 +54,21 @@ impl LiveSqlCache {
             .create_physical_plan(&logical)
             .await
             .map_err(|e| DbError::Pipeline(format!("{what} physical: {e}")))?;
-        Ok(Self { handle, physical })
+        let task_ctx = ctx.task_ctx();
+        Ok(Self {
+            handle,
+            physical,
+            task_ctx,
+        })
     }
 
     pub(crate) async fn apply(
         &self,
-        ctx: &SessionContext,
         op_name: &str,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DbError> {
         self.handle.swap(batches);
-        execute_cached_physical(ctx, op_name, &self.physical).await
+        execute_cached_physical(self.task_ctx.clone(), op_name, &self.physical).await
     }
 }
 
@@ -90,11 +96,10 @@ impl HavingSqlCache {
 
     pub(crate) async fn apply(
         &self,
-        ctx: &SessionContext,
         op_name: &str,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DbError> {
-        self.0.apply(ctx, op_name, batches).await
+        self.0.apply(op_name, batches).await
     }
 }
 
@@ -245,6 +250,6 @@ pub(crate) async fn apply_post_projection(
         .sql_cache
         .as_ref()
         .expect("sql_cache built above")
-        .apply(ctx, op_name, batches)
+        .apply(op_name, batches)
         .await
 }

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
+use datafusion::execution::TaskContext;
 use datafusion::prelude::SessionContext;
 #[cfg(feature = "cluster")]
 use laminar_core::shuffle::ShuffleMessage;
@@ -176,6 +177,7 @@ pub(crate) struct SqlQueryOperator {
     op_name: Arc<str>,
     sql: String,
     ctx: SessionContext,
+    task_ctx: Arc<TaskContext>,
     state: QueryState,
     prom: Option<Arc<EngineMetrics>>,
     pending_restore: Option<AggStateCheckpoint>,
@@ -210,10 +212,12 @@ impl SqlQueryOperator {
         emit_changelog: bool,
         idle_ttl_ms: Option<u64>,
     ) -> Self {
+        let task_ctx = ctx.task_ctx();
         Self {
             op_name: Arc::from(name),
             sql: sql.to_string(),
             ctx,
+            task_ctx,
             state: QueryState::Uninit,
             prom,
             pending_restore: None,
@@ -404,8 +408,7 @@ impl SqlQueryOperator {
                 "internal: execute_cached_plan called on non-CachedPlan state".into(),
             ));
         };
-        let task_ctx = self.ctx.task_ctx();
-        datafusion::physical_plan::collect(plan.clone(), task_ctx)
+        datafusion::physical_plan::collect(plan.clone(), self.task_ctx.clone())
             .await
             .map_err(|e| DbError::query_pipeline(&*self.op_name, &e))
     }
@@ -431,7 +434,12 @@ impl SqlQueryOperator {
                         "Compiled pre-agg projection failed, falling back to cached plan"
                     );
                     if let Some(physical) = agg_state.cached_pre_agg_physical() {
-                        super::execute_cached_physical(&self.ctx, &self.op_name, physical).await?
+                        super::execute_cached_physical(
+                            self.task_ctx.clone(),
+                            &self.op_name,
+                            physical,
+                        )
+                        .await?
                     } else {
                         return Err(DbError::Pipeline(format!(
                             "[LDB-8051] query '{}': compiled pre-agg failed and no cached plan: {e}",
@@ -441,7 +449,7 @@ impl SqlQueryOperator {
                 }
             }
         } else if let Some(physical) = agg_state.cached_pre_agg_physical() {
-            super::execute_cached_physical(&self.ctx, &self.op_name, physical).await?
+            super::execute_cached_physical(self.task_ctx.clone(), &self.op_name, physical).await?
         } else {
             return Err(DbError::Pipeline(format!(
                 "[LDB-8050] query '{}': no compiled projection or cached plan",
@@ -662,7 +670,7 @@ impl SqlQueryOperator {
         self.having_cache
             .as_ref()
             .expect("just initialized")
-            .apply(&self.ctx, &self.op_name, batches.to_vec())
+            .apply(&self.op_name, batches.to_vec())
             .await
     }
 }
@@ -829,7 +837,7 @@ impl GraphOperator for SqlQueryOperator {
                 }
             },
             QueryState::CachedPhysical(ref physical) => {
-                super::execute_cached_physical(&self.ctx, &self.op_name, physical).await
+                super::execute_cached_physical(self.task_ctx.clone(), &self.op_name, physical).await
             }
         }
     }

--- a/crates/laminar-db/src/operator/temporal_join.rs
+++ b/crates/laminar-db/src/operator/temporal_join.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
+use datafusion::execution::TaskContext;
 use datafusion::prelude::SessionContext;
 
 use laminar_sql::datafusion::lookup_join::LookupJoinType;
@@ -21,6 +22,7 @@ pub(crate) struct TemporalJoinOperator {
     op_name: Arc<str>,
     config: TemporalJoinTranslatorConfig,
     ctx: SessionContext,
+    task_ctx: Arc<TaskContext>,
     lookup_registry: Option<Arc<LookupTableRegistry>>,
     last_temporal_row_count: usize,
     projection: ProjectingJoinState,
@@ -38,6 +40,7 @@ impl TemporalJoinOperator {
             op_name: Arc::from(name),
             config,
             ctx: ctx.clone(),
+            task_ctx: ctx.task_ctx(),
             lookup_registry,
             last_temporal_row_count: 0,
             projection: ProjectingJoinState::new(name, ctx, projection_sql, "__temporal_tmp"),
@@ -166,9 +169,8 @@ impl TemporalJoinOperator {
             ))
         })?;
 
-        let task_ctx = self.ctx.state().task_ctx();
         let stream = exec
-            .execute(0, task_ctx)
+            .execute(0, self.task_ctx.clone())
             .map_err(|e| DbError::Pipeline(format!("temporal join [{}]: {e}", self.op_name)))?;
 
         let batches: Vec<RecordBatch> = stream

--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -242,7 +242,7 @@ impl GraphOperator for SqlFilterOperator {
         self.cache
             .as_ref()
             .unwrap()
-            .apply(&self.ctx, "pre-filter", batches)
+            .apply("pre-filter", batches)
             .await
     }
 


### PR DESCRIPTION
## What

`execute_cached_physical` rebuilt an `Arc<TaskContext>` from the `SessionContext` on **every** operator `collect()` — once per operator per cycle — and `SessionContext::task_ctx()` clones the session config and the scalar/aggregate/window function registries each call. At sub-second cycle cadence with many operators this is pure, repeated overhead on the hot path. `TemporalJoinOperator` was worse: it called `self.ctx.state().task_ctx()`, cloning the entire `SessionState` first.

## Change

Build the `Arc<TaskContext>` once per owner and reuse it (session config/functions are fixed after setup):

- `LiveSqlCache` caches `task_ctx` at build time (covers post-projection, HAVING, EOWC-raw, and the pre-filter operator transitively).
- `SqlQueryOperator` / `EowcQueryOperator` / `TemporalJoinOperator` build it once in `new()`.
- `TemporalJoin`'s per-cycle `state().task_ctx()` becomes an `Arc` bump.

Behavior-preserving — the cached physical plan and session state are already stable across cycles, so the task context can be too.

## Validation

- 758 lib tests pass.
- clippy clean for default and `state-tier` (implies `cluster`) feature sets.

Part of the perf-bottlenecks series (item P0.2).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache a per-operator `TaskContext` and reuse it across cycles to avoid rebuilding on every collect. This removes repeated cloning of session config and function registries in `datafusion` and reduces hot-path overhead with no behavior change.

- **Refactors**
  - `execute_cached_physical` now takes `Arc<TaskContext>` and stops deriving it from `SessionContext`.
  - `LiveSqlCache` builds and stores a `task_ctx`; `.apply(...)` no longer takes a `SessionContext`.
  - `SqlQueryOperator`, `EowcQueryOperator`, and `TemporalJoinOperator` create `task_ctx` in `new()` and reuse it; `TemporalJoinOperator` stops calling `self.ctx.state().task_ctx()` per cycle.
  - Updated post-projection, HAVING, pre-filter, and EOWC paths to use the cached `task_ctx`; behavior preserved.

<sup>Written for commit c85568d0dfa67494ae85b3f2fce92e6d8c086604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal execution context management across query operators to improve performance and reduce redundant operations during query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->