### PR TITLE
Cluster strict-EO vnode rotation + columnar agg checkpoint + MongoDB sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-connectors"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "arrow-array",
  "arrow-avro",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-core"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-db"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-derive"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "arrow",
  "laminar-connectors",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-server"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "laminar-sql"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.27.0"
+version = "0.27.1"
 authors = ["LaminarDB Contributors"]
 edition = "2021"
 rust-version = "1.95"

--- a/crates/laminar-connectors/src/kafka/offsets.rs
+++ b/crates/laminar-connectors/src/kafka/offsets.rs
@@ -109,40 +109,40 @@ impl OffsetTracker {
         cp
     }
 
-    /// Restores offset state from a [`SourceCheckpoint`].
-    ///
-    /// Parses keys in `"{topic}-{partition}"` format. Logs warnings for
-    /// unparseable entries rather than silently dropping them.
+    /// Restores offset state from a [`SourceCheckpoint`]. See
+    /// [`from_offset_map`](Self::from_offset_map) for the key format.
     #[must_use]
     pub fn from_checkpoint(cp: &SourceCheckpoint) -> Self {
+        Self::from_offset_map(cp.offsets())
+    }
+
+    /// Builds a tracker from a raw `"{topic}-{partition}" -> offset` map (the
+    /// connector-agnostic source-checkpoint representation). Topic names may
+    /// contain `-`, so the partition is split off the last `-`. Unparseable
+    /// entries are logged and skipped rather than silently dropped.
+    #[must_use]
+    pub fn from_offset_map(offsets: &HashMap<String, String>) -> Self {
         let mut tracker = Self::new();
-        for (key, value) in cp.offsets() {
-            match value.parse::<i64>() {
-                Ok(offset) => {
-                    if let Some(dash_pos) = key.rfind('-') {
-                        let topic = &key[..dash_pos];
-                        match key[dash_pos + 1..].parse::<i32>() {
-                            Ok(partition) => tracker.update_force(topic, partition, offset),
-                            Err(_) => {
-                                tracing::warn!(
-                                    key,
-                                    "skipping checkpoint entry with unparseable partition"
-                                );
-                            }
-                        }
-                    } else {
-                        tracing::warn!(
-                            key,
-                            "skipping checkpoint entry without topic-partition separator"
-                        );
-                    }
-                }
+        for (key, value) in offsets {
+            let Ok(offset) = value.parse::<i64>() else {
+                tracing::warn!(
+                    key,
+                    value,
+                    "skipping checkpoint entry with unparseable offset"
+                );
+                continue;
+            };
+            let Some(dash_pos) = key.rfind('-') else {
+                tracing::warn!(
+                    key,
+                    "skipping checkpoint entry without topic-partition separator"
+                );
+                continue;
+            };
+            match key[dash_pos + 1..].parse::<i32>() {
+                Ok(partition) => tracker.update_force(&key[..dash_pos], partition, offset),
                 Err(_) => {
-                    tracing::warn!(
-                        key,
-                        value,
-                        "skipping checkpoint entry with unparseable offset"
-                    );
+                    tracing::warn!(key, "skipping checkpoint entry with unparseable partition");
                 }
             }
         }
@@ -329,6 +329,38 @@ mod tests {
         assert_eq!(restored.get("events", 1), Some(200));
         assert_eq!(restored.get("orders", 0), Some(50));
         assert_eq!(restored.partition_count(), 3);
+    }
+
+    #[test]
+    fn from_offset_map_splits_partition_off_last_dash() {
+        // Topic names may contain '-': only the final segment is the partition.
+        let map = HashMap::from([
+            ("events-5".to_string(), "100".to_string()),
+            ("my-topic-2".to_string(), "7".to_string()),
+        ]);
+        let tracker = OffsetTracker::from_offset_map(&map);
+        assert_eq!(tracker.get("events", 5), Some(100));
+        assert_eq!(tracker.get("my-topic", 2), Some(7));
+        assert_eq!(tracker.partition_count(), 2);
+    }
+
+    #[test]
+    fn from_offset_map_skips_malformed_entries() {
+        let map = HashMap::from([
+            ("good-0".to_string(), "10".to_string()),
+            ("bad-partition-x".to_string(), "10".to_string()), // partition not an int
+            ("nodashseparator".to_string(), "10".to_string()), // no '-'
+            ("offset-0".to_string(), "notanumber".to_string()), // offset not an int
+        ]);
+        let tracker = OffsetTracker::from_offset_map(&map);
+        assert_eq!(tracker.get("good", 0), Some(10));
+        assert_eq!(tracker.partition_count(), 1);
+    }
+
+    #[test]
+    fn from_offset_map_empty_is_empty() {
+        let tracker = OffsetTracker::from_offset_map(&HashMap::new());
+        assert_eq!(tracker.partition_count(), 0);
     }
 
     #[test]

--- a/crates/laminar-connectors/src/kafka/rebalance.rs
+++ b/crates/laminar-connectors/src/kafka/rebalance.rs
@@ -97,14 +97,9 @@ pub struct LaminarConsumerContext {
     /// this value using `Relaxed` ordering, and only locks the mutex when
     /// a change is detected.
     revoke_generation: Arc<AtomicU64>,
-    /// Shared flag indicating whether the reader task has paused Kafka
-    /// partitions for backpressure. On `Assign`, newly assigned partitions
-    /// must be re-paused if this flag is true.
-    reader_paused: Arc<AtomicBool>,
-    /// Snapshot of consumed offsets, updated once per `poll_batch()` cycle.
-    /// Read on Assign to seek newly assigned partitions to last-consumed
-    /// offset + 1, preventing duplicates after broker failures.
-    offset_snapshot: Arc<Mutex<super::offsets::OffsetTracker>>,
+    /// Bumped on each Assign; the reader task seeks the newly-assigned partitions
+    /// from the poll loop (see the `KafkaSource` reader loop).
+    assign_generation: Arc<AtomicU64>,
     /// Counter bumped on every broker-confirmed commit. The on-checkpoint
     /// commit path issues `CommitMode::Sync`, so this is the authoritative
     /// success counter — `commit_callback` still fires for sync commits.
@@ -122,8 +117,7 @@ impl LaminarConsumerContext {
         rebalance_state: Arc<Mutex<RebalanceState>>,
         rebalance_metric: Arc<AtomicU64>,
         revoke_generation: Arc<AtomicU64>,
-        reader_paused: Arc<AtomicBool>,
-        offset_snapshot: Arc<Mutex<super::offsets::OffsetTracker>>,
+        assign_generation: Arc<AtomicU64>,
         commits_counter: IntCounter,
         commit_failures_counter: IntCounter,
     ) -> Self {
@@ -133,8 +127,7 @@ impl LaminarConsumerContext {
             rebalance_state,
             rebalance_metric,
             revoke_generation,
-            reader_paused,
-            offset_snapshot,
+            assign_generation,
             commits_counter,
             commit_failures_counter,
         }
@@ -156,14 +149,6 @@ impl LaminarConsumerContext {
     fn lock_rebalance_state(&self) -> std::sync::MutexGuard<'_, RebalanceState> {
         self.rebalance_state.lock().unwrap_or_else(|poisoned| {
             warn!("rebalance_state mutex poisoned, recovering");
-            poisoned.into_inner()
-        })
-    }
-
-    /// Locks the offset snapshot, recovering from poison.
-    fn lock_offset_snapshot(&self) -> std::sync::MutexGuard<'_, super::offsets::OffsetTracker> {
-        self.offset_snapshot.lock().unwrap_or_else(|poisoned| {
-            warn!("offset_snapshot mutex poisoned, recovering");
             poisoned.into_inner()
         })
     }
@@ -257,58 +242,15 @@ impl ConsumerContext for LaminarConsumerContext {
         use rdkafka::consumer::Rebalance;
 
         if let Rebalance::Assign(tpl) = rebalance {
-            // Seek assigned partitions to tracked offsets so we don't fall
-            // back to broker-stored group offsets (which may be stale or
-            // reset to earliest after a broker failure).
-            //
-            // Uses seek_partitions() instead of assign() to avoid clobbering
-            // the partition set under cooperative rebalancing, where the tpl
-            // contains only NEWLY assigned partitions (not the full set).
-            let assigned: Vec<(String, i32)> = tpl
-                .elements()
-                .iter()
-                .map(|e| (e.topic().to_string(), e.partition()))
-                .collect();
-
-            let seek_tpl = self.lock_offset_snapshot().to_seek_tpl(&assigned);
-
-            if seek_tpl.count() > 0 {
-                // Non-zero timeout: Duration::ZERO returns "In Progress" for every partition.
-                match base_consumer.seek_partitions(seek_tpl, std::time::Duration::from_secs(10)) {
-                    Ok(result) => {
-                        let errors: Vec<_> = result
-                            .elements()
-                            .iter()
-                            .filter(|e| e.error().is_err())
-                            .map(|e| format!("{}[{}]: {:?}", e.topic(), e.partition(), e.error()))
-                            .collect();
-                        if errors.is_empty() {
-                            info!(
-                                partition_count = result.count(),
-                                "seeked assigned partitions to tracked offsets"
-                            );
-                        } else {
-                            warn!(?errors, "some partitions failed to seek to tracked offsets");
-                        }
-                    }
-                    Err(e) => warn!(
-                        error = %e,
-                        "failed to seek assigned partitions to tracked offsets"
-                    ),
-                }
+            // Pause the newly-assigned partitions so librdkafka can't fetch from
+            // the reset position before the reader loop seeks them to their
+            // checkpointed offsets; the reader resumes them after the seek. (Seeking
+            // here fails — the partitions aren't fetch-ready yet in the callback.)
+            if let Err(e) = base_consumer.pause(tpl) {
+                warn!(error = %e, "failed to pause newly assigned partitions for seek");
             }
-
-            // Re-pause newly assigned partitions if backpressure is active.
-            if self.reader_paused.load(Ordering::Acquire) {
-                if let Err(e) = base_consumer.pause(tpl) {
-                    warn!(error = %e, "failed to re-pause newly assigned partitions");
-                } else {
-                    info!(
-                        partition_count = tpl.count(),
-                        "re-paused newly assigned partitions (reader backpressure active)"
-                    );
-                }
-            }
+            // Signal the reader loop to seek + resume from the live poll loop.
+            self.assign_generation.fetch_add(1, Ordering::Release);
         }
     }
 }
@@ -386,8 +328,7 @@ mod tests {
         let state = Arc::new(Mutex::new(RebalanceState::new()));
         let metric = Arc::new(AtomicU64::new(0));
         let revoke_gen = Arc::new(AtomicU64::new(0));
-        let reader_paused = Arc::new(AtomicBool::new(false));
-        let offset_snapshot = Arc::new(Mutex::new(super::super::offsets::OffsetTracker::new()));
+        let assign_gen = Arc::new(AtomicU64::new(0));
         let commits = IntCounter::new("test_commits", "test").unwrap();
         let commit_failures = IntCounter::new("test_commit_failures", "test").unwrap();
         let ctx = LaminarConsumerContext::new(
@@ -395,8 +336,7 @@ mod tests {
             state,
             metric,
             revoke_gen,
-            reader_paused,
-            offset_snapshot,
+            assign_gen,
             commits,
             commit_failures,
         );

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -435,7 +435,6 @@ impl KafkaSource {
                 if let Some((registry, self_id)) = &vnode_reassign {
                     let version = registry.assignment_version();
                     if version != last_assignment_version {
-                        last_assignment_version = version;
                         let current = consumer.assignment().unwrap_or_default();
                         let current_set: std::collections::HashSet<(String, i32)> = current
                             .elements()
@@ -483,27 +482,35 @@ impl KafkaSource {
                             }
                         }
 
+                        let mut ok = true;
                         if to_remove.count() > 0 {
                             if let Err(e) = consumer.incremental_unassign(&to_remove) {
                                 warn!(version, error = %e, "Kafka source unassign failed");
+                                ok = false;
                             }
                         }
                         if to_add.count() > 0 {
                             if let Err(e) = consumer.incremental_assign(&to_add) {
                                 warn!(version, error = %e, "Kafka source assign failed");
+                                ok = false;
                             }
                         }
-                        if to_remove.count() > 0 || to_add.count() > 0 {
-                            info!(
-                                version,
-                                acquired = to_add.count(),
-                                revoked = to_remove.count(),
-                                "Kafka source rebound partitions after vnode rotation"
-                            );
+                        // Record the version only on success, so a transient failure
+                        // retries instead of dropping the newly-owned partitions.
+                        if ok {
+                            if to_remove.count() > 0 || to_add.count() > 0 {
+                                info!(
+                                    version,
+                                    acquired = to_add.count(),
+                                    revoked = to_remove.count(),
+                                    "Kafka source rebound partitions after vnode rotation"
+                                );
+                            }
+                            // Revoked partitions are gone; their drain pauses no longer apply.
+                            drain_paused.retain(|(t, p)| owned_set.contains(&(t.to_string(), *p)));
+                            last_drain_gen = registry.draining_generation();
+                            last_assignment_version = version;
                         }
-                        // Revoked partitions are gone; their drain pauses no longer apply.
-                        drain_paused.retain(|(t, p)| owned_set.contains(&(t.to_string(), *p)));
-                        last_drain_gen = registry.draining_generation();
                     }
                 }
 
@@ -513,7 +520,6 @@ impl KafkaSource {
                 if let Some((registry, self_id)) = &vnode_reassign {
                     let drain_gen = registry.draining_generation();
                     if drain_gen != last_drain_gen {
-                        last_drain_gen = drain_gen;
                         let vnode_count = registry.vnode_count();
                         let want: std::collections::HashSet<(Arc<str>, i32)> = vnode_topic_meta
                             .iter()
@@ -530,19 +536,31 @@ impl KafkaSource {
                                 .map(move |p| (Arc::clone(&topic), p))
                             })
                             .collect();
+                        let mut ok = true;
                         let to_pause = tpl_of(want.difference(&drain_paused));
                         if to_pause.count() > 0 {
-                            let _ = consumer.pause(&to_pause);
+                            if let Err(e) = consumer.pause(&to_pause) {
+                                warn!(error = %e, "drain pause failed; will retry");
+                                ok = false;
+                            }
                         }
                         // Resume vnodes that stopped draining (rotation aborted), unless
                         // backpressure is holding everything.
                         if !is_paused {
                             let to_resume = tpl_of(drain_paused.difference(&want));
                             if to_resume.count() > 0 {
-                                let _ = consumer.resume(&to_resume);
+                                if let Err(e) = consumer.resume(&to_resume) {
+                                    warn!(error = %e, "drain resume failed; will retry");
+                                    ok = false;
+                                }
                             }
                         }
-                        drain_paused = want;
+                        // Advance only on success, else a partition that failed to pause
+                        // keeps consuming past the cut.
+                        if ok {
+                            drain_paused = want;
+                            last_drain_gen = drain_gen;
+                        }
                     }
                 }
 
@@ -563,11 +581,22 @@ impl KafkaSource {
                 // then resume — otherwise recovery resumes from auto.offset.reset.
                 let cur_assign_gen = assign_generation.load(Ordering::Acquire);
                 if cur_assign_gen != last_assign_gen {
-                    let assigned: Vec<(String, i32)> = lock_or_recover(&rebalance_state)
+                    let mut assigned: Vec<(String, i32)> = lock_or_recover(&rebalance_state)
                         .assigned_partitions()
                         .iter()
                         .cloned()
                         .collect();
+                    if assigned.is_empty() {
+                        // Vnode mode fires no rebalance callback, so use the live
+                        // assignment to seek the offsets restore() staged.
+                        if let Ok(a) = consumer.assignment() {
+                            assigned = a
+                                .elements()
+                                .iter()
+                                .map(|e| (e.topic().to_string(), e.partition()))
+                                .collect();
+                        }
+                    }
                     let seek_tpl = lock_or_recover(&reassign_snapshot).to_seek_tpl(&assigned);
                     let seek_ok = if seek_tpl.count() == 0 {
                         true // fresh start: nothing checkpointed to seek to
@@ -601,16 +630,23 @@ impl KafkaSource {
                     if seek_ok {
                         // Positioned — undo the callback's pause unless backpressure
                         // is currently holding partitions.
+                        let mut resumed_ok = true;
                         if !is_paused {
                             if let Ok(assignment) = consumer.assignment() {
-                                let _ = consumer.resume(&assignment);
-                                // Keep rotation-drained partitions paused.
-                                if !drain_paused.is_empty() {
+                                if let Err(e) = consumer.resume(&assignment) {
+                                    warn!(error = %e, "post-seek resume failed; will retry");
+                                    resumed_ok = false;
+                                } else if !drain_paused.is_empty() {
+                                    // Keep rotation-drained partitions paused.
                                     let _ = consumer.pause(&tpl_of(drain_paused.iter()));
                                 }
                             }
                         }
-                        last_assign_gen = cur_assign_gen;
+                        // Advance only when resumed, else the partitions stay paused
+                        // and never fetch.
+                        if resumed_ok {
+                            last_assign_gen = cur_assign_gen;
+                        }
                     }
                 }
 
@@ -634,7 +670,9 @@ impl KafkaSource {
                             is_paused = false;
                             // Keep rotation-drained partitions paused.
                             if !drain_paused.is_empty() {
-                                let _ = consumer.pause(&tpl_of(drain_paused.iter()));
+                                if let Err(e) = consumer.pause(&tpl_of(drain_paused.iter())) {
+                                    warn!(error = %e, "re-pause of drained partitions failed");
+                                }
                             }
                             debug!("reader: resumed Kafka partitions (fill={fill:.2})");
                         }
@@ -1647,6 +1685,9 @@ impl SourceConnector for KafkaSource {
             Ok(mut snapshot) => snapshot.clone_from(&self.offsets),
             Err(poisoned) => poisoned.into_inner().clone_from(&self.offsets),
         }
+        // Signal the seek block; vnode mode has no rebalance callback to apply the
+        // staged offsets, so without this recovery resumes from `startup.mode`.
+        self.assign_generation.fetch_add(1, Ordering::Release);
 
         Ok(())
     }

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -429,41 +429,83 @@ impl KafkaSource {
 
             loop {
                 // Engine-controlled re-assignment: when the vnode assignment
-                // rotates, rebind to the partitions this node now owns, seeking
-                // each to its tracked offset (manual assign gets no broker
-                // rebalance callback to do this for us).
+                // rotates, rebind to the partitions this node now owns. Apply only
+                // the DELTA (incremental assign/unassign) — a full re-assign would
+                // re-seek partitions the node is keeping and re-fetch records already
+                // buffered ahead in the reader channel, re-emitting committed rows.
+                // Newly-acquired partitions seek to their handoff/checkpoint offset;
+                // kept partitions are left exactly where the consumer is.
                 if let Some((registry, self_id)) = &vnode_reassign {
                     let version = registry.assignment_version();
                     if version != last_assignment_version {
                         last_assignment_version = version;
-                        let offsets = lock_or_recover(&reassign_snapshot).clone();
-                        // Previous owners' checkpointed offsets, staged by the engine
-                        // before the version bump; used only for partitions we have no
-                        // local offset for (those handed to us in this rotation).
-                        let resume = OffsetTracker::from_offset_map(&registry.resume_offsets());
-                        let tpl = build_vnode_assignment_tpl(
-                            registry,
-                            *self_id,
-                            &vnode_topic_meta,
-                            &offsets,
-                            &resume,
-                            reassign_default_offset,
-                        );
-                        match consumer.assign(&tpl) {
-                            Ok(()) => info!(
-                                version,
-                                owned_partitions = tpl.count(),
-                                "Kafka source re-assigned partitions after vnode rotation"
-                            ),
-                            Err(e) => warn!(
-                                version,
-                                error = %e,
-                                "Kafka source partition re-assignment failed"
-                            ),
+                        let current = consumer.assignment().unwrap_or_default();
+                        let current_set: std::collections::HashSet<(String, i32)> = current
+                            .elements()
+                            .iter()
+                            .map(|e| (e.topic().to_string(), e.partition()))
+                            .collect();
+
+                        let mut owned_set: std::collections::HashSet<(String, i32)> =
+                            std::collections::HashSet::new();
+                        for (topic, count) in &vnode_topic_meta {
+                            for p in crate::partition_assignment::owned_partitions(
+                                *count, registry, *self_id,
+                            ) {
+                                owned_set.insert((topic.to_string(), p));
+                            }
                         }
-                        // The new assignment resets pause state and drops revoked
-                        // partitions; any drain pauses no longer apply.
-                        drain_paused.clear();
+
+                        let mut to_remove = TopicPartitionList::new();
+                        for e in current.elements() {
+                            if !owned_set.contains(&(e.topic().to_string(), e.partition())) {
+                                let _ = to_remove.add_partition(e.topic(), e.partition());
+                            }
+                        }
+
+                        // Newly-acquired partitions resume from local offset, else the
+                        // previous owner's staged handoff offset, else the startup default.
+                        let offsets = lock_or_recover(&reassign_snapshot).clone();
+                        let resume = OffsetTracker::from_offset_map(&registry.resume_offsets());
+                        let mut to_add = TopicPartitionList::new();
+                        for (topic, count) in &vnode_topic_meta {
+                            for p in crate::partition_assignment::owned_partitions(
+                                *count, registry, *self_id,
+                            ) {
+                                if current_set.contains(&(topic.to_string(), p)) {
+                                    continue; // kept — leave untouched
+                                }
+                                let offset = match offsets
+                                    .get(topic.as_ref(), p)
+                                    .or_else(|| resume.get(topic.as_ref(), p))
+                                {
+                                    Some(o) => rdkafka::Offset::Offset(o + 1),
+                                    None => reassign_default_offset,
+                                };
+                                let _ = to_add.add_partition_offset(topic.as_ref(), p, offset);
+                            }
+                        }
+
+                        if to_remove.count() > 0 {
+                            if let Err(e) = consumer.incremental_unassign(&to_remove) {
+                                warn!(version, error = %e, "Kafka source unassign failed");
+                            }
+                        }
+                        if to_add.count() > 0 {
+                            if let Err(e) = consumer.incremental_assign(&to_add) {
+                                warn!(version, error = %e, "Kafka source assign failed");
+                            }
+                        }
+                        if to_remove.count() > 0 || to_add.count() > 0 {
+                            info!(
+                                version,
+                                acquired = to_add.count(),
+                                revoked = to_remove.count(),
+                                "Kafka source rebound partitions after vnode rotation"
+                            );
+                        }
+                        // Revoked partitions are gone; their drain pauses no longer apply.
+                        drain_paused.retain(|(t, p)| owned_set.contains(&(t.to_string(), *p)));
                         last_drain_gen = registry.draining_generation();
                     }
                 }
@@ -720,10 +762,6 @@ impl KafkaSource {
     }
 }
 
-/// Build the manual-`assign()` partition list for a vnode-assigned Kafka
-/// source: the partitions this node owns (`partition % vnode_count`), each
-/// positioned at its checkpointed offset + 1 when known (resume after the last
-/// consumed record), else `default_offset`.
 /// Build an offset-less `TopicPartitionList` from `(topic, partition)` refs, for
 /// `pause`/`resume` calls.
 fn tpl_of<'a>(parts: impl Iterator<Item = &'a (Arc<str>, i32)>) -> TopicPartitionList {
@@ -734,6 +772,12 @@ fn tpl_of<'a>(parts: impl Iterator<Item = &'a (Arc<str>, i32)>) -> TopicPartitio
     tpl
 }
 
+/// Build the manual-`assign()` partition list for a vnode-assigned Kafka source:
+/// the partitions this node owns (`partition % vnode_count`), each positioned at
+/// its checkpointed offset + 1 when known (resume after the last consumed record),
+/// else `default_offset`. Used for the initial `open()` assignment; rotation
+/// rebinds use `incremental_assign`/`incremental_unassign` so kept partitions are
+/// never re-seeked (see the reader loop).
 fn build_vnode_assignment_tpl(
     registry: &laminar_core::state::VnodeRegistry,
     self_id: laminar_core::state::NodeId,
@@ -917,7 +961,10 @@ impl SourceConnector for KafkaSource {
                     default_offset,
                 );
                 let owned = tpl.count();
-                consumer.assign(&tpl).map_err(|e| {
+                // Incremental from the empty initial assignment, so every later
+                // rotation rebind can also use incremental_assign/unassign (mixing a
+                // full assign() with incremental ops is rejected by librdkafka).
+                consumer.incremental_assign(&tpl).map_err(|e| {
                     ConnectorError::ConnectionFailed(format!("vnode partition assign failed: {e}"))
                 })?;
                 self.vnode_topic_meta = topic_meta;

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -429,11 +429,16 @@ impl KafkaSource {
                     if version != last_assignment_version {
                         last_assignment_version = version;
                         let offsets = lock_or_recover(&reassign_snapshot).clone();
+                        // Committed resume offsets for partitions handed to us in
+                        // this rotation, staged by the engine from the checkpoint
+                        // manifest just before the version bump.
+                        let acquired = registry.take_resume_hints();
                         let tpl = build_vnode_assignment_tpl(
                             registry,
                             *self_id,
                             &vnode_topic_meta,
                             &offsets,
+                            &acquired,
                             reassign_default_offset,
                         );
                         match consumer.assign(&tpl) {
@@ -610,14 +615,24 @@ fn build_vnode_assignment_tpl(
     self_id: laminar_core::state::NodeId,
     topic_meta: &[(Arc<str>, i32)],
     offsets: &OffsetTracker,
+    acquired: &std::collections::HashMap<(String, i32), i64>,
     default_offset: rdkafka::Offset,
 ) -> TopicPartitionList {
     let mut tpl = TopicPartitionList::new();
     for (topic, count) in topic_meta {
         for partition in crate::partition_assignment::owned_partitions(*count, registry, self_id) {
             let offset = match offsets.get(topic.as_ref(), partition) {
+                // Locally tracked: resume after the last record we consumed.
                 Some(o) => rdkafka::Offset::Offset(o + 1),
-                None => default_offset,
+                // No local offset → this partition was just handed to us in a vnode
+                // rotation. Resume from the committed checkpoint offset the engine
+                // staged (already next-to-fetch) instead of `default_offset` /
+                // `auto.offset.reset`, which would replay the partition prefix and
+                // emit duplicates.
+                None => match acquired.get(&(topic.to_string(), partition)) {
+                    Some(&o) => rdkafka::Offset::Offset(o),
+                    None => default_offset,
+                },
             };
             if let Err(e) = tpl.add_partition_offset(topic.as_ref(), partition, offset) {
                 warn!(
@@ -768,11 +783,17 @@ impl SourceConnector for KafkaSource {
                     ));
                 }
                 let default_offset = startup_default_offset(&kafka_config.startup_mode);
+                // Initial assignment: a fresh start has no local offsets (→ default)
+                // and recovery already staged committed offsets into `self.offsets`
+                // via restore(), so no rotation-acquisition lookup is needed here.
+                let acquired_none: std::collections::HashMap<(String, i32), i64> =
+                    std::collections::HashMap::new();
                 let tpl = build_vnode_assignment_tpl(
                     &registry,
                     self_id,
                     &topic_meta,
                     &self.offsets,
+                    &acquired_none,
                     default_offset,
                 );
                 let owned = tpl.count();

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -419,6 +419,13 @@ impl KafkaSource {
             let mut last_assignment_version = vnode_reassign
                 .as_ref()
                 .map_or(0, |(r, _)| r.assignment_version());
+            // Partitions paused for a pending rotation (their vnode is draining), so
+            // the pre-rotation checkpoint is a clean cut. Reconciled on drain-gen change.
+            let mut last_drain_gen = vnode_reassign
+                .as_ref()
+                .map_or(0, |(r, _)| r.draining_generation());
+            let mut drain_paused: std::collections::HashSet<(Arc<str>, i32)> =
+                std::collections::HashSet::new();
 
             loop {
                 // Engine-controlled re-assignment: when the vnode assignment
@@ -454,6 +461,51 @@ impl KafkaSource {
                                 "Kafka source partition re-assignment failed"
                             ),
                         }
+                        // The new assignment resets pause state and drops revoked
+                        // partitions; any drain pauses no longer apply.
+                        drain_paused.clear();
+                        last_drain_gen = registry.draining_generation();
+                    }
+                }
+
+                // Rotation drain: pause the partitions of vnodes about to be revoked
+                // from this node so the pre-rotation checkpoint is a clean cut (the
+                // previous owner stops consuming exactly at the sealed offset). On
+                // commit the partitions are dropped at the version rebind above; on
+                // abort the drain is cleared and they resume here.
+                if let Some((registry, self_id)) = &vnode_reassign {
+                    let drain_gen = registry.draining_generation();
+                    if drain_gen != last_drain_gen {
+                        last_drain_gen = drain_gen;
+                        let vnode_count = registry.vnode_count();
+                        let want: std::collections::HashSet<(Arc<str>, i32)> = vnode_topic_meta
+                            .iter()
+                            .flat_map(|(topic, count)| {
+                                let topic = Arc::clone(topic);
+                                crate::partition_assignment::owned_partitions(
+                                    *count, registry, *self_id,
+                                )
+                                .into_iter()
+                                .filter(|&p| {
+                                    u32::try_from(p)
+                                        .is_ok_and(|pid| registry.is_draining(pid % vnode_count))
+                                })
+                                .map(move |p| (Arc::clone(&topic), p))
+                            })
+                            .collect();
+                        let to_pause = tpl_of(want.difference(&drain_paused));
+                        if to_pause.count() > 0 {
+                            let _ = consumer.pause(&to_pause);
+                        }
+                        // Resume vnodes that stopped draining (rotation aborted), unless
+                        // backpressure is holding everything.
+                        if !is_paused {
+                            let to_resume = tpl_of(drain_paused.difference(&want));
+                            if to_resume.count() > 0 {
+                                let _ = consumer.resume(&to_resume);
+                            }
+                        }
+                        drain_paused = want;
                     }
                 }
 
@@ -518,6 +570,10 @@ impl KafkaSource {
                         if !is_paused {
                             if let Ok(assignment) = consumer.assignment() {
                                 let _ = consumer.resume(&assignment);
+                                // Keep rotation-drained partitions paused.
+                                if !drain_paused.is_empty() {
+                                    let _ = consumer.pause(&tpl_of(drain_paused.iter()));
+                                }
                             }
                         }
                         last_assign_gen = cur_assign_gen;
@@ -542,6 +598,10 @@ impl KafkaSource {
                     if let Ok(assignment) = consumer.assignment() {
                         if consumer.resume(&assignment).is_ok() {
                             is_paused = false;
+                            // Keep rotation-drained partitions paused.
+                            if !drain_paused.is_empty() {
+                                let _ = consumer.pause(&tpl_of(drain_paused.iter()));
+                            }
                             debug!("reader: resumed Kafka partitions (fill={fill:.2})");
                         }
                     }
@@ -664,6 +724,16 @@ impl KafkaSource {
 /// source: the partitions this node owns (`partition % vnode_count`), each
 /// positioned at its checkpointed offset + 1 when known (resume after the last
 /// consumed record), else `default_offset`.
+/// Build an offset-less `TopicPartitionList` from `(topic, partition)` refs, for
+/// `pause`/`resume` calls.
+fn tpl_of<'a>(parts: impl Iterator<Item = &'a (Arc<str>, i32)>) -> TopicPartitionList {
+    let mut tpl = TopicPartitionList::new();
+    for (topic, partition) in parts {
+        let _ = tpl.add_partition(topic.as_ref(), *partition);
+    }
+    tpl
+}
+
 fn build_vnode_assignment_tpl(
     registry: &laminar_core::state::VnodeRegistry,
     self_id: laminar_core::state::NodeId,

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -88,6 +88,9 @@ pub struct KafkaSource {
     /// Bumped on each partition revoke; `poll_batch` compares it lock-free to
     /// detect a revoke and purge the lost partitions' offsets.
     revoke_generation: Arc<AtomicU64>,
+    /// Bumped on each partition assign; the reader loop seeks the newly-assigned
+    /// partitions on change (see the seek block in `ensure_reader_started`).
+    assign_generation: Arc<AtomicU64>,
     last_seen_revoke_gen: u64,
     schema_registry: Option<Arc<SchemaRegistryClient>>,
     data_ready: Arc<Notify>,
@@ -103,9 +106,6 @@ pub struct KafkaSource {
     /// `(topic, partition, high_watermark)` from the reader task, for lag computation.
     #[allow(clippy::type_complexity)]
     high_watermarks_rx: Option<tokio::sync::watch::Receiver<Vec<(Arc<str>, i32, i64)>>>,
-    /// Set while the reader has paused partitions for backpressure; re-pauses
-    /// newly assigned partitions on rebalance.
-    reader_paused: Arc<AtomicBool>,
     /// Offset snapshot for the rebalance callback's seek-on-assign, refreshed
     /// once per `poll_batch()` cycle.
     offset_snapshot: Arc<Mutex<OffsetTracker>>,
@@ -216,6 +216,7 @@ impl KafkaSource {
             rebalance_state: Arc::new(Mutex::new(RebalanceState::new())),
             rebalance_counter: Arc::new(AtomicU64::new(0)),
             revoke_generation: Arc::new(AtomicU64::new(0)),
+            assign_generation: Arc::new(AtomicU64::new(0)),
             last_seen_revoke_gen: 0,
             schema_registry,
             data_ready: Arc::new(Notify::new()),
@@ -228,7 +229,6 @@ impl KafkaSource {
             commit_tx: None,
             watermark_tracker,
             high_watermarks_rx: None,
-            reader_paused: Arc::new(AtomicBool::new(false)),
             offset_snapshot: Arc::new(Mutex::new(OffsetTracker::new())),
             vnode_assignment: None,
             vnode_topic_meta: Vec::new(),
@@ -312,8 +312,8 @@ impl KafkaSource {
         let channel_len = Arc::clone(&self.channel_len);
         let capture_headers = self.config.include_headers;
         let reader_channel_capacity = self.config.reader_channel_capacity;
-        let reader_paused = Arc::clone(&self.reader_paused);
         let revoke_generation = Arc::clone(&self.revoke_generation);
+        let assign_generation = Arc::clone(&self.assign_generation);
         let rebalance_state = Arc::clone(&self.rebalance_state);
         let pause_threshold = self.config.backpressure_high_watermark;
         let resume_threshold = self.config.backpressure_low_watermark;
@@ -413,6 +413,7 @@ impl KafkaSource {
                 std::collections::HashSet::new();
             let mut is_paused = false;
             let mut last_revoke_gen: u64 = 0;
+            let mut last_assign_gen: u64 = 0;
             // Track the vnode assignment generation; open() already assigned at
             // the current version, so only a later rotation triggers a rebind.
             let mut last_assignment_version = vnode_reassign
@@ -429,16 +430,16 @@ impl KafkaSource {
                     if version != last_assignment_version {
                         last_assignment_version = version;
                         let offsets = lock_or_recover(&reassign_snapshot).clone();
-                        // Committed resume offsets for partitions handed to us in
-                        // this rotation, staged by the engine from the checkpoint
-                        // manifest just before the version bump.
-                        let acquired = registry.take_resume_hints();
+                        // Previous owners' checkpointed offsets, staged by the engine
+                        // before the version bump; used only for partitions we have no
+                        // local offset for (those handed to us in this rotation).
+                        let resume = OffsetTracker::from_offset_map(&registry.resume_offsets());
                         let tpl = build_vnode_assignment_tpl(
                             registry,
                             *self_id,
                             &vnode_topic_meta,
                             &offsets,
-                            &acquired,
+                            &resume,
                             reassign_default_offset,
                         );
                         match consumer.assign(&tpl) {
@@ -467,6 +468,62 @@ impl KafkaSource {
                     let _ = seen_tx.send(seen_partitions.iter().cloned().collect());
                 }
 
+                // A rebalance assigned new partitions; the callback paused them so
+                // they can't fetch from `auto.offset.reset` before we position them.
+                // Seek to the checkpointed offsets HERE — in the live poll loop where
+                // the assignment is fetch-ready (the in-callback seek fails with
+                // `Local: Erroneous state`) — then resume. This is what makes source
+                // offset recovery actually take effect; without it the consumer would
+                // resume from the reset position and skip or duplicate records.
+                let cur_assign_gen = assign_generation.load(Ordering::Acquire);
+                if cur_assign_gen != last_assign_gen {
+                    let assigned: Vec<(String, i32)> = lock_or_recover(&rebalance_state)
+                        .assigned_partitions()
+                        .iter()
+                        .cloned()
+                        .collect();
+                    let seek_tpl = lock_or_recover(&reassign_snapshot).to_seek_tpl(&assigned);
+                    let seek_ok = if seek_tpl.count() == 0 {
+                        true // fresh start: nothing checkpointed to seek to
+                    } else {
+                        match consumer.seek_partitions(seek_tpl, std::time::Duration::from_secs(5))
+                        {
+                            Ok(result) => {
+                                let failed = result
+                                    .elements()
+                                    .iter()
+                                    .filter(|e| e.error().is_err())
+                                    .count();
+                                if failed == 0 {
+                                    info!(
+                                        partition_count = result.count(),
+                                        "seeked assigned partitions to checkpointed offsets"
+                                    );
+                                    true
+                                } else {
+                                    // Not all fetch-ready yet — retry next loop.
+                                    debug!(failed, "assign-seek incomplete; will retry");
+                                    false
+                                }
+                            }
+                            Err(e) => {
+                                debug!(error = %e, "assign-seek failed; will retry");
+                                false
+                            }
+                        }
+                    };
+                    if seek_ok {
+                        // Positioned — undo the callback's pause unless backpressure
+                        // is currently holding partitions.
+                        if !is_paused {
+                            if let Ok(assignment) = consumer.assignment() {
+                                let _ = consumer.resume(&assignment);
+                            }
+                        }
+                        last_assign_gen = cur_assign_gen;
+                    }
+                }
+
                 // Backpressure: pause/resume Kafka partitions based on channel fill.
                 #[allow(clippy::cast_precision_loss)]
                 let fill = if reader_channel_capacity > 0 {
@@ -478,7 +535,6 @@ impl KafkaSource {
                     if let Ok(assignment) = consumer.assignment() {
                         if consumer.pause(&assignment).is_ok() {
                             is_paused = true;
-                            reader_paused.store(true, Ordering::Release);
                             debug!("reader: paused Kafka partitions (fill={fill:.2})");
                         }
                     }
@@ -486,7 +542,6 @@ impl KafkaSource {
                     if let Ok(assignment) = consumer.assignment() {
                         if consumer.resume(&assignment).is_ok() {
                             is_paused = false;
-                            reader_paused.store(false, Ordering::Release);
                             debug!("reader: resumed Kafka partitions (fill={fill:.2})");
                         }
                     }
@@ -562,7 +617,6 @@ impl KafkaSource {
                                         if let Ok(assignment) = consumer.assignment() {
                                             if consumer.pause(&assignment).is_ok() {
                                                 is_paused = true;
-                                                reader_paused.store(true, Ordering::Release);
                                                 debug!("reader: paused partitions (channel full)");
                                             }
                                         }
@@ -615,24 +669,22 @@ fn build_vnode_assignment_tpl(
     self_id: laminar_core::state::NodeId,
     topic_meta: &[(Arc<str>, i32)],
     offsets: &OffsetTracker,
-    acquired: &std::collections::HashMap<(String, i32), i64>,
+    resume: &OffsetTracker,
     default_offset: rdkafka::Offset,
 ) -> TopicPartitionList {
     let mut tpl = TopicPartitionList::new();
     for (topic, count) in topic_meta {
         for partition in crate::partition_assignment::owned_partitions(*count, registry, self_id) {
-            let offset = match offsets.get(topic.as_ref(), partition) {
-                // Locally tracked: resume after the last record we consumed.
-                Some(o) => rdkafka::Offset::Offset(o + 1),
+            let offset = match offsets
+                .get(topic.as_ref(), partition)
                 // No local offset → this partition was just handed to us in a vnode
-                // rotation. Resume from the committed checkpoint offset the engine
-                // staged (already next-to-fetch) instead of `default_offset` /
-                // `auto.offset.reset`, which would replay the partition prefix and
-                // emit duplicates.
-                None => match acquired.get(&(topic.to_string(), partition)) {
-                    Some(&o) => rdkafka::Offset::Offset(o),
-                    None => default_offset,
-                },
+                // rotation; fall back to the previous owner's checkpointed position
+                // the engine staged, instead of auto.offset.reset (which replays the
+                // prefix and emits duplicates).
+                .or_else(|| resume.get(topic.as_ref(), partition))
+            {
+                Some(o) => rdkafka::Offset::Offset(o + 1),
+                None => default_offset,
             };
             if let Err(e) = tpl.add_partition_offset(topic.as_ref(), partition, offset) {
                 warn!(
@@ -734,8 +786,7 @@ impl SourceConnector for KafkaSource {
             Arc::clone(&self.rebalance_state),
             Arc::clone(&self.rebalance_counter),
             Arc::clone(&self.revoke_generation),
-            Arc::clone(&self.reader_paused),
-            Arc::clone(&self.offset_snapshot),
+            Arc::clone(&self.assign_generation),
             // IntCounter::clone is an Arc bump; these are shared with the
             // metrics struct and bumped from librdkafka's background thread
             // inside `commit_callback`.
@@ -784,16 +835,15 @@ impl SourceConnector for KafkaSource {
                 }
                 let default_offset = startup_default_offset(&kafka_config.startup_mode);
                 // Initial assignment: a fresh start has no local offsets (→ default)
-                // and recovery already staged committed offsets into `self.offsets`
-                // via restore(), so no rotation-acquisition lookup is needed here.
-                let acquired_none: std::collections::HashMap<(String, i32), i64> =
-                    std::collections::HashMap::new();
+                // and recovery already loaded committed offsets into `self.offsets`
+                // via restore(), so there are no rotation resume offsets to apply.
+                let no_resume = OffsetTracker::new();
                 let tpl = build_vnode_assignment_tpl(
                     &registry,
                     self_id,
                     &topic_meta,
                     &self.offsets,
-                    &acquired_none,
+                    &no_resume,
                     default_offset,
                 );
                 let owned = tpl.count();
@@ -1480,10 +1530,9 @@ impl SourceConnector for KafkaSource {
 
     /// Restores the consumer to checkpointed offsets.
     ///
-    /// Offsets are staged in `offset_snapshot`; the actual `seek_partitions`
-    /// runs in `post_rebalance` when the group coordinator hands us the
-    /// assignment. Calling `consumer.assign()` here would switch out of
-    /// `subscribe()` mode and produce `Local: Erroneous state`.
+    /// Only stages offsets into `offset_snapshot`; the reader loop performs the
+    /// actual `seek_partitions` once the assignment is fetch-ready (seeking here
+    /// or in the rebalance callback yields `Local: Erroneous state`).
     async fn restore(&mut self, checkpoint: &SourceCheckpoint) -> Result<(), ConnectorError> {
         info!(
             epoch = checkpoint.epoch(),
@@ -1698,6 +1747,37 @@ mod tests {
         assert_eq!(cp.get_offset("events-1"), None); // vnode 1 → node1
         assert_eq!(cp.get_offset("events-2"), Some("300")); // vnode 2 → node0
         assert_eq!(cp.get_offset("events-3"), None); // vnode 3 → node1
+    }
+
+    #[test]
+    fn build_vnode_assignment_tpl_offset_precedence() {
+        // local offset > resume (manifest handoff) offset > startup default.
+        let node0 = laminar_core::state::NodeId(0);
+        let registry = laminar_core::state::VnodeRegistry::single_owner(4, node0);
+        let topic_meta = vec![(Arc::from("events"), 4)];
+
+        let mut local = OffsetTracker::new();
+        local.update_force("events", 0, 100); // p0: local only
+        local.update_force("events", 2, 200); // p2: local AND resume → local wins
+
+        let mut resume = OffsetTracker::new();
+        resume.update_force("events", 1, 50); // p1: resume only
+        resume.update_force("events", 2, 999); // p2: shadowed by local
+
+        let tpl = build_vnode_assignment_tpl(
+            &registry,
+            node0,
+            &topic_meta,
+            &local,
+            &resume,
+            rdkafka::Offset::Beginning,
+        );
+
+        let offset_of = |p: i32| tpl.find_partition("events", p).map(|e| e.offset());
+        assert_eq!(offset_of(0), Some(rdkafka::Offset::Offset(101))); // local + 1
+        assert_eq!(offset_of(1), Some(rdkafka::Offset::Offset(51))); // resume + 1
+        assert_eq!(offset_of(2), Some(rdkafka::Offset::Offset(201))); // local wins
+        assert_eq!(offset_of(3), Some(rdkafka::Offset::Beginning)); // default
     }
 
     #[test]

--- a/crates/laminar-connectors/src/kafka/source.rs
+++ b/crates/laminar-connectors/src/kafka/source.rs
@@ -428,13 +428,10 @@ impl KafkaSource {
                 std::collections::HashSet::new();
 
             loop {
-                // Engine-controlled re-assignment: when the vnode assignment
-                // rotates, rebind to the partitions this node now owns. Apply only
-                // the DELTA (incremental assign/unassign) — a full re-assign would
-                // re-seek partitions the node is keeping and re-fetch records already
-                // buffered ahead in the reader channel, re-emitting committed rows.
-                // Newly-acquired partitions seek to their handoff/checkpoint offset;
-                // kept partitions are left exactly where the consumer is.
+                // On rotation, apply only the DELTA (incremental assign/unassign): a
+                // full re-assign would re-seek kept partitions and re-fetch records
+                // already buffered ahead, re-emitting committed rows. Newly-acquired
+                // partitions seek to their handoff offset; kept ones are untouched.
                 if let Some((registry, self_id)) = &vnode_reassign {
                     let version = registry.assignment_version();
                     if version != last_assignment_version {
@@ -511,10 +508,8 @@ impl KafkaSource {
                 }
 
                 // Rotation drain: pause the partitions of vnodes about to be revoked
-                // from this node so the pre-rotation checkpoint is a clean cut (the
-                // previous owner stops consuming exactly at the sealed offset). On
-                // commit the partitions are dropped at the version rebind above; on
-                // abort the drain is cleared and they resume here.
+                // so the pre-rotation checkpoint is a clean cut. On commit they're
+                // dropped at the rebind above; on abort the drain clears and they resume.
                 if let Some((registry, self_id)) = &vnode_reassign {
                     let drain_gen = registry.draining_generation();
                     if drain_gen != last_drain_gen {
@@ -562,13 +557,10 @@ impl KafkaSource {
                     let _ = seen_tx.send(seen_partitions.iter().cloned().collect());
                 }
 
-                // A rebalance assigned new partitions; the callback paused them so
-                // they can't fetch from `auto.offset.reset` before we position them.
-                // Seek to the checkpointed offsets HERE — in the live poll loop where
-                // the assignment is fetch-ready (the in-callback seek fails with
-                // `Local: Erroneous state`) — then resume. This is what makes source
-                // offset recovery actually take effect; without it the consumer would
-                // resume from the reset position and skip or duplicate records.
+                // Newly-assigned partitions were paused by the callback. Seek to the
+                // checkpointed offsets HERE, in the poll loop where the assignment is
+                // fetch-ready (the in-callback seek fails `Local: Erroneous state`),
+                // then resume — otherwise recovery resumes from auto.offset.reset.
                 let cur_assign_gen = assign_generation.load(Ordering::Acquire);
                 if cur_assign_gen != last_assign_gen {
                     let assigned: Vec<(String, i32)> = lock_or_recover(&rebalance_state)
@@ -772,12 +764,9 @@ fn tpl_of<'a>(parts: impl Iterator<Item = &'a (Arc<str>, i32)>) -> TopicPartitio
     tpl
 }
 
-/// Build the manual-`assign()` partition list for a vnode-assigned Kafka source:
-/// the partitions this node owns (`partition % vnode_count`), each positioned at
-/// its checkpointed offset + 1 when known (resume after the last consumed record),
-/// else `default_offset`. Used for the initial `open()` assignment; rotation
-/// rebinds use `incremental_assign`/`incremental_unassign` so kept partitions are
-/// never re-seeked (see the reader loop).
+/// Partition list for the initial `open()` assignment of a vnode-assigned source:
+/// owned partitions (`partition % vnode_count`) at their checkpointed offset + 1,
+/// else `default_offset`. Rotations rebind incrementally in the reader loop.
 fn build_vnode_assignment_tpl(
     registry: &laminar_core::state::VnodeRegistry,
     self_id: laminar_core::state::NodeId,
@@ -791,10 +780,8 @@ fn build_vnode_assignment_tpl(
         for partition in crate::partition_assignment::owned_partitions(*count, registry, self_id) {
             let offset = match offsets
                 .get(topic.as_ref(), partition)
-                // No local offset → this partition was just handed to us in a vnode
-                // rotation; fall back to the previous owner's checkpointed position
-                // the engine staged, instead of auto.offset.reset (which replays the
-                // prefix and emits duplicates).
+                // No local offset → handed to us in a rotation; fall back to the
+                // previous owner's staged position, not auto.offset.reset.
                 .or_else(|| resume.get(topic.as_ref(), partition))
             {
                 Some(o) => rdkafka::Offset::Offset(o + 1),
@@ -948,9 +935,8 @@ impl SourceConnector for KafkaSource {
                     ));
                 }
                 let default_offset = startup_default_offset(&kafka_config.startup_mode);
-                // Initial assignment: a fresh start has no local offsets (→ default)
-                // and recovery already loaded committed offsets into `self.offsets`
-                // via restore(), so there are no rotation resume offsets to apply.
+                // restore() already loaded committed offsets into self.offsets, so
+                // there are no rotation resume offsets at open().
                 let no_resume = OffsetTracker::new();
                 let tpl = build_vnode_assignment_tpl(
                     &registry,
@@ -961,9 +947,8 @@ impl SourceConnector for KafkaSource {
                     default_offset,
                 );
                 let owned = tpl.count();
-                // Incremental from the empty initial assignment, so every later
-                // rotation rebind can also use incremental_assign/unassign (mixing a
-                // full assign() with incremental ops is rejected by librdkafka).
+                // Incremental from empty so rebinds can stay incremental — librdkafka
+                // rejects mixing a full assign() with incremental_assign/unassign.
                 consumer.incremental_assign(&tpl).map_err(|e| {
                     ConnectorError::ConnectionFailed(format!("vnode partition assign failed: {e}"))
                 })?;

--- a/crates/laminar-connectors/src/mongodb/sink.rs
+++ b/crates/laminar-connectors/src/mongodb/sink.rs
@@ -223,6 +223,43 @@ fn arrow_value_to_json(col: &dyn arrow_array::Array, row: usize) -> serde_json::
             let arr = col.as_any().downcast_ref::<LargeStringArray>().unwrap();
             serde_json::Value::String(arr.value(row).to_string())
         }
+        DataType::Timestamp(time_unit, _) => {
+            let timestamp_ms = match time_unit {
+                arrow_schema::TimeUnit::Second => {
+                    let arr = col
+                        .as_any()
+                        .downcast_ref::<arrow_array::TimestampSecondArray>()
+                        .unwrap();
+                    arr.value(row) * 1000
+                }
+                arrow_schema::TimeUnit::Millisecond => {
+                    let arr = col
+                        .as_any()
+                        .downcast_ref::<arrow_array::TimestampMillisecondArray>()
+                        .unwrap();
+                    arr.value(row)
+                }
+                arrow_schema::TimeUnit::Microsecond => {
+                    let arr = col
+                        .as_any()
+                        .downcast_ref::<arrow_array::TimestampMicrosecondArray>()
+                        .unwrap();
+                    arr.value(row) / 1000
+                }
+                arrow_schema::TimeUnit::Nanosecond => {
+                    let arr = col
+                        .as_any()
+                        .downcast_ref::<arrow_array::TimestampNanosecondArray>()
+                        .unwrap();
+                    arr.value(row) / 1_000_000
+                }
+            };
+            serde_json::json!({
+                "$date": {
+                    "$numberLong": timestamp_ms.to_string()
+                }
+            })
+        }
         _ => {
             // Fallback: use Arrow's display format.
             let formatted = arrow_cast::display::ArrayFormatter::try_new(
@@ -275,9 +312,34 @@ fn json_from_float(col: &dyn arrow_array::Array, row: usize) -> serde_json::Valu
     }
 }
 
+/// Convert a JSON value to BSON, interpreting `MongoDB` Extended JSON (e.g. the
+/// `$date` emitted for timestamp columns). serde's structural `to_bson`/`to_document`
+/// would store `$date` as a literal sub-document, not a BSON date.
+#[cfg(feature = "mongodb-cdc")]
+fn json_to_bson(value: &serde_json::Value) -> Result<mongodb::bson::Bson, ConnectorError> {
+    mongodb::bson::Bson::try_from(value.clone())
+        .map_err(|e| ConnectorError::WriteError(format!("JSON to BSON: {e}")))
+}
+
+#[cfg(feature = "mongodb-cdc")]
+fn json_to_bson_document(
+    value: &serde_json::Value,
+) -> Result<mongodb::bson::Document, ConnectorError> {
+    match json_to_bson(value)? {
+        mongodb::bson::Bson::Document(doc) => Ok(doc),
+        other => Err(ConnectorError::WriteError(format!(
+            "expected a BSON document, got {:?}",
+            other.element_type()
+        ))),
+    }
+}
+
 #[async_trait]
 impl SinkConnector for MongoDbSink {
-    async fn open(&mut self, _config: &ConnectorConfig) -> Result<(), ConnectorError> {
+    async fn open(&mut self, config: &ConnectorConfig) -> Result<(), ConnectorError> {
+        if !config.properties().is_empty() {
+            self.config = MongoDbSinkConfig::from_config(config)?;
+        }
         self.config.validate()?;
 
         #[cfg(feature = "mongodb-cdc")]
@@ -508,10 +570,7 @@ impl MongoDbSink {
             WriteMode::Insert => {
                 let bson_docs: Vec<Document> = docs
                     .iter()
-                    .map(|v| {
-                        mongodb::bson::to_document(v)
-                            .map_err(|e| ConnectorError::WriteError(format!("to BSON: {e}")))
-                    })
+                    .map(json_to_bson_document)
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let opts = mongodb::options::InsertManyOptions::builder()
@@ -532,8 +591,7 @@ impl MongoDbSink {
 
             WriteMode::Upsert { ref key_fields } => {
                 for val in docs {
-                    let bson_doc = mongodb::bson::to_document(val)
-                        .map_err(|e| ConnectorError::WriteError(format!("to BSON: {e}")))?;
+                    let bson_doc = json_to_bson_document(val)?;
 
                     let mut filter = Document::new();
                     for key in key_fields {
@@ -567,8 +625,7 @@ impl MongoDbSink {
 
             WriteMode::Replace { upsert_on_missing } => {
                 for val in docs {
-                    let bson_doc = mongodb::bson::to_document(val)
-                        .map_err(|e| ConnectorError::WriteError(format!("to BSON: {e}")))?;
+                    let bson_doc = json_to_bson_document(val)?;
 
                     // Use _id as the filter for replacement.
                     let filter = match bson_doc.get("_id") {
@@ -606,8 +663,7 @@ impl MongoDbSink {
                     match op {
                         "I" => {
                             let full_doc = Self::parse_cdc_field(val, "_full_document")?;
-                            let bson_doc = mongodb::bson::to_document(full_doc.as_ref())
-                                .map_err(|e| ConnectorError::WriteError(format!("to BSON: {e}")))?;
+                            let bson_doc = json_to_bson_document(full_doc.as_ref())?;
                             collection.insert_one(bson_doc).await.map_err(|e| {
                                 ConnectorError::WriteError(format!("cdc insert: {e}"))
                             })?;
@@ -616,19 +672,14 @@ impl MongoDbSink {
                         "U" => {
                             let dk = Self::parse_cdc_field(val, "_document_key")?;
                             let ud = Self::parse_cdc_field(val, "_update_desc")?;
-                            let filter = mongodb::bson::to_document(dk.as_ref()).map_err(|e| {
-                                ConnectorError::WriteError(format!("filter BSON: {e}"))
-                            })?;
+                            let filter = json_to_bson_document(dk.as_ref())?;
 
                             // Transform updateDescription into update operators.
                             // Raw format: { "updatedFields": {...}, "removedFields": [...] }
                             // Required:   { "$set": {...}, "$unset": {...} }
                             let mut update = mongodb::bson::Document::new();
                             if let Some(updated) = ud.get("updatedFields") {
-                                let bson = mongodb::bson::to_bson(updated).map_err(|e| {
-                                    ConnectorError::WriteError(format!("updatedFields BSON: {e}"))
-                                })?;
-                                update.insert("$set", bson);
+                                update.insert("$set", json_to_bson(updated)?);
                             }
                             if let Some(removed) =
                                 ud.get("removedFields").and_then(|v| v.as_array())
@@ -659,13 +710,8 @@ impl MongoDbSink {
                         "R" => {
                             let dk = Self::parse_cdc_field(val, "_document_key")?;
                             let full_doc = Self::parse_cdc_field(val, "_full_document")?;
-                            let filter = mongodb::bson::to_document(dk.as_ref()).map_err(|e| {
-                                ConnectorError::WriteError(format!("filter BSON: {e}"))
-                            })?;
-                            let replacement = mongodb::bson::to_document(full_doc.as_ref())
-                                .map_err(|e| {
-                                    ConnectorError::WriteError(format!("replace BSON: {e}"))
-                                })?;
+                            let filter = json_to_bson_document(dk.as_ref())?;
+                            let replacement = json_to_bson_document(full_doc.as_ref())?;
                             let opts = mongodb::options::ReplaceOptions::builder()
                                 .upsert(Some(true))
                                 .build();
@@ -680,9 +726,7 @@ impl MongoDbSink {
                         }
                         "D" => {
                             let dk = Self::parse_cdc_field(val, "_document_key")?;
-                            let filter = mongodb::bson::to_document(dk.as_ref()).map_err(|e| {
-                                ConnectorError::WriteError(format!("filter BSON: {e}"))
-                            })?;
+                            let filter = json_to_bson_document(dk.as_ref())?;
                             collection.delete_one(filter).await.map_err(|e| {
                                 ConnectorError::WriteError(format!("cdc delete: {e}"))
                             })?;
@@ -779,6 +823,19 @@ mod tests {
 
         assert_eq!(docs[0]["id"], 0);
         assert_eq!(docs[0]["name"], "user_0");
+    }
+
+    #[cfg(feature = "mongodb-cdc")]
+    #[test]
+    fn timestamp_column_becomes_bson_date() {
+        let arr = arrow_array::TimestampMillisecondArray::from(vec![1_700_000_000_000_i64]);
+        let json = arrow_value_to_json(&arr, 0);
+        match json_to_bson(&json).unwrap() {
+            mongodb::bson::Bson::DateTime(dt) => {
+                assert_eq!(dt.timestamp_millis(), 1_700_000_000_000);
+            }
+            other => panic!("expected BSON DateTime, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/laminar-connectors/src/mongodb/sink.rs
+++ b/crates/laminar-connectors/src/mongodb/sink.rs
@@ -751,6 +751,8 @@ impl MongoDbSink {
                             ConnectorError::WriteError(format!("replace: {e}"))
                         })?;
                 }
+                // replace_one with upsert is an upsert; count it like Upsert mode.
+                self.metrics.record_upserts(count);
             }
 
             WriteMode::CdcReplay => {

--- a/crates/laminar-connectors/src/mongodb/sink.rs
+++ b/crates/laminar-connectors/src/mongodb/sink.rs
@@ -155,6 +155,27 @@ impl MongoDbSink {
         (docs, byte_estimate)
     }
 
+    /// Arrow batches → BSON documents directly (no `serde_json::Value` hop), for the
+    /// insert/upsert/replace paths. Returns `(docs, byte_estimate)`.
+    #[cfg(feature = "mongodb-cdc")]
+    fn batches_to_bson_docs(&self) -> (Vec<mongodb::bson::Document>, u64) {
+        let mut docs = Vec::with_capacity(self.buffered_rows);
+        let mut bytes: u64 = 0;
+        for batch in &self.buffer {
+            let schema = batch.schema();
+            for row in 0..batch.num_rows() {
+                let mut doc = mongodb::bson::Document::new();
+                for (col_idx, field) in schema.fields().iter().enumerate() {
+                    let value = arrow_value_to_bson(batch.column(col_idx), row);
+                    bytes += bson_size(&value) + field.name().len() as u64;
+                    doc.insert(field.name().clone(), value);
+                }
+                docs.push(doc);
+            }
+        }
+        (docs, bytes)
+    }
+
     /// Clears the internal buffer after a flush.
     fn clear_buffer(&mut self) {
         self.buffer.clear();
@@ -170,21 +191,30 @@ impl MongoDbSink {
             return Ok(WriteResult::new(0, 0));
         }
 
-        let (docs, byte_estimate) = self.batches_to_json_docs();
-        let doc_count = docs.len();
-
+        // CDC replay parses a JSON envelope (_op/_full_document/_update_desc), so it
+        // keeps the serde_json path; every other mode goes Arrow → BSON directly.
         #[cfg(feature = "mongodb-cdc")]
-        {
-            self.write_docs(&docs).await?;
-        }
+        let (doc_count, byte_estimate) = if matches!(self.config.write_mode, WriteMode::CdcReplay) {
+            let (docs, bytes) = self.batches_to_json_docs();
+            let n = docs.len();
+            self.write_cdc_docs(&docs).await?;
+            (n, bytes)
+        } else {
+            let (docs, bytes) = self.batches_to_bson_docs();
+            let n = docs.len();
+            self.write_bson_docs(docs).await?;
+            (n, bytes)
+        };
 
         #[cfg(not(feature = "mongodb-cdc"))]
-        {
+        let (doc_count, byte_estimate) = {
+            let (docs, bytes) = self.batches_to_json_docs();
             debug!(
-                count = doc_count,
+                count = docs.len(),
                 "flush (no-op without mongodb-cdc feature)"
             );
-        }
+            (docs.len(), bytes)
+        };
 
         self.metrics.record_flush(doc_count as u64, byte_estimate);
         self.clear_buffer();
@@ -223,43 +253,9 @@ fn arrow_value_to_json(col: &dyn arrow_array::Array, row: usize) -> serde_json::
             let arr = col.as_any().downcast_ref::<LargeStringArray>().unwrap();
             serde_json::Value::String(arr.value(row).to_string())
         }
-        DataType::Timestamp(time_unit, _) => {
-            let timestamp_ms = match time_unit {
-                arrow_schema::TimeUnit::Second => {
-                    let arr = col
-                        .as_any()
-                        .downcast_ref::<arrow_array::TimestampSecondArray>()
-                        .unwrap();
-                    arr.value(row) * 1000
-                }
-                arrow_schema::TimeUnit::Millisecond => {
-                    let arr = col
-                        .as_any()
-                        .downcast_ref::<arrow_array::TimestampMillisecondArray>()
-                        .unwrap();
-                    arr.value(row)
-                }
-                arrow_schema::TimeUnit::Microsecond => {
-                    let arr = col
-                        .as_any()
-                        .downcast_ref::<arrow_array::TimestampMicrosecondArray>()
-                        .unwrap();
-                    arr.value(row) / 1000
-                }
-                arrow_schema::TimeUnit::Nanosecond => {
-                    let arr = col
-                        .as_any()
-                        .downcast_ref::<arrow_array::TimestampNanosecondArray>()
-                        .unwrap();
-                    arr.value(row) / 1_000_000
-                }
-            };
-            serde_json::json!({
-                "$date": {
-                    "$numberLong": timestamp_ms.to_string()
-                }
-            })
-        }
+        DataType::Timestamp(..) => serde_json::json!({
+            "$date": { "$numberLong": timestamp_millis(col, row).to_string() }
+        }),
         _ => {
             // Fallback: use Arrow's display format.
             let formatted = arrow_cast::display::ArrayFormatter::try_new(
@@ -309,6 +305,121 @@ fn json_from_float(col: &dyn arrow_array::Array, row: usize) -> serde_json::Valu
             }
         }
         Err(_) => serde_json::Value::Null,
+    }
+}
+
+/// Milliseconds since epoch for a timestamp column cell, normalizing the unit.
+/// Sub-millisecond precision is truncated (BSON dates are millisecond-resolution).
+fn timestamp_millis(col: &dyn arrow_array::Array, row: usize) -> i64 {
+    use arrow_array::{
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray,
+    };
+    let DataType::Timestamp(unit, _) = col.data_type() else {
+        return 0;
+    };
+    let a = col.as_any();
+    match unit {
+        arrow_schema::TimeUnit::Second => {
+            a.downcast_ref::<TimestampSecondArray>().unwrap().value(row) * 1000
+        }
+        arrow_schema::TimeUnit::Millisecond => a
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap()
+            .value(row),
+        arrow_schema::TimeUnit::Microsecond => {
+            a.downcast_ref::<TimestampMicrosecondArray>()
+                .unwrap()
+                .value(row)
+                / 1000
+        }
+        arrow_schema::TimeUnit::Nanosecond => {
+            a.downcast_ref::<TimestampNanosecondArray>()
+                .unwrap()
+                .value(row)
+                / 1_000_000
+        }
+    }
+}
+
+/// Convert one Arrow cell straight to BSON for the insert/upsert/replace paths,
+/// skipping the `serde_json::Value` intermediate (and the number string round-trip)
+/// that the CDC path still needs. Integers stay width-faithful; timestamps become
+/// BSON dates; anything without a native BSON scalar falls back to a display string.
+#[cfg(feature = "mongodb-cdc")]
+fn arrow_value_to_bson(col: &dyn arrow_array::Array, row: usize) -> mongodb::bson::Bson {
+    use arrow_array::{
+        BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+        LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    };
+    use mongodb::bson::Bson;
+
+    if col.is_null(row) {
+        return Bson::Null;
+    }
+    let a = col.as_any();
+    let i32_of = |v: i32| Bson::Int32(v);
+    match col.data_type() {
+        DataType::Boolean => Bson::Boolean(a.downcast_ref::<BooleanArray>().unwrap().value(row)),
+        DataType::Int8 => i32_of(i32::from(a.downcast_ref::<Int8Array>().unwrap().value(row))),
+        DataType::Int16 => i32_of(i32::from(
+            a.downcast_ref::<Int16Array>().unwrap().value(row),
+        )),
+        DataType::Int32 => i32_of(a.downcast_ref::<Int32Array>().unwrap().value(row)),
+        DataType::Int64 => Bson::Int64(a.downcast_ref::<Int64Array>().unwrap().value(row)),
+        DataType::UInt8 => i32_of(i32::from(
+            a.downcast_ref::<UInt8Array>().unwrap().value(row),
+        )),
+        DataType::UInt16 => i32_of(i32::from(
+            a.downcast_ref::<UInt16Array>().unwrap().value(row),
+        )),
+        DataType::UInt32 => Bson::Int64(i64::from(
+            a.downcast_ref::<UInt32Array>().unwrap().value(row),
+        )),
+        DataType::UInt64 => {
+            let v = a.downcast_ref::<UInt64Array>().unwrap().value(row);
+            i64::try_from(v).map_or_else(|_| Bson::String(v.to_string()), Bson::Int64)
+        }
+        DataType::Float32 => Bson::Double(f64::from(
+            a.downcast_ref::<Float32Array>().unwrap().value(row),
+        )),
+        DataType::Float64 => Bson::Double(a.downcast_ref::<Float64Array>().unwrap().value(row)),
+        DataType::Utf8 => Bson::String(
+            a.downcast_ref::<StringArray>()
+                .unwrap()
+                .value(row)
+                .to_string(),
+        ),
+        DataType::LargeUtf8 => Bson::String(
+            a.downcast_ref::<LargeStringArray>()
+                .unwrap()
+                .value(row)
+                .to_string(),
+        ),
+        DataType::Timestamp(..) => Bson::DateTime(mongodb::bson::DateTime::from_millis(
+            timestamp_millis(col, row),
+        )),
+        _ => match arrow_cast::display::ArrayFormatter::try_new(
+            col,
+            &arrow_cast::display::FormatOptions::default(),
+        ) {
+            Ok(fmt) => Bson::String(fmt.value(row).to_string()),
+            Err(_) => Bson::Null,
+        },
+    }
+}
+
+/// Rough wire-size of a scalar BSON value, for the throughput metric (avoids a
+/// serialization pass just to count bytes).
+#[cfg(feature = "mongodb-cdc")]
+fn bson_size(v: &mongodb::bson::Bson) -> u64 {
+    use mongodb::bson::Bson;
+    match v {
+        Bson::String(s) => s.len() as u64 + 5,
+        Bson::Boolean(_) | Bson::Int32(_) => 5,
+        Bson::Int64(_) | Bson::Double(_) | Bson::DateTime(_) => 9,
+        Bson::Null => 1,
+        _ => 16,
     }
 }
 
@@ -557,42 +668,38 @@ impl MongoDbSink {
     /// Writes JSON value documents to `MongoDB` using the configured write mode.
     ///
     /// Accepts `serde_json::Value` directly (no intermediate string round-trip).
-    #[allow(clippy::too_many_lines)]
-    async fn write_docs(&self, docs: &[serde_json::Value]) -> Result<(), ConnectorError> {
-        use mongodb::bson::{doc, Document};
+    /// Insert/upsert/replace from documents already in BSON (no JSON hop). CDC
+    /// replay goes through [`write_cdc_docs`](Self::write_cdc_docs) instead.
+    async fn write_bson_docs(
+        &self,
+        docs: Vec<mongodb::bson::Document>,
+    ) -> Result<(), ConnectorError> {
+        use mongodb::bson::{doc, Bson, Document};
 
         let collection = self
             .collection
             .as_ref()
             .ok_or_else(|| ConnectorError::Internal("collection not initialized".to_string()))?;
+        let count = docs.len() as u64;
 
         match &self.config.write_mode {
             WriteMode::Insert => {
-                let bson_docs: Vec<Document> = docs
-                    .iter()
-                    .map(json_to_bson_document)
-                    .collect::<Result<Vec<_>, _>>()?;
-
                 let opts = mongodb::options::InsertManyOptions::builder()
                     .ordered(Some(self.config.ordered))
                     .build();
-
                 collection
-                    .insert_many(bson_docs)
+                    .insert_many(docs)
                     .with_options(opts)
                     .await
                     .map_err(|e| {
                         self.metrics.record_error();
                         ConnectorError::WriteError(format!("insert_many: {e}"))
                     })?;
-
-                self.metrics.record_inserts(docs.len() as u64);
+                self.metrics.record_inserts(count);
             }
 
             WriteMode::Upsert { ref key_fields } => {
-                for val in docs {
-                    let bson_doc = json_to_bson_document(val)?;
-
+                for bson_doc in docs {
                     let mut filter = Document::new();
                     for key in key_fields {
                         if let Some(v) = bson_doc.get(key) {
@@ -605,11 +712,9 @@ impl MongoDbSink {
                              exist in the document"
                         )));
                     }
-
                     let opts = mongodb::options::ReplaceOptions::builder()
                         .upsert(Some(true))
                         .build();
-
                     collection
                         .replace_one(filter, bson_doc)
                         .with_options(opts)
@@ -619,19 +724,14 @@ impl MongoDbSink {
                             ConnectorError::WriteError(format!("upsert: {e}"))
                         })?;
                 }
-
-                self.metrics.record_upserts(docs.len() as u64);
+                self.metrics.record_upserts(count);
             }
 
             WriteMode::Replace { upsert_on_missing } => {
-                for val in docs {
-                    let bson_doc = json_to_bson_document(val)?;
-
-                    // Use _id as the filter for replacement.
+                let upsert = *upsert_on_missing;
+                for bson_doc in docs {
                     let filter = match bson_doc.get("_id") {
-                        Some(id) if *id != mongodb::bson::Bson::Null => {
-                            doc! { "_id": id.clone() }
-                        }
+                        Some(id) if *id != Bson::Null => doc! { "_id": id.clone() },
                         _ => {
                             return Err(ConnectorError::WriteError(
                                 "Replace mode requires a non-null _id field in document"
@@ -639,11 +739,9 @@ impl MongoDbSink {
                             ));
                         }
                     };
-
                     let opts = mongodb::options::ReplaceOptions::builder()
-                        .upsert(Some(*upsert_on_missing))
+                        .upsert(Some(upsert))
                         .build();
-
                     collection
                         .replace_one(filter, bson_doc)
                         .with_options(opts)
@@ -656,86 +754,98 @@ impl MongoDbSink {
             }
 
             WriteMode::CdcReplay => {
-                // CDC replay processes each document based on its _op field.
-                for val in docs {
-                    let op = val.get("_op").and_then(|v| v.as_str()).unwrap_or("I");
+                return Err(ConnectorError::Internal(
+                    "CDC replay must go through write_cdc_docs".to_string(),
+                ));
+            }
+        }
 
-                    match op {
-                        "I" => {
-                            let full_doc = Self::parse_cdc_field(val, "_full_document")?;
-                            let bson_doc = json_to_bson_document(full_doc.as_ref())?;
-                            collection.insert_one(bson_doc).await.map_err(|e| {
-                                ConnectorError::WriteError(format!("cdc insert: {e}"))
-                            })?;
-                            self.metrics.record_inserts(1);
-                        }
-                        "U" => {
-                            let dk = Self::parse_cdc_field(val, "_document_key")?;
-                            let ud = Self::parse_cdc_field(val, "_update_desc")?;
-                            let filter = json_to_bson_document(dk.as_ref())?;
+        self.metrics.record_bulk_write();
+        Ok(())
+    }
 
-                            // Transform updateDescription into update operators.
-                            // Raw format: { "updatedFields": {...}, "removedFields": [...] }
-                            // Required:   { "$set": {...}, "$unset": {...} }
-                            let mut update = mongodb::bson::Document::new();
-                            if let Some(updated) = ud.get("updatedFields") {
-                                update.insert("$set", json_to_bson(updated)?);
-                            }
-                            if let Some(removed) =
-                                ud.get("removedFields").and_then(|v| v.as_array())
-                            {
-                                if !removed.is_empty() {
-                                    let unset_doc: mongodb::bson::Document = removed
-                                        .iter()
-                                        .filter_map(|f| f.as_str())
-                                        .map(|f| {
-                                            (
-                                                f.to_string(),
-                                                mongodb::bson::Bson::String(String::new()),
-                                            )
-                                        })
-                                        .collect();
-                                    update.insert("$unset", unset_doc);
-                                }
-                            }
-                            if update.is_empty() {
-                                continue;
-                            }
+    /// CDC replay: each doc is a changelog envelope (`_op`/`_full_document`/
+    /// `_document_key`/`_update_desc`) applied as the matching `MongoDB` op.
+    #[allow(clippy::too_many_lines)]
+    async fn write_cdc_docs(&self, docs: &[serde_json::Value]) -> Result<(), ConnectorError> {
+        let collection = self
+            .collection
+            .as_ref()
+            .ok_or_else(|| ConnectorError::Internal("collection not initialized".to_string()))?;
 
-                            collection.update_one(filter, update).await.map_err(|e| {
-                                ConnectorError::WriteError(format!("cdc update: {e}"))
-                            })?;
-                            self.metrics.record_upserts(1);
-                        }
-                        "R" => {
-                            let dk = Self::parse_cdc_field(val, "_document_key")?;
-                            let full_doc = Self::parse_cdc_field(val, "_full_document")?;
-                            let filter = json_to_bson_document(dk.as_ref())?;
-                            let replacement = json_to_bson_document(full_doc.as_ref())?;
-                            let opts = mongodb::options::ReplaceOptions::builder()
-                                .upsert(Some(true))
-                                .build();
-                            collection
-                                .replace_one(filter, replacement)
-                                .with_options(opts)
-                                .await
-                                .map_err(|e| {
-                                    ConnectorError::WriteError(format!("cdc replace: {e}"))
-                                })?;
-                            self.metrics.record_upserts(1);
-                        }
-                        "D" => {
-                            let dk = Self::parse_cdc_field(val, "_document_key")?;
-                            let filter = json_to_bson_document(dk.as_ref())?;
-                            collection.delete_one(filter).await.map_err(|e| {
-                                ConnectorError::WriteError(format!("cdc delete: {e}"))
-                            })?;
-                            self.metrics.record_deletes(1);
-                        }
-                        _ => {
-                            debug!(op = op, "lifecycle event — no write issued");
+        for val in docs {
+            let op = val.get("_op").and_then(|v| v.as_str()).unwrap_or("I");
+
+            match op {
+                "I" => {
+                    let full_doc = Self::parse_cdc_field(val, "_full_document")?;
+                    let bson_doc = json_to_bson_document(full_doc.as_ref())?;
+                    collection
+                        .insert_one(bson_doc)
+                        .await
+                        .map_err(|e| ConnectorError::WriteError(format!("cdc insert: {e}")))?;
+                    self.metrics.record_inserts(1);
+                }
+                "U" => {
+                    let dk = Self::parse_cdc_field(val, "_document_key")?;
+                    let ud = Self::parse_cdc_field(val, "_update_desc")?;
+                    let filter = json_to_bson_document(dk.as_ref())?;
+
+                    // Transform updateDescription into update operators.
+                    // Raw format: { "updatedFields": {...}, "removedFields": [...] }
+                    // Required:   { "$set": {...}, "$unset": {...} }
+                    let mut update = mongodb::bson::Document::new();
+                    if let Some(updated) = ud.get("updatedFields") {
+                        update.insert("$set", json_to_bson(updated)?);
+                    }
+                    if let Some(removed) = ud.get("removedFields").and_then(|v| v.as_array()) {
+                        if !removed.is_empty() {
+                            let unset_doc: mongodb::bson::Document = removed
+                                .iter()
+                                .filter_map(|f| f.as_str())
+                                .map(|f| {
+                                    (f.to_string(), mongodb::bson::Bson::String(String::new()))
+                                })
+                                .collect();
+                            update.insert("$unset", unset_doc);
                         }
                     }
+                    if update.is_empty() {
+                        continue;
+                    }
+
+                    collection
+                        .update_one(filter, update)
+                        .await
+                        .map_err(|e| ConnectorError::WriteError(format!("cdc update: {e}")))?;
+                    self.metrics.record_upserts(1);
+                }
+                "R" => {
+                    let dk = Self::parse_cdc_field(val, "_document_key")?;
+                    let full_doc = Self::parse_cdc_field(val, "_full_document")?;
+                    let filter = json_to_bson_document(dk.as_ref())?;
+                    let replacement = json_to_bson_document(full_doc.as_ref())?;
+                    let opts = mongodb::options::ReplaceOptions::builder()
+                        .upsert(Some(true))
+                        .build();
+                    collection
+                        .replace_one(filter, replacement)
+                        .with_options(opts)
+                        .await
+                        .map_err(|e| ConnectorError::WriteError(format!("cdc replace: {e}")))?;
+                    self.metrics.record_upserts(1);
+                }
+                "D" => {
+                    let dk = Self::parse_cdc_field(val, "_document_key")?;
+                    let filter = json_to_bson_document(dk.as_ref())?;
+                    collection
+                        .delete_one(filter)
+                        .await
+                        .map_err(|e| ConnectorError::WriteError(format!("cdc delete: {e}")))?;
+                    self.metrics.record_deletes(1);
+                }
+                _ => {
+                    debug!(op = op, "lifecycle event — no write issued");
                 }
             }
         }
@@ -836,6 +946,25 @@ mod tests {
             }
             other => panic!("expected BSON DateTime, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "mongodb-cdc")]
+    #[test]
+    fn arrow_to_bson_maps_scalar_types() {
+        use mongodb::bson::Bson;
+        let ts = arrow_array::TimestampMillisecondArray::from(vec![Some(1_700_000_000_000), None]);
+        assert!(
+            matches!(arrow_value_to_bson(&ts, 0), Bson::DateTime(dt) if dt.timestamp_millis() == 1_700_000_000_000)
+        );
+        assert_eq!(arrow_value_to_bson(&ts, 1), Bson::Null);
+        assert_eq!(
+            arrow_value_to_bson(&Int64Array::from(vec![42]), 0),
+            Bson::Int64(42)
+        );
+        assert_eq!(
+            arrow_value_to_bson(&StringArray::from(vec!["x"]), 0),
+            Bson::String("x".to_string())
+        );
     }
 
     #[test]

--- a/crates/laminar-connectors/tests/kafka_vnode_drain.rs
+++ b/crates/laminar-connectors/tests/kafka_vnode_drain.rs
@@ -1,0 +1,161 @@
+//! B2 source-pause: a vnode-partitioned Kafka source must stop consuming the
+//! partitions of vnodes marked draining (so a pre-rotation checkpoint is a clean
+//! cut), and resume them when the drain clears.
+//!
+//! Needs a real broker. Skips (does not fail) when `LAMINAR_KAFKA_BROKERS`
+//! (default `127.0.0.1:19092`) is unreachable, so it's a no-op in environments
+//! without one. Run against a broker with:
+//!   LAMINAR_KAFKA_BROKERS=127.0.0.1:19192 \
+//!     cargo test -p laminar-connectors --features kafka --test kafka_vnode_drain -- --nocapture
+
+#![cfg(feature = "kafka")]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::client::DefaultClientContext;
+use rdkafka::config::ClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use tokio::time::sleep;
+
+use laminar_connectors::config::ConnectorConfig;
+use laminar_connectors::connector::SourceConnector;
+use laminar_connectors::kafka::{KafkaSource, KafkaSourceConfig, StartupMode, TopicSubscription};
+use laminar_core::state::{NodeId, VnodeRegistry};
+
+const DEFAULT_BROKERS: &str = "127.0.0.1:19092";
+
+/// Brokers if the first one is reachable, else `None` (skip the test).
+fn broker() -> Option<String> {
+    let brokers = std::env::var("LAMINAR_KAFKA_BROKERS").unwrap_or_else(|_| DEFAULT_BROKERS.into());
+    let addr: std::net::SocketAddr = brokers.split(',').next()?.trim().parse().ok()?;
+    std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(1)).ok()?;
+    Some(brokers)
+}
+
+fn schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new("seq", DataType::Int64, false)]))
+}
+
+async fn create_topic(brokers: &str, topic: &str, partitions: i32) {
+    let admin: AdminClient<DefaultClientContext> = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .create()
+        .expect("admin client");
+    let new = NewTopic::new(topic, partitions, TopicReplication::Fixed(1));
+    admin
+        .create_topics([&new], &AdminOptions::new())
+        .await
+        .expect("create_topics");
+}
+
+/// Produce `seq in [start, start+count)` as `{"seq": n}`, keyed by `seq` so the
+/// default partitioner spreads them across partitions.
+async fn produce(brokers: &str, topic: &str, start: i64, count: i64) {
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "10000")
+        .create()
+        .expect("producer");
+    for n in start..start + count {
+        let payload = format!(r#"{{"seq":{n}}}"#);
+        let key = n.to_string();
+        producer
+            .send(
+                FutureRecord::to(topic).payload(&payload).key(&key),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("send");
+    }
+}
+
+/// Last-consumed offset for one partition, from the source checkpoint (`-1` = none yet).
+fn part_offset(source: &KafkaSource, topic: &str, partition: i32) -> i64 {
+    source
+        .checkpoint()
+        .get_offset(&format!("{topic}-{partition}"))
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(-1)
+}
+
+/// Poll for `dur`, draining whatever the reader has buffered.
+async fn poll_for(source: &mut KafkaSource, dur: Duration) {
+    let deadline = Instant::now() + dur;
+    while Instant::now() < deadline {
+        let _ = source.poll_batch(1000).await;
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn source_pauses_draining_vnode_partitions() {
+    let Some(brokers) = broker() else {
+        eprintln!("kafka_vnode_drain: no reachable broker — skipping");
+        return;
+    };
+
+    const PARTS: i32 = 4;
+    let topic = format!("vnode-drain-{}", std::process::id());
+    create_topic(&brokers, &topic, PARTS).await;
+    produce(&brokers, &topic, 0, 400).await;
+
+    // One node owns every vnode; with vnode_count == partition count, partition p
+    // binds to vnode p, so the source manually assigns all four partitions.
+    let registry = Arc::new(VnodeRegistry::single_owner(PARTS as u32, NodeId(0)));
+    let cfg = KafkaSourceConfig {
+        bootstrap_servers: brokers.clone(),
+        group_id: format!("vnode-drain-grp-{}", std::process::id()),
+        subscription: TopicSubscription::Topics(vec![topic.clone()]),
+        startup_mode: StartupMode::Earliest,
+        ..KafkaSourceConfig::default()
+    };
+    let mut source = KafkaSource::new(schema(), cfg, None);
+    source.set_vnode_assignment(Arc::clone(&registry), NodeId(0));
+    source.open(&ConnectorConfig::new("kafka")).await.unwrap();
+
+    // Consume the initial batch across all partitions.
+    poll_for(&mut source, Duration::from_secs(4)).await;
+    assert!(
+        (0..PARTS).all(|p| part_offset(&source, &topic, p) >= 0),
+        "every partition should have advanced before draining: {:?}",
+        (0..PARTS)
+            .map(|p| part_offset(&source, &topic, p))
+            .collect::<Vec<_>>(),
+    );
+
+    // Drain vnode 1 → the source pauses partition 1. Let the pause take effect and
+    // any already-buffered partition-1 records flush, then snapshot the cut.
+    registry.mark_draining(&[1]);
+    poll_for(&mut source, Duration::from_secs(3)).await;
+    let cut_p1 = part_offset(&source, &topic, 1);
+    let pre_p0 = part_offset(&source, &topic, 0);
+
+    // Produce more to every partition; only the non-draining ones should advance.
+    produce(&brokers, &topic, 400, 600).await;
+    poll_for(&mut source, Duration::from_secs(6)).await;
+
+    assert_eq!(
+        part_offset(&source, &topic, 1),
+        cut_p1,
+        "draining partition 1 must not advance past the cut",
+    );
+    assert!(
+        part_offset(&source, &topic, 0) > pre_p0,
+        "a non-draining partition must keep consuming (p0 {pre_p0} -> {})",
+        part_offset(&source, &topic, 0),
+    );
+
+    // Clear the drain → partition 1 resumes.
+    registry.clear_draining();
+    poll_for(&mut source, Duration::from_secs(6)).await;
+    assert!(
+        part_offset(&source, &topic, 1) > cut_p1,
+        "partition 1 must resume after the drain clears ({cut_p1} -> {})",
+        part_offset(&source, &topic, 1),
+    );
+
+    source.close().await.unwrap();
+}

--- a/crates/laminar-connectors/tests/kafka_vnode_drain.rs
+++ b/crates/laminar-connectors/tests/kafka_vnode_drain.rs
@@ -85,7 +85,7 @@ fn part_offset(source: &KafkaSource, topic: &str, partition: i32) -> i64 {
 async fn poll_for(source: &mut KafkaSource, dur: Duration) {
     let deadline = Instant::now() + dur;
     while Instant::now() < deadline {
-        let _ = source.poll_batch(1000).await;
+        source.poll_batch(1000).await.expect("poll_batch");
         sleep(Duration::from_millis(50)).await;
     }
 }

--- a/crates/laminar-core/src/checkpoint/checkpoint_store.rs
+++ b/crates/laminar-core/src/checkpoint/checkpoint_store.rs
@@ -1489,6 +1489,55 @@ mod tests {
         assert_eq!(op.decode_inline().unwrap(), b"data");
     }
 
+    /// B1 foundation gap (KNOWN-FAILING): in cluster mode every node writes its
+    /// OWN partial manifest — only the partitions it owns — to the shared store,
+    /// which has a single `latest.txt` pointer and no cross-node merge. So
+    /// `load_latest()` returns one node's offsets, not a global union, and a node
+    /// acquiring a partition can't reliably find the previous owner's committed
+    /// position (it resumes from `auto.offset.reset` → duplicates). This asserts
+    /// the DESIRED post-fix behavior (a globally-complete manifest) and therefore
+    /// fails today; remove `#[ignore]` when the leader-merged global manifest lands.
+    #[tokio::test]
+    #[ignore = "B1: documents the multi-node manifest-completeness gap; flip when leader-merged manifest lands"]
+    async fn manifest_handoff_is_globally_complete_across_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+
+        // Node 0 checkpoints only the partition it owns (events-0)…
+        let mut n0 = make_manifest(1, 5);
+        n0.source_offsets.insert(
+            "kafka-src".into(),
+            ConnectorCheckpoint::with_offsets(
+                5,
+                HashMap::from([("events-0".into(), "100".into())]),
+            ),
+        );
+        store.save(&n0).await.unwrap();
+
+        // …node 1 checkpoints its own partition (events-1), a different id but the
+        // same shared `latest.txt`. Last writer wins.
+        let mut n1 = make_manifest(2, 5);
+        n1.source_offsets.insert(
+            "kafka-src".into(),
+            ConnectorCheckpoint::with_offsets(
+                5,
+                HashMap::from([("events-1".into(), "200".into())]),
+            ),
+        );
+        store.save(&n1).await.unwrap();
+
+        // A node acquiring events-0 on rotation reads the latest manifest for its
+        // offset. The handoff is only sound if the manifest is a global union.
+        let latest = store.load_latest().await.unwrap().unwrap();
+        let offsets = &latest.source_offsets.get("kafka-src").unwrap().offsets;
+        assert_eq!(
+            offsets.get("events-0"),
+            Some(&"100".to_string()),
+            "previous owner's offset must survive the handoff (global manifest)"
+        );
+        assert_eq!(offsets.get("events-1"), Some(&"200".to_string()));
+    }
+
     #[tokio::test]
     async fn test_empty_latest_txt() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/laminar-core/src/checkpoint/checkpoint_store.rs
+++ b/crates/laminar-core/src/checkpoint/checkpoint_store.rs
@@ -1489,55 +1489,6 @@ mod tests {
         assert_eq!(op.decode_inline().unwrap(), b"data");
     }
 
-    /// B1 foundation gap (KNOWN-FAILING): in cluster mode every node writes its
-    /// OWN partial manifest — only the partitions it owns — to the shared store,
-    /// which has a single `latest.txt` pointer and no cross-node merge. So
-    /// `load_latest()` returns one node's offsets, not a global union, and a node
-    /// acquiring a partition can't reliably find the previous owner's committed
-    /// position (it resumes from `auto.offset.reset` → duplicates). This asserts
-    /// the DESIRED post-fix behavior (a globally-complete manifest) and therefore
-    /// fails today; remove `#[ignore]` when the leader-merged global manifest lands.
-    #[tokio::test]
-    #[ignore = "B1: documents the multi-node manifest-completeness gap; flip when leader-merged manifest lands"]
-    async fn manifest_handoff_is_globally_complete_across_nodes() {
-        let dir = tempfile::tempdir().unwrap();
-        let store = make_store(dir.path());
-
-        // Node 0 checkpoints only the partition it owns (events-0)…
-        let mut n0 = make_manifest(1, 5);
-        n0.source_offsets.insert(
-            "kafka-src".into(),
-            ConnectorCheckpoint::with_offsets(
-                5,
-                HashMap::from([("events-0".into(), "100".into())]),
-            ),
-        );
-        store.save(&n0).await.unwrap();
-
-        // …node 1 checkpoints its own partition (events-1), a different id but the
-        // same shared `latest.txt`. Last writer wins.
-        let mut n1 = make_manifest(2, 5);
-        n1.source_offsets.insert(
-            "kafka-src".into(),
-            ConnectorCheckpoint::with_offsets(
-                5,
-                HashMap::from([("events-1".into(), "200".into())]),
-            ),
-        );
-        store.save(&n1).await.unwrap();
-
-        // A node acquiring events-0 on rotation reads the latest manifest for its
-        // offset. The handoff is only sound if the manifest is a global union.
-        let latest = store.load_latest().await.unwrap().unwrap();
-        let offsets = &latest.source_offsets.get("kafka-src").unwrap().offsets;
-        assert_eq!(
-            offsets.get("events-0"),
-            Some(&"100".to_string()),
-            "previous owner's offset must survive the handoff (global manifest)"
-        );
-        assert_eq!(offsets.get("events-1"), Some(&"200".to_string()));
-    }
-
     #[tokio::test]
     async fn test_empty_latest_txt() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -335,6 +335,25 @@ impl ClusterController {
             .max()
     }
 
+    /// Announce that this node has adopted a draining snapshot version (paused its
+    /// revoking partitions) so the leader can wait for every node before taking the
+    /// pre-rotation checkpoint.
+    pub async fn announce_drained_version(&self, version: u64) {
+        self.kv
+            .write("control:drained-version", version.to_string())
+            .await;
+    }
+
+    /// Each peer's adopted draining-snapshot version from gossip KV.
+    pub async fn read_drained_versions(&self) -> Vec<(NodeId, u64)> {
+        self.kv
+            .scan("control:drained-version")
+            .await
+            .into_iter()
+            .filter_map(|(n, v)| v.parse::<u64>().ok().map(|ver| (n, ver)))
+            .collect()
+    }
+
     /// Start the direct gRPC barrier sync server.
     ///
     /// # Errors

--- a/crates/laminar-core/src/cluster/control/snapshot.rs
+++ b/crates/laminar-core/src/cluster/control/snapshot.rs
@@ -36,6 +36,13 @@ pub struct AssignmentSnapshot {
     pub vnodes: BTreeMap<u32, NodeId>,
     /// Wall-clock timestamp of the last update, millis since epoch.
     pub updated_at_ms: i64,
+    /// Pre-rotation drain phase: when set, this snapshot carries the *intended*
+    /// next assignment but ownership has NOT changed yet. Nodes mark the vnodes
+    /// they are about to lose as draining (pausing those source partitions) so the
+    /// pre-rotation checkpoint is a clean cut; the leader then publishes the same
+    /// assignment with `draining = false` to commit the rotation.
+    #[serde(default)]
+    pub draining: bool,
 }
 
 impl AssignmentSnapshot {
@@ -46,6 +53,7 @@ impl AssignmentSnapshot {
             version: 0,
             vnodes: BTreeMap::new(),
             updated_at_ms: 0,
+            draining: false,
         }
     }
 
@@ -60,6 +68,7 @@ impl AssignmentSnapshot {
             version: self.version + 1,
             vnodes,
             updated_at_ms: now_ms,
+            draining: false,
         }
     }
 
@@ -493,5 +502,27 @@ mod tests {
         let snap = AssignmentSnapshot::empty().next(map);
         let back = snap.to_vnode_vec(u32::try_from(assignment.len()).expect("test len fits u32"));
         assert_eq!(back, assignment);
+    }
+
+    #[test]
+    fn draining_defaults_false_and_survives_roundtrip() {
+        // `next` produces a committed (non-draining) snapshot.
+        let mut vnodes = BTreeMap::new();
+        vnodes.insert(0, NodeId(1));
+        let committed = AssignmentSnapshot::empty().next(vnodes);
+        assert!(!committed.draining);
+
+        // The draining flag round-trips through JSON.
+        let mut drain = committed.clone();
+        drain.draining = true;
+        let json = serde_json::to_vec(&drain).unwrap();
+        let back: AssignmentSnapshot = serde_json::from_slice(&json).unwrap();
+        assert!(back.draining);
+        assert_eq!(back.version, drain.version);
+
+        // An older snapshot JSON without the field deserializes as not draining.
+        let legacy = r#"{"version":3,"vnodes":{},"updated_at_ms":0}"#;
+        let parsed: AssignmentSnapshot = serde_json::from_str(legacy).unwrap();
+        assert!(!parsed.draining);
     }
 }

--- a/crates/laminar-core/src/state/backend.rs
+++ b/crates/laminar-core/src/state/backend.rs
@@ -126,6 +126,32 @@ pub trait StateBackend: Send + Sync + 'static {
         epoch: u64,
     ) -> Result<Vec<(String, Bytes)>, StateBackendError>;
 
+    /// Persist this node's source-checkpoint offsets for `epoch` (opaque
+    /// connector key/value bytes), keyed by a per-node `node_key` so writers
+    /// don't collide. A node acquiring a partition on a later rotation unions
+    /// every node's blob (see [`read_source_offsets`](Self::read_source_offsets))
+    /// to resume from the committed cut instead of `auto.offset.reset`. Same
+    /// fence as `write_partial`. Default no-op: handoff degrades to the source's
+    /// configured startup offset.
+    async fn write_source_offsets(
+        &self,
+        epoch: u64,
+        node_key: &str,
+        assignment_version: u64,
+        bytes: Bytes,
+    ) -> Result<(), StateBackendError> {
+        let _ = (epoch, node_key, assignment_version, bytes);
+        Ok(())
+    }
+
+    /// Every node's source-offset blob for `epoch` (see
+    /// [`write_source_offsets`](Self::write_source_offsets)). The caller unions
+    /// them into the global offset map. Default empty.
+    async fn read_source_offsets(&self, epoch: u64) -> Result<Vec<Bytes>, StateBackendError> {
+        let _ = epoch;
+        Ok(Vec::new())
+    }
+
     /// Durability barrier: true once every `vnode` partial and every
     /// `required_descriptors` key for `epoch` is persisted, sealing the epoch.
     /// Sinks do not commit until it returns `Ok(true)`. `required_descriptors`

--- a/crates/laminar-core/src/state/config.rs
+++ b/crates/laminar-core/src/state/config.rs
@@ -432,9 +432,8 @@ seed_peers = ["10.0.0.1:7946", "10.0.0.2:7946"]
         use crate::checkpoint::object_store_builder::ObjectStoreBuilderError;
 
         let c = StateBackendConfig::object_store("s3://bucket/path", "node-0");
-        let err = match c.build().await {
-            Ok(_) => panic!("s3 must not build without the aws feature"),
-            Err(e) => e,
+        let Err(err) = c.build().await else {
+            panic!("s3 must not build without the aws feature");
         };
         assert!(
             matches!(

--- a/crates/laminar-core/src/state/in_process.rs
+++ b/crates/laminar-core/src/state/in_process.rs
@@ -205,41 +205,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_offsets_union_across_nodes() {
-        let b = InProcessBackend::new(4);
-        // Two nodes each persist their own partitions' offsets at the same epoch.
-        b.write_source_offsets(
-            7,
-            "node-1",
-            0,
-            Bytes::from_static(b"{\"events-0\":\"100\"}"),
-        )
-        .await
-        .unwrap();
-        b.write_source_offsets(
-            7,
-            "node-2",
-            0,
-            Bytes::from_static(b"{\"events-1\":\"200\"}"),
-        )
-        .await
-        .unwrap();
-
-        // A node acquiring a partition reads every node's blob and unions them.
-        let blobs = b.read_source_offsets(7).await.unwrap();
-        assert_eq!(
-            blobs.len(),
-            2,
-            "both nodes' blobs are returned for the epoch"
-        );
-        assert!(b.read_source_offsets(8).await.unwrap().is_empty());
-
-        // Pruning drops them with their epoch.
-        b.prune_before(8).await.unwrap();
-        assert!(b.read_source_offsets(7).await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
     async fn epoch_complete_requires_every_vnode() {
         let b = InProcessBackend::new(4);
         let vnodes = [0u32, 1, 2];

--- a/crates/laminar-core/src/state/in_process.rs
+++ b/crates/laminar-core/src/state/in_process.rs
@@ -16,6 +16,8 @@ pub struct InProcessBackend {
     partials: RwLock<FxHashMap<(u32, u64), Bytes>>,
     /// `epoch -> key -> descriptor`, the in-memory analogue of `epoch=N/commit/`.
     descriptors: RwLock<FxHashMap<u64, FxHashMap<String, Bytes>>>,
+    /// `epoch -> node_key -> source offsets`, the analogue of `epoch=N/srcoff/`.
+    source_offsets: RwLock<FxHashMap<u64, FxHashMap<String, Bytes>>>,
     /// Epochs sealed by [`epoch_complete`](StateBackend::epoch_complete) — the
     /// in-memory analogue of the object-store `_COMMIT` markers.
     sealed: RwLock<BTreeSet<u64>>,
@@ -29,6 +31,7 @@ impl InProcessBackend {
         Self {
             partials: RwLock::new(FxHashMap::default()),
             descriptors: RwLock::new(FxHashMap::default()),
+            source_offsets: RwLock::new(FxHashMap::default()),
             sealed: RwLock::new(BTreeSet::new()),
             vnode_capacity,
         }
@@ -105,6 +108,30 @@ impl StateBackend for InProcessBackend {
             .unwrap_or_default())
     }
 
+    async fn write_source_offsets(
+        &self,
+        epoch: u64,
+        node_key: &str,
+        _assignment_version: u64,
+        bytes: Bytes,
+    ) -> Result<(), StateBackendError> {
+        self.source_offsets
+            .write()
+            .entry(epoch)
+            .or_default()
+            .insert(node_key.to_string(), bytes);
+        Ok(())
+    }
+
+    async fn read_source_offsets(&self, epoch: u64) -> Result<Vec<Bytes>, StateBackendError> {
+        Ok(self
+            .source_offsets
+            .read()
+            .get(&epoch)
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default())
+    }
+
     async fn epoch_complete(
         &self,
         epoch: u64,
@@ -151,6 +178,9 @@ impl StateBackend for InProcessBackend {
             .write()
             .retain(|&(_, epoch), _| epoch >= before);
         self.descriptors.write().retain(|&epoch, _| epoch >= before);
+        self.source_offsets
+            .write()
+            .retain(|&epoch, _| epoch >= before);
         self.sealed.write().retain(|&epoch| epoch >= before);
         Ok(())
     }
@@ -172,6 +202,41 @@ mod tests {
         let got = b.read_partial(2, 7).await.unwrap().unwrap();
         assert_eq!(got, payload);
         assert!(b.read_partial(2, 8).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn source_offsets_union_across_nodes() {
+        let b = InProcessBackend::new(4);
+        // Two nodes each persist their own partitions' offsets at the same epoch.
+        b.write_source_offsets(
+            7,
+            "node-1",
+            0,
+            Bytes::from_static(b"{\"events-0\":\"100\"}"),
+        )
+        .await
+        .unwrap();
+        b.write_source_offsets(
+            7,
+            "node-2",
+            0,
+            Bytes::from_static(b"{\"events-1\":\"200\"}"),
+        )
+        .await
+        .unwrap();
+
+        // A node acquiring a partition reads every node's blob and unions them.
+        let blobs = b.read_source_offsets(7).await.unwrap();
+        assert_eq!(
+            blobs.len(),
+            2,
+            "both nodes' blobs are returned for the epoch"
+        );
+        assert!(b.read_source_offsets(8).await.unwrap().is_empty());
+
+        // Pruning drops them with their epoch.
+        b.prune_before(8).await.unwrap();
+        assert!(b.read_source_offsets(7).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/laminar-core/src/state/object_store.rs
+++ b/crates/laminar-core/src/state/object_store.rs
@@ -115,6 +115,10 @@ impl ObjectStoreBackend {
         OsPath::from(format!("epoch={epoch}/commit/{key}"))
     }
 
+    fn source_offsets_path(epoch: u64, node_key: &str) -> OsPath {
+        OsPath::from(format!("epoch={epoch}/srcoff/{node_key}"))
+    }
+
     /// Parse `N` from a location whose first path segment is `epoch=N`.
     /// `None` for any sibling object that doesn't follow the layout.
     /// `str::split` always yields at least one segment.
@@ -222,6 +226,53 @@ impl StateBackend for ObjectStoreBackend {
                 .await
                 .map_err(|e| StateBackendError::Io(e.to_string()))?;
             out.push((key, bytes));
+        }
+        Ok(out)
+    }
+
+    async fn write_source_offsets(
+        &self,
+        epoch: u64,
+        node_key: &str,
+        assignment_version: u64,
+        bytes: Bytes,
+    ) -> Result<(), StateBackendError> {
+        let authoritative = self.authoritative_version.load(Ordering::Acquire);
+        if authoritative > 0 && assignment_version < authoritative {
+            return Err(StateBackendError::StaleVersion {
+                caller: assignment_version,
+                authoritative,
+            });
+        }
+        self.store
+            .put(
+                &Self::source_offsets_path(epoch, node_key),
+                PutPayload::from(bytes),
+            )
+            .await
+            .map_err(|e| StateBackendError::Io(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn read_source_offsets(&self, epoch: u64) -> Result<Vec<Bytes>, StateBackendError> {
+        use tokio_stream::StreamExt;
+
+        let prefix = OsPath::from(format!("epoch={epoch}/srcoff/"));
+        let mut entries = self.store.list(Some(&prefix));
+        let mut out = Vec::new();
+        while let Some(entry) = entries.next().await {
+            let loc = entry
+                .map_err(|e| StateBackendError::Io(e.to_string()))?
+                .location;
+            let bytes = self
+                .store
+                .get(&loc)
+                .await
+                .map_err(|e| StateBackendError::Io(e.to_string()))?
+                .bytes()
+                .await
+                .map_err(|e| StateBackendError::Io(e.to_string()))?;
+            out.push(bytes);
         }
         Ok(out)
     }
@@ -472,6 +523,39 @@ mod tests {
             .unwrap();
         let got = backend.read_partial(0, 1).await.unwrap().unwrap();
         assert_eq!(&got[..], b"hello");
+    }
+
+    #[tokio::test]
+    async fn source_offsets_union_and_prune() {
+        let dir = tempdir().unwrap();
+        let backend = ObjectStoreBackend::new(make_store(dir.path()), "node-0", 4);
+
+        backend
+            .write_source_offsets(
+                7,
+                "node-1",
+                0,
+                Bytes::from_static(b"{\"events-0\":\"100\"}"),
+            )
+            .await
+            .unwrap();
+        backend
+            .write_source_offsets(
+                7,
+                "node-2",
+                0,
+                Bytes::from_static(b"{\"events-1\":\"200\"}"),
+            )
+            .await
+            .unwrap();
+
+        let blobs = backend.read_source_offsets(7).await.unwrap();
+        assert_eq!(blobs.len(), 2);
+        assert!(backend.read_source_offsets(8).await.unwrap().is_empty());
+
+        // Lives under `epoch=7/srcoff/`, so the epoch-prefix prune reclaims it.
+        backend.prune_before(8).await.unwrap();
+        assert!(backend.read_source_offsets(7).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/laminar-core/src/state/vnode.rs
+++ b/crates/laminar-core/src/state/vnode.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
-use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -100,6 +100,13 @@ pub struct VnodeRegistry {
     /// serialized — rebuilt (all `Active`) from the `AssignmentSnapshot`
     /// on boot, so adding it never touches a wire format.
     lifecycle: Arc<[AtomicU8]>,
+    /// Per-vnode "draining" flag, set on a vnode this node is about to lose in a
+    /// rotation so a partitioned source pauses that vnode's input until the cut.
+    /// Orthogonal to `lifecycle`: a draining vnode is still owned and still emits;
+    /// it only stops *consuming*. `draining_generation` lets the source detect a
+    /// change lock-free without an assignment-version bump.
+    draining: Arc<[AtomicBool]>,
+    draining_generation: AtomicU64,
     /// Opaque source-checkpoint offsets (connector-defined key/value strings)
     /// staged by the engine just before an assignment-version bump. A partitioned
     /// source reads them on rebind to resume partitions it is acquiring from the
@@ -138,6 +145,8 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
+            draining: new_draining(vnode_count),
+            draining_generation: AtomicU64::new(0),
             resume_offsets: parking_lot::Mutex::new(Arc::new(ResumeOffsets::new())),
         }
     }
@@ -159,6 +168,8 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
+            draining: new_draining(vnode_count),
+            draining_generation: AtomicU64::new(0),
             resume_offsets: parking_lot::Mutex::new(Arc::new(ResumeOffsets::new())),
         }
     }
@@ -317,11 +328,55 @@ impl VnodeRegistry {
             })
             .collect()
     }
+
+    /// Mark `vnodes` as draining for a pending rotation so a partitioned source
+    /// pauses their input until the pre-rotation checkpoint cut. Out-of-range ids
+    /// are ignored. Bumps the draining generation so the source observes it.
+    pub fn mark_draining(&self, vnodes: &[u32]) {
+        for &v in vnodes {
+            if let Some(slot) = self.draining.get(v as usize) {
+                slot.store(true, Ordering::Release);
+            }
+        }
+        self.draining_generation.fetch_add(1, Ordering::Release);
+    }
+
+    /// Clear every draining flag (rotation committed or aborted). Bumps the
+    /// generation so the source resumes any partitions it paused for the drain.
+    pub fn clear_draining(&self) {
+        for slot in self.draining.iter() {
+            slot.store(false, Ordering::Release);
+        }
+        self.draining_generation.fetch_add(1, Ordering::Release);
+    }
+
+    /// Whether `vnode` is currently draining. Out-of-range ids report false.
+    #[must_use]
+    pub fn is_draining(&self, vnode: u32) -> bool {
+        self.draining
+            .get(vnode as usize)
+            .is_some_and(|s| s.load(Ordering::Acquire))
+    }
+
+    /// Monotonic counter bumped on each draining change; the source compares it
+    /// lock-free to detect drain/undrain without an assignment-version bump.
+    #[must_use]
+    pub fn draining_generation(&self) -> u64 {
+        self.draining_generation.load(Ordering::Acquire)
+    }
 }
 
 /// Build a fresh lifecycle array with every vnode [`Active`].
 fn new_lifecycle(vnode_count: u32) -> Arc<[AtomicU8]> {
     std::iter::repeat_with(|| AtomicU8::new(VnodeLifecycleState::ACTIVE))
+        .take(vnode_count as usize)
+        .collect::<Vec<_>>()
+        .into()
+}
+
+/// Build a fresh draining array with every vnode not draining.
+fn new_draining(vnode_count: u32) -> Arc<[AtomicBool]> {
+    std::iter::repeat_with(|| AtomicBool::new(false))
         .take(vnode_count as usize)
         .collect::<Vec<_>>()
         .into()
@@ -652,6 +707,37 @@ mod tests {
         r.mark_restoring(&[2]);
         r.set_assignment(vec![NodeId(1), NodeId(1), NodeId(1), NodeId(1)].into());
         assert!(r.is_restoring(2));
+    }
+
+    #[test]
+    fn draining_marks_clear_and_bump_generation() {
+        let r = VnodeRegistry::new(4);
+        let g0 = r.draining_generation();
+        assert!(!r.is_draining(1));
+
+        r.mark_draining(&[1, 3]);
+        assert!(r.is_draining(1));
+        assert!(r.is_draining(3));
+        assert!(!r.is_draining(0));
+        assert!(r.draining_generation() > g0, "mark bumps the generation");
+
+        let g1 = r.draining_generation();
+        r.clear_draining();
+        assert!(!r.is_draining(1));
+        assert!(!r.is_draining(3));
+        assert!(r.draining_generation() > g1, "clear bumps the generation");
+    }
+
+    #[test]
+    fn draining_is_orthogonal_to_lifecycle_and_ignores_out_of_range() {
+        let r = VnodeRegistry::new(2);
+        // A draining vnode still emits (lifecycle stays Active) — only consumption pauses.
+        r.mark_draining(&[0]);
+        assert!(r.is_draining(0));
+        assert!(!r.is_restoring(0));
+        // Out-of-range ids are ignored, no panic.
+        r.mark_draining(&[5, 99]);
+        assert!(!r.is_draining(5));
     }
 
     // -- Topology-aware placement --------------------------------------------

--- a/crates/laminar-core/src/state/vnode.rs
+++ b/crates/laminar-core/src/state/vnode.rs
@@ -82,6 +82,13 @@ impl VnodeLifecycleState {
     }
 }
 
+/// Opaque source-checkpoint offsets (connector-defined `"key" -> "value"`
+/// strings) staged for a rotation handoff. A private alias keeps the single
+/// `disallowed_types` exception (cold path, mirrors the checkpoint map shape) in
+/// one place rather than blanket-allowing this perf-sensitive module.
+#[allow(clippy::disallowed_types)]
+type ResumeOffsets = std::collections::HashMap<String, String>;
+
 /// Runtime registry of vnode topology and assignment.
 pub struct VnodeRegistry {
     vnode_count: u32,
@@ -93,12 +100,12 @@ pub struct VnodeRegistry {
     /// serialized — rebuilt (all `Active`) from the `AssignmentSnapshot`
     /// on boot, so adding it never touches a wire format.
     lifecycle: Arc<[AtomicU8]>,
-    /// Committed source resume offsets staged by the engine just before an
-    /// assignment-version bump, for partitions this node is acquiring in a
-    /// rotation. Keyed `(topic, partition) -> next-offset-to-fetch`. Drained by
-    /// the Kafka source on its next rebind so acquired partitions resume from the
-    /// previous owner's sealed checkpoint position instead of `auto.offset.reset`.
-    resume_hints: parking_lot::Mutex<std::collections::HashMap<(String, i32), i64>>,
+    /// Opaque source-checkpoint offsets (connector-defined key/value strings)
+    /// staged by the engine just before an assignment-version bump. A partitioned
+    /// source reads them on rebind to resume partitions it is acquiring from the
+    /// previous owner's sealed position instead of `auto.offset.reset`. The engine
+    /// stays connector-agnostic; the source interprets the keys.
+    resume_offsets: parking_lot::Mutex<Arc<ResumeOffsets>>,
 }
 
 impl std::fmt::Debug for VnodeRegistry {
@@ -131,7 +138,7 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
-            resume_hints: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            resume_offsets: parking_lot::Mutex::new(Arc::new(ResumeOffsets::new())),
         }
     }
 
@@ -152,29 +159,27 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
-            resume_hints: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            resume_offsets: parking_lot::Mutex::new(Arc::new(ResumeOffsets::new())),
         }
     }
 
-    /// Stage committed source resume offsets for partitions about to be acquired
-    /// in a rotation, keyed `(topic, partition) -> next-offset-to-fetch`. MUST be
-    /// called before [`set_assignment_and_version`](Self::set_assignment_and_version)
-    /// so the source observes them when it rebinds for the new version.
-    pub fn stage_resume_hints(&self, hints: std::collections::HashMap<(String, i32), i64>) {
-        if hints.is_empty() {
+    /// Stage opaque source-checkpoint offsets for the next rebind. MUST be called
+    /// before [`set_assignment_and_version`](Self::set_assignment_and_version) so
+    /// the source observes them. Replaces any prior staging; an empty map is
+    /// ignored so a transient load failure can't clobber a good snapshot.
+    pub fn stage_resume_offsets(&self, offsets: ResumeOffsets) {
+        if offsets.is_empty() {
             return;
         }
-        self.resume_hints.lock().extend(hints);
+        *self.resume_offsets.lock() = Arc::new(offsets);
     }
 
-    /// Drain the staged source resume offsets (see
-    /// [`stage_resume_hints`](Self::stage_resume_hints)). Returns and clears the
-    /// map; entries the caller does not use are dropped — they are only valid for
-    /// the rotation that staged them.
+    /// The staged source-checkpoint offsets (see
+    /// [`stage_resume_offsets`](Self::stage_resume_offsets)). Reads (does not
+    /// drain), so every source on this node sees the same snapshot on rebind.
     #[must_use]
-    pub fn take_resume_hints(&self) -> std::collections::HashMap<(String, i32), i64> {
-        let mut guard = self.resume_hints.lock();
-        std::mem::take(&mut *guard)
+    pub fn resume_offsets(&self) -> Arc<ResumeOffsets> {
+        Arc::clone(&self.resume_offsets.lock())
     }
 
     /// Number of vnodes.

--- a/crates/laminar-core/src/state/vnode.rs
+++ b/crates/laminar-core/src/state/vnode.rs
@@ -93,6 +93,12 @@ pub struct VnodeRegistry {
     /// serialized — rebuilt (all `Active`) from the `AssignmentSnapshot`
     /// on boot, so adding it never touches a wire format.
     lifecycle: Arc<[AtomicU8]>,
+    /// Committed source resume offsets staged by the engine just before an
+    /// assignment-version bump, for partitions this node is acquiring in a
+    /// rotation. Keyed `(topic, partition) -> next-offset-to-fetch`. Drained by
+    /// the Kafka source on its next rebind so acquired partitions resume from the
+    /// previous owner's sealed checkpoint position instead of `auto.offset.reset`.
+    resume_hints: parking_lot::Mutex<std::collections::HashMap<(String, i32), i64>>,
 }
 
 impl std::fmt::Debug for VnodeRegistry {
@@ -125,6 +131,7 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
+            resume_hints: parking_lot::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -145,7 +152,29 @@ impl VnodeRegistry {
             assignment: RwLock::new(assignment),
             assignment_version: AtomicU64::new(1),
             lifecycle: new_lifecycle(vnode_count),
+            resume_hints: parking_lot::Mutex::new(std::collections::HashMap::new()),
         }
+    }
+
+    /// Stage committed source resume offsets for partitions about to be acquired
+    /// in a rotation, keyed `(topic, partition) -> next-offset-to-fetch`. MUST be
+    /// called before [`set_assignment_and_version`](Self::set_assignment_and_version)
+    /// so the source observes them when it rebinds for the new version.
+    pub fn stage_resume_hints(&self, hints: std::collections::HashMap<(String, i32), i64>) {
+        if hints.is_empty() {
+            return;
+        }
+        self.resume_hints.lock().extend(hints);
+    }
+
+    /// Drain the staged source resume offsets (see
+    /// [`stage_resume_hints`](Self::stage_resume_hints)). Returns and clears the
+    /// map; entries the caller does not use are dropped — they are only valid for
+    /// the rotation that staged them.
+    #[must_use]
+    pub fn take_resume_hints(&self) -> std::collections::HashMap<(String, i32), i64> {
+        let mut guard = self.resume_hints.lock();
+        std::mem::take(&mut *guard)
     }
 
     /// Number of vnodes.

--- a/crates/laminar-core/src/streaming/checkpoint.rs
+++ b/crates/laminar-core/src/streaming/checkpoint.rs
@@ -28,6 +28,11 @@ pub struct StreamCheckpointConfig {
     /// Fail checkpoints once committer lag exceeds `max_uncommitted_epochs`,
     /// bounding object-storage growth at the cost of pausing progress. Default off.
     pub uncommitted_epochs_backpressure: bool,
+    /// Durability-gate poll first interval in ms. `None` = default (100). Tighten
+    /// on a low-latency object store to cut poll quantization.
+    pub restorable_gate_poll_initial_ms: Option<u64>,
+    /// Durability-gate poll backoff cap in ms. `None` = default (1000).
+    pub restorable_gate_poll_max_ms: Option<u64>,
 }
 
 /// Errors from checkpoint operations.

--- a/crates/laminar-core/src/streaming/checkpoint.rs
+++ b/crates/laminar-core/src/streaming/checkpoint.rs
@@ -28,10 +28,9 @@ pub struct StreamCheckpointConfig {
     /// Fail checkpoints once committer lag exceeds `max_uncommitted_epochs`,
     /// bounding object-storage growth at the cost of pausing progress. Default off.
     pub uncommitted_epochs_backpressure: bool,
-    /// Durability-gate poll first interval in ms. `None` = default (100). Tighten
-    /// on a low-latency object store to cut poll quantization.
+    /// Durability-gate poll first interval (ms). `None` = engine default (100).
     pub restorable_gate_poll_initial_ms: Option<u64>,
-    /// Durability-gate poll backoff cap in ms. `None` = default (1000).
+    /// Durability-gate poll backoff cap (ms). `None` = engine default (1000).
     pub restorable_gate_poll_max_ms: Option<u64>,
 }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -3784,6 +3784,80 @@ mod tests {
         let sv = ScalarValue::Binary(Some(vec![1, 2, 3]));
         assert_eq!(round_trip(&sv), sv);
     }
+
+    /// Profiling (not a correctness test): measures the on-task whole-node
+    /// `checkpoint_groups` capture cost vs group count — the cost an incremental
+    /// (dirty-only) capture would shrink (Track A1). Reports total time, ns/group,
+    /// and serialized size, so the incremental win for a given dirty ratio is
+    /// `ns/group * dirty_count`. `#[ignore]`d; run in release:
+    /// `cargo test -p laminar-db --release profile_checkpoint_capture -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "profiling; run with --release --ignored --nocapture"]
+    async fn profile_checkpoint_capture_cost() {
+        for &n in &[10_000usize, 100_000, 1_000_000] {
+            let ctx = SessionContext::new();
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("value", DataType::Float64, false),
+            ]));
+            let dummy = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![
+                    Arc::new(arrow::array::Int64Array::from(vec![0i64])),
+                    Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+                ],
+            )
+            .unwrap();
+            let mem =
+                datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+                    .unwrap();
+            ctx.register_table("events", Arc::new(mem)).unwrap();
+            let mut state = IncrementalAggState::try_from_sql(
+                &ctx,
+                "SELECT id, SUM(value) AS total FROM events GROUP BY id",
+                false,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+            let pre = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, true),
+                Field::new("__agg_input_1", DataType::Float64, true),
+            ]));
+            #[allow(clippy::cast_precision_loss)]
+            let batch = RecordBatch::try_new(
+                pre,
+                vec![
+                    Arc::new(arrow::array::Int64Array::from(
+                        (0..n as i64).collect::<Vec<_>>(),
+                    )),
+                    Arc::new(arrow::array::Float64Array::from(
+                        (0..n).map(|i| i as f64).collect::<Vec<_>>(),
+                    )),
+                ],
+            )
+            .unwrap();
+            state.process_batch(&batch, 0).unwrap();
+
+            let t0 = std::time::Instant::now();
+            let cp = state.checkpoint_groups().unwrap();
+            let elapsed = t0.elapsed();
+
+            let bytes: usize = cp
+                .groups
+                .iter()
+                .map(|g| g.key.len() + g.acc_states.iter().map(Vec::len).sum::<usize>())
+                .sum();
+            #[allow(clippy::cast_precision_loss)]
+            let ns_per_group = elapsed.as_nanos() as f64 / n as f64;
+            println!(
+                "checkpoint_groups: {n:>9} groups -> {elapsed:>11.2?}  ({ns_per_group:6.0} ns/group)  ~{} KiB",
+                bytes / 1024
+            );
+            assert_eq!(cp.groups.len(), n);
+        }
+    }
 }
 
 /// Per-vnode checkpoint partitioning + merge-apply (the cross-node vnode

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -164,21 +164,22 @@ impl AggFuncSpec {
     }
 }
 
-/// Snapshot an accumulator's state for a checkpoint and rebuild it in place.
+/// Snapshot an accumulator's state for a checkpoint and rebuild it in place,
+/// returning the raw `Vec<ScalarValue>` (no IPC framing — the columnar agg path
+/// batches across groups instead).
 ///
-/// `Accumulator::state()` may drain internal state (e.g. DISTINCT hash sets);
-/// we rebuild the accumulator from the snapshot so it keeps running correctly.
-/// `retractable` must match how the accumulator was created.
-pub(crate) fn snapshot_and_rebuild(
+/// `Accumulator::state()` may drain internal state (e.g. DISTINCT hash sets); we
+/// rebuild the accumulator from the snapshot so it keeps running correctly. The
+/// rebuild happens before returning, so a later encode failure can never leave
+/// the accumulator empty. `retractable` must match how the accumulator was created.
+pub(crate) fn snapshot_state_scalars(
     acc: &mut Box<dyn datafusion_expr::Accumulator>,
     spec: &AggFuncSpec,
     retractable: bool,
-) -> Result<Vec<u8>, DbError> {
+) -> Result<Vec<ScalarValue>, DbError> {
     let state = acc
         .state()
         .map_err(|e| DbError::Pipeline(format!("accumulator state: {e}")))?;
-    // Rebuild before serializing: a scalars_to_ipc failure must not leave
-    // the accumulator empty for the next cycle.
     let arrays: Vec<ArrayRef> = state
         .iter()
         .map(|sv| {
@@ -195,19 +196,248 @@ pub(crate) fn snapshot_and_rebuild(
         .merge_batch(&arrays)
         .map_err(|e| DbError::Pipeline(format!("accumulator rebuild: {e}")))?;
     *acc = rebuilt;
-    let ipc = scalars_to_ipc(&state)?;
-    Ok(ipc)
+    Ok(state)
+}
+
+/// IPC-bytes variant of [`snapshot_state_scalars`], kept for EOWC's per-group
+/// [`GroupCheckpoint`] shape.
+pub(crate) fn snapshot_and_rebuild(
+    acc: &mut Box<dyn datafusion_expr::Accumulator>,
+    spec: &AggFuncSpec,
+    retractable: bool,
+) -> Result<Vec<u8>, DbError> {
+    let state = snapshot_state_scalars(acc, spec, retractable)?;
+    scalars_to_ipc(&state)
+}
+
+/// Build an IPC stream from arrays as the columns of a single batch; empty input
+/// (no columns) → empty `Vec`.
+fn arrays_to_ipc(arrays: &[ArrayRef]) -> Result<Vec<u8>, DbError> {
+    if arrays.is_empty() {
+        return Ok(Vec::new());
+    }
+    let fields: Vec<Arc<Field>> = arrays
+        .iter()
+        .enumerate()
+        .map(|(i, a)| Arc::new(Field::new(format!("c{i}"), a.data_type().clone(), true)))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+    let batch = RecordBatch::try_new(schema, arrays.to_vec())
+        .map_err(|e| DbError::Pipeline(format!("columnar batch build: {e}")))?;
+    laminar_core::serialization::serialize_batch_stream(&batch)
+        .map_err(|e| DbError::Pipeline(format!("columnar IPC encode: {e}")))
+}
+
+/// Columnar encode result: `(keys IPC, per-accumulator state IPC, last_updated_ms)`.
+type ColumnarEncoding = (Vec<u8>, Vec<Vec<u8>>, Vec<i64>);
+
+/// Encode groups columnar: keys in one IPC batch, each accumulator's state across
+/// all groups in one IPC batch. Row `j` of every batch refers to `entries[j]`.
+fn encode_groups_columnar(
+    row_converter: &arrow::row::RowConverter,
+    num_group_cols: usize,
+    agg_specs: &[AggFuncSpec],
+    retractable: bool,
+    entries: &mut [(arrow::row::OwnedRow, &mut GroupEntry)],
+) -> Result<ColumnarEncoding, DbError> {
+    if entries.is_empty() {
+        return Ok((Vec::new(), Vec::new(), Vec::new()));
+    }
+    let n = entries.len();
+
+    let keys_ipc = if num_group_cols == 0 {
+        Vec::new()
+    } else {
+        let key_arrays = row_converter
+            .convert_rows(entries.iter().map(|(k, _)| k.row()))
+            .map_err(|e| DbError::Pipeline(format!("group key array build: {e}")))?;
+        arrays_to_ipc(&key_arrays)?
+    };
+
+    // Per accumulator, per group: collect state scalars (also rebuilds the acc).
+    let num_accs = agg_specs.len();
+    let mut acc_rows: Vec<Vec<Vec<ScalarValue>>> =
+        (0..num_accs).map(|_| Vec::with_capacity(n)).collect();
+    let mut last_updated_ms = Vec::with_capacity(n);
+    for (_, entry) in entries.iter_mut() {
+        last_updated_ms.push(entry.last_updated_ms);
+        for (i, acc) in entry.accs.iter_mut().enumerate() {
+            acc_rows[i].push(snapshot_state_scalars(acc, &agg_specs[i], retractable)?);
+        }
+    }
+
+    let mut acc_state_ipc = Vec::with_capacity(num_accs);
+    for rows in acc_rows {
+        let arity = rows.first().map_or(0, Vec::len);
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(arity);
+        for c in 0..arity {
+            let col = ScalarValue::iter_to_array(rows.iter().map(|s| s[c].clone()))
+                .map_err(|e| DbError::Pipeline(format!("acc state column build: {e}")))?;
+            columns.push(col);
+        }
+        acc_state_ipc.push(arrays_to_ipc(&columns)?);
+    }
+
+    Ok((keys_ipc, acc_state_ipc, last_updated_ms))
+}
+
+struct DecodedGroup {
+    row_key: arrow::row::OwnedRow,
+    accs: Vec<Box<dyn datafusion_expr::Accumulator>>,
+    last_updated_ms: i64,
+}
+
+/// Per-group decoded state: `(key, last_updated_ms, per-accumulator state arrays)`.
+type DecodedGroupState = (arrow::row::OwnedRow, i64, Vec<Vec<ArrayRef>>);
+
+/// Decode a columnar checkpoint to per-group state arrays. Keys round-trip through
+/// the row converter's own column types, so no per-type coercion is needed.
+fn decode_columnar_state_arrays(
+    row_converter: &arrow::row::RowConverter,
+    keys_ipc: &[u8],
+    acc_state_ipc: &[Vec<u8>],
+    last_updated_ms: &[i64],
+) -> Result<Vec<DecodedGroupState>, DbError> {
+    let n = last_updated_ms.len();
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let key_rows = if keys_ipc.is_empty() {
+        None
+    } else {
+        let batch = laminar_core::serialization::deserialize_batch_stream(keys_ipc)
+            .map_err(|e| DbError::Pipeline(format!("keys IPC decode: {e}")))?;
+        Some(
+            row_converter
+                .convert_columns(batch.columns())
+                .map_err(|e| DbError::Pipeline(format!("keys row convert: {e}")))?,
+        )
+    };
+    let acc_batches: Vec<Option<RecordBatch>> = acc_state_ipc
+        .iter()
+        .map(|bytes| {
+            if bytes.is_empty() {
+                Ok(None)
+            } else {
+                laminar_core::serialization::deserialize_batch_stream(bytes)
+                    .map(Some)
+                    .map_err(|e| DbError::Pipeline(format!("acc state IPC decode: {e}")))
+            }
+        })
+        .collect::<Result<_, _>>()?;
+
+    let mut out = Vec::with_capacity(n);
+    for (j, &updated_ms) in last_updated_ms.iter().enumerate() {
+        let row_key = match &key_rows {
+            Some(rows) => rows.row(j).owned(),
+            None => global_aggregate_key(),
+        };
+        let mut state_arrays: Vec<Vec<ArrayRef>> = Vec::with_capacity(acc_batches.len());
+        for batch in &acc_batches {
+            let arrays = match batch {
+                Some(b) => (0..b.num_columns())
+                    .map(|c| {
+                        let sv = ScalarValue::try_from_array(b.column(c), j)
+                            .map_err(|e| DbError::Pipeline(format!("acc state scalar: {e}")))?;
+                        sv.to_array()
+                            .map_err(|e| DbError::Pipeline(format!("scalar to array: {e}")))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
+            state_arrays.push(arrays);
+        }
+        out.push((row_key, updated_ms, state_arrays));
+    }
+    Ok(out)
+}
+
+/// Build fresh accumulators, merging each decoded state-array set into its own.
+fn build_accumulators_from_state(
+    agg_specs: &[AggFuncSpec],
+    retractable: bool,
+    state_arrays: &[Vec<ArrayRef>],
+) -> Result<Vec<Box<dyn datafusion_expr::Accumulator>>, DbError> {
+    let mut accs = Vec::with_capacity(agg_specs.len());
+    for (i, spec) in agg_specs.iter().enumerate() {
+        let mut acc = if retractable {
+            spec.create_retractable_accumulator()?
+        } else {
+            spec.create_accumulator()?
+        };
+        if let Some(arrays) = state_arrays.get(i) {
+            if !arrays.is_empty() {
+                acc.merge_batch(arrays)
+                    .map_err(|e| DbError::Pipeline(format!("accumulator merge: {e}")))?;
+            }
+        }
+        accs.push(acc);
+    }
+    Ok(accs)
+}
+
+/// Inverse of [`encode_groups_columnar`]: rebuild one [`DecodedGroup`] per row.
+fn decode_groups_columnar(
+    row_converter: &arrow::row::RowConverter,
+    agg_specs: &[AggFuncSpec],
+    retractable: bool,
+    keys_ipc: &[u8],
+    acc_state_ipc: &[Vec<u8>],
+    last_updated_ms: &[i64],
+) -> Result<Vec<DecodedGroup>, DbError> {
+    decode_columnar_state_arrays(row_converter, keys_ipc, acc_state_ipc, last_updated_ms)?
+        .into_iter()
+        .map(|(row_key, last_updated_ms, state_arrays)| {
+            Ok(DecodedGroup {
+                row_key,
+                accs: build_accumulators_from_state(agg_specs, retractable, &state_arrays)?,
+                last_updated_ms,
+            })
+        })
+        .collect()
+}
+
+/// Row-concatenate two IPC stream batches sharing a schema; an empty side passes
+/// the other through unchanged.
+#[cfg(feature = "cluster")]
+fn concat_columnar_ipc(a: &[u8], b: &[u8]) -> Result<Vec<u8>, DbError> {
+    if a.is_empty() {
+        return Ok(b.to_vec());
+    }
+    if b.is_empty() {
+        return Ok(a.to_vec());
+    }
+    let ba = laminar_core::serialization::deserialize_batch_stream(a)
+        .map_err(|e| DbError::Pipeline(format!("columnar concat decode: {e}")))?;
+    let bb = laminar_core::serialization::deserialize_batch_stream(b)
+        .map_err(|e| DbError::Pipeline(format!("columnar concat decode: {e}")))?;
+    let merged = arrow::compute::concat_batches(&ba.schema(), [&ba, &bb])
+        .map_err(|e| DbError::Pipeline(format!("columnar concat: {e}")))?;
+    laminar_core::serialization::serialize_batch_stream(&merged)
+        .map_err(|e| DbError::Pipeline(format!("columnar concat encode: {e}")))
 }
 
 #[cfg(feature = "cluster")]
-fn scalars_to_arrays(scalars: &[ScalarValue]) -> Result<Vec<ArrayRef>, DbError> {
-    scalars
-        .iter()
-        .map(|sv| {
-            sv.to_array()
-                .map_err(|e| DbError::Pipeline(format!("scalar to array: {e}")))
-        })
-        .collect()
+impl AggStateCheckpoint {
+    /// Append another checkpoint's groups, assuming disjoint keys (per-vnode
+    /// slices of one query): row-concatenate the columnar batches and stamps.
+    pub(crate) fn append_disjoint(&mut self, other: AggStateCheckpoint) -> Result<(), DbError> {
+        self.keys_ipc = concat_columnar_ipc(&self.keys_ipc, &other.keys_ipc)?;
+        if self.acc_state_ipc.is_empty() {
+            self.acc_state_ipc = other.acc_state_ipc;
+        } else {
+            for (dst, src) in self
+                .acc_state_ipc
+                .iter_mut()
+                .zip(other.acc_state_ipc.iter())
+            {
+                *dst = concat_columnar_ipc(dst, src)?;
+            }
+        }
+        self.last_updated_ms.extend(other.last_updated_ms);
+        self.last_emitted.extend(other.last_emitted);
+        Ok(())
+    }
 }
 
 /// Minimum interval between full O(groups) size re-walks.
@@ -1053,39 +1283,47 @@ impl IncrementalAggState {
 
     pub(crate) fn checkpoint_groups(&mut self) -> Result<AggStateCheckpoint, DbError> {
         let fingerprint = self.query_fingerprint();
-        let mut groups = Vec::with_capacity(self.groups.len());
-        for (row_key, entry) in &mut self.groups {
-            let sv_key =
-                row_to_scalar_key_with_types(&self.row_converter, row_key, &self.group_types)?;
-            let key_ipc = scalars_to_ipc(&sv_key)?;
-            let retractable = self.weight_col_idx.is_some();
-            let mut acc_states = Vec::with_capacity(entry.accs.len());
-            for (i, acc) in entry.accs.iter_mut().enumerate() {
-                acc_states.push(snapshot_and_rebuild(acc, &self.agg_specs[i], retractable)?);
-            }
-            groups.push(GroupCheckpoint {
-                key: key_ipc,
-                acc_states,
-                last_updated_ms: entry.last_updated_ms,
-            });
-        }
-        let mut last_emitted_cp = Vec::new();
-        if self.emit_changelog {
-            for (row_key, vals) in &self.last_emitted {
-                let sv_key =
-                    row_to_scalar_key_with_types(&self.row_converter, row_key, &self.group_types)?;
-                last_emitted_cp.push(EmittedCheckpoint {
-                    key: scalars_to_ipc(&sv_key)?,
-                    values: scalars_to_ipc(vals)?,
-                });
-            }
-        }
+        let retractable = self.weight_col_idx.is_some();
+        let mut entries: Vec<(arrow::row::OwnedRow, &mut GroupEntry)> = self
+            .groups
+            .iter_mut()
+            .map(|(k, v)| (k.clone(), v))
+            .collect();
+        let (keys_ipc, acc_state_ipc, last_updated_ms) = encode_groups_columnar(
+            &self.row_converter,
+            self.num_group_cols,
+            &self.agg_specs,
+            retractable,
+            &mut entries,
+        )?;
+
+        let last_emitted = self.checkpoint_last_emitted()?;
 
         Ok(AggStateCheckpoint {
             fingerprint,
-            groups,
-            last_emitted: last_emitted_cp,
+            keys_ipc,
+            acc_state_ipc,
+            last_updated_ms,
+            last_emitted,
         })
+    }
+
+    /// Encode the changelog `last_emitted` map per-entry (still keyed individually;
+    /// columnarizing it is out of scope). Empty unless `emit_changelog`.
+    fn checkpoint_last_emitted(&self) -> Result<Vec<EmittedCheckpoint>, DbError> {
+        if !self.emit_changelog {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::with_capacity(self.last_emitted.len());
+        for (row_key, vals) in &self.last_emitted {
+            let sv_key =
+                row_to_scalar_key_with_types(&self.row_converter, row_key, &self.group_types)?;
+            out.push(EmittedCheckpoint {
+                key: scalars_to_ipc(&sv_key)?,
+                values: scalars_to_ipc(vals)?,
+            });
+        }
+        Ok(out)
     }
 
     pub(crate) fn restore_groups(
@@ -1101,50 +1339,29 @@ impl IncrementalAggState {
         }
         // Build locally then swap so a mid-list decode error can't leave
         // last_emitted partially populated.
+        let retractable = self.weight_col_idx.is_some();
+        let decoded = decode_groups_columnar(
+            &self.row_converter,
+            &self.agg_specs,
+            retractable,
+            &checkpoint.keys_ipc,
+            &checkpoint.acc_state_ipc,
+            &checkpoint.last_updated_ms,
+        )?;
+        let restored = decoded.len();
         let mut new_groups: AHashMap<arrow::row::OwnedRow, GroupEntry> =
-            AHashMap::with_capacity(checkpoint.groups.len());
-        for gc in &checkpoint.groups {
-            let sv_key = ipc_to_scalars(&gc.key)?;
-            let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
-
-            let mut accs = Vec::with_capacity(self.agg_specs.len());
-            for (i, spec) in self.agg_specs.iter().enumerate() {
-                let mut acc = if self.weight_col_idx.is_some() {
-                    spec.create_retractable_accumulator()?
-                } else {
-                    spec.create_accumulator()?
-                };
-                if i < gc.acc_states.len() {
-                    let state_scalars = ipc_to_scalars(&gc.acc_states[i])?;
-                    let arrays: Vec<ArrayRef> = state_scalars
-                        .iter()
-                        .map(|sv| {
-                            sv.to_array()
-                                .map_err(|e| DbError::Pipeline(format!("scalar to array: {e}")))
-                        })
-                        .collect::<Result<_, _>>()?;
-                    acc.merge_batch(&arrays)
-                        .map_err(|e| DbError::Pipeline(format!("accumulator merge: {e}")))?;
-                }
-                accs.push(acc);
-            }
+            AHashMap::with_capacity(restored);
+        for g in decoded {
             new_groups.insert(
-                row_key,
+                g.row_key,
                 GroupEntry {
-                    accs,
-                    last_updated_ms: gc.last_updated_ms,
+                    accs: g.accs,
+                    last_updated_ms: g.last_updated_ms,
                 },
             );
         }
 
-        let mut new_last_emitted: AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>> =
-            AHashMap::with_capacity(checkpoint.last_emitted.len());
-        for ec in &checkpoint.last_emitted {
-            let sv_key = ipc_to_scalars(&ec.key)?;
-            let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
-            let vals = ipc_to_scalars(&ec.values)?;
-            new_last_emitted.insert(row_key, vals);
-        }
+        let new_last_emitted = self.decode_last_emitted(&checkpoint.last_emitted)?;
 
         self.groups = new_groups;
         self.last_emitted = new_last_emitted;
@@ -1159,7 +1376,23 @@ impl IncrementalAggState {
             self.cold_vnodes.clear();
             self.dirty_all = true;
         }
-        Ok(checkpoint.groups.len())
+        Ok(restored)
+    }
+
+    /// Decode the per-entry changelog `last_emitted` checkpoint into the live map.
+    fn decode_last_emitted(
+        &self,
+        entries: &[EmittedCheckpoint],
+    ) -> Result<AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>>, DbError> {
+        let mut out: AHashMap<arrow::row::OwnedRow, Vec<ScalarValue>> =
+            AHashMap::with_capacity(entries.len());
+        for ec in entries {
+            let sv_key = ipc_to_scalars(&ec.key)?;
+            let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
+            let vals = ipc_to_scalars(&ec.values)?;
+            out.insert(row_key, vals);
+        }
+        Ok(out)
     }
 
     /// Partition state into one [`AggStateCheckpoint`] per vnode using the same hash as the shuffle.
@@ -1186,32 +1419,39 @@ impl IncrementalAggState {
             }
         };
 
-        let mut buckets: std::collections::HashMap<u32, AggStateCheckpoint> =
-            std::collections::HashMap::new();
-        let mut new_bucket = || AggStateCheckpoint {
-            fingerprint,
-            groups: Vec::new(),
-            last_emitted: Vec::new(),
-        };
-
+        // Bucket the live groups by vnode first, then columnar-encode each subset.
+        let mut by_vnode: std::collections::HashMap<
+            u32,
+            Vec<(arrow::row::OwnedRow, &mut GroupEntry)>,
+        > = std::collections::HashMap::new();
         for (row_key, entry) in &mut self.groups {
             let vnode = vnode_of(row_key);
-            let sv_key =
-                row_to_scalar_key_with_types(&self.row_converter, row_key, &self.group_types)?;
-            let key_ipc = scalars_to_ipc(&sv_key)?;
-            let mut acc_states = Vec::with_capacity(entry.accs.len());
-            for (i, acc) in entry.accs.iter_mut().enumerate() {
-                acc_states.push(snapshot_and_rebuild(acc, &self.agg_specs[i], retractable)?);
-            }
-            buckets
+            by_vnode
                 .entry(vnode)
-                .or_insert_with(&mut new_bucket)
-                .groups
-                .push(GroupCheckpoint {
-                    key: key_ipc,
-                    acc_states,
-                    last_updated_ms: entry.last_updated_ms,
-                });
+                .or_default()
+                .push((row_key.clone(), entry));
+        }
+
+        let mut buckets: std::collections::HashMap<u32, AggStateCheckpoint> =
+            std::collections::HashMap::with_capacity(by_vnode.len());
+        for (vnode, mut entries) in by_vnode {
+            let (keys_ipc, acc_state_ipc, last_updated_ms) = encode_groups_columnar(
+                &self.row_converter,
+                self.num_group_cols,
+                &self.agg_specs,
+                retractable,
+                &mut entries,
+            )?;
+            buckets.insert(
+                vnode,
+                AggStateCheckpoint {
+                    fingerprint,
+                    keys_ipc,
+                    acc_state_ipc,
+                    last_updated_ms,
+                    last_emitted: Vec::new(),
+                },
+            );
         }
 
         if self.emit_changelog {
@@ -1221,7 +1461,13 @@ impl IncrementalAggState {
                     row_to_scalar_key_with_types(&self.row_converter, row_key, &self.group_types)?;
                 buckets
                     .entry(vnode)
-                    .or_insert_with(&mut new_bucket)
+                    .or_insert_with(|| AggStateCheckpoint {
+                        fingerprint,
+                        keys_ipc: Vec::new(),
+                        acc_state_ipc: Vec::new(),
+                        last_updated_ms: Vec::new(),
+                        last_emitted: Vec::new(),
+                    })
                     .last_emitted
                     .push(EmittedCheckpoint {
                         key: scalars_to_ipc(&sv_key)?,
@@ -1258,11 +1504,17 @@ impl IncrementalAggState {
             )));
         }
 
-        for gc in &checkpoint.groups {
-            let sv_key = ipc_to_scalars(&gc.key)?;
-            let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
-            // merge_batch changes the group's value relative to last_emitted, so the
-            // changelog path must re-evaluate it (the diff still gates actual output).
+        let retractable = self.weight_col_idx.is_some();
+        let per_group = decode_columnar_state_arrays(
+            &self.row_converter,
+            &checkpoint.keys_ipc,
+            &checkpoint.acc_state_ipc,
+            &checkpoint.last_updated_ms,
+        )?;
+        let merged = per_group.len();
+        for (row_key, last_updated_ms, state_arrays) in per_group {
+            // merge_batch changes the group's value vs last_emitted, so the changelog
+            // path must re-evaluate it (the diff still gates actual output).
             if self.emit_changelog {
                 self.dirty_keys.insert(row_key.clone());
             }
@@ -1270,45 +1522,30 @@ impl IncrementalAggState {
                 std::collections::hash_map::Entry::Occupied(mut occ) => {
                     let entry = occ.get_mut();
                     for (i, acc) in entry.accs.iter_mut().enumerate() {
-                        if let Some(state_bytes) = gc.acc_states.get(i) {
-                            let state_scalars = ipc_to_scalars(state_bytes)?;
-                            let arrays = scalars_to_arrays(&state_scalars)?;
-                            acc.merge_batch(&arrays).map_err(|e| {
-                                DbError::Pipeline(format!("accumulator merge: {e}"))
-                            })?;
+                        if let Some(arrays) = state_arrays.get(i) {
+                            if !arrays.is_empty() {
+                                acc.merge_batch(arrays).map_err(|e| {
+                                    DbError::Pipeline(format!("accumulator merge: {e}"))
+                                })?;
+                            }
                         }
                     }
-                    entry.last_updated_ms = entry.last_updated_ms.max(gc.last_updated_ms);
+                    entry.last_updated_ms = entry.last_updated_ms.max(last_updated_ms);
                 }
                 std::collections::hash_map::Entry::Vacant(vac) => {
-                    let mut accs = Vec::with_capacity(self.agg_specs.len());
-                    for (i, spec) in self.agg_specs.iter().enumerate() {
-                        let mut acc = if self.weight_col_idx.is_some() {
-                            spec.create_retractable_accumulator()?
-                        } else {
-                            spec.create_accumulator()?
-                        };
-                        if let Some(state_bytes) = gc.acc_states.get(i) {
-                            let state_scalars = ipc_to_scalars(state_bytes)?;
-                            let arrays = scalars_to_arrays(&state_scalars)?;
-                            acc.merge_batch(&arrays).map_err(|e| {
-                                DbError::Pipeline(format!("accumulator merge: {e}"))
-                            })?;
-                        }
-                        accs.push(acc);
-                    }
                     vac.insert(GroupEntry {
-                        accs,
-                        last_updated_ms: gc.last_updated_ms,
+                        accs: build_accumulators_from_state(
+                            &self.agg_specs,
+                            retractable,
+                            &state_arrays,
+                        )?,
+                        last_updated_ms,
                     });
                 }
             }
         }
 
-        for ec in &checkpoint.last_emitted {
-            let sv_key = ipc_to_scalars(&ec.key)?;
-            let row_key = scalar_key_to_owned_row(&self.row_converter, &sv_key, &self.group_types)?;
-            let vals = ipc_to_scalars(&ec.values)?;
+        for (row_key, vals) in self.decode_last_emitted(&checkpoint.last_emitted)? {
             self.last_emitted.entry(row_key).or_insert(vals);
         }
 
@@ -1316,7 +1553,7 @@ impl IncrementalAggState {
         self.size_cache.invalidate();
         // No dirty_all: callers mark only the merged vnode dirty, so other
         // clean vnodes remain demotable.
-        Ok(checkpoint.groups.len())
+        Ok(merged)
     }
 }
 
@@ -2354,7 +2591,7 @@ mod tests {
 
         let buckets = state.checkpoint_groups_by_vnode(VNODES).unwrap();
         let (&v, slice) = buckets.iter().next().unwrap();
-        let demoted_groups = slice.groups.len();
+        let demoted_groups = slice.last_updated_ms.len();
         assert!(demoted_groups > 0);
         let groups_before = state.groups.len();
 
@@ -2762,7 +2999,7 @@ mod tests {
 
         // Checkpoint
         let cp = state.checkpoint_groups().unwrap();
-        assert_eq!(cp.groups.len(), 1);
+        assert_eq!(cp.last_updated_ms.len(), 1);
 
         // Create a fresh state and restore
         let (_, mut state2) =
@@ -2809,7 +3046,7 @@ mod tests {
         state.process_batch(&batch, i64::MIN).unwrap();
 
         let cp = state.checkpoint_groups().unwrap();
-        assert_eq!(cp.groups.len(), 3);
+        assert_eq!(cp.last_updated_ms.len(), 3);
 
         let (_, mut state2) =
             setup_agg_state("SELECT name, SUM(value) as total FROM events GROUP BY name").await;
@@ -2818,6 +3055,86 @@ mod tests {
 
         let result = state2.emit().unwrap();
         assert_eq!(result[0].num_rows(), 3);
+    }
+
+    /// Columnar checkpoint round-trip with a mix of accumulator shapes
+    /// (SUM, COUNT(*), MAX) across several groups: restored emit must equal
+    /// the original emit row-for-row.
+    #[tokio::test]
+    async fn test_agg_checkpoint_roundtrip_mixed_accumulators() {
+        let sql = "SELECT name, SUM(value) AS s, COUNT(*) AS c, MAX(value) AS m \
+                   FROM events GROUP BY name";
+        let (_, mut state) = setup_agg_state(sql).await;
+
+        // Pre-agg layout for [name] + SUM(value), COUNT(*), MAX(value):
+        // group col, then __agg_input_1 (SUM), __agg_input_2 (COUNT* dummy bool), __agg_input_3 (MAX).
+        let pre_agg_schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+            Field::new("__agg_input_2", DataType::Boolean, true),
+            Field::new("__agg_input_3", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&pre_agg_schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "a", "b", "a", "b", "c", "a",
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    10.0, 20.0, 30.0, 40.0, 50.0, 5.0,
+                ])),
+                Arc::new(arrow::array::BooleanArray::from(vec![true; 6])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    10.0, 20.0, 30.0, 40.0, 50.0, 5.0,
+                ])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, i64::MIN).unwrap();
+        let original = state.emit().unwrap();
+
+        let cp = state.checkpoint_groups().unwrap();
+        assert_eq!(cp.last_updated_ms.len(), 3);
+
+        let (_, mut state2) = setup_agg_state(sql).await;
+        assert_eq!(state2.restore_groups(&cp).unwrap(), 3);
+        let restored = state2.emit().unwrap();
+
+        // Compare as (name -> (s, c, m)) maps so HashMap iteration order is irrelevant.
+        let collect = |batches: &[RecordBatch]| {
+            let mut out: std::collections::BTreeMap<String, (f64, i64, f64)> =
+                std::collections::BTreeMap::new();
+            for b in batches {
+                let names = b
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::StringArray>()
+                    .unwrap();
+                let s = b
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<arrow::array::Float64Array>()
+                    .unwrap();
+                let c = b
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<arrow::array::Int64Array>()
+                    .unwrap();
+                let m = b
+                    .column(3)
+                    .as_any()
+                    .downcast_ref::<arrow::array::Float64Array>()
+                    .unwrap();
+                for i in 0..b.num_rows() {
+                    out.insert(
+                        names.value(i).to_string(),
+                        (s.value(i), c.value(i), m.value(i)),
+                    );
+                }
+            }
+            out
+        };
+        assert_eq!(collect(&original), collect(&restored));
     }
 
     #[tokio::test]
@@ -3825,7 +4142,7 @@ mod tests {
                 Field::new("id", DataType::Int64, true),
                 Field::new("__agg_input_1", DataType::Float64, true),
             ]));
-            #[allow(clippy::cast_precision_loss)]
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
             let batch = RecordBatch::try_new(
                 pre,
                 vec![
@@ -3844,18 +4161,15 @@ mod tests {
             let cp = state.checkpoint_groups().unwrap();
             let elapsed = t0.elapsed();
 
-            let bytes: usize = cp
-                .groups
-                .iter()
-                .map(|g| g.key.len() + g.acc_states.iter().map(Vec::len).sum::<usize>())
-                .sum();
+            let bytes: usize =
+                cp.keys_ipc.len() + cp.acc_state_ipc.iter().map(Vec::len).sum::<usize>();
             #[allow(clippy::cast_precision_loss)]
             let ns_per_group = elapsed.as_nanos() as f64 / n as f64;
             println!(
                 "checkpoint_groups: {n:>9} groups -> {elapsed:>11.2?}  ({ns_per_group:6.0} ns/group)  ~{} KiB",
                 bytes / 1024
             );
-            assert_eq!(cp.groups.len(), n);
+            assert_eq!(cp.last_updated_ms.len(), n);
         }
     }
 }
@@ -3963,10 +4277,10 @@ mod vnode_partition_tests {
         let full = a.checkpoint_groups().unwrap();
 
         // Every group lands in exactly one vnode slice — union == the whole.
-        let partitioned: usize = by_vnode.values().map(|cp| cp.groups.len()).sum();
+        let partitioned: usize = by_vnode.values().map(|cp| cp.last_updated_ms.len()).sum();
         assert_eq!(
             partitioned,
-            full.groups.len(),
+            full.last_updated_ms.len(),
             "per-vnode slices must cover every group exactly once",
         );
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -294,6 +294,7 @@ type DecodedGroupState = (arrow::row::OwnedRow, i64, Vec<Vec<ArrayRef>>);
 /// the row converter's own column types, so no per-type coercion is needed.
 fn decode_columnar_state_arrays(
     row_converter: &arrow::row::RowConverter,
+    num_group_cols: usize,
     keys_ipc: &[u8],
     acc_state_ipc: &[Vec<u8>],
     last_updated_ms: &[i64],
@@ -301,6 +302,13 @@ fn decode_columnar_state_arrays(
     let n = last_updated_ms.len();
     if n == 0 {
         return Ok(Vec::new());
+    }
+    // A grouped aggregate always encodes keys; empty key bytes with groups present
+    // means a truncated/corrupt checkpoint, not the global (no-GROUP-BY) key.
+    if num_group_cols > 0 && keys_ipc.is_empty() {
+        return Err(DbError::Pipeline(format!(
+            "columnar checkpoint shape: {n} groups but no key bytes"
+        )));
     }
     let key_rows = if keys_ipc.is_empty() {
         None
@@ -406,22 +414,29 @@ fn validate_columnar_acc_shape(
 /// Inverse of [`encode_groups_columnar`]: rebuild one [`DecodedGroup`] per row.
 fn decode_groups_columnar(
     row_converter: &arrow::row::RowConverter,
+    num_group_cols: usize,
     agg_specs: &[AggFuncSpec],
     retractable: bool,
     keys_ipc: &[u8],
     acc_state_ipc: &[Vec<u8>],
     last_updated_ms: &[i64],
 ) -> Result<Vec<DecodedGroup>, DbError> {
-    decode_columnar_state_arrays(row_converter, keys_ipc, acc_state_ipc, last_updated_ms)?
-        .into_iter()
-        .map(|(row_key, last_updated_ms, state_arrays)| {
-            Ok(DecodedGroup {
-                row_key,
-                accs: build_accumulators_from_state(agg_specs, retractable, &state_arrays)?,
-                last_updated_ms,
-            })
+    decode_columnar_state_arrays(
+        row_converter,
+        num_group_cols,
+        keys_ipc,
+        acc_state_ipc,
+        last_updated_ms,
+    )?
+    .into_iter()
+    .map(|(row_key, last_updated_ms, state_arrays)| {
+        Ok(DecodedGroup {
+            row_key,
+            accs: build_accumulators_from_state(agg_specs, retractable, &state_arrays)?,
+            last_updated_ms,
         })
-        .collect()
+    })
+    .collect()
 }
 
 /// Row-concatenate two IPC stream batches sharing a schema; an empty side passes
@@ -1370,6 +1385,7 @@ impl IncrementalAggState {
         let retractable = self.weight_col_idx.is_some();
         let decoded = decode_groups_columnar(
             &self.row_converter,
+            self.num_group_cols,
             &self.agg_specs,
             retractable,
             &checkpoint.keys_ipc,
@@ -1536,6 +1552,7 @@ impl IncrementalAggState {
         let retractable = self.weight_col_idx.is_some();
         let per_group = decode_columnar_state_arrays(
             &self.row_converter,
+            self.num_group_cols,
             &checkpoint.keys_ipc,
             &checkpoint.acc_state_ipc,
             &checkpoint.last_updated_ms,

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -307,22 +307,32 @@ fn decode_columnar_state_arrays(
     } else {
         let batch = laminar_core::serialization::deserialize_batch_stream(keys_ipc)
             .map_err(|e| DbError::Pipeline(format!("keys IPC decode: {e}")))?;
-        Some(
-            row_converter
-                .convert_columns(batch.columns())
-                .map_err(|e| DbError::Pipeline(format!("keys row convert: {e}")))?,
-        )
+        let rows = row_converter
+            .convert_columns(batch.columns())
+            .map_err(|e| DbError::Pipeline(format!("keys row convert: {e}")))?;
+        if rows.num_rows() != n {
+            return Err(DbError::Pipeline(format!(
+                "columnar checkpoint shape: {} key rows vs {n} groups",
+                rows.num_rows()
+            )));
+        }
+        Some(rows)
     };
     let acc_batches: Vec<Option<RecordBatch>> = acc_state_ipc
         .iter()
         .map(|bytes| {
             if bytes.is_empty() {
-                Ok(None)
-            } else {
-                laminar_core::serialization::deserialize_batch_stream(bytes)
-                    .map(Some)
-                    .map_err(|e| DbError::Pipeline(format!("acc state IPC decode: {e}")))
+                return Ok(None);
             }
+            let batch = laminar_core::serialization::deserialize_batch_stream(bytes)
+                .map_err(|e| DbError::Pipeline(format!("acc state IPC decode: {e}")))?;
+            if batch.num_rows() != n {
+                return Err(DbError::Pipeline(format!(
+                    "columnar checkpoint shape: acc batch {} rows vs {n} groups",
+                    batch.num_rows()
+                )));
+            }
+            Ok(Some(batch))
         })
         .collect::<Result<_, _>>()?;
 
@@ -374,6 +384,23 @@ fn build_accumulators_from_state(
         accs.push(acc);
     }
     Ok(accs)
+}
+
+/// Reject a checkpoint whose per-accumulator state-batch count doesn't match the
+/// query's aggregates — a truncated/corrupt slice the fingerprint can't catch.
+/// An empty checkpoint carries no acc batches by construction, so skip it.
+fn validate_columnar_acc_shape(
+    checkpoint: &AggStateCheckpoint,
+    agg_specs: &[AggFuncSpec],
+) -> Result<(), DbError> {
+    if !checkpoint.last_updated_ms.is_empty() && checkpoint.acc_state_ipc.len() != agg_specs.len() {
+        return Err(DbError::Pipeline(format!(
+            "columnar checkpoint shape: {} accumulator states vs {} aggregates",
+            checkpoint.acc_state_ipc.len(),
+            agg_specs.len()
+        )));
+    }
+    Ok(())
 }
 
 /// Inverse of [`encode_groups_columnar`]: rebuild one [`DecodedGroup`] per row.
@@ -1337,6 +1364,7 @@ impl IncrementalAggState {
                 checkpoint.fingerprint, current_fp
             )));
         }
+        validate_columnar_acc_shape(checkpoint, &self.agg_specs)?;
         // Build locally then swap so a mid-list decode error can't leave
         // last_emitted partially populated.
         let retractable = self.weight_col_idx.is_some();
@@ -1503,6 +1531,7 @@ impl IncrementalAggState {
                 checkpoint.fingerprint,
             )));
         }
+        validate_columnar_acc_shape(checkpoint, &self.agg_specs)?;
 
         let retractable = self.weight_col_idx.is_some();
         let per_group = decode_columnar_state_arrays(
@@ -4161,8 +4190,9 @@ mod tests {
             let cp = state.checkpoint_groups().unwrap();
             let elapsed = t0.elapsed();
 
-            let bytes: usize =
-                cp.keys_ipc.len() + cp.acc_state_ipc.iter().map(Vec::len).sum::<usize>();
+            let bytes: usize = cp.keys_ipc.len()
+                + cp.acc_state_ipc.iter().map(Vec::len).sum::<usize>()
+                + cp.last_updated_ms.len() * 8;
             #[allow(clippy::cast_precision_loss)]
             let ns_per_group = elapsed.as_nanos() as f64 / n as f64;
             println!(

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -467,7 +467,17 @@ impl AggStateCheckpoint {
         self.keys_ipc = concat_columnar_ipc(&self.keys_ipc, &other.keys_ipc)?;
         if self.acc_state_ipc.is_empty() {
             self.acc_state_ipc = other.acc_state_ipc;
-        } else {
+        } else if !other.acc_state_ipc.is_empty() {
+            // Both are slices of one query, so the accumulator-column counts must
+            // match; a mismatch would row-misalign keys vs accs in a way the
+            // fingerprint can't catch. (An empty `other` contributes no rows.)
+            if self.acc_state_ipc.len() != other.acc_state_ipc.len() {
+                return Err(DbError::Pipeline(format!(
+                    "append_disjoint: accumulator column count mismatch ({} vs {})",
+                    self.acc_state_ipc.len(),
+                    other.acc_state_ipc.len()
+                )));
+            }
             for (dst, src) in self
                 .acc_state_ipc
                 .iter_mut()
@@ -1045,10 +1055,12 @@ impl IncrementalAggState {
             }
             if let Some(count) = self.delta_vnode_count {
                 let v = self.delta_vnode_of(row_ref.as_ref(), count);
-                self.dirty_keys_by_vnode
-                    .entry(v)
-                    .or_default()
-                    .insert(row_ref.owned());
+                let owned = row_ref.owned();
+                // Re-touching a key supersedes any pending tombstone for it.
+                if let Some(s) = self.removed_by_vnode.get_mut(&v) {
+                    s.remove(&owned);
+                }
+                self.dirty_keys_by_vnode.entry(v).or_default().insert(owned);
             }
         }
         self.state_gen = self.state_gen.wrapping_add(1);
@@ -1098,10 +1110,11 @@ impl IncrementalAggState {
             self.weight_col_idx,
         );
         if self.delta_vnode_count.is_some() {
-            self.dirty_keys_by_vnode
-                .entry(0)
-                .or_default()
-                .insert(global_aggregate_key());
+            let key = global_aggregate_key();
+            if let Some(s) = self.removed_by_vnode.get_mut(&0) {
+                s.remove(&key);
+            }
+            self.dirty_keys_by_vnode.entry(0).or_default().insert(key);
         }
         if self.emit_changelog {
             self.dirty_keys.insert(empty_key);
@@ -1739,6 +1752,9 @@ impl IncrementalAggState {
             }
             if let Some(count) = self.delta_vnode_count {
                 let v = self.delta_vnode_of(row_key.as_ref(), count);
+                if let Some(s) = self.removed_by_vnode.get_mut(&v) {
+                    s.remove(&row_key);
+                }
                 self.dirty_keys_by_vnode
                     .entry(v)
                     .or_default()
@@ -3153,12 +3169,18 @@ mod tests {
         // Producer state: seed a,b,c then take a FULL baseline (opens the delta window).
         let mut producer = changelog_agg(&ctx).await;
         producer.set_delta_enabled(true);
-        feed(&mut producer, &[("a", 1.0), ("b", 2.0), ("c", 3.0)], 1000);
+        feed(
+            &mut producer,
+            &[("a", 1.0), ("b", 2.0), ("c", 3.0), ("d", 4.0)],
+            1000,
+        );
         let base = producer.checkpoint_groups_by_vnode(V).unwrap();
 
-        // Change a (+10) and b (+20); let c go idle and evict it (a tombstone).
+        // Change a,b; let c,d go idle and evict both; then re-add d — its tombstone
+        // must clear so it is encoded as changed, not removed.
         feed(&mut producer, &[("a", 10.0), ("b", 20.0)], 5000);
         producer.evict_idle(5000).unwrap();
+        feed(&mut producer, &[("d", 7.0)], 6000);
         let delta = producer.encode_delta_for_vnode(0).unwrap();
 
         // Consumer: restore the FULL base, then apply the delta — must match the producer.

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -550,6 +550,16 @@ pub(crate) struct IncrementalAggState {
     // Groups for these vnodes were dropped; captures stage a cold marker.
     #[cfg(feature = "state-tier")]
     cold_vnodes: rustc_hash::FxHashSet<u32>,
+    // ── Delta-state tracking (Lever 2, Phase 1) ─────────────────────────────
+    // When delta capture is enabled, the keys mutated / removed since the last
+    // per-vnode capture, bucketed by vnode. Populated only while `delta_vnode_count`
+    // is set (off by default → zero cost). Consumed by the delta encode (Phase 2).
+    // `delta_enabled` is read only by the cluster per-vnode capture.
+    #[cfg(feature = "cluster")]
+    delta_enabled: bool,
+    delta_vnode_count: Option<u32>,
+    dirty_keys_by_vnode: AHashMap<u32, AHashSet<arrow::row::OwnedRow>>,
+    removed_by_vnode: AHashMap<u32, AHashSet<arrow::row::OwnedRow>>,
 }
 
 impl IncrementalAggState {
@@ -846,7 +856,32 @@ impl IncrementalAggState {
             dirty_all: false,
             #[cfg(feature = "state-tier")]
             cold_vnodes: rustc_hash::FxHashSet::default(),
+            #[cfg(feature = "cluster")]
+            delta_enabled: false,
+            delta_vnode_count: None,
+            dirty_keys_by_vnode: AHashMap::new(),
+            removed_by_vnode: AHashMap::new(),
         }))
+    }
+
+    /// Enable per-vnode delta tracking. Off by default; the first per-vnode capture
+    /// after this starts recording mutated/removed keys for the delta encode (Phase 2).
+    #[cfg(all(test, feature = "cluster"))]
+    pub(crate) fn set_delta_enabled(&mut self, enabled: bool) {
+        self.delta_enabled = enabled;
+    }
+
+    /// Vnode for a group key (row bytes) under delta bucketing — mirrors the
+    /// capture/tier mapping.
+    fn delta_vnode_of(&self, key_bytes: &[u8], count: u32) -> u32 {
+        if self.num_group_cols == 0 {
+            0
+        } else {
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                (laminar_core::state::key_hash(key_bytes) % u64::from(count)) as u32
+            }
+        }
     }
 
     /// Evict idle groups and return retraction records. Requires both `emit_changelog` and `idle_ttl_ms`.
@@ -887,6 +922,16 @@ impl IncrementalAggState {
                     }
                 };
                 self.dirty_vnodes.insert(v);
+            }
+            if let Some(count) = self.delta_vnode_count {
+                let v = self.delta_vnode_of(key.as_ref(), count);
+                if let Some(s) = self.dirty_keys_by_vnode.get_mut(&v) {
+                    s.remove(key);
+                }
+                self.removed_by_vnode
+                    .entry(v)
+                    .or_default()
+                    .insert(key.clone());
             }
             if let Some(old) = self.last_emitted.remove(key) {
                 retract_keys.push(key.clone());
@@ -990,6 +1035,13 @@ impl IncrementalAggState {
             if self.emit_changelog {
                 self.dirty_keys.insert(row_ref.owned());
             }
+            if let Some(count) = self.delta_vnode_count {
+                let v = self.delta_vnode_of(row_ref.as_ref(), count);
+                self.dirty_keys_by_vnode
+                    .entry(v)
+                    .or_default()
+                    .insert(row_ref.owned());
+            }
         }
         self.state_gen = self.state_gen.wrapping_add(1);
 
@@ -1037,6 +1089,12 @@ impl IncrementalAggState {
             &self.agg_specs,
             self.weight_col_idx,
         );
+        if self.delta_vnode_count.is_some() {
+            self.dirty_keys_by_vnode
+                .entry(0)
+                .or_default()
+                .insert(global_aggregate_key());
+        }
         if self.emit_changelog {
             self.dirty_keys.insert(empty_key);
         }
@@ -1412,6 +1470,9 @@ impl IncrementalAggState {
         // Restored state is internally consistent (groups == last_emitted), so
         // nothing is pending for the changelog path.
         self.dirty_keys.clear();
+        // The restored state is the new baseline — no pending delta entries.
+        self.dirty_keys_by_vnode.clear();
+        self.removed_by_vnode.clear();
         self.state_gen = self.state_gen.wrapping_add(1);
         self.size_cache.invalidate();
         // All state is in memory; block demotion until the next capture re-baselines.
@@ -1527,6 +1588,14 @@ impl IncrementalAggState {
             self.dirty_vnodes.clear();
             self.dirty_all = false;
         }
+        // Delta tracking restarts from this capture (Lever 2). Enabling here means
+        // the first delta-capable capture is the chain root (FULL), with subsequent
+        // mutations recorded into the per-vnode sets for the next checkpoint.
+        if self.delta_enabled {
+            self.delta_vnode_count = Some(vnode_count);
+            self.dirty_keys_by_vnode.clear();
+            self.removed_by_vnode.clear();
+        }
 
         Ok(buckets)
     }
@@ -1563,6 +1632,13 @@ impl IncrementalAggState {
             // path must re-evaluate it (the diff still gates actual output).
             if self.emit_changelog {
                 self.dirty_keys.insert(row_key.clone());
+            }
+            if let Some(count) = self.delta_vnode_count {
+                let v = self.delta_vnode_of(row_key.as_ref(), count);
+                self.dirty_keys_by_vnode
+                    .entry(v)
+                    .or_default()
+                    .insert(row_key.clone());
             }
             match self.groups.entry(row_key) {
                 std::collections::hash_map::Entry::Occupied(mut occ) => {
@@ -2860,6 +2936,44 @@ mod tests {
             r2.iter().map(RecordBatch::num_rows).sum::<usize>(),
             2,
             "merged group must re-emit retract+insert",
+        );
+    }
+
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn delta_tracking_records_dirty_keys_per_vnode_and_resets_on_capture() {
+        const VNODES: u32 = 4;
+        let (_, mut state) =
+            setup_agg_state("SELECT name, SUM(value) as total FROM events GROUP BY name").await;
+        state.set_delta_enabled(true);
+
+        // First per-vnode capture establishes the delta baseline and starts a window.
+        state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        assert!(state.dirty_keys_by_vnode.is_empty());
+
+        let pre_agg = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("__agg_input_1", DataType::Float64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            pre_agg,
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0])),
+            ],
+        )
+        .unwrap();
+        state.process_batch(&batch, 1000).unwrap();
+
+        // Every mutated key is recorded, bucketed by vnode.
+        let tracked: usize = state.dirty_keys_by_vnode.values().map(|s| s.len()).sum();
+        assert_eq!(tracked, 3, "all mutated keys tracked in the delta window");
+
+        // The next capture resets the window.
+        state.checkpoint_groups_by_vnode(VNODES).unwrap();
+        assert!(
+            state.dirty_keys_by_vnode.is_empty(),
+            "capture resets the per-vnode dirty set",
         );
     }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -622,6 +622,14 @@ pub(crate) struct GroupEntry {
     pub(crate) last_updated_ms: i64,
 }
 
+/// A per-vnode state delta (Lever 2): the groups changed since the chain base
+/// (columnar, same shape as a `FULL` slice) plus the keys removed (tombstones).
+#[cfg(all(test, feature = "cluster"))]
+pub(crate) struct AggVnodeDelta {
+    pub(crate) changed: AggStateCheckpoint,
+    pub(crate) tombstones_ipc: Vec<u8>,
+}
+
 impl IncrementalAggState {
     /// Attempt to build an `IncrementalAggState` by introspecting the logical
     /// plan of the given SQL query. Returns `None` if the query does not
@@ -1598,6 +1606,102 @@ impl IncrementalAggState {
         }
 
         Ok(buckets)
+    }
+
+    /// Encode the per-vnode state DELTA (Lever 2 phase 2): the groups changed and
+    /// the keys removed for `vnode` since the last capture, from the phase-1 dirty
+    /// sets. Changed groups reuse the columnar FULL encoding over the subset;
+    /// removed keys are columnar-encoded as tombstones. Decoded + applied onto the
+    /// chain base by [`apply_delta`](Self::apply_delta). Phase-3 wires it into the
+    /// capture + recovery path; until then it is exercised only by tests.
+    #[cfg(all(test, feature = "cluster"))]
+    pub(crate) fn encode_delta_for_vnode(&mut self, vnode: u32) -> Result<AggVnodeDelta, DbError> {
+        let fingerprint = self.query_fingerprint();
+        let retractable = self.weight_col_idx.is_some();
+
+        let changed = self
+            .dirty_keys_by_vnode
+            .get(&vnode)
+            .cloned()
+            .unwrap_or_default();
+        let mut entries: Vec<(arrow::row::OwnedRow, &mut GroupEntry)> = self
+            .groups
+            .iter_mut()
+            .filter(|(k, _)| changed.contains(*k))
+            .map(|(k, v)| (k.clone(), v))
+            .collect();
+        let (keys_ipc, acc_state_ipc, last_updated_ms) = encode_groups_columnar(
+            &self.row_converter,
+            self.num_group_cols,
+            &self.agg_specs,
+            retractable,
+            &mut entries,
+        )?;
+
+        let removed: Vec<arrow::row::OwnedRow> = self
+            .removed_by_vnode
+            .get(&vnode)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
+        let tombstones_ipc = if removed.is_empty() {
+            Vec::new()
+        } else {
+            let arrays = self
+                .row_converter
+                .convert_rows(removed.iter().map(arrow::row::OwnedRow::row))
+                .map_err(|e| DbError::Pipeline(format!("tombstone key build: {e}")))?;
+            arrays_to_ipc(&arrays)?
+        };
+
+        Ok(AggVnodeDelta {
+            changed: AggStateCheckpoint {
+                fingerprint,
+                keys_ipc,
+                acc_state_ipc,
+                last_updated_ms,
+                last_emitted: Vec::new(),
+            },
+            tombstones_ipc,
+        })
+    }
+
+    /// Apply a delta onto live state (Lever 2 phase 2): each changed group's
+    /// accumulators are REPLACED from the delta's post-update state (never additively
+    /// re-merged), and tombstoned keys are removed.
+    #[cfg(all(test, feature = "cluster"))]
+    pub(crate) fn apply_delta(&mut self, delta: &AggVnodeDelta) -> Result<(), DbError> {
+        let retractable = self.weight_col_idx.is_some();
+        let per_group = decode_columnar_state_arrays(
+            &self.row_converter,
+            self.num_group_cols,
+            &delta.changed.keys_ipc,
+            &delta.changed.acc_state_ipc,
+            &delta.changed.last_updated_ms,
+        )?;
+        for (row_key, last_updated_ms, state_arrays) in per_group {
+            let accs = build_accumulators_from_state(&self.agg_specs, retractable, &state_arrays)?;
+            self.groups.insert(
+                row_key,
+                GroupEntry {
+                    accs,
+                    last_updated_ms,
+                },
+            );
+        }
+        if !delta.tombstones_ipc.is_empty() {
+            let batch =
+                laminar_core::serialization::deserialize_batch_stream(&delta.tombstones_ipc)
+                    .map_err(|e| DbError::Pipeline(format!("tombstone decode: {e}")))?;
+            let rows = self
+                .row_converter
+                .convert_columns(batch.columns())
+                .map_err(|e| DbError::Pipeline(format!("tombstone row convert: {e}")))?;
+            for i in 0..rows.num_rows() {
+                self.groups.remove(&rows.row(i).owned());
+            }
+        }
+        self.state_gen = self.state_gen.wrapping_add(1);
+        Ok(())
     }
 
     /// Fold a checkpoint's accumulator states into live state via `merge_batch`.
@@ -2974,6 +3078,98 @@ mod tests {
         assert!(
             state.dirty_keys_by_vnode.is_empty(),
             "capture resets the per-vnode dirty set",
+        );
+    }
+
+    #[cfg(feature = "cluster")]
+    #[tokio::test]
+    async fn delta_round_trip_reproduces_changed_and_removed_groups() {
+        use std::collections::BTreeMap;
+        // Single vnode → every key lands in vnode 0, so one delta carries all changes.
+        const V: u32 = 1;
+
+        fn pre_agg_schema() -> SchemaRef {
+            Arc::new(Schema::new(vec![
+                Field::new("name", DataType::Utf8, true),
+                Field::new("__agg_input_1", DataType::Float64, true),
+            ]))
+        }
+        fn feed(state: &mut IncrementalAggState, rows: &[(&str, f64)], ts: i64) {
+            let names: Vec<&str> = rows.iter().map(|(n, _)| *n).collect();
+            let vals: Vec<f64> = rows.iter().map(|(_, v)| *v).collect();
+            let batch = RecordBatch::try_new(
+                pre_agg_schema(),
+                vec![
+                    Arc::new(arrow::array::StringArray::from(names)),
+                    Arc::new(arrow::array::Float64Array::from(vals)),
+                ],
+            )
+            .unwrap();
+            state.process_batch(&batch, ts).unwrap();
+        }
+        // Group key bytes -> accumulator value, for state equality.
+        fn group_vals(state: &mut IncrementalAggState) -> BTreeMap<Vec<u8>, String> {
+            state
+                .groups
+                .iter_mut()
+                .map(|(k, v)| {
+                    (
+                        k.as_ref().to_vec(),
+                        format!("{:?}", v.accs[0].evaluate().unwrap()),
+                    )
+                })
+                .collect()
+        }
+        async fn changelog_agg(ctx: &SessionContext) -> IncrementalAggState {
+            let mut s = IncrementalAggState::try_from_sql(
+                ctx,
+                "SELECT name, SUM(value) as total FROM events GROUP BY name",
+                true,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            s.idle_ttl_ms = Some(1000);
+            s
+        }
+
+        let ctx = laminar_sql::create_session_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+        let dummy = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["x"])),
+                Arc::new(arrow::array::Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+        let mem = datafusion::datasource::MemTable::try_new(Arc::clone(&schema), vec![vec![dummy]])
+            .unwrap();
+        ctx.register_table("events", Arc::new(mem)).unwrap();
+
+        // Producer state: seed a,b,c then take a FULL baseline (opens the delta window).
+        let mut producer = changelog_agg(&ctx).await;
+        producer.set_delta_enabled(true);
+        feed(&mut producer, &[("a", 1.0), ("b", 2.0), ("c", 3.0)], 1000);
+        let base = producer.checkpoint_groups_by_vnode(V).unwrap();
+
+        // Change a (+10) and b (+20); let c go idle and evict it (a tombstone).
+        feed(&mut producer, &[("a", 10.0), ("b", 20.0)], 5000);
+        producer.evict_idle(5000).unwrap();
+        let delta = producer.encode_delta_for_vnode(0).unwrap();
+
+        // Consumer: restore the FULL base, then apply the delta — must match the producer.
+        let mut consumer = changelog_agg(&ctx).await;
+        consumer.restore_groups(base.get(&0).unwrap()).unwrap();
+        consumer.apply_delta(&delta).unwrap();
+
+        assert_eq!(
+            group_vals(&mut consumer),
+            group_vals(&mut producer),
+            "base + delta must reproduce the producer's state (changed replaced, tombstoned removed)",
         );
     }
 

--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -468,9 +468,8 @@ impl AggStateCheckpoint {
         if self.acc_state_ipc.is_empty() {
             self.acc_state_ipc = other.acc_state_ipc;
         } else if !other.acc_state_ipc.is_empty() {
-            // Both are slices of one query, so the accumulator-column counts must
-            // match; a mismatch would row-misalign keys vs accs in a way the
-            // fingerprint can't catch. (An empty `other` contributes no rows.)
+            // Slices of one query → equal accumulator-column counts; a mismatch would
+            // row-misalign keys vs accs (an empty `other` is a no-op).
             if self.acc_state_ipc.len() != other.acc_state_ipc.len() {
                 return Err(DbError::Pipeline(format!(
                     "append_disjoint: accumulator column count mismatch ({} vs {})",
@@ -560,11 +559,9 @@ pub(crate) struct IncrementalAggState {
     // Groups for these vnodes were dropped; captures stage a cold marker.
     #[cfg(feature = "state-tier")]
     cold_vnodes: rustc_hash::FxHashSet<u32>,
-    // ── Delta-state tracking (Lever 2, Phase 1) ─────────────────────────────
-    // When delta capture is enabled, the keys mutated / removed since the last
-    // per-vnode capture, bucketed by vnode. Populated only while `delta_vnode_count`
-    // is set (off by default → zero cost). Consumed by the delta encode (Phase 2).
-    // `delta_enabled` is read only by the cluster per-vnode capture.
+    // Delta-state tracking: keys mutated / removed since the last per-vnode capture,
+    // bucketed by vnode. Populated only while `delta_vnode_count` is set (off by
+    // default → zero cost).
     #[cfg(feature = "cluster")]
     delta_enabled: bool,
     delta_vnode_count: Option<u32>,
@@ -882,15 +879,12 @@ impl IncrementalAggState {
         }))
     }
 
-    /// Enable per-vnode delta tracking. Off by default; the first per-vnode capture
-    /// after this starts recording mutated/removed keys for the delta encode (Phase 2).
     #[cfg(all(test, feature = "cluster"))]
     pub(crate) fn set_delta_enabled(&mut self, enabled: bool) {
         self.delta_enabled = enabled;
     }
 
-    /// Vnode for a group key (row bytes) under delta bucketing — mirrors the
-    /// capture/tier mapping.
+    /// Vnode for a group key under delta bucketing — same hash as the capture path.
     fn delta_vnode_of(&self, key_bytes: &[u8], count: u32) -> u32 {
         if self.num_group_cols == 0 {
             0
@@ -1609,9 +1603,8 @@ impl IncrementalAggState {
             self.dirty_vnodes.clear();
             self.dirty_all = false;
         }
-        // Delta tracking restarts from this capture (Lever 2). Enabling here means
-        // the first delta-capable capture is the chain root (FULL), with subsequent
-        // mutations recorded into the per-vnode sets for the next checkpoint.
+        // Delta tracking re-bases on this capture: the dirty sets reset, so the next
+        // checkpoint's delta is measured against the state staged here.
         if self.delta_enabled {
             self.delta_vnode_count = Some(vnode_count);
             self.dirty_keys_by_vnode.clear();
@@ -1621,12 +1614,8 @@ impl IncrementalAggState {
         Ok(buckets)
     }
 
-    /// Encode the per-vnode state DELTA (Lever 2 phase 2): the groups changed and
-    /// the keys removed for `vnode` since the last capture, from the phase-1 dirty
-    /// sets. Changed groups reuse the columnar FULL encoding over the subset;
-    /// removed keys are columnar-encoded as tombstones. Decoded + applied onto the
-    /// chain base by [`apply_delta`](Self::apply_delta). Phase-3 wires it into the
-    /// capture + recovery path; until then it is exercised only by tests.
+    /// Encode the state delta for `vnode` from the dirty sets: changed groups via the
+    /// columnar FULL encoding over the subset, removed keys as tombstones.
     #[cfg(all(test, feature = "cluster"))]
     pub(crate) fn encode_delta_for_vnode(&mut self, vnode: u32) -> Result<AggVnodeDelta, DbError> {
         let fingerprint = self.query_fingerprint();
@@ -1678,9 +1667,8 @@ impl IncrementalAggState {
         })
     }
 
-    /// Apply a delta onto live state (Lever 2 phase 2): each changed group's
-    /// accumulators are REPLACED from the delta's post-update state (never additively
-    /// re-merged), and tombstoned keys are removed.
+    /// Apply a delta onto live state: changed groups replace per key (the delta
+    /// carries post-update state, never additively re-merged); tombstoned keys removed.
     #[cfg(all(test, feature = "cluster"))]
     pub(crate) fn apply_delta(&mut self, delta: &AggVnodeDelta) -> Result<(), DbError> {
         let retractable = self.weight_col_idx.is_some();
@@ -3166,7 +3154,7 @@ mod tests {
             .unwrap();
         ctx.register_table("events", Arc::new(mem)).unwrap();
 
-        // Producer state: seed a,b,c then take a FULL baseline (opens the delta window).
+        // Producer: seed the keys, then take a FULL baseline (opens the delta window).
         let mut producer = changelog_agg(&ctx).await;
         producer.set_delta_enabled(true);
         feed(

--- a/crates/laminar-db/src/aggregate_state/checkpoints.rs
+++ b/crates/laminar-db/src/aggregate_state/checkpoints.rs
@@ -1,7 +1,7 @@
 //! Serializable checkpoint shapes for aggregate, join, and window state.
 //!
-//! Scalar fields (`key`, `acc_states`, `values`) hold Arrow IPC one-row batches
-//! from `scalars_to_ipc`. Join buffer fields hold full multi-row IPC batches.
+//! `AggStateCheckpoint` is columnar; `GroupCheckpoint` (window/EOWC) and
+//! `EmittedCheckpoint` hold one-row IPC tuples; join buffers hold multi-row batches.
 
 use std::hash::{Hash, Hasher};
 
@@ -21,12 +21,17 @@ fn default_last_updated() -> i64 {
     i64::MIN
 }
 
+/// Columnar running-aggregate state: all keys in one IPC batch, each accumulator's
+/// state across all groups in one IPC batch. Row `j` of `keys_ipc`, every
+/// `acc_state_ipc[i]`, and `last_updated_ms[j]` refer to the same group.
 #[derive(
     Clone, serde::Serialize, serde::Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
 )]
 pub(crate) struct AggStateCheckpoint {
     pub fingerprint: u64,
-    pub groups: Vec<GroupCheckpoint>,
+    pub keys_ipc: Vec<u8>,
+    pub acc_state_ipc: Vec<Vec<u8>>,
+    pub last_updated_ms: Vec<i64>,
     #[serde(default)]
     pub last_emitted: Vec<EmittedCheckpoint>,
 }

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -650,36 +650,37 @@ impl CheckpointCoordinator {
     /// strings). Staged onto the vnode registry during a rotation so an acquiring
     /// source resumes its newly-owned partitions from the previous owner's sealed
     /// position. The engine does not interpret the keys — the source filters to
-    /// the partitions it owns. Best-effort: empty on any error so the source
-    /// falls back to its configured startup offset.
+    /// the partitions it owns. An empty backend or no committed epoch yields an empty
+    /// map (nothing to hand off); a backend read FAILURE is propagated so the caller
+    /// defers the rotation rather than letting an exactly-once source silently fall
+    /// back to its startup offset and re-emit.
     #[cfg(feature = "cluster")]
-    pub(crate) async fn acquired_source_offsets(&self) -> HashMap<String, String> {
+    pub(crate) async fn acquired_source_offsets(&self) -> Result<HashMap<String, String>, DbError> {
         let mut merged = HashMap::new();
         let Some(ref backend) = self.state_backend else {
-            return merged;
+            return Ok(merged);
         };
         let epoch = match backend.latest_committed_epoch().await {
             Ok(Some(e)) => e,
-            Ok(None) => return merged,
+            Ok(None) => return Ok(merged),
             Err(e) => {
-                warn!(error = %e, "source offset handoff: latest_committed_epoch failed");
-                return merged;
+                return Err(DbError::Checkpoint(format!(
+                    "source-offset handoff: latest_committed_epoch failed: {e}"
+                )))
             }
         };
-        let blobs = match backend.read_source_offsets(epoch).await {
-            Ok(b) => b,
-            Err(e) => {
-                warn!(error = %e, "source offset handoff: read_source_offsets failed");
-                return merged;
-            }
-        };
+        let blobs = backend.read_source_offsets(epoch).await.map_err(|e| {
+            DbError::Checkpoint(format!(
+                "source-offset handoff: read_source_offsets failed: {e}"
+            ))
+        })?;
         for blob in blobs {
             match serde_json::from_slice::<HashMap<String, String>>(&blob) {
                 Ok(m) => merged.extend(m),
                 Err(e) => warn!(error = %e, "source offset handoff: skipping undecodable blob"),
             }
         }
-        merged
+        Ok(merged)
     }
 
     /// Begin the initial epoch on all exactly-once sinks.

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -610,28 +610,76 @@ impl CheckpointCoordinator {
         self.config.coordinated_committer_poll
     }
 
-    /// All source-checkpoint offsets from the latest durable manifest, as one
-    /// opaque map of connector-defined key/value strings.
-    ///
-    /// Staged onto the vnode registry during a rotation so an acquiring source can
-    /// resume partitions from the previous owner's sealed position instead of
-    /// `auto.offset.reset`. The engine does not interpret the keys — the source
-    /// parses and filters to the partitions it owns. Best-effort: empty on any
-    /// load error so the source falls back to its configured startup offset.
+    /// Persist this node's source offsets for `epoch` to the shared state backend,
+    /// keyed per node, so a node that acquires one of its partitions on a later
+    /// rotation can resume from the committed cut (see
+    /// [`acquired_source_offsets`](Self::acquired_source_offsets)) instead of
+    /// `auto.offset.reset`. Written pre-seal so a sealed epoch always carries it;
+    /// a write error fails the epoch. No-op outside a real cluster assignment
+    /// (version 0) or without a backend.
+    async fn persist_source_offset_handoff(
+        &self,
+        epoch: u64,
+        source_offsets: &HashMap<String, ConnectorCheckpoint>,
+    ) -> Result<(), DbError> {
+        if self.assignment_version == 0 {
+            return Ok(());
+        }
+        let Some(ref backend) = self.state_backend else {
+            return Ok(());
+        };
+        let flat: HashMap<String, String> = source_offsets
+            .values()
+            .flat_map(|cp| cp.offsets.iter().map(|(k, v)| (k.clone(), v.clone())))
+            .collect();
+        if flat.is_empty() {
+            return Ok(());
+        }
+        let bytes = serde_json::to_vec(&flat)
+            .map_err(|e| DbError::Checkpoint(format!("source-offset handoff encode: {e}")))?;
+        let node_key = format!("node-{}", self.self_node_id());
+        backend
+            .write_source_offsets(epoch, &node_key, self.assignment_version, bytes.into())
+            .await
+            .map_err(|e| DbError::Checkpoint(format!("source-offset handoff write: {e}")))?;
+        Ok(())
+    }
+
+    /// The global source-offset map for the latest sealed epoch, unioned from
+    /// every node's blob in the shared state backend (opaque connector key/value
+    /// strings). Staged onto the vnode registry during a rotation so an acquiring
+    /// source resumes its newly-owned partitions from the previous owner's sealed
+    /// position. The engine does not interpret the keys — the source filters to
+    /// the partitions it owns. Best-effort: empty on any error so the source
+    /// falls back to its configured startup offset.
     #[cfg(feature = "cluster")]
-    pub(crate) async fn latest_source_offsets(&self) -> HashMap<String, String> {
-        match self.store.load_latest().await {
-            Ok(Some(m)) => m
-                .source_offsets
-                .values()
-                .flat_map(|cp| cp.offsets.iter().map(|(k, v)| (k.clone(), v.clone())))
-                .collect(),
-            Ok(None) => HashMap::new(),
+    pub(crate) async fn acquired_source_offsets(&self) -> HashMap<String, String> {
+        let mut merged = HashMap::new();
+        let Some(ref backend) = self.state_backend else {
+            return merged;
+        };
+        let epoch = match backend.latest_committed_epoch().await {
+            Ok(Some(e)) => e,
+            Ok(None) => return merged,
             Err(e) => {
-                warn!(error = %e, "source offset handoff: failed to load latest manifest");
-                HashMap::new()
+                warn!(error = %e, "source offset handoff: latest_committed_epoch failed");
+                return merged;
+            }
+        };
+        let blobs = match backend.read_source_offsets(epoch).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "source offset handoff: read_source_offsets failed");
+                return merged;
+            }
+        };
+        for blob in blobs {
+            match serde_json::from_slice::<HashMap<String, String>>(&blob) {
+                Ok(m) => merged.extend(m),
+                Err(e) => warn!(error = %e, "source offset handoff: skipping undecodable blob"),
             }
         }
+        merged
     }
 
     /// Begin the initial epoch on all exactly-once sinks.
@@ -1992,6 +2040,14 @@ impl CheckpointCoordinator {
             self.config.state_inline_threshold,
         );
 
+        if let Err(e) = self
+            .persist_source_offset_handoff(epoch, &manifest.source_offsets)
+            .await
+        {
+            self.pending_vnode_states.clear();
+            return Err(e);
+        }
+
         self.phase = CheckpointPhase::Persisting;
         if let Err(e) = self.save_manifest(Arc::new(manifest), state_data).await {
             self.pending_vnode_states.clear();
@@ -2190,6 +2246,21 @@ impl CheckpointCoordinator {
                     epoch,
                     start,
                     format!("vnode partial write failed: {e}"),
+                )
+                .await);
+        }
+
+        if let Err(e) = self
+            .persist_source_offset_handoff(epoch, &manifest.source_offsets)
+            .await
+        {
+            error!(checkpoint_id, epoch, error = %e, "source-offset handoff write failed");
+            return Ok(self
+                .fail_epoch(
+                    checkpoint_id,
+                    epoch,
+                    start,
+                    format!("source-offset handoff write failed: {e}"),
                 )
                 .await);
         }

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -610,6 +610,60 @@ impl CheckpointCoordinator {
         self.config.coordinated_committer_poll
     }
 
+    /// Committed Kafka source offsets for the partitions bound to `acquiring`
+    /// vnodes, read from the latest durable checkpoint manifest. Keyed
+    /// `(topic, partition) -> next-offset-to-fetch`.
+    ///
+    /// Used during a vnode rotation so a node that acquires a partition resumes
+    /// it from the previous owner's sealed position instead of replaying from
+    /// `auto.offset.reset` (which emits duplicates). Best-effort: returns empty
+    /// on any load error so the source falls back to its configured startup
+    /// offset.
+    #[cfg(feature = "cluster")]
+    pub(crate) async fn acquired_source_resume_hints(
+        &self,
+        acquiring: &[u32],
+        vnode_count: u32,
+    ) -> HashMap<(String, i32), i64> {
+        let mut hints = HashMap::new();
+        if acquiring.is_empty() || vnode_count == 0 {
+            return hints;
+        }
+        let manifest = match self.store.load_latest().await {
+            Ok(Some(m)) => m,
+            Ok(None) => return hints,
+            Err(e) => {
+                warn!(error = %e, "source offset handoff: failed to load latest manifest");
+                return hints;
+            }
+        };
+        let acquiring: std::collections::HashSet<u32> = acquiring.iter().copied().collect();
+        for cp in manifest.source_offsets.values() {
+            for (key, val) in &cp.offsets {
+                // key format: "{topic}-{partition}" (topic names may contain '-').
+                let Some((topic, partition)) = key.rsplit_once('-') else {
+                    continue;
+                };
+                let (Ok(partition), Ok(offset)) =
+                    (partition.parse::<i32>(), val.parse::<i64>())
+                else {
+                    continue;
+                };
+                if partition < 0 {
+                    continue;
+                }
+                #[allow(clippy::cast_sign_loss)]
+                let vnode = (partition as u32) % vnode_count;
+                if acquiring.contains(&vnode) {
+                    // Manifest stores the last-consumed offset; the source seeks
+                    // the next record to fetch.
+                    hints.insert((topic.to_string(), partition), offset + 1);
+                }
+            }
+        }
+        hints
+    }
+
     /// Begin the initial epoch on all exactly-once sinks.
     ///
     /// Must be called once after all sinks are registered and before any writes. Subsequent

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -84,12 +84,10 @@ pub struct CheckpointConfig {
     /// Followers upload asynchronously after the capture ack, so the durability gate polls
     /// rather than checking once. Expiry aborts the epoch.
     pub restorable_gate_timeout: Duration,
-    /// Durability-gate poll first interval. The gate re-checks object-store
-    /// presence on an exponential schedule from here to `restorable_gate_poll_max`.
-    /// Tighten both on a low-latency object store to cut the poll quantization;
-    /// the defaults (100ms/1s) suit a higher-latency store.
+    /// Durability-gate poll: first interval, backing off exponentially to the cap.
+    /// Tighten on a low-latency store to cut poll quantization.
     pub restorable_gate_poll_initial: Duration,
-    /// Durability-gate poll backoff cap (see `restorable_gate_poll_initial`).
+    /// Durability-gate poll backoff cap.
     pub restorable_gate_poll_max: Duration,
     /// Max pipelined epochs between `Aligned` and restorable. Exactly-once pipelines cap at 1.
     pub max_in_flight_epochs: u64,
@@ -1097,10 +1095,8 @@ impl CheckpointCoordinator {
     ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
-        // Each poll LISTs the epoch prefix; back off exponentially from the configured
-        // initial to the cap. Gates serialize on the coordinator mutex so at most one
-        // loop runs at a time regardless of pipeline depth. Clamp to a 1ms floor and
-        // keep the cap >= initial so a 0ms config can't spin the loop under the mutex.
+        // Back off exponentially from the configured initial to the cap. Clamp to a
+        // 1ms floor (cap >= initial) so a 0ms config can't spin the gate under the mutex.
         let initial_poll = self
             .config
             .restorable_gate_poll_initial

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -1099,9 +1099,13 @@ impl CheckpointCoordinator {
 
         // Each poll LISTs the epoch prefix; back off exponentially from the configured
         // initial to the cap. Gates serialize on the coordinator mutex so at most one
-        // loop runs at a time regardless of pipeline depth.
-        let initial_poll = self.config.restorable_gate_poll_initial;
-        let max_poll = self.config.restorable_gate_poll_max;
+        // loop runs at a time regardless of pipeline depth. Clamp to a 1ms floor and
+        // keep the cap >= initial so a 0ms config can't spin the loop under the mutex.
+        let initial_poll = self
+            .config
+            .restorable_gate_poll_initial
+            .max(Duration::from_millis(1));
+        let max_poll = self.config.restorable_gate_poll_max.max(initial_poll);
 
         let Some(ref backend) = self.state_backend else {
             return Ok(());

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -84,6 +84,13 @@ pub struct CheckpointConfig {
     /// Followers upload asynchronously after the capture ack, so the durability gate polls
     /// rather than checking once. Expiry aborts the epoch.
     pub restorable_gate_timeout: Duration,
+    /// Durability-gate poll first interval. The gate re-checks object-store
+    /// presence on an exponential schedule from here to `restorable_gate_poll_max`.
+    /// Tighten both on a low-latency object store to cut the poll quantization;
+    /// the defaults (100ms/1s) suit a higher-latency store.
+    pub restorable_gate_poll_initial: Duration,
+    /// Durability-gate poll backoff cap (see `restorable_gate_poll_initial`).
+    pub restorable_gate_poll_max: Duration,
     /// Max pipelined epochs between `Aligned` and restorable. Exactly-once pipelines cap at 1.
     pub max_in_flight_epochs: u64,
     /// Cap on in-flight captured-state bytes. At the cap, barrier admission pauses.
@@ -116,6 +123,8 @@ impl Default for CheckpointConfig {
             quorum_timeout: Duration::from_secs(3),
             // Last-resort bound: fail-fasts catch dead participants in seconds.
             restorable_gate_timeout: Duration::from_secs(10),
+            restorable_gate_poll_initial: Duration::from_millis(100),
+            restorable_gate_poll_max: Duration::from_secs(1),
             max_in_flight_epochs: 4,
             max_staged_bytes: 512 * 1024 * 1024,
             max_uncommitted_epochs: 1024,
@@ -1088,10 +1097,11 @@ impl CheckpointCoordinator {
     ) -> Result<(), String> {
         use laminar_core::state::StateBackendError;
 
-        // Each poll LISTs the epoch prefix; back off exponentially. Gates serialize on the
-        // coordinator mutex so at most one loop runs at a time regardless of pipeline depth.
-        const INITIAL_POLL: Duration = Duration::from_millis(100);
-        const MAX_POLL: Duration = Duration::from_secs(1);
+        // Each poll LISTs the epoch prefix; back off exponentially from the configured
+        // initial to the cap. Gates serialize on the coordinator mutex so at most one
+        // loop runs at a time regardless of pipeline depth.
+        let initial_poll = self.config.restorable_gate_poll_initial;
+        let max_poll = self.config.restorable_gate_poll_max;
 
         let Some(ref backend) = self.state_backend else {
             return Ok(());
@@ -1103,7 +1113,7 @@ impl CheckpointCoordinator {
         }
 
         let deadline = Instant::now() + self.config.restorable_gate_timeout;
-        let mut interval = INITIAL_POLL;
+        let mut interval = initial_poll;
         let mut last_state = String::from("not all vnodes persisted");
         loop {
             if epoch < self.rotation_epoch_floor {
@@ -1155,7 +1165,7 @@ impl CheckpointCoordinator {
                 ));
             }
             tokio::time::sleep(interval).await;
-            interval = (interval * 2).min(MAX_POLL);
+            interval = (interval * 2).min(max_poll);
         }
     }
 

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -610,58 +610,28 @@ impl CheckpointCoordinator {
         self.config.coordinated_committer_poll
     }
 
-    /// Committed Kafka source offsets for the partitions bound to `acquiring`
-    /// vnodes, read from the latest durable checkpoint manifest. Keyed
-    /// `(topic, partition) -> next-offset-to-fetch`.
+    /// All source-checkpoint offsets from the latest durable manifest, as one
+    /// opaque map of connector-defined key/value strings.
     ///
-    /// Used during a vnode rotation so a node that acquires a partition resumes
-    /// it from the previous owner's sealed position instead of replaying from
-    /// `auto.offset.reset` (which emits duplicates). Best-effort: returns empty
-    /// on any load error so the source falls back to its configured startup
-    /// offset.
+    /// Staged onto the vnode registry during a rotation so an acquiring source can
+    /// resume partitions from the previous owner's sealed position instead of
+    /// `auto.offset.reset`. The engine does not interpret the keys — the source
+    /// parses and filters to the partitions it owns. Best-effort: empty on any
+    /// load error so the source falls back to its configured startup offset.
     #[cfg(feature = "cluster")]
-    pub(crate) async fn acquired_source_resume_hints(
-        &self,
-        acquiring: &[u32],
-        vnode_count: u32,
-    ) -> HashMap<(String, i32), i64> {
-        let mut hints = HashMap::new();
-        if acquiring.is_empty() || vnode_count == 0 {
-            return hints;
-        }
-        let manifest = match self.store.load_latest().await {
-            Ok(Some(m)) => m,
-            Ok(None) => return hints,
+    pub(crate) async fn latest_source_offsets(&self) -> HashMap<String, String> {
+        match self.store.load_latest().await {
+            Ok(Some(m)) => m
+                .source_offsets
+                .values()
+                .flat_map(|cp| cp.offsets.iter().map(|(k, v)| (k.clone(), v.clone())))
+                .collect(),
+            Ok(None) => HashMap::new(),
             Err(e) => {
                 warn!(error = %e, "source offset handoff: failed to load latest manifest");
-                return hints;
-            }
-        };
-        let acquiring: std::collections::HashSet<u32> = acquiring.iter().copied().collect();
-        for cp in manifest.source_offsets.values() {
-            for (key, val) in &cp.offsets {
-                // key format: "{topic}-{partition}" (topic names may contain '-').
-                let Some((topic, partition)) = key.rsplit_once('-') else {
-                    continue;
-                };
-                let (Ok(partition), Ok(offset)) =
-                    (partition.parse::<i32>(), val.parse::<i64>())
-                else {
-                    continue;
-                };
-                if partition < 0 {
-                    continue;
-                }
-                #[allow(clippy::cast_sign_loss)]
-                let vnode = (partition as u32) % vnode_count;
-                if acquiring.contains(&vnode) {
-                    // Manifest stores the last-consumed offset; the source seeks
-                    // the next record to fetch.
-                    hints.insert((topic.to_string(), partition), offset + 1);
-                }
+                HashMap::new()
             }
         }
-        hints
     }
 
     /// Begin the initial epoch on all exactly-once sinks.

--- a/crates/laminar-db/src/checkpoint_coordinator/tests.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator/tests.rs
@@ -1041,7 +1041,7 @@ async fn source_offset_handoff_round_trip() {
     assert!(backend.epoch_complete(5, &[0, 1, 2, 3], &[]).await.unwrap());
 
     // A node acquiring events-0 on rotation recovers the committed offset.
-    let acquired = coord.acquired_source_offsets().await;
+    let acquired = coord.acquired_source_offsets().await.unwrap();
     assert_eq!(acquired.get("events-0"), Some(&"100".to_string()));
 }
 

--- a/crates/laminar-db/src/checkpoint_coordinator/tests.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator/tests.rs
@@ -1003,6 +1003,48 @@ async fn gate_checks_full_registry_not_just_owned() {
     );
 }
 
+/// B1: each node persists its source offsets every checkpoint; once the epoch
+/// seals, a node acquiring a partition reads the union of every node's blob and
+/// recovers the committed offset instead of falling back to `auto.offset.reset`.
+#[cfg(feature = "cluster")]
+#[tokio::test]
+#[allow(clippy::disallowed_types)]
+async fn source_offset_handoff_round_trip() {
+    use bytes::Bytes;
+    use laminar_core::state::{InProcessBackend, StateBackend};
+    let dir = tempfile::tempdir().unwrap();
+    let mut coord = make_coordinator(dir.path()).await;
+    let backend = Arc::new(InProcessBackend::new(4));
+    coord.set_state_backend(backend.clone());
+    coord.set_assignment_version(1); // >0 so the handoff actually writes
+
+    let mut source_offsets = HashMap::new();
+    source_offsets.insert(
+        "kafka".to_string(),
+        ConnectorCheckpoint::with_offsets(
+            5,
+            HashMap::from([("events-0".to_string(), "100".to_string())]),
+        ),
+    );
+    coord
+        .persist_source_offset_handoff(5, &source_offsets)
+        .await
+        .unwrap();
+
+    // Seal epoch 5 so it becomes the latest committed epoch.
+    for v in 0u32..4 {
+        backend
+            .write_partial(v, 5, 1, Bytes::from_static(b"x"))
+            .await
+            .unwrap();
+    }
+    assert!(backend.epoch_complete(5, &[0, 1, 2, 3], &[]).await.unwrap());
+
+    // A node acquiring events-0 on rotation recovers the committed offset.
+    let acquired = coord.acquired_source_offsets().await;
+    assert_eq!(acquired.get("events-0"), Some(&"100".to_string()));
+}
+
 /// Followers ack at capture and upload partials
 /// asynchronously, so the leader's restorable gate must *wait* for
 /// late partials rather than failing on the first check.

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -108,9 +108,7 @@ pub struct LaminarDB {
     /// Set when a `stop_pipeline` times out so the watcher finalizes ShuttingDown→Created;
     /// keeps it from racing a normal stop/shutdown, which finalize themselves.
     pub(crate) stop_timed_out: Arc<std::sync::atomic::AtomicBool>,
-    /// Set at pipeline start when the pipeline has an exactly-once sink, so vnode
-    /// rotations run the pre-rotation source drain (B2). Read by
-    /// [`requires_rotation_drain`](Self::requires_rotation_drain).
+    /// Set at pipeline start when a sink is exactly-once; gates the rotation drain.
     pub(crate) rotation_drain_required: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) runtime_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Decoupled coordinated-commit committer task; aborted on shutdown.
@@ -596,12 +594,9 @@ impl LaminarDB {
         let mut guard = self.coordinator.lock().await;
         let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
 
-        // Before bumping the assignment version (which triggers the source's
-        // partition rebind), stage the cluster-wide source offsets (unioned from
-        // every node's blob in the shared state backend) so an acquiring source
-        // resumes newly-owned partitions from the previous owner's sealed position
-        // instead of auto.offset.reset (which duplicates). Only when this node is
-        // actually acquiring a vnode. Operator state is rehydrated separately below.
+        // Stage the cluster-wide sealed source offsets before the version bump so an
+        // acquiring source resumes newly-owned partitions from the previous owner's
+        // position, not auto.offset.reset. Only when this node acquires a vnode.
         let acquiring_any = {
             let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
             (0..vnode_count).any(|v| {
@@ -615,8 +610,7 @@ impl LaminarDB {
         }
 
         registry.set_assignment_and_version(new_assignment, snapshot.version);
-        // The rotation committed: drop any pre-rotation drain marks. Revoked
-        // partitions are gone from the new assignment; the source resumes the rest.
+        // Rotation committed — drop the drain marks (revoked partitions are gone).
         registry.clear_draining();
         let new_owned = laminar_core::state::owned_vnodes(&registry, self_id);
         if let Some(backend) = self.state_backend.lock().clone() {
@@ -689,12 +683,10 @@ impl LaminarDB {
         adoption
     }
 
-    /// Adopt the DRAIN phase of a rotation: mark the vnodes this node is about to
-    /// lose (owned now, not owned in `snapshot`) as draining so the source pauses
-    /// their partitions for a clean pre-rotation checkpoint cut. Ownership is NOT
-    /// changed — the committed snapshot (`draining = false`) does that later via
-    /// [`adopt_assignment_snapshot`](Self::adopt_assignment_snapshot). Returns the
-    /// vnodes marked draining (for the leader to log / wait on).
+    /// Mark the vnodes this node is about to lose as draining (source pauses their
+    /// partitions for a clean checkpoint cut); does NOT change ownership. Returns
+    /// them so the leader can wait on the drain. The committed snapshot rotates
+    /// ownership later via [`adopt_assignment_snapshot`](Self::adopt_assignment_snapshot).
     #[cfg(feature = "cluster")]
     pub fn adopt_draining_snapshot(
         &self,
@@ -728,16 +720,9 @@ impl LaminarDB {
         revoking
     }
 
-    /// Whether vnode rotations should run the pre-rotation source drain (B2).
-    ///
-    /// True when the running pipeline has an exactly-once sink: there the old
-    /// owner must stop consuming a rotating partition at the checkpoint cut, or it
-    /// emits records past the sealed offset that a non-upsert sink can't dedup.
-    /// Set from the actual registered sinks at pipeline start (the server
-    /// configures delivery per sink, not via the DB-level `delivery_guarantee`).
-    /// At-least-once pipelines skip the drain and tolerate the bounded rotation
-    /// duplicate. (An all-upsert EO pipeline would absorb the dup too; skipping the
-    /// drain there is a future optimization — correctness doesn't depend on it.)
+    /// Whether vnode rotations run the pre-rotation source drain — true when a sink
+    /// is exactly-once, so the old owner stops at the checkpoint cut rather than
+    /// emitting past the sealed offset. At-least-once pipelines skip it.
     #[must_use]
     pub fn requires_rotation_drain(&self) -> bool {
         self.rotation_drain_required

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -592,26 +592,20 @@ impl LaminarDB {
         let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
 
         // Before bumping the assignment version (which triggers the source's
-        // partition rebind), stage the committed Kafka source offsets for the
-        // partitions bound to vnodes this node is ACQUIRING. The source seeks
-        // those partitions to the previous owner's sealed checkpoint position
-        // instead of replaying from auto.offset.reset — preventing duplicate
-        // emission on rotation. Operator state is rehydrated separately below.
-        let acquiring: Vec<u32> = {
+        // partition rebind), stage the latest manifest's source offsets so an
+        // acquiring source can resume newly-owned partitions from the previous
+        // owner's sealed position instead of auto.offset.reset (which duplicates).
+        // Only when this node is actually acquiring a vnode — otherwise skip the
+        // object-store read. Operator state is rehydrated separately below.
+        let acquiring_any = {
             let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
-            (0..vnode_count)
-                .filter(|&v| {
-                    new_assignment.get(v as usize).copied() == Some(self_id)
-                        && !old_set.contains(&v)
-                })
-                .collect()
+            (0..vnode_count).any(|v| {
+                new_assignment.get(v as usize).copied() == Some(self_id) && !old_set.contains(&v)
+            })
         };
-        if !acquiring.is_empty() {
+        if acquiring_any {
             if let Some(coord) = guard.as_ref() {
-                let hints = coord
-                    .acquired_source_resume_hints(&acquiring, vnode_count)
-                    .await;
-                registry.stage_resume_hints(hints);
+                registry.stage_resume_offsets(coord.latest_source_offsets().await);
             }
         }
 

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -590,6 +590,31 @@ impl LaminarDB {
         // Hold the coord mutex so registry + fence updates land between epochs.
         let mut guard = self.coordinator.lock().await;
         let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
+
+        // Before bumping the assignment version (which triggers the source's
+        // partition rebind), stage the committed Kafka source offsets for the
+        // partitions bound to vnodes this node is ACQUIRING. The source seeks
+        // those partitions to the previous owner's sealed checkpoint position
+        // instead of replaying from auto.offset.reset — preventing duplicate
+        // emission on rotation. Operator state is rehydrated separately below.
+        let acquiring: Vec<u32> = {
+            let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
+            (0..vnode_count)
+                .filter(|&v| {
+                    new_assignment.get(v as usize).copied() == Some(self_id)
+                        && !old_set.contains(&v)
+                })
+                .collect()
+        };
+        if !acquiring.is_empty() {
+            if let Some(coord) = guard.as_ref() {
+                let hints = coord
+                    .acquired_source_resume_hints(&acquiring, vnode_count)
+                    .await;
+                registry.stage_resume_hints(hints);
+            }
+        }
+
         registry.set_assignment_and_version(new_assignment, snapshot.version);
         let new_owned = laminar_core::state::owned_vnodes(&registry, self_id);
         if let Some(backend) = self.state_backend.lock().clone() {

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -564,6 +564,7 @@ impl LaminarDB {
     /// Rehydration runs after the coordinator lock is released so a slow
     /// object-store read can't stall the checkpoint cadence.
     #[cfg(feature = "cluster")]
+    #[allow(clippy::too_many_lines)] // sequential rotation steps read better inline
     pub async fn adopt_assignment_snapshot(
         &self,
         snapshot: laminar_core::cluster::control::AssignmentSnapshot,
@@ -592,21 +593,52 @@ impl LaminarDB {
 
         // Hold the coord mutex so registry + fence updates land between epochs.
         let mut guard = self.coordinator.lock().await;
-        let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
+        // Re-check under the lock: a concurrent adopt may have advanced the version,
+        // which we must not regress.
+        if snapshot.version <= registry.assignment_version() {
+            return SnapshotAdoption {
+                adopted: false,
+                version: snapshot.version,
+                ..SnapshotAdoption::default()
+            };
+        }
 
-        // Stage the cluster-wide sealed source offsets before the version bump so an
-        // acquiring source resumes newly-owned partitions from the previous owner's
-        // position, not auto.offset.reset. Only when this node acquires a vnode.
-        let acquiring_any = {
-            let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
-            (0..vnode_count).any(|v| {
+        let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
+        let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
+        // Compute from the new assignment before publishing it, so the Restoring marks
+        // below land before the ownership flip.
+        let newly_acquired: Vec<u32> = (0..vnode_count)
+            .filter(|&v| {
                 new_assignment.get(v as usize).copied() == Some(self_id) && !old_set.contains(&v)
             })
-        };
-        if acquiring_any {
+            .collect();
+
+        // Stage the sealed source offsets before the version bump (acquiring source
+        // resumes from the previous owner's cut). A handoff-read failure defers the
+        // rotation — exactly-once must not fall back to startup and re-emit.
+        if !newly_acquired.is_empty() {
             if let Some(coord) = guard.as_ref() {
-                registry.stage_resume_offsets(coord.acquired_source_offsets().await);
+                match coord.acquired_source_offsets().await {
+                    Ok(offsets) => registry.stage_resume_offsets(offsets),
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e, version = snapshot.version,
+                            "source-offset handoff read failed; deferring rotation"
+                        );
+                        return SnapshotAdoption {
+                            adopted: false,
+                            version: snapshot.version,
+                            ..SnapshotAdoption::default()
+                        };
+                    }
+                }
             }
+        }
+
+        // Mark Restoring before the ownership flip so emission stays suppressed as the
+        // shuffle starts routing rows here.
+        if !newly_acquired.is_empty() {
+            registry.mark_restoring(&newly_acquired);
         }
 
         registry.set_assignment_and_version(new_assignment, snapshot.version);
@@ -622,20 +654,6 @@ impl LaminarDB {
             coord.set_gate_vnode_set((0..vnode_count).collect());
         }
         drop(guard);
-
-        let old_set: std::collections::HashSet<u32> = old_owned.into_iter().collect();
-        let newly_acquired: Vec<u32> = new_owned
-            .into_iter()
-            .filter(|v| !old_set.contains(v))
-            .collect();
-
-        // Mark Restoring before the (slow) durable read so the operator suppresses
-        // emission from the moment the shuffle starts routing rows here. Vnodes
-        // with no durable state flip back to Active immediately; staged ones stay
-        // Restoring until the graph applies their state.
-        if !newly_acquired.is_empty() {
-            registry.mark_restoring(&newly_acquired);
-        }
 
         let mut adoption = SnapshotAdoption {
             adopted: true,
@@ -709,6 +727,10 @@ impl LaminarDB {
                 registry.owner(v) == self_id && next.get(v as usize).copied() != Some(self_id)
             })
             .collect();
+        // Reset first so only this snapshot's revoking set stays marked (a newer
+        // draining snapshot may skip the committed snapshot that would have cleared
+        // the previous marks).
+        registry.clear_draining();
         if !revoking.is_empty() {
             tracing::info!(
                 count = revoking.len(),

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -610,6 +610,9 @@ impl LaminarDB {
         }
 
         registry.set_assignment_and_version(new_assignment, snapshot.version);
+        // The rotation committed: drop any pre-rotation drain marks. Revoked
+        // partitions are gone from the new assignment; the source resumes the rest.
+        registry.clear_draining();
         let new_owned = laminar_core::state::owned_vnodes(&registry, self_id);
         if let Some(backend) = self.state_backend.lock().clone() {
             backend.set_authoritative_version(snapshot.version);
@@ -679,6 +682,60 @@ impl LaminarDB {
             "adopted assignment snapshot",
         );
         adoption
+    }
+
+    /// Adopt the DRAIN phase of a rotation: mark the vnodes this node is about to
+    /// lose (owned now, not owned in `snapshot`) as draining so the source pauses
+    /// their partitions for a clean pre-rotation checkpoint cut. Ownership is NOT
+    /// changed — the committed snapshot (`draining = false`) does that later via
+    /// [`adopt_assignment_snapshot`](Self::adopt_assignment_snapshot). Returns the
+    /// vnodes marked draining (for the leader to log / wait on).
+    #[cfg(feature = "cluster")]
+    pub fn adopt_draining_snapshot(
+        &self,
+        snapshot: &laminar_core::cluster::control::AssignmentSnapshot,
+    ) -> Vec<u32> {
+        let Some(registry) = self.vnode_registry.lock().clone() else {
+            return Vec::new();
+        };
+        let vnode_count = registry.vnode_count();
+        let self_id = self
+            .cluster_controller
+            .lock()
+            .as_ref()
+            .map_or(laminar_core::state::NodeId(0), |c| {
+                laminar_core::state::NodeId(c.instance_id().0)
+            });
+        let next = snapshot.to_vnode_vec(vnode_count);
+        let revoking: Vec<u32> = (0..vnode_count)
+            .filter(|&v| {
+                registry.owner(v) == self_id && next.get(v as usize).copied() != Some(self_id)
+            })
+            .collect();
+        if !revoking.is_empty() {
+            tracing::info!(
+                count = revoking.len(),
+                version = snapshot.version,
+                "pre-rotation drain: pausing source for revoking vnodes"
+            );
+            registry.mark_draining(&revoking);
+        }
+        revoking
+    }
+
+    /// Whether vnode rotations should run the pre-rotation source drain (B2).
+    ///
+    /// Only under exactly-once: there the old owner must stop consuming a rotating
+    /// partition at the checkpoint cut, or it emits records past the sealed offset
+    /// that a non-upsert sink can't dedup. At-least-once pipelines tolerate the
+    /// bounded rotation duplicate and skip the drain. (An all-upsert exactly-once
+    /// pipeline would absorb the dup too; skipping the drain there is a future
+    /// optimization — correctness doesn't depend on it.)
+    #[cfg(feature = "cluster")]
+    #[must_use]
+    pub fn requires_rotation_drain(&self) -> bool {
+        self.config.delivery_guarantee
+            == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
     }
 
     /// Staged vnode state from the most recent rebalance adoptions, keyed by vnode.

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -592,11 +592,11 @@ impl LaminarDB {
         let old_owned = laminar_core::state::owned_vnodes(&registry, self_id);
 
         // Before bumping the assignment version (which triggers the source's
-        // partition rebind), stage the latest manifest's source offsets so an
-        // acquiring source can resume newly-owned partitions from the previous
-        // owner's sealed position instead of auto.offset.reset (which duplicates).
-        // Only when this node is actually acquiring a vnode — otherwise skip the
-        // object-store read. Operator state is rehydrated separately below.
+        // partition rebind), stage the cluster-wide source offsets (unioned from
+        // every node's blob in the shared state backend) so an acquiring source
+        // resumes newly-owned partitions from the previous owner's sealed position
+        // instead of auto.offset.reset (which duplicates). Only when this node is
+        // actually acquiring a vnode. Operator state is rehydrated separately below.
         let acquiring_any = {
             let old_set: std::collections::HashSet<u32> = old_owned.iter().copied().collect();
             (0..vnode_count).any(|v| {
@@ -605,7 +605,7 @@ impl LaminarDB {
         };
         if acquiring_any {
             if let Some(coord) = guard.as_ref() {
-                registry.stage_resume_offsets(coord.latest_source_offsets().await);
+                registry.stage_resume_offsets(coord.acquired_source_offsets().await);
             }
         }
 

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -108,6 +108,10 @@ pub struct LaminarDB {
     /// Set when a `stop_pipeline` times out so the watcher finalizes ShuttingDown→Created;
     /// keeps it from racing a normal stop/shutdown, which finalize themselves.
     pub(crate) stop_timed_out: Arc<std::sync::atomic::AtomicBool>,
+    /// Set at pipeline start when the pipeline has an exactly-once sink, so vnode
+    /// rotations run the pre-rotation source drain (B2). Read by
+    /// [`requires_rotation_drain`](Self::requires_rotation_drain).
+    pub(crate) rotation_drain_required: Arc<std::sync::atomic::AtomicBool>,
     pub(crate) runtime_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Decoupled coordinated-commit committer task; aborted on shutdown.
     pub(crate) committer_handle: parking_lot::Mutex<Option<tokio::task::JoinHandle<()>>>,
@@ -365,6 +369,7 @@ impl LaminarDB {
             state: Arc::new(std::sync::atomic::AtomicU8::new(DbState::Created as u8)),
             last_fault: Arc::new(parking_lot::Mutex::new(None)),
             stop_timed_out: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            rotation_drain_required: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             runtime_handle: parking_lot::Mutex::new(None),
             committer_handle: parking_lot::Mutex::new(None),
             shutdown_signal: Arc::new(tokio::sync::Notify::new()),
@@ -725,17 +730,18 @@ impl LaminarDB {
 
     /// Whether vnode rotations should run the pre-rotation source drain (B2).
     ///
-    /// Only under exactly-once: there the old owner must stop consuming a rotating
-    /// partition at the checkpoint cut, or it emits records past the sealed offset
-    /// that a non-upsert sink can't dedup. At-least-once pipelines tolerate the
-    /// bounded rotation duplicate and skip the drain. (An all-upsert exactly-once
-    /// pipeline would absorb the dup too; skipping the drain there is a future
-    /// optimization — correctness doesn't depend on it.)
-    #[cfg(feature = "cluster")]
+    /// True when the running pipeline has an exactly-once sink: there the old
+    /// owner must stop consuming a rotating partition at the checkpoint cut, or it
+    /// emits records past the sealed offset that a non-upsert sink can't dedup.
+    /// Set from the actual registered sinks at pipeline start (the server
+    /// configures delivery per sink, not via the DB-level `delivery_guarantee`).
+    /// At-least-once pipelines skip the drain and tolerate the bounded rotation
+    /// duplicate. (An all-upsert EO pipeline would absorb the dup too; skipping the
+    /// drain there is a future optimization — correctness doesn't depend on it.)
     #[must_use]
     pub fn requires_rotation_drain(&self) -> bool {
-        self.config.delivery_guarantee
-            == laminar_connectors::connector::DeliveryGuarantee::ExactlyOnce
+        self.rotation_drain_required
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Staged vnode state from the most recent rebalance adoptions, keyed by vnode.

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -1092,8 +1092,7 @@ impl GraphOperator for SqlQueryOperator {
                 // Fold into the pending restore; vnodes are disjoint so concatenating groups is safe.
                 match self.pending_restore {
                     Some(ref mut existing) if existing.fingerprint == cp.fingerprint => {
-                        existing.groups.extend(cp.groups);
-                        existing.last_emitted.extend(cp.last_emitted);
+                        existing.append_disjoint(cp)?;
                     }
                     Some(_) => tracing::warn!(
                         query = %self.op_name, vnode,
@@ -1396,7 +1395,10 @@ mod promotion_tests {
         let decoded: AggOpCheckpoint =
             rkyv::from_bytes::<AggOpCheckpoint, rkyv::rancor::Error>(&manifest.data).unwrap();
         assert!(
-            decoded.agg.as_ref().is_some_and(|a| a.groups.is_empty()),
+            decoded
+                .agg
+                .as_ref()
+                .is_some_and(|a| a.last_updated_ms.is_empty()),
             "all vnodes demoted → manifest carries no groups"
         );
         let mut cold_listed: Vec<u32> = decoded.cold_vnodes.clone();

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -1394,12 +1394,13 @@ mod promotion_tests {
         let manifest = op.checkpoint().unwrap().expect("non-empty manifest");
         let decoded: AggOpCheckpoint =
             rkyv::from_bytes::<AggOpCheckpoint, rkyv::rancor::Error>(&manifest.data).unwrap();
+        let agg = decoded.agg.as_ref().expect("agg payload present");
         assert!(
-            decoded
-                .agg
-                .as_ref()
-                .is_some_and(|a| a.last_updated_ms.is_empty()),
-            "all vnodes demoted → manifest carries no groups"
+            agg.last_updated_ms.is_empty()
+                && agg.keys_ipc.is_empty()
+                && agg.acc_state_ipc.iter().all(Vec::is_empty)
+                && agg.last_emitted.is_empty(),
+            "all vnodes demoted → manifest carries no group-bearing payload"
         );
         let mut cold_listed: Vec<u32> = decoded.cold_vnodes.clone();
         cold_listed.sort_unstable();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -1562,6 +1562,14 @@ impl LaminarDB {
                     );
                 }
             }
+
+            // Drive the B2 pre-rotation drain off the actual sinks: an exactly-once
+            // sink can't dedup a rotation duplicate, so a vnode rotation must pause
+            // the source at the checkpoint cut. (The DB-level `delivery_guarantee` is
+            // not set by the server, which configures delivery per sink.)
+            let has_eo_sink = sinks.iter().any(|(_, h, _, _, _)| h.exactly_once());
+            self.rotation_drain_required
+                .store(has_eo_sink, std::sync::atomic::Ordering::Release);
         }
 
         let shutdown = self.shutdown_signal.clone();

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -336,6 +336,14 @@ impl LaminarDB {
                     .max_uncommitted_epochs
                     .unwrap_or(defaults.max_uncommitted_epochs),
                 uncommitted_epochs_backpressure: cp_config.uncommitted_epochs_backpressure,
+                restorable_gate_poll_initial: cp_config.restorable_gate_poll_initial_ms.map_or(
+                    defaults.restorable_gate_poll_initial,
+                    std::time::Duration::from_millis,
+                ),
+                restorable_gate_poll_max: cp_config.restorable_gate_poll_max_ms.map_or(
+                    defaults.restorable_gate_poll_max,
+                    std::time::Duration::from_millis,
+                ),
                 ..defaults
             };
             let mut coord = CheckpointCoordinator::new(config, store).await?;

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -31,15 +31,11 @@ pub struct RebalanceConfig {
     pub checkpoint_timeout: Duration,
     /// Delay before retrying a failed rotation.
     pub retry_delay: Duration,
-    /// Bound on waiting for every live node to ack it adopted the draining
-    /// snapshot (paused its revoking partitions) before the pre-rotation
-    /// checkpoint. On timeout the rotation aborts and clears the drain. Must
-    /// exceed `watcher_poll` so nodes get a chance to observe the snapshot.
+    /// Bound on waiting for all live nodes to ack the draining snapshot before the
+    /// pre-rotation checkpoint; on timeout the rotation aborts. Must exceed `watcher_poll`.
     pub drain_ack_timeout: Duration,
-    /// Settle after the drain quorum acks, before the pre-rotation checkpoint:
-    /// covers the source reacting to the pause and the pipeline draining buffered
-    /// records so the checkpoint is a clean cut. Only used under exactly-once
-    /// (see [`LaminarDB::requires_rotation_drain`]).
+    /// Settle after the drain acks so the source reacts and buffered records flush,
+    /// before the checkpoint cut. Exactly-once only.
     pub drain_settle: Duration,
     /// Locality tier the placement metrics group by (0 = coarsest).
     pub placement_isolation_tier: usize,
@@ -356,12 +352,9 @@ async fn try_rebalance(
         );
     }
 
-    // Barrier-aligned handoff (B2): under exactly-once, first publish a draining
-    // snapshot so every node pauses the partitions of vnodes it is about to lose,
-    // settle, then take the pre-rotation checkpoint as a clean cut — the old owner
-    // stops consuming exactly at the sealed offset, so no records are emitted past
-    // it. Skipped when shedding a dead node (it can't drain) or when the pipeline
-    // isn't exactly-once.
+    // Exactly-once handoff: publish a draining snapshot so every node pauses the
+    // partitions it's losing, settle, then checkpoint as a clean cut. Skipped when
+    // shedding a dead node (it can't drain) or when not exactly-once.
     if !shedding_dead && db.requires_rotation_drain() {
         let mut drain = current.next(new_vnodes.clone());
         drain.draining = true;
@@ -374,9 +367,8 @@ async fn try_rebalance(
                 db.adopt_draining_snapshot(&drain);
                 controller.announce_snapshot_version(drain.version).await;
                 controller.announce_drained_version(drain.version).await;
-                // Wait for EVERY live node to ack it adopted the drain (paused its
-                // revoking partitions) before checkpointing — a fixed sleep would
-                // race the watcher poll interval and checkpoint un-paused nodes.
+                // Wait for every live node to ack the pause before checkpointing —
+                // a fixed sleep would race the watcher poll and capture un-paused nodes.
                 let acked =
                     await_drain_quorum(controller, live, drain.version, config.drain_ack_timeout)
                         .await;
@@ -385,14 +377,11 @@ async fn try_rebalance(
                     let _ = commit_snapshot(db, store, controller, abort, drain.version).await;
                     return Err("drain ack quorum not reached before timeout".into());
                 }
-                // Acked = paused; this short settle covers the source reacting and the
-                // pipeline flushing buffered records so the checkpoint is a clean cut.
                 tokio::time::sleep(config.drain_settle).await;
                 let ckpt = pre_rotation_checkpoint(db, config).await?;
                 if !ckpt {
-                    // Checkpoint failed mid-drain: re-publish the CURRENT assignment
-                    // (no rotation) so nodes clear the drain and resume, then surface
-                    // the failure for retry. Availability over strictness on failure.
+                    // Re-publish the current assignment so nodes clear the drain and
+                    // resume, then surface the failure for retry.
                     let abort = drain.next(current.vnodes.clone());
                     let _ = commit_snapshot(db, store, controller, abort, drain.version).await;
                     return Err("pre-rotation checkpoint failed during drain".into());

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -378,13 +378,15 @@ async fn try_rebalance(
                     return Err("drain ack quorum not reached before timeout".into());
                 }
                 tokio::time::sleep(config.drain_settle).await;
-                let ckpt = pre_rotation_checkpoint(db, config).await?;
-                if !ckpt {
-                    // Re-publish the current assignment so nodes clear the drain and
-                    // resume, then surface the failure for retry.
+                // Abort the drain on failure OR timeout (not just Ok(false)) — a bare
+                // `?` here would leave nodes stuck draining.
+                let checkpointed = pre_rotation_checkpoint(db, config).await;
+                if !matches!(checkpointed, Ok(true)) {
                     let abort = drain.next(current.vnodes.clone());
                     let _ = commit_snapshot(db, store, controller, abort, drain.version).await;
-                    return Err("pre-rotation checkpoint failed during drain".into());
+                    return Err(checkpointed
+                        .err()
+                        .unwrap_or_else(|| "pre-rotation checkpoint failed during drain".into()));
                 }
                 let commit = drain.next(new_vnodes);
                 return commit_snapshot(db, store, controller, commit, drain.version).await;

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -31,11 +31,15 @@ pub struct RebalanceConfig {
     pub checkpoint_timeout: Duration,
     /// Delay before retrying a failed rotation.
     pub retry_delay: Duration,
-    /// Settle window after publishing the draining snapshot, before the
-    /// pre-rotation checkpoint: time for every node to observe the drain, pause
-    /// the revoking partitions, and let the pipeline drain buffered records so the
-    /// checkpoint is a clean cut. Only used under exactly-once (see
-    /// [`LaminarDB::requires_rotation_drain`]).
+    /// Bound on waiting for every live node to ack it adopted the draining
+    /// snapshot (paused its revoking partitions) before the pre-rotation
+    /// checkpoint. On timeout the rotation aborts and clears the drain. Must
+    /// exceed `watcher_poll` so nodes get a chance to observe the snapshot.
+    pub drain_ack_timeout: Duration,
+    /// Settle after the drain quorum acks, before the pre-rotation checkpoint:
+    /// covers the source reacting to the pause and the pipeline draining buffered
+    /// records so the checkpoint is a clean cut. Only used under exactly-once
+    /// (see [`LaminarDB::requires_rotation_drain`]).
     pub drain_settle: Duration,
     /// Locality tier the placement metrics group by (0 = coarsest).
     pub placement_isolation_tier: usize,
@@ -52,6 +56,7 @@ impl Default for RebalanceConfig {
             // rotation is what restores commit availability).
             checkpoint_timeout: Duration::from_secs(15),
             retry_delay: Duration::from_secs(2),
+            drain_ack_timeout: Duration::from_secs(10),
             drain_settle: Duration::from_secs(1),
             placement_isolation_tier: 0,
         }
@@ -68,6 +73,7 @@ impl RebalanceConfig {
             rebalance_debounce: Duration::from_millis(500),
             checkpoint_timeout: Duration::from_secs(30),
             retry_delay: Duration::from_millis(500),
+            drain_ack_timeout: Duration::from_secs(5),
             drain_settle: Duration::from_millis(300),
             placement_isolation_tier: 0,
         }
@@ -134,6 +140,10 @@ pub fn spawn_snapshot_watcher(
                     {
                         last_drained = snap.version;
                         db.adopt_draining_snapshot(&snap);
+                        // Ack so the leader knows we've paused before it checkpoints.
+                        if let Some(ref c) = controller {
+                            c.announce_drained_version(snap.version).await;
+                        }
                     }
                     Ok(Some(snap)) if !snap.draining && snap.version > local => {
                         debug!(local, remote = snap.version, "adopting newer assignment");
@@ -363,7 +373,20 @@ async fn try_rebalance(
             RotateOutcome::Rotated => {
                 db.adopt_draining_snapshot(&drain);
                 controller.announce_snapshot_version(drain.version).await;
-                // Let every node observe the drain, pause, and flush buffered records.
+                controller.announce_drained_version(drain.version).await;
+                // Wait for EVERY live node to ack it adopted the drain (paused its
+                // revoking partitions) before checkpointing — a fixed sleep would
+                // race the watcher poll interval and checkpoint un-paused nodes.
+                let acked =
+                    await_drain_quorum(controller, live, drain.version, config.drain_ack_timeout)
+                        .await;
+                if !acked {
+                    let abort = drain.next(current.vnodes.clone());
+                    let _ = commit_snapshot(db, store, controller, abort, drain.version).await;
+                    return Err("drain ack quorum not reached before timeout".into());
+                }
+                // Acked = paused; this short settle covers the source reacting and the
+                // pipeline flushing buffered records so the checkpoint is a clean cut.
                 tokio::time::sleep(config.drain_settle).await;
                 let ckpt = pre_rotation_checkpoint(db, config).await?;
                 if !ckpt {
@@ -417,6 +440,34 @@ async fn pre_rotation_checkpoint(
         })?
         .map_err(|e| e.to_string())?;
     Ok(ckpt.success)
+}
+
+/// Wait until every node in `live` has gossip-acked it adopted draining `version`
+/// (paused its revoking partitions). Returns false on timeout. Polls because the
+/// ack arrives via gossip after each node's watcher observes the draining snapshot.
+async fn await_drain_quorum(
+    controller: &Arc<ClusterController>,
+    live: &[NodeId],
+    version: u64,
+    timeout: Duration,
+) -> bool {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let acked: std::collections::HashSet<NodeId> = controller
+                .read_drained_versions()
+                .await
+                .into_iter()
+                .filter(|(_, v)| *v >= version)
+                .map(|(n, _)| n)
+                .collect();
+            if live.iter().all(|n| acked.contains(n)) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .is_ok()
 }
 
 /// CAS a committed (non-draining) snapshot, adopt it, announce, and prune. On a

--- a/crates/laminar-db/src/rebalance.rs
+++ b/crates/laminar-db/src/rebalance.rs
@@ -31,6 +31,12 @@ pub struct RebalanceConfig {
     pub checkpoint_timeout: Duration,
     /// Delay before retrying a failed rotation.
     pub retry_delay: Duration,
+    /// Settle window after publishing the draining snapshot, before the
+    /// pre-rotation checkpoint: time for every node to observe the drain, pause
+    /// the revoking partitions, and let the pipeline drain buffered records so the
+    /// checkpoint is a clean cut. Only used under exactly-once (see
+    /// [`LaminarDB::requires_rotation_drain`]).
+    pub drain_settle: Duration,
     /// Locality tier the placement metrics group by (0 = coarsest).
     pub placement_isolation_tier: usize,
 }
@@ -46,6 +52,7 @@ impl Default for RebalanceConfig {
             // rotation is what restores commit availability).
             checkpoint_timeout: Duration::from_secs(15),
             retry_delay: Duration::from_secs(2),
+            drain_settle: Duration::from_secs(1),
             placement_isolation_tier: 0,
         }
     }
@@ -61,6 +68,7 @@ impl RebalanceConfig {
             rebalance_debounce: Duration::from_millis(500),
             checkpoint_timeout: Duration::from_secs(30),
             retry_delay: Duration::from_millis(500),
+            drain_settle: Duration::from_millis(300),
             placement_isolation_tier: 0,
         }
     }
@@ -95,6 +103,9 @@ pub fn spawn_snapshot_watcher(
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         ticker.tick().await; // burn the immediate first tick
         let mut published_version = 0;
+        // Highest draining snapshot already adopted; a draining snapshot doesn't
+        // bump the registry version, so this prevents re-adopting it every tick.
+        let mut last_drained = 0u64;
         loop {
             tokio::select! {
                 biased;
@@ -114,7 +125,17 @@ pub fn spawn_snapshot_watcher(
 
             if remote_newer {
                 match store.load().await {
-                    Ok(Some(snap)) if snap.version > local => {
+                    // Drain phase: pause the partitions of vnodes we're about to
+                    // lose; ownership is unchanged so the registry version stays put.
+                    Ok(Some(snap))
+                        if snap.draining
+                            && snap.version > local
+                            && snap.version != last_drained =>
+                    {
+                        last_drained = snap.version;
+                        db.adopt_draining_snapshot(&snap);
+                    }
+                    Ok(Some(snap)) if !snap.draining && snap.version > local => {
                         debug!(local, remote = snap.version, "adopting newer assignment");
                         let adoption = db.adopt_assignment_snapshot(snap).await;
                         log_adoption("watcher", &adoption);
@@ -323,26 +344,92 @@ async fn try_rebalance(
             "rotation sheds a dead node — skipping the pre-rotation drain \
              checkpoint (it cannot seal without the dead node's captures)"
         );
-    } else {
-        let ckpt = tokio::time::timeout(config.checkpoint_timeout, db.checkpoint())
+    }
+
+    // Barrier-aligned handoff (B2): under exactly-once, first publish a draining
+    // snapshot so every node pauses the partitions of vnodes it is about to lose,
+    // settle, then take the pre-rotation checkpoint as a clean cut — the old owner
+    // stops consuming exactly at the sealed offset, so no records are emitted past
+    // it. Skipped when shedding a dead node (it can't drain) or when the pipeline
+    // isn't exactly-once.
+    if !shedding_dead && db.requires_rotation_drain() {
+        let mut drain = current.next(new_vnodes.clone());
+        drain.draining = true;
+        match store
+            .save_if_version(&drain, current.version)
             .await
-            .map_err(|_| {
-                format!(
-                    "pre-rotation checkpoint did not complete within {}s",
-                    config.checkpoint_timeout.as_secs()
-                )
-            })?
-            .map_err(|e| e.to_string())?;
-        if !ckpt.success {
-            return Err(ckpt
-                .error
-                .unwrap_or_else(|| "checkpoint returned success=false".into()));
+            .map_err(|e| e.to_string())?
+        {
+            RotateOutcome::Rotated => {
+                db.adopt_draining_snapshot(&drain);
+                controller.announce_snapshot_version(drain.version).await;
+                // Let every node observe the drain, pause, and flush buffered records.
+                tokio::time::sleep(config.drain_settle).await;
+                let ckpt = pre_rotation_checkpoint(db, config).await?;
+                if !ckpt {
+                    // Checkpoint failed mid-drain: re-publish the CURRENT assignment
+                    // (no rotation) so nodes clear the drain and resume, then surface
+                    // the failure for retry. Availability over strictness on failure.
+                    let abort = drain.next(current.vnodes.clone());
+                    let _ = commit_snapshot(db, store, controller, abort, drain.version).await;
+                    return Err("pre-rotation checkpoint failed during drain".into());
+                }
+                let commit = drain.next(new_vnodes);
+                return commit_snapshot(db, store, controller, commit, drain.version).await;
+            }
+            RotateOutcome::Conflict(winner) => {
+                let v = winner.version;
+                adopt_any(db, winner).await;
+                controller.announce_snapshot_version(v).await;
+                return Ok(Some(v));
+            }
         }
     }
 
-    let proposal = current.next(new_vnodes);
+    // Single-phase path: dead-node shedding, or a non-exactly-once pipeline that
+    // tolerates the bounded rotation duplicate.
+    if !shedding_dead && !pre_rotation_checkpoint(db, config).await? {
+        return Err("pre-rotation checkpoint returned success=false".into());
+    }
+    commit_snapshot(
+        db,
+        store,
+        controller,
+        current.next(new_vnodes),
+        current.version,
+    )
+    .await
+}
+
+/// Run the pre-rotation checkpoint with the configured timeout. `Ok(true)` on a
+/// successful seal, `Ok(false)` if the checkpoint ran but did not succeed.
+async fn pre_rotation_checkpoint(
+    db: &Arc<LaminarDB>,
+    config: RebalanceConfig,
+) -> Result<bool, String> {
+    let ckpt = tokio::time::timeout(config.checkpoint_timeout, db.checkpoint())
+        .await
+        .map_err(|_| {
+            format!(
+                "pre-rotation checkpoint did not complete within {}s",
+                config.checkpoint_timeout.as_secs()
+            )
+        })?
+        .map_err(|e| e.to_string())?;
+    Ok(ckpt.success)
+}
+
+/// CAS a committed (non-draining) snapshot, adopt it, announce, and prune. On a
+/// CAS conflict adopt the winner instead and let the next cycle re-evaluate.
+async fn commit_snapshot(
+    db: &Arc<LaminarDB>,
+    store: &Arc<AssignmentSnapshotStore>,
+    controller: &Arc<ClusterController>,
+    proposal: AssignmentSnapshot,
+    prev_version: u64,
+) -> Result<Option<u64>, String> {
     match store
-        .save_if_version(&proposal, current.version)
+        .save_if_version(&proposal, prev_version)
         .await
         .map_err(|e| e.to_string())?
     {
@@ -352,19 +439,27 @@ async fn try_rebalance(
             log_adoption("rebalance", &adoption);
             controller.announce_snapshot_version(v).await;
             // Retain [v-1, v] as slack for in-flight readers.
-            let prune = v.saturating_sub(1);
-            if let Err(e) = store.prune_before(prune).await {
+            if let Err(e) = store.prune_before(v.saturating_sub(1)).await {
                 warn!(error = %e, "snapshot prune failed");
             }
             Ok(Some(v))
         }
         RotateOutcome::Conflict(winner) => {
             let v = winner.version;
-            let adoption = db.adopt_assignment_snapshot(winner).await;
-            log_adoption("rebalance-conflict", &adoption);
+            adopt_any(db, winner).await;
             controller.announce_snapshot_version(v).await;
             Ok(Some(v))
         }
+    }
+}
+
+/// Adopt a snapshot whether it is a draining or a committed one.
+async fn adopt_any(db: &Arc<LaminarDB>, snap: AssignmentSnapshot) {
+    if snap.draining {
+        db.adopt_draining_snapshot(&snap);
+    } else {
+        let adoption = db.adopt_assignment_snapshot(snap).await;
+        log_adoption("rebalance-conflict", &adoption);
     }
 }
 

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -486,6 +486,93 @@ mod rebalance {
         harness.shutdown().await;
     }
 
+    /// B2 barrier-aligned handoff: the draining phase marks a node's to-be-lost
+    /// vnodes draining (so its source pauses them for a clean checkpoint cut)
+    /// WITHOUT changing ownership; the committed phase then rotates and clears the
+    /// drain.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn snapshot_watcher_handles_draining_phase() {
+        let mut harness = ClusterEngineHarness::spawn(N_NODES, VNODE_COUNT).await;
+        harness.start_all().await;
+
+        let store: Arc<AssignmentSnapshotStore> =
+            Arc::clone(&harness.nodes[0].assignment_snapshot_store);
+        let seed = store.load().await.unwrap().unwrap();
+
+        let leader = NodeId(harness.nodes[harness.leader_idx()].instance_id.0);
+        let follower_idx = harness.follower_idxs()[0];
+        let lost = harness.nodes[follower_idx].owned_vnodes();
+        assert!(
+            !lost.is_empty(),
+            "test needs the follower to own vnodes to drain"
+        );
+
+        // Everything moves to the leader; the follower loses all its vnodes.
+        let mut vnodes = BTreeMap::new();
+        for v in 0..VNODE_COUNT {
+            vnodes.insert(v, leader);
+        }
+
+        // Phase 1: draining snapshot — the follower marks its lost vnodes draining
+        // but ownership (the registry version) does not change.
+        let pre_version = harness.nodes[follower_idx]
+            .vnode_registry
+            .assignment_version();
+        let mut drain = seed.next(vnodes.clone());
+        drain.draining = true;
+        assert!(matches!(
+            store.save_if_version(&drain, seed.version).await.unwrap(),
+            RotateOutcome::Rotated,
+        ));
+        wait_for(
+            || {
+                lost.iter()
+                    .all(|&v| harness.nodes[follower_idx].vnode_registry.is_draining(v))
+            },
+            "follower marks its lost vnodes draining",
+        )
+        .await;
+        assert_eq!(
+            harness.nodes[follower_idx]
+                .vnode_registry
+                .assignment_version(),
+            pre_version,
+            "drain phase must not change ownership",
+        );
+
+        // Phase 2: committed snapshot — ownership rotates and the drain clears.
+        let commit = drain.next(vnodes);
+        let expected = commit.version;
+        assert!(matches!(
+            store.save_if_version(&commit, drain.version).await.unwrap(),
+            RotateOutcome::Rotated,
+        ));
+        wait_for(
+            || {
+                harness
+                    .nodes
+                    .iter()
+                    .all(|n| n.vnode_registry.assignment_version() >= expected)
+            },
+            "every node adopts the committed snapshot",
+        )
+        .await;
+        for node in &harness.nodes {
+            for v in 0..VNODE_COUNT {
+                assert!(
+                    !node.vnode_registry.is_draining(v),
+                    "draining must clear on commit",
+                );
+            }
+        }
+        assert_eq!(
+            harness.nodes[harness.leader_idx()].owned_vnodes().len(),
+            VNODE_COUNT as usize,
+        );
+
+        harness.shutdown().await;
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_rotation_picks_single_winner() {
         let mut harness = ClusterEngineHarness::spawn(N_NODES, VNODE_COUNT).await;

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -464,8 +464,7 @@ pub struct CheckpointSection {
     #[serde(default)]
     pub uncommitted_epochs_backpressure: bool,
     /// Durability-gate poll first interval in ms (default 100). Tighten on a
-    /// low-latency object store to cut the poll quantization that dominates
-    /// sub-second checkpoint latency.
+    /// low-latency object store to cut poll quantization.
     #[serde(default)]
     pub restorable_gate_poll_initial_ms: Option<u64>,
     /// Durability-gate poll backoff cap in ms (default 1000).

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -463,6 +463,14 @@ pub struct CheckpointSection {
     /// `max_uncommitted_epochs`, bounding object-storage growth. Default false.
     #[serde(default)]
     pub uncommitted_epochs_backpressure: bool,
+    /// Durability-gate poll first interval in ms (default 100). Tighten on a
+    /// low-latency object store to cut the poll quantization that dominates
+    /// sub-second checkpoint latency.
+    #[serde(default)]
+    pub restorable_gate_poll_initial_ms: Option<u64>,
+    /// Durability-gate poll backoff cap in ms (default 1000).
+    #[serde(default)]
+    pub restorable_gate_poll_max_ms: Option<u64>,
 }
 
 impl Default for CheckpointSection {
@@ -476,6 +484,8 @@ impl Default for CheckpointSection {
             max_staged_bytes: None,
             max_uncommitted_epochs: None,
             uncommitted_epochs_backpressure: false,
+            restorable_gate_poll_initial_ms: None,
+            restorable_gate_poll_max_ms: None,
         }
     }
 }

--- a/crates/laminar-server/src/server.rs
+++ b/crates/laminar-server/src/server.rs
@@ -294,6 +294,8 @@ pub(crate) fn apply_checkpoint_config(
         max_staged_bytes: checkpoint.max_staged_bytes,
         max_uncommitted_epochs: checkpoint.max_uncommitted_epochs,
         uncommitted_epochs_backpressure: checkpoint.uncommitted_epochs_backpressure,
+        restorable_gate_poll_initial_ms: checkpoint.restorable_gate_poll_initial_ms,
+        restorable_gate_poll_max_ms: checkpoint.restorable_gate_poll_max_ms,
     };
     builder = builder.checkpoint(cfg);
 

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -139,6 +139,12 @@ fn eo_topic(id: usize) -> String {
 
 fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -> PathBuf {
     let depth = env_u64("LAMINAR_SOAK_DEPTH", 4);
+    // A/B the durability-gate poll cadence: `LAMINAR_SOAK_GATE_POLL_MS` sets the
+    // initial (and, unless `_MAX_MS` overrides, the cap). Unset = engine default.
+    let gate_poll = std::env::var("LAMINAR_SOAK_GATE_POLL_MS").map_or(String::new(), |ms| {
+        let max = std::env::var("LAMINAR_SOAK_GATE_POLL_MAX_MS").unwrap_or_else(|_| ms.clone());
+        format!("restorable_gate_poll_initial_ms = {ms}\nrestorable_gate_poll_max_ms = {max}")
+    });
     // Vnode partials go through the [state] backend, NOT [checkpoint] -
     // without a SHARED state store each node writes partials to its own
     // local default and the leader durability gate (which lists the
@@ -234,6 +240,7 @@ url = "{url}"
 interval = "{interval_ms}ms"
 max_retained = 5
 max_in_flight_epochs = {depth}
+{gate_poll}
 
 [checkpoint.storage]
 {storage}
@@ -574,6 +581,25 @@ fn three_node_kill9_soak() {
     }
 
     eprintln!("soak: completed {round} rounds ({kills} kills), final epoch {floor}");
+
+    // Durability-gate poll wait vs whole checkpoint (leader-only metric; sum across
+    // nodes picks it up). avg = histogram sum/count.
+    {
+        let m = |n: &str| -> f64 { nodes.iter().filter_map(|x| x.metric(n)).sum() };
+        let gw_sum = m("laminardb_checkpoint_restorable_gate_wait_seconds_sum");
+        let gw_cnt = m("laminardb_checkpoint_restorable_gate_wait_seconds_count");
+        let cd_sum = m("laminardb_checkpoint_duration_seconds_sum");
+        let cd_cnt = m("laminardb_checkpoint_duration_seconds_count");
+        if gw_cnt > 0.0 {
+            eprintln!(
+                "soak: PROFILE gate-wait avg={:.0}ms over {} obs; checkpoint_duration avg={:.0}ms over {} obs",
+                gw_sum / gw_cnt * 1000.0,
+                gw_cnt as u64,
+                cd_sum / cd_cnt.max(1.0) * 1000.0,
+                cd_cnt as u64,
+            );
+        }
+    }
 
     // Tier validation: scrape while every node is still live (the Kafka
     // diff below kills them all). Demotions prove the budget→demote

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -142,8 +142,14 @@ fn write_config(dir: &Path, id: usize, interval_ms: u64, checkpoint_url: &str) -
     // A/B the durability-gate poll cadence: `LAMINAR_SOAK_GATE_POLL_MS` sets the
     // initial (and, unless `_MAX_MS` overrides, the cap). Unset = engine default.
     let gate_poll = std::env::var("LAMINAR_SOAK_GATE_POLL_MS").map_or(String::new(), |ms| {
-        let max = std::env::var("LAMINAR_SOAK_GATE_POLL_MAX_MS").unwrap_or_else(|_| ms.clone());
-        format!("restorable_gate_poll_initial_ms = {ms}\nrestorable_gate_poll_max_ms = {max}")
+        let initial: u64 = ms
+            .parse()
+            .expect("LAMINAR_SOAK_GATE_POLL_MS must be a u64 (ms)");
+        let max: u64 = std::env::var("LAMINAR_SOAK_GATE_POLL_MAX_MS").map_or(initial, |v| {
+            v.parse()
+                .expect("LAMINAR_SOAK_GATE_POLL_MAX_MS must be a u64 (ms)")
+        });
+        format!("restorable_gate_poll_initial_ms = {initial}\nrestorable_gate_poll_max_ms = {max}")
     });
     // Vnode partials go through the [state] backend, NOT [checkpoint] -
     // without a SHARED state store each node writes partials to its own

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -620,3 +620,344 @@ fn three_node_kill9_soak() {
         verify_exactly_once_output(&brokers);
     }
 }
+
+// ── Graceful-rotation soak (B2) ─────────────────────────────────────────────
+
+/// Node config for the graceful-rotation soak: a SHARED vnode-partitioned Kafka
+/// source over `input_topic`, a pass-through pipeline, and a per-node exactly-once
+/// Kafka sink. The exactly-once sink is what makes a vnode rotation run the B2
+/// pre-rotation drain. `seeds` covers all nodes (incl. the one added mid-run).
+fn write_graceful_config(
+    dir: &Path,
+    id: usize,
+    n_nodes: usize,
+    interval_ms: u64,
+    checkpoint_url: &str,
+    brokers: &str,
+    input_topic: &str,
+) -> PathBuf {
+    let state_shared = dir.join("state");
+    std::fs::create_dir_all(&state_shared).unwrap();
+    let state_url = format!(
+        "file:///{}",
+        state_shared.display().to_string().replace('\\', "/")
+    );
+    let http = BASE_PORT + id as u16;
+    let gossip = BASE_PORT + 100 + id as u16;
+    let seeds: Vec<String> = (0..n_nodes)
+        .map(|i| format!("\"127.0.0.1:{}\"", BASE_PORT + 100 + i as u16))
+        .collect();
+    let data_dir = dir.join(format!("node{id}-data"));
+    std::fs::create_dir_all(&data_dir).unwrap();
+
+    let toml = format!(
+        r#"
+node_id = "n{id}"
+storage_dir = "{data}"
+
+[server]
+mode = "cluster"
+bind = "127.0.0.1:{http}"
+
+[discovery]
+strategy = "gossip"
+seeds = [{seeds}]
+gossip_port = {gossip}
+advertise_host = "127.0.0.1"
+
+[coordination]
+strategy = "raft"
+
+[state]
+backend = "object_store"
+url = "{state_url}"
+instance_id = "n{id}"
+vnode_capacity = 64
+
+[checkpoint]
+url = "{url}"
+interval = "{interval_ms}ms"
+max_retained = 5
+max_in_flight_epochs = 4
+
+[[source]]
+name = "kin"
+connector = "kafka"
+format = "json"
+[source.properties]
+"bootstrap.servers" = "{brokers}"
+topic = "{input_topic}"
+"group.id" = "soak-grace-n{id}"
+"startup.mode" = "earliest"
+[[source.schema]]
+name = "seq"
+type = "BIGINT"
+nullable = false
+
+[[pipeline]]
+name = "passthrough"
+sql = "SELECT seq FROM kin"
+
+[[sink]]
+name = "kout"
+pipeline = "passthrough"
+connector = "kafka"
+delivery = "exactly_once"
+[sink.properties]
+"bootstrap.servers" = "{brokers}"
+topic = "{topic}"
+format = "json"
+"delivery.guarantee" = "exactly-once"
+"#,
+        data = data_dir.display().to_string().replace('\\', "/"),
+        seeds = seeds.join(", "),
+        url = checkpoint_url,
+        topic = eo_topic(id),
+    );
+    let path = dir.join(format!("node{id}.toml"));
+    std::fs::write(&path, toml).unwrap();
+    path
+}
+
+/// Create `topic` with `partitions` partitions (blocking; the admin API is async).
+fn kafka_create_topic(brokers: &str, topic: &str, partitions: i32) {
+    use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+    use rdkafka::client::DefaultClientContext;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let admin: AdminClient<DefaultClientContext> = rdkafka::ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .create()
+            .expect("admin client");
+        let new = NewTopic::new(topic, partitions, TopicReplication::Fixed(1));
+        admin
+            .create_topics([&new], &AdminOptions::new())
+            .await
+            .expect("create_topics");
+    });
+}
+
+/// Produce `{"seq": n}` for `n in 0..count`, keyed by `seq` (spreads across
+/// partitions), paced near `rps` so the cluster is still consuming during the
+/// mid-run rotation. Blocks until all are produced and flushed.
+fn produce_seq(brokers: &str, topic: &str, count: i64, rps: u64) {
+    use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
+    let producer: BaseProducer = rdkafka::ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .create()
+        .expect("producer");
+    let batch = (rps / 20).max(1) as i64; // ~20 bursts/sec
+    let mut n = 0i64;
+    while n < count {
+        for _ in 0..batch.min(count - n) {
+            let payload = format!(r#"{{"seq":{n}}}"#);
+            let key = n.to_string();
+            let mut rec = BaseRecord::to(topic).payload(&payload).key(&key);
+            loop {
+                match producer.send(rec) {
+                    Ok(()) => break,
+                    Err((
+                        rdkafka::error::KafkaError::MessageProduction(
+                            rdkafka::types::RDKafkaErrorCode::QueueFull,
+                        ),
+                        r,
+                    )) => {
+                        rec = r;
+                        producer.poll(Duration::from_millis(20));
+                    }
+                    Err((e, _)) => panic!("produce: {e}"),
+                }
+            }
+            n += 1;
+        }
+        producer.poll(Duration::from_millis(0));
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    producer.flush(Duration::from_secs(60)).expect("flush");
+}
+
+/// All `seq` values across every node's output topic, with per-topic counts.
+fn collect_output_seqs(brokers: &str, n_nodes: usize) -> (Vec<i64>, Vec<usize>) {
+    use rdkafka::consumer::{BaseConsumer, Consumer};
+    use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
+    let mut all = Vec::new();
+    let mut per_topic = vec![0usize; n_nodes];
+    for id in 0..n_nodes {
+        let topic = eo_topic(id);
+        let consumer: BaseConsumer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set(
+                "group.id",
+                format!("soak-grace-diff-{}", std::process::id()),
+            )
+            .set("enable.auto.commit", "false")
+            .set("auto.offset.reset", "earliest")
+            .set("isolation.level", "read_committed")
+            .create()
+            .expect("diff consumer");
+        let Ok(md) = consumer.fetch_metadata(Some(&topic), Duration::from_secs(10)) else {
+            continue; // topic may not exist yet (node never owned a partition)
+        };
+        let parts: Vec<i32> = md
+            .topics()
+            .first()
+            .map(|t| {
+                t.partitions()
+                    .iter()
+                    .map(rdkafka::metadata::MetadataPartition::id)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if parts.is_empty() {
+            continue;
+        }
+        let mut tpl = TopicPartitionList::new();
+        for p in parts {
+            tpl.add_partition_offset(&topic, p, Offset::Beginning)
+                .unwrap();
+        }
+        consumer.assign(&tpl).expect("assign");
+        let mut idle = 0u32;
+        while idle < 5 {
+            match consumer.poll(Duration::from_secs(2)) {
+                Some(Ok(msg)) => {
+                    idle = 0;
+                    let v: serde_json::Value =
+                        serde_json::from_slice(msg.payload().unwrap_or_default()).expect("json");
+                    all.push(v["seq"].as_i64().expect("seq"));
+                    per_topic[id] += 1;
+                }
+                Some(Err(e)) => panic!("{topic}: consume error: {e}"),
+                None => idle += 1,
+            }
+        }
+    }
+    (all, per_topic)
+}
+
+/// B2 end-to-end: a shared Kafka source is consumed across the cluster; adding a
+/// node mid-run triggers a GRACEFUL vnode rotation (the exactly-once sink makes it
+/// run the pre-rotation drain). The union of all output topics must then be a
+/// dense `0..=TOTAL-1` with no duplicates — proving the rotation handed off each
+/// partition at a clean cut.
+#[test]
+#[ignore = "spawns 4 real laminardb processes; needs LAMINAR_SOAK_KAFKA_BROKERS; run with --ignored"]
+fn graceful_rotation_kafka_soak() {
+    let brokers = std::env::var("LAMINAR_SOAK_KAFKA_BROKERS")
+        .expect("graceful_rotation_kafka_soak requires LAMINAR_SOAK_KAFKA_BROKERS");
+    let interval_ms = env_u64("LAMINAR_SOAK_INTERVAL_MS", 200).max(100);
+    let total: i64 = env_u64("LAMINAR_SOAK_TOTAL", 12000) as i64;
+    const INITIAL: usize = 3;
+    const ALL: usize = 4; // a 4th node joins mid-run
+                          // Enough partitions that the added node reliably acquires some (64 vnodes,
+                          // 4 nodes → ~1/4 each; with 12 partitions the join almost surely moves one).
+    const PARTS: i32 = 12;
+
+    let input = format!("soak-grace-in-{}", std::process::id());
+    kafka_create_topic(&brokers, &input, PARTS);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cp = dir.path().join("checkpoints");
+    std::fs::create_dir_all(&cp).unwrap();
+    let url = format!("file:///{}", cp.display().to_string().replace('\\', "/"));
+    let log_dir =
+        Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!("soak-grace-{}", std::process::id()));
+    std::fs::create_dir_all(&log_dir).unwrap();
+    eprintln!("soak: node logs in {}", log_dir.display());
+
+    let mut nodes: Vec<Node> = (0..ALL)
+        .map(|id| Node {
+            id,
+            config_path: write_graceful_config(
+                dir.path(),
+                id,
+                // Seed only the initial set so formation completes before node 3
+                // exists; node 3 joins the running cluster via gossip on these seeds.
+                INITIAL,
+                interval_ms,
+                &url,
+                &brokers,
+                &input,
+            ),
+            log_path: log_dir.join(format!("node{id}.log")),
+            child: None,
+            http_port: BASE_PORT + id as u16,
+        })
+        .collect();
+
+    for id in 0..INITIAL {
+        nodes[id].spawn();
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    wait_for(
+        "initial nodes serving /metrics",
+        Duration::from_secs(60),
+        || nodes[..INITIAL].iter().all(|n| n.epoch().is_some()),
+    );
+    assert_progress(&nodes[..INITIAL], 0.0, Duration::from_secs(90), "startup");
+    eprintln!("soak: 3 nodes up; producing {total} records");
+
+    // Produce on a background thread at a modest rate so records are STILL
+    // flowing after the rotation settles — otherwise the backlog is consumed
+    // before node 3 acquires its partitions and it never sees data. At ~400/s a
+    // 12k run spans ~30s, well past the join + settle.
+    let (pb, pt) = (brokers.clone(), input.clone());
+    let producer = std::thread::spawn(move || produce_seq(&pb, &pt, total, 400));
+
+    std::thread::sleep(Duration::from_secs(3));
+    eprintln!("soak: adding node 3 → graceful rotation");
+    nodes[3].spawn();
+    wait_for("node 3 serving /metrics", Duration::from_secs(60), || {
+        nodes[3].epoch().is_some()
+    });
+    // Let the two-phase drain + reassignment settle; production continues meanwhile
+    // so node 3 consumes fresh records on its newly-acquired partitions.
+    std::thread::sleep(Duration::from_secs(15));
+
+    producer.join().expect("producer thread");
+    eprintln!("soak: produced all; waiting for the cluster to drain output");
+    wait_for("all records sunk", Duration::from_secs(180), || {
+        let (seqs, _) = collect_output_seqs(&brokers, ALL);
+        let mut s = seqs;
+        s.sort_unstable();
+        s.dedup();
+        s.len() >= total as usize
+    });
+
+    // Every input was already observed committed (the wait above reads
+    // read_committed), so the sinks are idle with no open transactions. Read the
+    // diff against the live, settled cluster: killing first only races the diff
+    // consumer against the kill and can surface transient phantom reads.
+    std::thread::sleep(Duration::from_secs(5));
+    let (mut seqs, per_topic) = collect_output_seqs(&brokers, ALL);
+    let count = seqs.len();
+    seqs.sort_unstable();
+    seqs.dedup();
+    let duplicates = count - seqs.len();
+    let max = seqs.last().copied().unwrap_or(-1);
+    let mut gaps = Vec::new();
+    let mut expected = 0i64;
+    for &s in &seqs {
+        if s != expected {
+            gaps.push((expected, s));
+            expected = s;
+        }
+        expected += 1;
+    }
+    eprintln!("soak: per-node output counts {per_topic:?}");
+    assert!(
+        per_topic[3] > 0,
+        "node 3 produced no output — the graceful rotation never moved partitions \
+         to it, so B2 was not exercised (per-topic {per_topic:?})",
+    );
+    assert!(
+        duplicates == 0 && gaps.is_empty() && max == total - 1,
+        "graceful-rotation exactly-once VIOLATED — {count} records, max seq {max} \
+         (want {}), {duplicates} duplicate(s), gap(s) {gaps:?}",
+        total - 1,
+    );
+    eprintln!("soak: graceful rotation exactly-once OK — union dense 0..={max}, 0 duplicates");
+}

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -785,7 +785,7 @@ fn collect_output_seqs(brokers: &str, n_nodes: usize) -> (Vec<i64>, Vec<usize>) 
     use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
     let mut all = Vec::new();
     let mut per_topic = vec![0usize; n_nodes];
-    for id in 0..n_nodes {
+    for (id, topic_count) in per_topic.iter_mut().enumerate() {
         let topic = eo_topic(id);
         let consumer: BaseConsumer = ClientConfig::new()
             .set("bootstrap.servers", brokers)
@@ -828,7 +828,7 @@ fn collect_output_seqs(brokers: &str, n_nodes: usize) -> (Vec<i64>, Vec<usize>) 
                     let v: serde_json::Value =
                         serde_json::from_slice(msg.payload().unwrap_or_default()).expect("json");
                     all.push(v["seq"].as_i64().expect("seq"));
-                    per_topic[id] += 1;
+                    *topic_count += 1;
                 }
                 Some(Err(e)) => panic!("{topic}: consume error: {e}"),
                 None => idle += 1,
@@ -887,8 +887,8 @@ fn graceful_rotation_kafka_soak() {
         })
         .collect();
 
-    for id in 0..INITIAL {
-        nodes[id].spawn();
+    for node in nodes.iter_mut().take(INITIAL) {
+        node.spawn();
         std::thread::sleep(Duration::from_millis(500));
     }
     wait_for(

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -623,14 +623,14 @@ fn three_node_kill9_soak() {
 
 // ── Graceful-rotation soak (B2) ─────────────────────────────────────────────
 
-/// Node config for the graceful-rotation soak: a SHARED vnode-partitioned Kafka
-/// source over `input_topic`, a pass-through pipeline, and a per-node exactly-once
-/// Kafka sink. The exactly-once sink is what makes a vnode rotation run the B2
-/// pre-rotation drain. `seeds` covers all nodes (incl. the one added mid-run).
+/// Node config for the graceful-rotation soak: a shared vnode-partitioned Kafka
+/// source, a pass-through pipeline, and a per-node exactly-once Kafka sink (the
+/// exactly-once sink is what makes a rotation run the pre-rotation drain). Seeds
+/// `n_seeds` nodes — the joiner discovers the cluster via gossip on these seeds.
 fn write_graceful_config(
     dir: &Path,
     id: usize,
-    n_nodes: usize,
+    n_seeds: usize,
     interval_ms: u64,
     checkpoint_url: &str,
     brokers: &str,
@@ -644,7 +644,7 @@ fn write_graceful_config(
     );
     let http = BASE_PORT + id as u16;
     let gossip = BASE_PORT + 100 + id as u16;
-    let seeds: Vec<String> = (0..n_nodes)
+    let seeds: Vec<String> = (0..n_seeds)
         .map(|i| format!("\"127.0.0.1:{}\"", BASE_PORT + 100 + i as u16))
         .collect();
     let data_dir = dir.join(format!("node{id}-data"));
@@ -852,8 +852,7 @@ fn graceful_rotation_kafka_soak() {
     let total: i64 = env_u64("LAMINAR_SOAK_TOTAL", 12000) as i64;
     const INITIAL: usize = 3;
     const ALL: usize = 4; // a 4th node joins mid-run
-                          // Enough partitions that the added node reliably acquires some (64 vnodes,
-                          // 4 nodes → ~1/4 each; with 12 partitions the join almost surely moves one).
+                          // Enough partitions that the joining node reliably acquires some.
     const PARTS: i32 = 12;
 
     let input = format!("soak-grace-in-{}", std::process::id());
@@ -900,10 +899,8 @@ fn graceful_rotation_kafka_soak() {
     assert_progress(&nodes[..INITIAL], 0.0, Duration::from_secs(90), "startup");
     eprintln!("soak: 3 nodes up; producing {total} records");
 
-    // Produce on a background thread at a modest rate so records are STILL
-    // flowing after the rotation settles — otherwise the backlog is consumed
-    // before node 3 acquires its partitions and it never sees data. At ~400/s a
-    // 12k run spans ~30s, well past the join + settle.
+    // Modest rate so records are still flowing after the rotation settles —
+    // otherwise the backlog drains before node 3 acquires its partitions.
     let (pb, pt) = (brokers.clone(), input.clone());
     let producer = std::thread::spawn(move || produce_seq(&pb, &pt, total, 400));
 
@@ -927,10 +924,8 @@ fn graceful_rotation_kafka_soak() {
         s.len() >= total as usize
     });
 
-    // Every input was already observed committed (the wait above reads
-    // read_committed), so the sinks are idle with no open transactions. Read the
-    // diff against the live, settled cluster: killing first only races the diff
-    // consumer against the kill and can surface transient phantom reads.
+    // The wait above already saw every input committed, so read the diff against
+    // the live, settled cluster — killing first races the diff into phantom reads.
     std::thread::sleep(Duration::from_secs(5));
     let (mut seqs, per_topic) = collect_output_seqs(&brokers, ALL);
     let count = seqs.len();


### PR DESCRIPTION
Three independent workstreams on one branch. Each is self-contained; happy to split into separate PRs if preferred.

---

## 1. Cluster strict exactly-once vnode rotation

Closes duplicate emission when a graceful vnode rotation (scale up/down) moves a Kafka partition between nodes under an exactly-once sink. Empirically decomposed and validated:

- **Source-offset handoff (B1)** — an acquiring node resumes a newly-owned partition from the previous owner's sealed offset (unioned from each node's per-vnode blob in the shared state backend), not `auto.offset.reset`.
- **Barrier-aligned drain (B2)** — under an exactly-once sink the leader publishes a *draining* `AssignmentSnapshot`, every node pauses the partitions of vnodes it's about to lose, the leader waits for a **gossip drain-ack quorum** (not a fixed sleep), then takes the pre-rotation checkpoint as a clean cut. Without it: **247 dups** in the soak (the old owner seals past-cut records on a moving partition).
- **Gate wiring fix** — `requires_rotation_drain` was reading the DB-level delivery guarantee, which the server never sets (delivery is per-sink). It now derives from the actual exactly-once sinks, so B2 actually runs in prod.
- **Incremental rebind fix** — the reader did a full `consumer.assign()` of all owned partitions on rotation, re-seeking *kept* partitions to a lagging offset snapshot and re-fetching records already buffered ahead → re-emitted committed rows. Now uses `incremental_assign`/`incremental_unassign` so kept partitions are untouched. Without it: a flaky ~3-dup residual.

**Validation:** a new graceful 4-node Kafka-source soak (`graceful_rotation_kafka_soak`) — shared 12-partition source, 3 nodes + EO sinks, 4th node added mid-stream — ran **3 consecutive times with the output union dense `0..=N`, 0 duplicates** (rpk-confirmed durable). A broker-gated connector test (`kafka_vnode_drain`) proves the source-pause primitive directly. Disabling either fix reproduces its dup class (247 / ~3), so both earn their keep.

## 2. Columnar aggregate checkpoint (Track A3)

Per-group Arrow-IPC streams made checkpoint encoding O(groups) (a schema header per group, ~9µs/group). Encode columnar instead — all keys in one batch, each accumulator's state across all groups in one batch — decoded back through shared helpers reused by the single-node, cluster per-vnode, and merge paths. Destructive-state rebuild and atomic restore (build-then-swap) preserved; defensive shape checks on decode.

**1M groups: 9.98s → 1.10s (~9×), ~56× smaller.** Format change, no migration (no external users).

## 3. MongoDB sink

- **Timestamp handling** — Arrow timestamp columns now land as BSON dates (via Extended-JSON `$date` → `Bson::try_from`), not literal sub-documents.
- **Throughput** — insert/upsert/replace now convert Arrow → BSON **directly**, dropping the `serde_json::Value` intermediate, a `serde_json::to_string` byte-estimate pass, and the per-number `ArrayFormatter`→string→parse round-trip (three passes/row on the write path). CDC replay keeps the JSON path (it parses a changelog envelope that is inherently JSON).

---

### Verification
clippy `-D warnings` + fmt clean across `cluster`, `kafka`, and `mongodb-cdc` feature sets; lib + connector unit tests green. The graceful-rotation soak and the `kafka_vnode_drain` connector test are `#[ignore]`/broker-gated (need a Redpanda broker via `LAMINAR_SOAK_KAFKA_BROKERS` / `LAMINAR_KAFKA_BROKERS`).

### Known follow-ups (non-blocking)
- Drain timings (`drain_settle`, `drain_ack_timeout`) use sensible defaults but aren't operator-tunable from server config yet.
- The graceful-rotation soak covers a 2PC sink; an append-only-sink variant would exercise B2's stated charter directly (B2 is already proven necessary even for 2PC).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes vnode rotations strictly exactly-once, speeds aggregate checkpoints with a columnar format, and accelerates the MongoDB sink. Adds configurable durability-gate polling and hardens delta-checkpoint correctness.

- **New Features**
  - Strict-EO vnode rotation: draining snapshot with gossip acks; source-offset handoff via the shared state backend; deterministic seek-before-fetch; incremental assign/unassign to avoid re-fetch.
  - Columnar aggregate checkpoints: ≈9× faster and ~56× smaller; no migration.
  - MongoDB sink: direct Arrow→BSON path for insert/upsert/replace; Arrow timestamps stored as BSON Date.
  - Per-vnode delta groundwork: dirty-key tracking (off by default) plus a test-validated delta encode/apply codec (not yet wired into capture/recovery).

- **Bug Fixes**
  - Kafka source robustness: bump pause/resume/seek generations and assignment version only on success; recovery seeks checkpointed offsets.
  - Rotation safety: abort and clear the drain on checkpoint error/timeout; defer rotation on handoff-read failure; clear stale drain marks; mark newly-acquired vnodes Restoring; validate columnar checkpoints.
  - Delta correctness: re-touching a key clears a pending tombstone (prevents change+tombstone conflicts); `AggStateCheckpoint::append_disjoint` validates accumulator-column counts.
  - Durability gate: clamp the configurable poll cadence to a ≥1ms floor with cap ≥ initial.

<sup>Written for commit f367b9ee676246385c66298fb14e831d02185470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exactly-once rotation drain phase with drained-version quorum support.
  * Added per-node source-offset handoff persistence for improved recovery.
  * Introduced feature-gated MongoDB BSON fast-path for inserts/updates/upserts and CDC replay (including enhanced timestamp handling).
  * Added durability-gate polling configuration (initial/max).
* **Improvements**
  * Enhanced Kafka rebalance/rotation to coordinate partition pause/resume and vnode-aware rebind behavior more reliably.
  * Improved checkpoint/aggregate state encoding for performance and consistency; Mongo sink now honors provided connector properties.
* **Tests**
  * Added Kafka vnode-drain integration coverage and expanded source-offset handoff/checkpoint and offset parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->