### PR TITLE
perf(db): incremental changelog aggregate emission via dirty-group set

### DIFF
--- a/crates/laminar-db/benches/stream_executor_bench.rs
+++ b/crates/laminar-db/benches/stream_executor_bench.rs
@@ -57,6 +57,30 @@ fn synthetic_batch(rows: usize) -> RecordBatch {
     .unwrap()
 }
 
+/// Batch whose `id` ranges over `[0, num_groups)` (offset by `base`), so
+/// `GROUP BY id` yields exactly `num_groups` groups. Other columns are filler.
+fn keyed_batch(rows: usize, num_groups: usize, base: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows)
+        .map(|i| ((base + i) % num_groups) as i64)
+        .collect();
+    let regions: Vec<&str> = (0..rows).map(|_| "us-east").collect();
+    let prices: Vec<f64> = (0..rows).map(|i| 10.0 + (i as f64) * 0.1).collect();
+    let quantities: Vec<i64> = (0..rows).map(|i| (i % 100) as i64 + 1).collect();
+    let timestamps: Vec<i64> = (0..rows).map(|i| 1_000_000 + i as i64).collect();
+
+    RecordBatch::try_new(
+        bench_schema(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(regions)),
+            Arc::new(Float64Array::from(prices)),
+            Arc::new(Int64Array::from(quantities)),
+            Arc::new(Int64Array::from(timestamps)),
+        ],
+    )
+    .unwrap()
+}
+
 /// A trivial type implementing `FromBatch` for subscription polling.
 struct RowCount(#[allow(dead_code)] usize);
 
@@ -299,10 +323,71 @@ fn bench_query_chain(c: &mut Criterion) {
     group.finish();
 }
 
+/// Subscribe, push, then poll until one emit lands. Subscribe-before-push so the
+/// emit isn't missed; `poll` is non-blocking so no tokio context is needed (the
+/// pipeline runs on the runtime workers started by `db.start()`).
+fn push_and_wait(db: &LaminarDB, source: &laminar_db::UntypedSourceHandle, batch: RecordBatch) {
+    let mut sub = db.subscribe::<RowCount>("agg_hc").unwrap();
+    source.push_arrow(batch).unwrap();
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        if sub.poll().is_some() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+/// High-cardinality `GROUP BY id`: warm the group table to `num_groups`, then push
+/// a 64-row batch per cycle and measure the emit. Pre-P0.1a the changelog emit
+/// re-scans every group; after, only touched ones. `running_state` (replace-all,
+/// unchanged by P0.1a) is the control; `emit_changes` is the delta path under test.
+fn bench_agg_high_cardinality(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("agg_high_cardinality");
+    let create_source = "CREATE SOURCE trades (id BIGINT, region VARCHAR, price DOUBLE, quantity BIGINT, ts BIGINT)";
+
+    for &num_groups in &[1_000usize, 100_000] {
+        for (label, tail) in [("running_state", ""), ("emit_changes", " EMIT CHANGES")] {
+            let ddl = format!(
+                "CREATE STREAM agg_hc AS SELECT id, SUM(price) AS total FROM trades GROUP BY id{tail}"
+            );
+            group.bench_function(format!("{label}_{num_groups}_groups"), |b| {
+                b.iter_batched(
+                    || {
+                        let db = LaminarDB::open().unwrap();
+                        let source = rt.block_on(async {
+                            db.execute(create_source).await.unwrap();
+                            db.execute(&ddl).await.unwrap();
+                            db.start().await.unwrap();
+                            db.source_untyped("trades").unwrap()
+                        });
+                        // Warm: populate all num_groups groups.
+                        push_and_wait(&db, &source, keyed_batch(num_groups, num_groups, 0));
+                        (db, source, keyed_batch(64, num_groups, 0))
+                    },
+                    |(db, source, small)| {
+                        push_and_wait(&db, &source, small);
+                        std::hint::black_box(&db);
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_plain_select,
     bench_agg_group_by,
+    bench_agg_high_cardinality,
     bench_sort_limit,
     bench_query_chain,
 );

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -7,7 +7,7 @@
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use rustc_hash::FxHashMap;
 
 use arrow::array::ArrayRef;
@@ -260,6 +260,10 @@ pub(crate) struct IncrementalAggState {
     max_groups: usize,
     emit_changelog: bool,
     last_emitted: AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>>,
+    // Group keys touched since the last emit. The changelog path re-evaluates only
+    // these instead of scanning every group. Transient (cleared each emit),
+    // populated only when emit_changelog, so not checkpointed.
+    dirty_keys: AHashSet<arrow::row::OwnedRow>,
     pub(crate) idle_ttl_ms: Option<u64>,
     weight_col_idx: Option<usize>,
     // None = no per-vnode capture yet; dirty tracking is off.
@@ -559,6 +563,7 @@ impl IncrementalAggState {
             max_groups: 1_000_000,
             emit_changelog,
             last_emitted: AHashMap::new(),
+            dirty_keys: AHashSet::new(),
             idle_ttl_ms: None,
             weight_col_idx,
             #[cfg(feature = "state-tier")]
@@ -710,6 +715,9 @@ impl IncrementalAggState {
                 self.weight_col_idx,
             )?;
             entry.last_updated_ms = watermark_ms;
+            if self.emit_changelog {
+                self.dirty_keys.insert(row_ref.owned());
+            }
         }
         self.state_gen = self.state_gen.wrapping_add(1);
 
@@ -750,13 +758,17 @@ impl IncrementalAggState {
         #[allow(clippy::cast_possible_truncation)]
         let all_indices: Vec<u32> = (0..batch.num_rows() as u32).collect();
         self.state_gen = self.state_gen.wrapping_add(1);
-        Self::update_group_accumulators(
+        let res = Self::update_group_accumulators(
             &mut entry.accs,
             batch,
             &all_indices,
             &self.agg_specs,
             self.weight_col_idx,
-        )
+        );
+        if self.emit_changelog {
+            self.dirty_keys.insert(empty_key);
+        }
+        res
     }
 
     /// Update accumulators for a group: one `take()` per column per accumulator, no per-row allocation.
@@ -900,7 +912,15 @@ impl IncrementalAggState {
         let mut insert_keys: Vec<arrow::row::OwnedRow> = Vec::new();
         let mut insert_vals: Vec<Vec<ScalarValue>> = Vec::new();
 
-        for (key, entry) in &mut self.groups {
+        // Only touched groups can differ from `last_emitted`. Take the set so the loop
+        // can borrow `groups`/`last_emitted`; restore it cleared to reuse the allocation.
+        let mut dirty = std::mem::take(&mut self.dirty_keys);
+        for key in &dirty {
+            // A dirty key absent from `groups` was removed by `evict_idle`, which
+            // already emitted its retraction; skip it.
+            let Some(entry) = self.groups.get_mut(key) else {
+                continue;
+            };
             let current: Vec<ScalarValue> = entry
                 .accs
                 .iter_mut()
@@ -937,18 +957,18 @@ impl IncrementalAggState {
                 self.last_emitted.insert(key.clone(), current);
             }
         }
+        dirty.clear();
+        self.dirty_keys = dirty;
 
-        let deleted: Vec<arrow::row::OwnedRow> = self
-            .last_emitted
-            .keys()
-            .filter(|k| !self.groups.contains_key(*k))
-            .cloned()
-            .collect();
-        for key in &deleted {
-            let old = self.last_emitted.remove(key).unwrap();
-            retract_keys.push(key.clone());
-            retract_vals.push(old);
-        }
+        // Every remover (evict_idle, demote_vnode, restore/merge) drops the group from
+        // `last_emitted` too and evict_idle retracts, so no separate deletion pass is
+        // needed; the invariant below holds.
+        debug_assert!(
+            self.last_emitted
+                .keys()
+                .all(|k| self.groups.contains_key(k)),
+            "last_emitted must be a subset of groups"
+        );
 
         let total = retract_keys.len() + insert_keys.len();
         if total == 0 {
@@ -1128,6 +1148,9 @@ impl IncrementalAggState {
 
         self.groups = new_groups;
         self.last_emitted = new_last_emitted;
+        // Restored state is internally consistent (groups == last_emitted), so
+        // nothing is pending for the changelog path.
+        self.dirty_keys.clear();
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
         // All state is in memory; block demotion until the next capture re-baselines.
@@ -1238,6 +1261,11 @@ impl IncrementalAggState {
         for gc in &checkpoint.groups {
             let sv_key = ipc_to_scalars(&gc.key)?;
             let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
+            // merge_batch changes the group's value relative to last_emitted, so the
+            // changelog path must re-evaluate it (the diff still gates actual output).
+            if self.emit_changelog {
+                self.dirty_keys.insert(row_key.clone());
+            }
             match self.groups.entry(row_key) {
                 std::collections::hash_map::Entry::Occupied(mut occ) => {
                     let entry = occ.get_mut();
@@ -2491,6 +2519,67 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn merge_groups_reemits_changed_group_on_changelog() {
+        // Regression: merge_groups folds extra accumulator state into an existing
+        // group, changing its value relative to last_emitted. The changelog emit
+        // only visits dirty keys, so merge_groups must mark the merged group dirty
+        // or the change is silently dropped downstream.
+        let ctx = laminar_sql::create_session_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let dummy = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["x"])),
+                Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+            .unwrap();
+        ctx.register_table("events", Arc::new(mem)).unwrap();
+        let mut state = IncrementalAggState::try_from_sql(
+            &ctx,
+            "SELECT name, SUM(value) as total FROM events GROUP BY name",
+            true,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            pre_agg_schema,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a"])),
+                Arc::new(arrow::array::Float64Array::from(vec![10.0])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, 1000).unwrap();
+        let r1 = state.emit().unwrap();
+        assert_eq!(r1.iter().map(RecordBatch::num_rows).sum::<usize>(), 1); // a: +10
+
+        // Fold a's own slice back in (the rebalance/promotion apply path): a -> 20.
+        let cp = state.checkpoint_groups().unwrap();
+        state.merge_groups(&cp).unwrap();
+
+        // a changed (10 -> 20) and must re-emit retract(old) + insert(new).
+        let r2 = state.emit().unwrap();
+        assert_eq!(
+            r2.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            2,
+            "merged group must re-emit retract+insert",
+        );
+    }
+
     #[tokio::test]
     async fn test_size_estimate_throttled_cache_and_invalidate() {
         let (_, mut state) =
@@ -2856,6 +2945,93 @@ mod tests {
         // Cycle 3: no new data, nothing changed → empty output.
         let r3 = state.emit().unwrap();
         assert!(r3.is_empty() || r3.iter().all(|b| b.num_rows() == 0));
+    }
+
+    #[tokio::test]
+    async fn changelog_restore_emits_no_duplicates_then_resumes() {
+        // After recovery, restored groups are already reflected downstream (last_emitted
+        // is restored in lockstep with groups), so the first post-restore emit must be
+        // empty — re-emitting would duplicate. A later change must still emit normally.
+        let ctx = SessionContext::new();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("symbol", DataType::Utf8, false),
+            Field::new("price", DataType::Int64, false),
+        ]));
+        let seed = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["X"])),
+                Arc::new(arrow::array::Int64Array::from(vec![1])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(schema, vec![vec![seed]]).unwrap();
+        ctx.register_table("t", Arc::new(mem)).unwrap();
+
+        let sql = "SELECT symbol, SUM(price) AS total FROM t GROUP BY symbol";
+        let mut state = IncrementalAggState::try_from_sql(&ctx, sql, true)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let pre_agg = Arc::new(Schema::new(vec![
+            Field::new("symbol", DataType::Utf8, true),
+            Field::new("price", DataType::Int64, true),
+        ]));
+        let b1 = RecordBatch::try_new(
+            Arc::clone(&pre_agg),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["AAPL", "GOOG"])),
+                Arc::new(arrow::array::Int64Array::from(vec![100, 200])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&b1, 1000).unwrap();
+        assert_eq!(
+            state
+                .emit()
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2
+        ); // AAPL +1, GOOG +1
+
+        // Recover into a fresh state from the post-emit checkpoint.
+        let cp = state.checkpoint_groups().unwrap();
+        let mut restored = IncrementalAggState::try_from_sql(&ctx, sql, true)
+            .await
+            .unwrap()
+            .unwrap();
+        restored.restore_groups(&cp).unwrap();
+
+        // First emit after restore: nothing new → empty (no duplicate inserts).
+        let r0 = restored.emit().unwrap();
+        assert!(
+            r0.is_empty() || r0.iter().all(|b| b.num_rows() == 0),
+            "restored groups must not be re-emitted"
+        );
+
+        // A real change resumes normally: AAPL 100 -> 150 emits retract + insert.
+        let b2 = RecordBatch::try_new(
+            pre_agg,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["AAPL"])),
+                Arc::new(arrow::array::Int64Array::from(vec![50])),
+            ],
+        )
+        .unwrap();
+        restored.process_batch(&b2, 2000).unwrap();
+        assert_eq!(
+            restored
+                .emit()
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2,
+            "post-restore change must emit retract+insert"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`emit_changelog_delta` re-evaluated **every** group and diffed it against `last_emitted` on every cycle — `O(all groups)` regardless of how few changed. A single input row to a 1M-group `EMIT CHANGES` aggregate re-evaluated 1M accumulators per cycle.

## Change

Track the groups touched since the last emit (`dirty_keys`) and re-evaluate only those. The diff against `last_emitted` still gates output, so the changelog stream is unchanged — pure cost reduction, `O(all groups)` → `O(touched)`.

- `dirty_keys` populated in `process_batch` / `process_batch_no_groups`, changelog-only, so the running-state path and checkpoints are untouched. Transient (cleared each emit) → not checkpointed.
- `merge_groups` (cluster rehydration) folds extra state into existing groups, changing their value vs `last_emitted`, so it marks merged keys dirty — otherwise the dirty-set emit would silently drop the change. Adds a regression test (this path had **no** coverage).
- Removed the deletion rescan: every group remover (`evict_idle`, `demote_vnode`, restore, merge) drops the group from `last_emitted` in lockstep, so `last_emitted ⊆ groups` always holds and the rescan was dead. Replaced with a `debug_assert` of the invariant.

## Benchmark (criterion, before/after)

Added a high-cardinality `GROUP BY` bench as the regression guard (the existing `agg_group_by` bench uses 4 groups — the case where full re-emission is free, so it can't detect this).

| Case | Before | After | |
|---|---|---|---|
| `emit_changes` / 100k groups | 54.8 ms | **10.1 ms** | **−81.5%** (p<0.05) |
| `emit_changes` / 1k groups | 9.7 ms | 11.9 ms | no change (within the ~10ms harness round-trip floor) |
| `running_state` / 100k groups | 30.6 ms | 30.0 ms | no change (control — this path is intentionally untouched) |

After the change the changelog cost is **flat across a 100× group-count increase** (10.1ms @ 100k ≈ 11.9ms @ 1k) — the signature of `O(touched)`.

## Validation

- 759 lib tests + 12 changelog/cluster tests pass (incl. the new `merge_groups` regression test).
- clippy clean for default and `state-tier` feature sets.

## Notes for reviewers

- The other 4 benches in `stream_executor_bench.rs` are **pre-existing broken** — they use a mock-connector source that ignores `push_arrow` and a `wait_for_output` that panics outside a tokio runtime, so they compile but were never run. The new bench uses the proven push-only pattern (`LaminarDB::open()` + connector-less source + `db.start()` + non-blocking `poll`). Fixing the others is left as separate cleanup to keep this PR focused.
- A separate pre-existing bug was found and recorded (not in scope here): `asof_join_in_materialized_view_emits_backward_match` times out under `--features state-tier` on `main` (confirmed with these changes reverted).

Part of the perf-bottlenecks series (item P0.1a).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make changelog aggregate emission evaluate only changed groups by tracking a `dirty_keys` set, cutting emit time by ~81% at 100k groups (54.8ms → 10.1ms). Output is unchanged; running-state remains untouched.

- **Refactors**
  - Track `dirty_keys` when changelog is enabled; populate in `process_batch`/`process_batch_no_groups`, clear after each emit and on restore; not checkpointed.
  - Emit re-evaluates only dirty groups; removed deletion rescan and added a `debug_assert` that `last_emitted ⊆ groups`.
  - Added a high-cardinality `GROUP BY` bench that measures both `running_state` and `EMIT CHANGES` paths.

- **Bug Fixes**
  - `merge_groups` marks merged keys dirty so changed groups re-emit on changelog; added a regression test.
  - Added a test to ensure post-restore emits no duplicates and later changes re-emit correctly.

<sup>Written for commit ed29cda67af44e1eeb1f79afaa9a2ce5dfe8ed49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced performance for grouped aggregation queries with large group counts by optimizing changelog emission tracking, reducing computational overhead.

* **Tests**
  * Added high-cardinality aggregation benchmarks to measure query performance with large group counts and varying data emission patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->