### PR TITLE
perf(db): cache SessionState in temporal join to avoid per-cycle clone

### DIFF
--- a/crates/laminar-db/src/operator/temporal_join.rs
+++ b/crates/laminar-db/src/operator/temporal_join.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use datafusion::execution::TaskContext;
+use datafusion::execution::{SessionState, TaskContext};
 use datafusion::prelude::SessionContext;
 
 use laminar_sql::datafusion::lookup_join::LookupJoinType;
@@ -21,7 +21,9 @@ use crate::operator_graph::{GraphOperator, OperatorCheckpoint};
 pub(crate) struct TemporalJoinOperator {
     op_name: Arc<str>,
     config: TemporalJoinTranslatorConfig,
-    ctx: SessionContext,
+    // Session state is fixed after setup; cache it so the per-cycle MemTable scan
+    // doesn't clone it (and the whole SessionState) every cycle.
+    cached_state: SessionState,
     task_ctx: Arc<TaskContext>,
     lookup_registry: Option<Arc<LookupTableRegistry>>,
     last_temporal_row_count: usize,
@@ -39,7 +41,7 @@ impl TemporalJoinOperator {
         Self {
             op_name: Arc::from(name),
             config,
-            ctx: ctx.clone(),
+            cached_state: ctx.state(),
             task_ctx: ctx.task_ctx(),
             lookup_registry,
             last_temporal_row_count: 0,
@@ -146,7 +148,7 @@ impl TemporalJoinOperator {
         })?;
 
         let input = mem_table
-            .scan(&self.ctx.state(), None, &[], None)
+            .scan(&self.cached_state, None, &[], None)
             .await
             .map_err(|e| {
                 DbError::Pipeline(format!("temporal join [{}]: scan: {e}", self.op_name))


### PR DESCRIPTION
## What

`TemporalJoinOperator::execute_versioned_join` called `self.ctx.state()` **every cycle** to feed the stream-side `MemTable` scan — and `SessionContext::state()` clones the entire `SessionState` (config + scalar/aggregate/window function registries) each call, on the per-cycle join path.

## Change

Cache the `SessionState` once at construction (it's fixed after setup — same rationale as the existing `task_ctx` cache from #437) and use it for the scan. The `ctx` field is removed: its only read was that per-cycle `state()` call, so it became dead; `new()` also no longer clones the `SessionContext`.

Behavior-preserving — the cached state has identical content to a fresh clone.

```
-    ctx: SessionContext,
+    cached_state: SessionState,
...
-    ctx: ctx.clone(),
+    cached_state: ctx.state(),
...
-        .scan(&self.ctx.state(), None, &[], None)
+        .scan(&self.cached_state, None, &[], None)
```

## Validation

- 760 lib tests pass; clippy + fmt clean. Feature-independent (no `cfg`-gated code touched; `new()` signature unchanged).

## Out of scope

The per-cycle `MemTable` + `VersionedLookupJoinExec` construction wraps the per-cycle stream batches and the (mutable) versioned table, so they aren't cacheable without a swappable-input rework. The `SessionState` clone was the dominant *fixed* per-cycle overhead; the rest scales with the data (the join itself).

Part of the perf-bottlenecks series (item P1.3).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache `SessionState` in the temporal join operator to avoid cloning it every cycle during `MemTable` scans. This removes hot-path overhead with no behavior changes.

- **Refactors**
  - Cache `SessionState` at construction and use it in `MemTable::scan`.
  - Remove `ctx: SessionContext`; stop calling `state()` each cycle.
  - Keep `task_ctx` unchanged; no API changes to `new()`.

<sup>Written for commit 6689a4e4c885659f2882a291c273d61e996c8229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

