### PR TITLE
test(db): checkpoint-capture profiling test (Track A1 phase 2)

### DIFF
--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -3784,6 +3784,80 @@ mod tests {
         let sv = ScalarValue::Binary(Some(vec![1, 2, 3]));
         assert_eq!(round_trip(&sv), sv);
     }
+
+    /// Profiling (not a correctness test): measures the on-task whole-node
+    /// `checkpoint_groups` capture cost vs group count — the cost an incremental
+    /// (dirty-only) capture would shrink (Track A1). Reports total time, ns/group,
+    /// and serialized size, so the incremental win for a given dirty ratio is
+    /// `ns/group * dirty_count`. `#[ignore]`d; run in release:
+    /// `cargo test -p laminar-db --release profile_checkpoint_capture -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "profiling; run with --release --ignored --nocapture"]
+    async fn profile_checkpoint_capture_cost() {
+        for &n in &[10_000usize, 100_000, 1_000_000] {
+            let ctx = SessionContext::new();
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("value", DataType::Float64, false),
+            ]));
+            let dummy = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(arrow::array::Int64Array::from(vec![0i64])),
+                    Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+                ],
+            )
+            .unwrap();
+            let mem =
+                datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+                    .unwrap();
+            ctx.register_table("events", Arc::new(mem)).unwrap();
+            let mut state = IncrementalAggState::try_from_sql(
+                &ctx,
+                "SELECT id, SUM(value) AS total FROM events GROUP BY id",
+                false,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+            let pre = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, true),
+                Field::new("__agg_input_1", DataType::Float64, true),
+            ]));
+            #[allow(clippy::cast_precision_loss)]
+            let batch = RecordBatch::try_new(
+                pre,
+                vec![
+                    Arc::new(arrow::array::Int64Array::from(
+                        (0..n as i64).collect::<Vec<_>>(),
+                    )),
+                    Arc::new(arrow::array::Float64Array::from(
+                        (0..n).map(|i| i as f64).collect::<Vec<_>>(),
+                    )),
+                ],
+            )
+            .unwrap();
+            state.process_batch(&batch, 0).unwrap();
+
+            let t0 = std::time::Instant::now();
+            let cp = state.checkpoint_groups().unwrap();
+            let elapsed = t0.elapsed();
+
+            let bytes: usize = cp
+                .groups
+                .iter()
+                .map(|g| g.key.len() + g.acc_states.iter().map(Vec::len).sum::<usize>())
+                .sum();
+            #[allow(clippy::cast_precision_loss)]
+            let ns_per_group = elapsed.as_nanos() as f64 / n as f64;
+            println!(
+                "checkpoint_groups: {n:>9} groups -> {elapsed:>11.2?}  ({ns_per_group:6.0} ns/group)  ~{} KiB",
+                bytes / 1024
+            );
+            assert_eq!(cp.groups.len(), n);
+        }
+    }
 }
 
 /// Per-vnode checkpoint partitioning + merge-apply (the cross-node vnode


### PR DESCRIPTION
## What

Adds `profile_checkpoint_capture_cost` (`#[ignore]`d, run in release) — a profiling tool that times the on-task whole-node `checkpoint_groups` capture vs group count. It's the evidence for the checkpoint-capture (Track A) design and a re-runnable guard for the eventual fix.

```
cargo test -p laminar-db --release profile_checkpoint_capture -- --ignored --nocapture
```

## Findings (release)

| groups | on-task `checkpoint_groups` | per-group | serialized size |
|---|---|---|---|
| 10k | 82 ms | 8.2 µs | ~8.9 MiB |
| 100k | 894 ms | 8.9 µs | ~89 MiB |
| 1M | 9.98 s | 10.0 µs | ~890 MiB |

- Strictly **O(groups)** at ~9 µs/group.
- The on-task stall is the bottleneck: a 100k-group aggregate stalls the pipeline **~0.9s per checkpoint** — 9× the 100ms target; 1M groups ≈ 10s. Sub-second checkpointing is impossible for large keyed aggregates today.
- ~890 B/group + ~9µs/group implicate the **per-group Arrow-IPC framing** — `scalars_to_ipc` writes a full IPC stream *with schema header* per group key and per accumulator state.

## Implication

This reorders the checkpoint-capture plan (`docs/plans/incremental-aggregate-checkpoint-a1-2026-06-20.md`): the **columnar-serialization fix (A3)** — one IPC encode per operator instead of per-group framing — is a constant-factor (~9×) win that is workload-independent, contained to `checkpoint_groups`/`restore_groups`, and needs **no recovery-model switch**, so it should precede the incremental-capture A1 (which does).

No production code changes — `#[ignore]`d test only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `profile_checkpoint_capture_cost`, an ignored release-only profiling test that measures whole-node `checkpoint_groups` capture cost vs group count. Confirms O(groups) cost and highlights the on-task stall driving Track A1/A3; no production changes.

- **New Features**
  - Profiling test in `laminar-db` reporting total time, ns/group, and serialized size; run: `cargo test -p laminar-db --release profile_checkpoint_capture -- --ignored --nocapture`.
  - Findings: ~9 µs/group and ~890 B/group, pointing to per-group Arrow IPC framing as the bottleneck for large aggregates.

<sup>Written for commit de3e0fbaaeb8e9d6763ef3fa8f5eb0579ed007c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance profiling test to benchmark checkpoint capture efficiency across datasets of increasing size, validating system scalability and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->