### PR TITLE
perf(db): replace per-cycle O(n) output/source scans with O(1) set lookups

### DIFF
--- a/crates/laminar-db/src/operator_graph.rs
+++ b/crates/laminar-db/src/operator_graph.rs
@@ -264,6 +264,8 @@ pub(crate) struct OperatorGraph {
     source_list: Vec<(Arc<str>, usize)>,
     source_node_ids: FxHashSet<usize>,
     output_map: FxHashMap<Arc<str>, usize>,
+    // Reverse of `output_map` (node id → is an output); rebuilt in `compute_topo_order`.
+    output_node_ids: FxHashSet<usize>,
     input_bufs: Vec<Vec<Vec<RecordBatch>>>,
     input_buf_bytes: Vec<Vec<usize>>,
     input_sources: Vec<Vec<usize>>,
@@ -318,6 +320,7 @@ impl OperatorGraph {
             source_list: Vec::new(),
             source_node_ids: FxHashSet::default(),
             output_map: FxHashMap::default(),
+            output_node_ids: FxHashSet::default(),
             input_bufs: Vec::new(),
             input_buf_bytes: Vec::new(),
             input_sources: Vec::new(),
@@ -443,8 +446,7 @@ impl OperatorGraph {
 
     pub fn has_pending_input(&self) -> bool {
         self.input_bufs.iter().enumerate().any(|(id, ports)| {
-            ports.iter().any(|port| !port.is_empty())
-                && !self.source_map.values().any(|&src| src == id)
+            ports.iter().any(|port| !port.is_empty()) && !self.source_node_ids.contains(&id)
         })
     }
 
@@ -1508,6 +1510,10 @@ impl OperatorGraph {
         self.source_list
             .extend(self.source_map.iter().map(|(k, v)| (Arc::clone(k), *v)));
 
+        self.output_node_ids.clear();
+        self.output_node_ids
+            .extend(self.output_map.values().copied());
+
         self.topo_dirty = false;
     }
 
@@ -1685,7 +1691,7 @@ impl OperatorGraph {
         }
         let node_name = Arc::clone(&self.nodes[node_id].name);
         let has_routes = !self.nodes[node_id].output_routes.is_empty();
-        let is_output = self.output_map.values().any(|&id| id == node_id);
+        let is_output = self.output_node_ids.contains(&node_id);
 
         if has_routes {
             let name_ref = node_name.as_ref();


### PR DESCRIPTION
## What

Two graph lookups did linear `.values().any()` scans:
- `execute_single_operator` computed `is_output` via `output_map.values().any(|&id| id == node_id)` for **every emitting operator every cycle**.
- `has_pending_input` scanned `source_map.values()` per node on each idle tick.

## Change

Use `O(1)` `FxHashSet` lookups, mirroring the existing `source_node_ids` set:
- Add `output_node_ids`, rebuilt in `compute_topo_order` alongside `source_list` — the single point that consumes `topo_dirty`, which every `output_map` mutation sets, so the set can't desync.
- `has_pending_input` now uses the existing `source_node_ids` set.

Behavior-preserving (same results, `O(n)` scan → `O(1)` lookup).

## Validation

- 760 lib tests pass (incl. MV/output tests — a wrong `is_output` set would make outputs vanish), clippy + fmt clean.

## Scope note

This is a **micro-optimization**, not a hot-path mover. I deliberately scoped down the plan's P1.4 list:
- **Skipped** metric-handle caching — invasive (per-operator cached prometheus children) for a marginal gain; not a clean "quick safe" change.
- **Skipped** gating the per-cycle `current_source_offsets` build — it's *not* redundant: those offsets feed `maybe_checkpoint(false, ...)`'s follower-poll / drained-checkpoint path every cycle, so gating it would break that path.

Part of the perf-bottlenecks series (item P1.4).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced per-cycle O(n) scans for output/source checks with O(1) set lookups to cut overhead on each emit and idle tick, with no behavior change.

- **Refactors**
  - Added `output_node_ids` (rebuilt in `compute_topo_order`) and used it in `execute_single_operator` instead of scanning `output_map`.
  - Updated `has_pending_input` to use `source_node_ids` instead of scanning `source_map`.

<sup>Written for commit 77f3f2b7da03c8aaf88ca74d7e282e96e73789dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal performance optimization to the operator graph processing logic, improving efficiency through optimized data structure lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->