### PR TITLE
perf(connectors): cache JSON decoder and decode from borrowed slices

### DIFF
--- a/crates/laminar-connectors/src/schema/json/decoder.rs
+++ b/crates/laminar-connectors/src/schema/json/decoder.rs
@@ -342,14 +342,32 @@ impl FormatDecoder for JsonDecoder {
         self.schema.clone()
     }
 
-    #[allow(clippy::too_many_lines)]
     fn decode_batch(&self, records: &[RawRecord]) -> SchemaResult<RecordBatch> {
-        if records.is_empty() {
+        let values: Vec<&[u8]> = records.iter().map(|r| r.value.as_slice()).collect();
+        self.decode_slices(&values)
+    }
+
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn format_name(&self) -> &str {
+        "json"
+    }
+}
+
+impl JsonDecoder {
+    /// Decode borrowed JSON payload slices into a `RecordBatch` — avoids the owned
+    /// copy a `RawRecord` requires. Used by the streaming deserializer.
+    ///
+    /// # Errors
+    /// Returns `SchemaError::DecodeError` if a payload is not valid JSON or the
+    /// decoded values cannot be assembled into the output schema.
+    #[allow(clippy::too_many_lines)]
+    pub fn decode_slices(&self, values: &[&[u8]]) -> SchemaResult<RecordBatch> {
+        if values.is_empty() {
             return Ok(RecordBatch::new_empty(self.schema.clone()));
         }
 
         let num_fields = self.schema.fields().len();
-        let capacity = records.len();
+        let capacity = values.len();
 
         // Initialise one builder per schema column.
         let mut builders = create_builders(&self.schema, capacity);
@@ -374,8 +392,8 @@ impl FormatDecoder for JsonDecoder {
         // Reusable populated-tracking buffer — avoids heap alloc per record.
         let mut populated = vec![false; num_fields];
 
-        for record in records {
-            let value: serde_json::Value = serde_json::from_slice(&record.value)
+        for &bytes in values {
+            let value: serde_json::Value = serde_json::from_slice(bytes)
                 .map_err(|e| SchemaError::DecodeError(format!("JSON parse error: {e}")))?;
 
             // Navigate json.path → default target (borrowed, ZERO alloc).
@@ -579,13 +597,6 @@ impl FormatDecoder for JsonDecoder {
             .map_err(|e| SchemaError::DecodeError(format!("RecordBatch construction: {e}")))
     }
 
-    #[allow(clippy::unnecessary_literal_bound)]
-    fn format_name(&self) -> &str {
-        "json"
-    }
-}
-
-impl JsonDecoder {
     /// O(n) field lookup. For schemas with many fields, consider switching
     /// to a `HashMap`; for typical schemas (<50 fields) linear scan is faster.
     fn field_index(&self, name: &str) -> Option<usize> {

--- a/crates/laminar-connectors/src/serde/json.rs
+++ b/crates/laminar-connectors/src/serde/json.rs
@@ -3,28 +3,47 @@
 //! Implements [`RecordDeserializer`] / [`RecordSerializer`] by delegating
 //! to [`JsonDecoder`] and [`JsonEncoder`].
 
+use std::sync::Arc;
+
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
+use parking_lot::Mutex;
 use serde_json::Value;
 
 use super::{Format, RecordDeserializer, RecordSerializer};
 use crate::error::SerdeError;
 use crate::schema::json::decoder::JsonDecoder;
 use crate::schema::json::encoder::JsonEncoder;
-use crate::schema::traits::{FormatDecoder, FormatEncoder};
-use crate::schema::types::RawRecord;
+use crate::schema::traits::FormatEncoder;
 
-/// JSON record deserializer. Delegates to [`JsonDecoder`].
+/// JSON record deserializer. Delegates to a cached [`JsonDecoder`].
 #[derive(Debug, Clone)]
 pub struct JsonDeserializer {
-    _private: (),
+    #[allow(clippy::type_complexity)]
+    decoder: Arc<Mutex<Option<(SchemaRef, Arc<JsonDecoder>)>>>,
 }
 
 impl JsonDeserializer {
     /// Creates a new JSON deserializer.
     #[must_use]
     pub fn new() -> Self {
-        Self { _private: () }
+        Self {
+            decoder: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Returns a cached [`JsonDecoder`] for `schema`, rebuilding it only when
+    /// the cached schema differs.
+    fn decoder_for(&self, schema: &SchemaRef) -> Arc<JsonDecoder> {
+        let mut cache = self.decoder.lock();
+        if let Some((cached_schema, cached)) = cache.as_ref() {
+            if Arc::ptr_eq(cached_schema, schema) || cached_schema == schema {
+                return cached.clone();
+            }
+        }
+        let decoder = Arc::new(JsonDecoder::new(schema.clone()));
+        *cache = Some((schema.clone(), decoder.clone()));
+        decoder
     }
 
     /// Deserializes a pre-parsed JSON [`Value`] into a [`RecordBatch`].
@@ -53,10 +72,8 @@ impl Default for JsonDeserializer {
 
 impl RecordDeserializer for JsonDeserializer {
     fn deserialize(&self, data: &[u8], schema: &SchemaRef) -> Result<RecordBatch, SerdeError> {
-        let decoder = JsonDecoder::new(schema.clone());
-        let record = RawRecord::new(data.to_vec());
-        decoder
-            .decode_one(&record)
+        let d = self.decoder_for(schema);
+        d.decode_slices(&[data])
             .map_err(|e| SerdeError::Json(e.to_string()))
     }
 
@@ -68,11 +85,8 @@ impl RecordDeserializer for JsonDeserializer {
         if records.is_empty() {
             return Ok(RecordBatch::new_empty(schema.clone()));
         }
-        let decoder = JsonDecoder::new(schema.clone());
-        let raw_records: Vec<RawRecord> =
-            records.iter().map(|r| RawRecord::new(r.to_vec())).collect();
-        decoder
-            .decode_batch(&raw_records)
+        let d = self.decoder_for(schema);
+        d.decode_slices(records)
             .map_err(|e| SerdeError::Json(e.to_string()))
     }
 


### PR DESCRIPTION
## What

`JsonDeserializer` (the JSON `RecordDeserializer` on the Kafka/ingest path) rebuilt a `JsonDecoder` on **every** `deserialize`/`deserialize_batch` — re-deriving `field_indices`/`column_extractions`/`epoch_units` per batch (the decoder's own documented *"Ring 2 one-time setup"*) — and copied every payload via `RawRecord::new(r.to_vec())`, even though `poll_batch` already hands over contiguous borrowed slices.

## Change

- **Cache the decoder** in `JsonDeserializer` (`Arc<Mutex<Option<(SchemaRef, Arc<JsonDecoder>)>>>`, rebuilt only if the schema changes — it doesn't, for a source). Mirrors the existing Avro decoder-cache idiom. Setup now runs once per source instead of per batch.
- **Decode from borrowed slices**: add `JsonDecoder::decode_slices(&[&[u8]])` (the existing `decode_batch` body, which only ever read `record.value`) and make the `FormatDecoder::decode_batch` a thin wrapper. `deserialize`/`deserialize_batch` decode the borrowed slices directly — no per-record `to_vec`.

Behavior-preserving: same decoder, same decode path, same lenient coercion / timestamp parsing / json_path / explode / jsonb. One nuance: `mismatch_count` (a diagnostic `AtomicU64` with **no external readers**) now accumulates across batches instead of resetting per batch — strictly more correct.

## Validation

- 94 JSON tests pass (incl. coercion, batch, roundtrip, explode, jsonb, unknown-fields, timestamp/path).
- 1402 connector lib tests pass (covers the `decode_batch` wrapper's other users: files/text/IPC decoders).
- clippy clean (`--all-targets`), fmt clean.

## Deliberately out of scope

The dominant per-record cost is the `serde_json::Value` **DOM** in `decode_slices` (`from_slice::<Value>` per record). `arrow_json` (a workspace dep) could skip it, but it does **not** replicate the lenient string→number coercion (asserted by `test_json_deserialize_coercion`), multi-format timestamp parsing, or per-record error isolation — so swapping it in would risk silent behavior changes. Left for a separate, behavior-gated effort.

Part of the perf-bottlenecks series (item P0.3).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the streaming JSON decoder and decode from borrowed slices to remove per-batch setup and avoid per-record copies. This reduces CPU and allocations on the Kafka/ingest JSON path without changing behavior.

- **Refactors**
  - Cache the decoder in `JsonDeserializer`; rebuild only when the schema changes (setup runs once per source).
  - Add `JsonDecoder::decode_slices(&[&[u8]])`; make `FormatDecoder::decode_batch` delegate to it; `deserialize`/`deserialize_batch` now pass borrowed slices (no per-record `to_vec`).
  - Behavior preserved; internal `mismatch_count` now accumulates across batches. Existing JSON and connector tests pass.

<sup>Written for commit c39b3bb27bb77c99e53894b29b6123da9573b686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

