### PR TITLE
feat(cluster): leader-coordinated recovery (restart-to-epoch)

### DIFF
--- a/crates/laminar-core/src/checkpoint_decision.rs
+++ b/crates/laminar-core/src/checkpoint_decision.rs
@@ -84,6 +84,31 @@ impl CheckpointDecisionStore {
         }
     }
 
+    /// Highest epoch with a commit marker (committed cluster-wide), or `None`.
+    ///
+    /// # Errors
+    /// Object-store I/O.
+    pub async fn highest_committed(&self) -> Result<Option<u64>, DecisionError> {
+        let root = OsPath::from("checkpoint-decisions/");
+        let mut entries = self.store.list(Some(&root));
+        let mut highest: Option<u64> = None;
+        while let Some(entry) = entries.next().await {
+            let entry = entry.map_err(|e| DecisionError::Io(e.to_string()))?;
+            let loc = entry.location.as_ref();
+            let rest = loc.strip_prefix("checkpoint-decisions/").unwrap_or("");
+            let Some(seg) = rest.split('/').next() else {
+                continue;
+            };
+            let Some(n) = seg.strip_prefix("epoch=") else {
+                continue;
+            };
+            if let Ok(epoch) = n.parse::<u64>() {
+                highest = Some(highest.map_or(epoch, |h: u64| h.max(epoch)));
+            }
+        }
+        Ok(highest)
+    }
+
     /// Delete commit markers for `epoch < before`. Called by the
     /// checkpoint coordinator after its state-backend prune so
     /// markers don't accumulate one-per-checkpoint forever.
@@ -166,6 +191,17 @@ mod tests {
         s.record_committed(1).await.unwrap();
         assert!(s.is_committed(1).await.unwrap());
         assert!(!s.is_committed(2).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn highest_committed_picks_max() {
+        let dir = tempdir().unwrap();
+        let s = store_in(dir.path());
+        assert_eq!(s.highest_committed().await.unwrap(), None);
+        s.record_committed(3).await.unwrap();
+        s.record_committed(7).await.unwrap();
+        s.record_committed(5).await.unwrap();
+        assert_eq!(s.highest_committed().await.unwrap(), Some(7));
     }
 
     #[tokio::test]

--- a/crates/laminar-core/src/cluster/control/barrier.rs
+++ b/crates/laminar-core/src/cluster/control/barrier.rs
@@ -39,6 +39,10 @@ pub enum Phase {
     Commit,
     /// Prepare failed; roll back.
     Abort,
+    /// Leader-coordinated global restart: every node rewinds to `epoch` (the highest
+    /// cluster-wide committed epoch) and reprocesses. `flags` carries the recovery id.
+    /// KV-only delivery (no phase RPC) — recovery is mutually exclusive with checkpointing.
+    Recover,
 }
 
 /// Leader-written barrier announcement.
@@ -538,7 +542,8 @@ async fn send_phase_rpc(
                 .map(|_| ())
                 .map_err(|e| ("abort", e))
         }
-        Phase::Prepare => Ok(()),
+        // KV-only: Prepare RPCs come from wait_for_quorum; Recover rides the gossip announcement.
+        Phase::Prepare | Phase::Recover => Ok(()),
     };
     result.map_err(|(rpc, e)| {
         clients_pool.lock().remove(&peer);
@@ -740,9 +745,9 @@ impl BarrierCoordinator {
                 // early (the RPC receiver does not persist the announcement).
                 let json = serde_json::to_string(ann).map_err(|e| e.to_string())?;
                 self.kv.write(ANNOUNCEMENT_KEY, json).await;
-                if ann.phase == Phase::Prepare {
-                    // Prepare gRPC calls are initiated by wait_for_quorum.
-                    // Redundant calls here cause duplicate prepare executions and timeouts on followers.
+                if matches!(ann.phase, Phase::Prepare | Phase::Recover) {
+                    // Prepare RPCs come from wait_for_quorum; Recover is gossip-only (observed
+                    // by the per-node recovery monitor). Redundant RPCs here would double-fire.
                 } else {
                     // A node's barrier address lingers in the KV after it dies,
                     // so announce to peers still Active in membership — a Commit

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -289,6 +289,12 @@ impl ClusterController {
         self.kv.write("control:fault-report", seq.to_string()).await;
     }
 
+    /// Clear this node's fault report after it recovers, so the report doesn't linger and
+    /// re-trigger recovery when a new/restarted leader reads it. `0` means "no fault".
+    pub async fn clear_fault_report(&self) {
+        self.kv.write("control:fault-report", "0".to_string()).await;
+    }
+
     /// Each visible node's reported fault sequence.
     pub async fn read_fault_reports(&self) -> Vec<(NodeId, u64)> {
         self.kv
@@ -523,6 +529,22 @@ impl ClusterController {
             .await?;
         let ann: BarrierAnnouncement = serde_json::from_str(&json).ok()?;
         (ann.phase == Phase::Recover).then_some(ann)
+    }
+
+    /// Overwrite this node's announcement slot with a non-`Recover` phase once a recovery
+    /// round finishes, so [`Self::observe_recover`] stops returning it (a peer that
+    /// restarts after the round, its in-memory generation reset, would otherwise replay it).
+    pub async fn clear_recover_announcement(&self, epoch: u64) {
+        let ann = BarrierAnnouncement {
+            epoch,
+            checkpoint_id: 0,
+            phase: Phase::Commit,
+            flags: 0,
+            min_watermark_ms: None,
+        };
+        if let Ok(json) = serde_json::to_string(&ann) {
+            self.kv.write(super::barrier::ANNOUNCEMENT_KEY, json).await;
+        }
     }
 
     /// Wait until [`Self::observe_barrier`] yields an announcement

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -35,6 +35,9 @@ pub struct ClusterController {
     /// excludes itself from [`Self::assignable_instances`] so the next
     /// rotation sheds its vnodes elsewhere before it exits.
     draining: Arc<AtomicBool>,
+    /// Held while a coordinated restart is in flight; the checkpoint gate consults it so
+    /// no checkpoint is injected mid-recovery.
+    recovering: Arc<AtomicBool>,
     /// Whether this node has announced itself as Active.
     active: Arc<AtomicBool>,
     /// Peers that recently failed a capture quorum (no ack within the
@@ -90,6 +93,7 @@ impl ClusterController {
             converged_for_checkpoint: watch::channel(true).0,
             cluster_min_watermark: Arc::new(AtomicI64::new(i64::MIN)),
             draining: Arc::new(AtomicBool::new(false)),
+            recovering: Arc::new(AtomicBool::new(false)),
             active: Arc::new(AtomicBool::new(true)),
             unresponsive: Arc::new(parking_lot::Mutex::new(rustc_hash::FxHashMap::default())),
             self_locality: parking_lot::RwLock::new(Locality::default()),
@@ -267,6 +271,49 @@ impl ClusterController {
     #[must_use]
     pub fn is_draining(&self) -> bool {
         self.draining.load(Ordering::SeqCst)
+    }
+
+    /// Set or clear the coordinated-recovery fence.
+    pub fn set_recovering(&self, recovering: bool) {
+        self.recovering.store(recovering, Ordering::SeqCst);
+    }
+
+    /// Whether a coordinated restart is in flight on this node.
+    #[must_use]
+    pub fn is_recovering(&self) -> bool {
+        self.recovering.load(Ordering::SeqCst)
+    }
+
+    /// Publish this node's fault sequence so the leader drives a recovery round.
+    pub async fn report_fault(&self, seq: u64) {
+        self.kv.write("control:fault-report", seq.to_string()).await;
+    }
+
+    /// Each visible node's reported fault sequence.
+    pub async fn read_fault_reports(&self) -> Vec<(NodeId, u64)> {
+        self.kv
+            .scan("control:fault-report")
+            .await
+            .into_iter()
+            .filter_map(|(n, v)| v.parse::<u64>().ok().map(|seq| (n, seq)))
+            .collect()
+    }
+
+    /// Publish the recovery generation this node has restored to.
+    pub async fn announce_recovered(&self, recovery_id: u64) {
+        self.kv
+            .write("control:recovered", recovery_id.to_string())
+            .await;
+    }
+
+    /// Each visible node's last restored recovery generation.
+    pub async fn read_recovered(&self) -> Vec<(NodeId, u64)> {
+        self.kv
+            .scan("control:recovered")
+            .await
+            .into_iter()
+            .filter_map(|(n, v)| v.parse::<u64>().ok().map(|id| (n, id)))
+            .collect()
     }
 
     /// Node ids eligible to own vnodes: `Active` peers, plus self unless
@@ -463,6 +510,19 @@ impl ClusterController {
     /// Propagates [`BarrierCoordinator::ack`] errors.
     pub async fn ack_barrier(&self, ack: &BarrierAck) -> Result<(), String> {
         self.barrier.ack(ack).await
+    }
+
+    /// The leader's current `Recover` announcement, if any. Reads the leader's gossip
+    /// slot directly: [`Self::observe_barrier`] merges by highest epoch, which would
+    /// shadow the recovery target (a lower epoch than the in-flight checkpoint).
+    pub async fn observe_recover(&self) -> Option<BarrierAnnouncement> {
+        let leader = self.current_leader()?;
+        let json = self
+            .kv
+            .read_from(leader, super::barrier::ANNOUNCEMENT_KEY)
+            .await?;
+        let ann: BarrierAnnouncement = serde_json::from_str(&json).ok()?;
+        (ann.phase == Phase::Recover).then_some(ann)
     }
 
     /// Wait until [`Self::observe_barrier`] yields an announcement

--- a/crates/laminar-core/src/cluster/control/controller.rs
+++ b/crates/laminar-core/src/cluster/control/controller.rs
@@ -289,8 +289,8 @@ impl ClusterController {
         self.kv.write("control:fault-report", seq.to_string()).await;
     }
 
-    /// Clear this node's fault report after it recovers, so the report doesn't linger and
-    /// re-trigger recovery when a new/restarted leader reads it. `0` means "no fault".
+    /// Clear this node's fault report (`0` = no fault) after it recovers, so a restarted
+    /// leader doesn't re-trigger recovery for an already-handled fault.
     pub async fn clear_fault_report(&self) {
         self.kv.write("control:fault-report", "0".to_string()).await;
     }
@@ -531,9 +531,8 @@ impl ClusterController {
         (ann.phase == Phase::Recover).then_some(ann)
     }
 
-    /// Overwrite this node's announcement slot with a non-`Recover` phase once a recovery
-    /// round finishes, so [`Self::observe_recover`] stops returning it (a peer that
-    /// restarts after the round, its in-memory generation reset, would otherwise replay it).
+    /// Overwrite this node's announcement slot with a non-`Recover` phase at the end of a
+    /// round, so [`Self::observe_recover`] stops returning a stale generation.
     pub async fn clear_recover_announcement(&self, epoch: u64) {
         let ann = BarrierAnnouncement {
             epoch,

--- a/crates/laminar-core/src/shuffle/transport.rs
+++ b/crates/laminar-core/src/shuffle/transport.rs
@@ -172,7 +172,10 @@ mod grpc {
 
     impl PeerConn {
         fn is_alive(&self) -> bool {
-            self.alive.load(Ordering::Acquire)
+            // `is_finished()` also catches a driver cancelled without flipping `alive` — an
+            // in-process restart drops the compute runtime it ran on, leaving an `alive`
+            // zombie that fails every send yet never reconnects.
+            self.alive.load(Ordering::Acquire) && !self.driver.is_finished()
         }
     }
 
@@ -299,6 +302,7 @@ mod grpc {
                 })?,
             };
 
+            tracing::debug!(peer, addr = %addr, "shuffle reconnecting to peer");
             let conn = Arc::new(open_call(self.local_id, addr)?);
 
             // Race: another task may have opened a live call meanwhile.
@@ -701,6 +705,7 @@ mod grpc {
                 }
             }
         }
+        tracing::debug!(peer, frames_received, "shuffle inbound stream ended");
         Ok(ShuffleSummary { frames_received })
     }
 

--- a/crates/laminar-db/src/builder.rs
+++ b/crates/laminar-db/src/builder.rs
@@ -379,6 +379,14 @@ impl LaminarDbBuilder {
         self
     }
 
+    /// Enable leader-coordinated recovery (cluster mode). The embedder must also call
+    /// [`LaminarDB::enable_coordinated_recovery`] after building.
+    #[must_use]
+    pub fn coordinated_recovery(mut self, enabled: bool) -> Self {
+        self.config.coordinated_recovery = enabled;
+        self
+    }
+
     /// Register custom connectors; the callback runs after built-ins are wired.
     #[must_use]
     pub fn register_connector(

--- a/crates/laminar-db/src/checkpoint_coordinator.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator.rs
@@ -2549,7 +2549,9 @@ impl CheckpointCoordinator {
 
         let mgr = RecoveryManager::new(&*self.store);
         // Sources are restored by the pipeline lifecycle; pass empty slices here.
-        let result = mgr.recover(&[], &self.sinks, &[]).await?;
+        let result = mgr
+            .recover(&[], &self.sinks, &[], self.decision_store.as_deref())
+            .await?;
 
         if let Some(ref recovered) = result {
             // Monotonic: the committed epoch may predate a Pending manifest that seeded ids.
@@ -2557,6 +2559,40 @@ impl CheckpointCoordinator {
                 .advance_to(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
             let (epoch, checkpoint_id) = self.allocator.peek();
             info!(epoch, checkpoint_id, "coordinator epoch set after recovery");
+        }
+
+        Ok(result)
+    }
+
+    /// Recover to a coordinated cluster target epoch instead of the local latest.
+    ///
+    /// # Errors
+    /// Returns `DbError::Checkpoint` if the store read fails.
+    pub async fn recover_to_epoch(
+        &mut self,
+        target_epoch: u64,
+    ) -> Result<Option<crate::recovery_manager::RecoveredState>, DbError> {
+        use crate::recovery_manager::RecoveryManager;
+
+        let mgr = RecoveryManager::new(&*self.store);
+        let result = mgr
+            .recover_to_epoch(
+                target_epoch,
+                &[],
+                &self.sinks,
+                &[],
+                self.decision_store.as_deref(),
+            )
+            .await?;
+
+        if let Some(ref recovered) = result {
+            self.allocator
+                .advance_to(recovered.epoch() + 1, recovered.manifest.checkpoint_id + 1);
+            let (epoch, checkpoint_id) = self.allocator.peek();
+            info!(
+                epoch,
+                checkpoint_id, "coordinator epoch set after coordinated recovery"
+            );
         }
 
         Ok(result)

--- a/crates/laminar-db/src/config.rs
+++ b/crates/laminar-db/src/config.rs
@@ -115,6 +115,9 @@ pub struct LaminarConfig {
     pub pipeline_backpressure_policy: BackpressurePolicy,
     /// Auto-restart policy applied when supervision is enabled.
     pub restart_policy: RestartPolicy,
+    /// Cluster mode: on a fatal fault, the leader rewinds every node to the highest
+    /// cluster-wide committed epoch instead of a local-only restart. Default off.
+    pub coordinated_recovery: bool,
 }
 
 impl Default for LaminarConfig {
@@ -139,6 +142,7 @@ impl Default for LaminarConfig {
             pipeline_max_input_buf_bytes: None,
             pipeline_backpressure_policy: BackpressurePolicy::default(),
             restart_policy: RestartPolicy::default(),
+            coordinated_recovery: false,
         }
     }
 }

--- a/crates/laminar-db/src/coordinated_recovery.rs
+++ b/crates/laminar-db/src/coordinated_recovery.rs
@@ -1,0 +1,235 @@
+//! Leader-coordinated global restart-to-epoch on a fatal fault (cluster mode).
+//!
+//! Every node rewinds to the highest cluster-wide committed epoch so a fault on one node
+//! can't leave the cross-node shuffle cut inconsistent. Off by default; soak-gated (see
+//! `docs/plans/1a-cluster-recovery-driver.md`).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use tokio::runtime::Handle;
+
+use laminar_core::cluster::control::{BarrierAnnouncement, ClusterController, Phase};
+use laminar_core::cluster::discovery::NodeId;
+
+use crate::LaminarDB;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const RESTORE_QUORUM_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Recovery generation, max-wins across leader change so a round keeps a stable id.
+const RECOVERY_GEN_KEY: &str = "control:recovery-gen";
+
+/// Per-process fault counter. Resets to 0 on restart, so the leader triggers on any
+/// change (not only an increase) to catch a re-fault after a restart.
+static FAULT_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Publish a fault so the leader drives a global restart; this node's monitor then
+/// restores it on observing `Recover`.
+pub(crate) async fn report_local_fault(controller: &ClusterController) {
+    let seq = FAULT_SEQ.fetch_add(1, Ordering::SeqCst) + 1;
+    controller.report_fault(seq).await;
+    tracing::warn!(seq, "reported local fault for coordinated cluster recovery");
+}
+
+/// Spawn the long-lived per-node monitor. It drives stop/start, so it must outlive those
+/// cycles — not spawned from `start_inner`.
+pub(crate) fn spawn_monitor(db: &Arc<LaminarDB>) {
+    let weak = Arc::downgrade(db);
+    tokio::spawn(async move {
+        RecoveryMonitor::default().run(weak).await;
+    });
+}
+
+#[derive(Default)]
+struct RecoveryMonitor {
+    applied_gen: u64,
+    handled_faults: FxHashMap<NodeId, u64>,
+}
+
+impl RecoveryMonitor {
+    async fn run(mut self, weak: Weak<LaminarDB>) {
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            let Some(db) = weak.upgrade() else {
+                return;
+            };
+            if db.is_closed() {
+                return;
+            }
+            let Some(controller) = db.cluster_controller.lock().clone() else {
+                continue;
+            };
+
+            // Any node restores on a Recover it hasn't applied; the leader also drives a
+            // new round when a fault report changes.
+            if let Some(ann) = controller.observe_recover().await {
+                if ann.flags > self.applied_gen {
+                    self.restore(&db, &controller, ann.epoch, ann.flags).await;
+                }
+            }
+            if controller.is_leader() && self.take_new_fault(&controller).await {
+                self.drive_round(&db, &controller).await;
+            }
+        }
+    }
+
+    /// `true` when any node's fault sequence changed since we last handled it.
+    async fn take_new_fault(&mut self, controller: &ClusterController) -> bool {
+        let mut triggered = false;
+        for (node, seq) in controller.read_fault_reports().await {
+            if self.handled_faults.get(&node) != Some(&seq) {
+                self.handled_faults.insert(node, seq);
+                triggered = true;
+            }
+        }
+        triggered
+    }
+
+    /// Leader: fix `N`, bump the generation, announce, restore self, then wait for every
+    /// live node to report restored before releasing the fence.
+    async fn drive_round(&mut self, db: &Arc<LaminarDB>, controller: &ClusterController) {
+        let Some(target) = compute_target_epoch(db).await else {
+            tracing::warn!("coordinated recovery: no committed epoch yet; skipping round");
+            return;
+        };
+        let gen_id = read_recovery_gen(controller).await + 1;
+        write_recovery_gen(controller, gen_id).await;
+
+        controller.set_recovering(true);
+        let ann = BarrierAnnouncement {
+            epoch: target,
+            checkpoint_id: 0,
+            phase: Phase::Recover,
+            flags: gen_id,
+            min_watermark_ms: None,
+        };
+        if let Err(e) = controller.announce_barrier(&ann).await {
+            tracing::error!(error = %e, "coordinated recovery: announce failed");
+            controller.set_recovering(false);
+            return;
+        }
+        tracing::warn!(
+            target_epoch = target,
+            gen = gen_id,
+            "leader announced recovery"
+        );
+
+        // Restore self into the quorum, marking applied so the observe path doesn't repeat it.
+        self.restore_pipeline(db, target).await;
+        self.applied_gen = gen_id;
+        controller.announce_recovered(gen_id).await;
+
+        wait_restore_quorum(controller, gen_id, RESTORE_QUORUM_TIMEOUT).await;
+        controller.set_recovering(false);
+        tracing::warn!(
+            gen = gen_id,
+            "coordinated recovery complete; fence released"
+        );
+    }
+
+    async fn restore(
+        &mut self,
+        db: &Arc<LaminarDB>,
+        controller: &ClusterController,
+        target: u64,
+        gen_id: u64,
+    ) {
+        controller.set_recovering(true);
+        self.restore_pipeline(db, target).await;
+        self.applied_gen = gen_id;
+        controller.announce_recovered(gen_id).await;
+        // Only the leader injects, so a follower clearing its fence before the quorum is fine.
+        controller.set_recovering(false);
+        tracing::warn!(
+            target_epoch = target,
+            gen = gen_id,
+            "node restored to recovery epoch"
+        );
+    }
+
+    /// Stop, arm the target, and restart from `N`, on a dedicated thread since `start()`
+    /// is `!Send`. The fence makes the stop skip its final checkpoint (which would commit
+    /// past `N`).
+    async fn restore_pipeline(&self, db: &Arc<LaminarDB>, target: u64) {
+        let db = Arc::clone(db);
+        let handle = Handle::current();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let spawned = std::thread::Builder::new()
+            .name("laminar-coord-recover".into())
+            .spawn(move || {
+                let res = handle.block_on(async move {
+                    // A faulted node is already stopped, so ignore the stop error.
+                    let _ = db.stop_pipeline().await;
+                    db.set_recover_target_epoch(target);
+                    db.start().await
+                });
+                let _ = tx.send(res);
+            });
+        if let Err(e) = spawned {
+            tracing::error!(error = %e, "coordinated recovery: failed to spawn restore thread");
+            return;
+        }
+        match rx.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(error = %e, "coordinated recovery restart failed"),
+            Err(_) => tracing::error!("coordinated recovery restore thread dropped"),
+        }
+    }
+}
+
+/// Highest epoch committed cluster-wide. Reads the DB-level decision store, so it works
+/// even when a faulted leader's own coordinator is stopped.
+async fn compute_target_epoch(db: &LaminarDB) -> Option<u64> {
+    let ds = db.decision_store.lock().clone()?;
+    ds.highest_committed().await.ok().flatten()
+}
+
+async fn read_recovery_gen(controller: &ClusterController) -> u64 {
+    controller
+        .kv()
+        .scan(RECOVERY_GEN_KEY)
+        .await
+        .into_iter()
+        .filter_map(|(_, v)| v.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+}
+
+async fn write_recovery_gen(controller: &ClusterController, gen_id: u64) {
+    controller
+        .kv()
+        .write(RECOVERY_GEN_KEY, gen_id.to_string())
+        .await;
+}
+
+/// Wait until every live node reports restored-to-`gen_id`, or the deadline (a dead node
+/// that never acks recovers on rejoin).
+async fn wait_restore_quorum(controller: &ClusterController, gen_id: u64, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let live: FxHashSet<NodeId> = controller.live_instances().into_iter().collect();
+        let acked: FxHashSet<NodeId> = controller
+            .read_recovered()
+            .await
+            .into_iter()
+            .filter(|(_, g)| *g >= gen_id)
+            .map(|(n, _)| n)
+            .collect();
+        if live.iter().all(|n| acked.contains(n)) {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let missing: Vec<NodeId> = live.into_iter().filter(|n| !acked.contains(n)).collect();
+            tracing::error!(
+                gen = gen_id,
+                ?missing,
+                "coordinated recovery: restore quorum timed out"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/crates/laminar-db/src/coordinated_recovery.rs
+++ b/crates/laminar-db/src/coordinated_recovery.rs
@@ -76,11 +76,13 @@ impl RecoveryMonitor {
         }
     }
 
-    /// `true` when any node's fault sequence changed since we last handled it.
+    /// `true` when any node's fault sequence changed since we last handled it. A `0`
+    /// report is "no fault" (cleared after recovery), so it never triggers — otherwise a
+    /// new/restarted leader would re-run recovery for an already-handled fault.
     async fn take_new_fault(&mut self, controller: &ClusterController) -> bool {
         let mut triggered = false;
         for (node, seq) in controller.read_fault_reports().await {
-            if self.handled_faults.get(&node) != Some(&seq) {
+            if seq != 0 && self.handled_faults.get(&node) != Some(&seq) {
                 self.handled_faults.insert(node, seq);
                 triggered = true;
             }
@@ -117,65 +119,99 @@ impl RecoveryMonitor {
             "leader announced recovery"
         );
 
-        // Restore self into the quorum, marking applied so the observe path doesn't repeat it.
-        self.restore_pipeline(db, target).await;
-        self.applied_gen = gen_id;
-        controller.announce_recovered(gen_id).await;
-
+        // Restore self into the quorum, holding the fence across the wait. On failure,
+        // release the fence and return — the observe path retries on the next tick
+        // (applied_gen is left unchanged).
+        if !self.restore_and_ack(db, controller, target, gen_id).await {
+            controller.set_recovering(false);
+            return;
+        }
         wait_restore_quorum(controller, gen_id, RESTORE_QUORUM_TIMEOUT).await;
         controller.set_recovering(false);
+        // Clear the Recover from our gossip slot so a peer that restarts after the round
+        // (its in-memory `applied_gen` reset to 0) doesn't replay this generation.
+        controller.clear_recover_announcement(target).await;
         tracing::warn!(
             gen = gen_id,
             "coordinated recovery complete; fence released"
         );
     }
 
+    /// Observe-path restore (follower, or a leader retrying after its own restore failed):
+    /// fence around the restart, then release it. `false` if the restart failed (retried
+    /// next tick). Only the leader injects checkpoints, so its fence lifetime is what
+    /// gates the cluster; a follower's is just final-checkpoint suppression.
     async fn restore(
         &mut self,
         db: &Arc<LaminarDB>,
         controller: &ClusterController,
         target: u64,
         gen_id: u64,
-    ) {
+    ) -> bool {
         controller.set_recovering(true);
-        self.restore_pipeline(db, target).await;
-        self.applied_gen = gen_id;
-        controller.announce_recovered(gen_id).await;
-        // Only the leader injects, so a follower clearing its fence before the quorum is fine.
+        let ok = self.restore_and_ack(db, controller, target, gen_id).await;
         controller.set_recovering(false);
-        tracing::warn!(
-            target_epoch = target,
-            gen = gen_id,
-            "node restored to recovery epoch"
-        );
+        if ok {
+            tracing::warn!(
+                target_epoch = target,
+                gen = gen_id,
+                "node restored to recovery epoch"
+            );
+        }
+        ok
     }
 
-    /// Stop, arm the target, and restart from `N`, on a dedicated thread since `start()`
-    /// is `!Send`. The fence makes the stop skip its final checkpoint (which would commit
-    /// past `N`).
-    async fn restore_pipeline(&self, db: &Arc<LaminarDB>, target: u64) {
-        let db = Arc::clone(db);
-        let handle = Handle::current();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let spawned = std::thread::Builder::new()
-            .name("laminar-coord-recover".into())
-            .spawn(move || {
-                let res = handle.block_on(async move {
-                    // A faulted node is already stopped, so ignore the stop error.
-                    let _ = db.stop_pipeline().await;
-                    db.set_recover_target_epoch(target);
-                    db.start().await
-                });
-                let _ = tx.send(res);
-            });
-        if let Err(e) = spawned {
-            tracing::error!(error = %e, "coordinated recovery: failed to spawn restore thread");
-            return;
+    /// Restart this node to `target` and, on success, ack the generation and clear this
+    /// node's fault report. Fence-neutral — the caller owns the fence. `false` on failure
+    /// (`applied_gen` and the fault report are left untouched so the next tick retries).
+    async fn restore_and_ack(
+        &mut self,
+        db: &Arc<LaminarDB>,
+        controller: &ClusterController,
+        target: u64,
+        gen_id: u64,
+    ) -> bool {
+        if !restore_pipeline(db, target).await {
+            return false;
         }
-        match rx.await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::error!(error = %e, "coordinated recovery restart failed"),
-            Err(_) => tracing::error!("coordinated recovery restore thread dropped"),
+        self.applied_gen = gen_id;
+        controller.announce_recovered(gen_id).await;
+        controller.clear_fault_report().await;
+        true
+    }
+}
+
+/// Stop, arm the target, and restart from `N`, on a dedicated thread since `start()` is
+/// `!Send`. `true` on a clean restart. The fence makes the stop skip its final checkpoint
+/// (which would commit past `N`).
+async fn restore_pipeline(db: &Arc<LaminarDB>, target: u64) -> bool {
+    let db = Arc::clone(db);
+    let handle = Handle::current();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let spawned = std::thread::Builder::new()
+        .name("laminar-coord-recover".into())
+        .spawn(move || {
+            let res = handle.block_on(async move {
+                // A faulted node is already stopped, so ignore the stop error.
+                let _ = db.stop_pipeline().await;
+                db.set_recover_target_epoch(target);
+                db.start().await
+            });
+            let _ = tx.send(res);
+        });
+    if let Err(e) = spawned {
+        tracing::error!(error = %e, "coordinated recovery: failed to spawn restore thread");
+        return false;
+    }
+    match rx.await {
+        Ok(Ok(())) => true,
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "coordinated recovery restart failed");
+            false
+        }
+        Err(_) => {
+            tracing::error!("coordinated recovery restore thread dropped");
+            false
         }
     }
 }

--- a/crates/laminar-db/src/coordinated_recovery.rs
+++ b/crates/laminar-db/src/coordinated_recovery.rs
@@ -18,6 +18,8 @@ use crate::LaminarDB;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
 const RESTORE_QUORUM_TIMEOUT: Duration = Duration::from_secs(90);
+/// How many times the leader retries restoring itself before abandoning the round.
+const SELF_RESTORE_ATTEMPTS: u32 = 3;
 
 /// Recovery generation, max-wins across leader change so a round keeps a stable id.
 const RECOVERY_GEN_KEY: &str = "control:recovery-gen";
@@ -76,9 +78,8 @@ impl RecoveryMonitor {
         }
     }
 
-    /// `true` when any node's fault sequence changed since we last handled it. A `0`
-    /// report is "no fault" (cleared after recovery), so it never triggers — otherwise a
-    /// new/restarted leader would re-run recovery for an already-handled fault.
+    /// `true` when any node's fault sequence changed since we last handled it. `0` is "no
+    /// fault" (cleared after recovery), so a restarted leader doesn't re-trigger a handled one.
     async fn take_new_fault(&mut self, controller: &ClusterController) -> bool {
         let mut triggered = false;
         for (node, seq) in controller.read_fault_reports().await {
@@ -90,8 +91,9 @@ impl RecoveryMonitor {
         triggered
     }
 
-    /// Leader: fix `N`, bump the generation, announce, restore self, then wait for every
-    /// live node to report restored before releasing the fence.
+    /// Leader: fix `N`, announce, restore self (retrying), then wait for every live node to
+    /// report restored. Always releases the fence and clears the announcement on exit — so a
+    /// failed round can't leave a stale `Recover` for a later peer-restart to replay.
     async fn drive_round(&mut self, db: &Arc<LaminarDB>, controller: &ClusterController) {
         let Some(target) = compute_target_epoch(db).await else {
             tracing::warn!("coordinated recovery: no committed epoch yet; skipping round");
@@ -119,28 +121,35 @@ impl RecoveryMonitor {
             "leader announced recovery"
         );
 
-        // Restore self into the quorum, holding the fence across the wait. On failure,
-        // release the fence and return — the observe path retries on the next tick
-        // (applied_gen is left unchanged).
-        if !self.restore_and_ack(db, controller, target, gen_id).await {
-            controller.set_recovering(false);
-            return;
+        // Retry self-restore inline so the round (and the cleanup below) stays in the
+        // leader's control; the lingering announcement gives peers time to observe it.
+        let mut restored = false;
+        for attempt in 1..=SELF_RESTORE_ATTEMPTS {
+            if self.restore_and_ack(db, controller, target, gen_id).await {
+                restored = true;
+                break;
+            }
+            tracing::warn!(
+                gen = gen_id,
+                attempt,
+                "leader self-restore failed; retrying"
+            );
         }
-        wait_restore_quorum(controller, gen_id, RESTORE_QUORUM_TIMEOUT).await;
+        if restored {
+            wait_restore_quorum(controller, gen_id, RESTORE_QUORUM_TIMEOUT).await;
+            tracing::warn!(
+                gen = gen_id,
+                "coordinated recovery complete; fence released"
+            );
+        } else {
+            tracing::error!(gen = gen_id, "leader self-restore failed; abandoning round");
+        }
         controller.set_recovering(false);
-        // Clear the Recover from our gossip slot so a peer that restarts after the round
-        // (its in-memory `applied_gen` reset to 0) doesn't replay this generation.
         controller.clear_recover_announcement(target).await;
-        tracing::warn!(
-            gen = gen_id,
-            "coordinated recovery complete; fence released"
-        );
     }
 
-    /// Observe-path restore (follower, or a leader retrying after its own restore failed):
-    /// fence around the restart, then release it. `false` if the restart failed (retried
-    /// next tick). Only the leader injects checkpoints, so its fence lifetime is what
-    /// gates the cluster; a follower's is just final-checkpoint suppression.
+    /// Observe-path restore (a follower seeing the leader's `Recover`): fence the restart,
+    /// then release it. `false` if it failed (retried next tick).
     async fn restore(
         &mut self,
         db: &Arc<LaminarDB>,
@@ -161,9 +170,8 @@ impl RecoveryMonitor {
         ok
     }
 
-    /// Restart this node to `target` and, on success, ack the generation and clear this
-    /// node's fault report. Fence-neutral — the caller owns the fence. `false` on failure
-    /// (`applied_gen` and the fault report are left untouched so the next tick retries).
+    /// Restart this node to `target`, then ack the generation and clear its fault report.
+    /// Fence-neutral. `false` on failure (state untouched so the next tick retries).
     async fn restore_and_ack(
         &mut self,
         db: &Arc<LaminarDB>,

--- a/crates/laminar-db/src/db.rs
+++ b/crates/laminar-db/src/db.rs
@@ -137,6 +137,13 @@ pub struct LaminarDB {
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller:
         parking_lot::Mutex<Option<Arc<laminar_core::cluster::control::ClusterController>>>,
+    /// When set, the next start restores to this cluster-agreed epoch instead of the
+    /// local latest (taken in `start_inner`).
+    #[cfg(feature = "cluster")]
+    pub(crate) recover_target_epoch: parking_lot::Mutex<Option<u64>>,
+    /// One-shot guard for the recovery-monitor spawn.
+    #[cfg(feature = "cluster")]
+    pub(crate) recovery_monitor_started: std::sync::atomic::AtomicBool,
     /// Paired with `vnode_registry`; the coordinator gates commits when both are installed.
     pub(crate) state_backend:
         parking_lot::Mutex<Option<Arc<dyn laminar_core::state::StateBackend>>>,
@@ -389,6 +396,10 @@ impl LaminarDB {
             mv_store: Arc::new(parking_lot::RwLock::new(crate::mv_store::MvStore::new())),
             #[cfg(feature = "cluster")]
             cluster_controller: parking_lot::Mutex::new(None),
+            #[cfg(feature = "cluster")]
+            recover_target_epoch: parking_lot::Mutex::new(None),
+            #[cfg(feature = "cluster")]
+            recovery_monitor_started: std::sync::atomic::AtomicBool::new(false),
             state_backend: parking_lot::Mutex::new(None),
             vnode_registry: parking_lot::Mutex::new(None),
             physical_optimizer_rules: physical_rules.into(),

--- a/crates/laminar-db/src/lib.rs
+++ b/crates/laminar-db/src/lib.rs
@@ -40,6 +40,8 @@ pub mod checkpoint_coordinator;
 mod config;
 mod connector_manager;
 mod coordinated_committer;
+#[cfg(feature = "cluster")]
+mod coordinated_recovery;
 mod core_window_state;
 mod db;
 /// Prometheus metrics for the streaming engine.

--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -108,6 +108,18 @@ pub trait PipelineCallback: Send + 'static {
         true
     }
 
+    /// `true` while a coordinated restart is in flight; the checkpoint gate holds and the
+    /// shutdown drain skips its final checkpoint. Default `false`.
+    fn is_recovering(&self) -> bool {
+        false
+    }
+
+    /// `true` if a fatal cycle error should fault for recovery rather than drop-and-continue
+    /// (exactly-once, or coordinated recovery). Default `false` (at-least-once drops).
+    fn fault_on_cycle_error(&self) -> bool {
+        false
+    }
+
     /// `true` when the cluster is converged enough for the leader to take a periodic
     /// checkpoint (see the gate in `StreamingCoordinator::maybe_checkpoint`). The
     /// cluster impl reads a watcher-published verdict locally — no gossip on the gate.
@@ -186,6 +198,13 @@ pub trait PipelineCallback: Send + 'static {
     /// Next checkpoint ID when managed externally.
     fn next_checkpoint_id(&self) -> Option<u64> {
         None
+    }
+
+    /// Gracefully close sinks on shutdown (abort open transactions, flush) so a restart
+    /// re-initialises cleanly. Default no-op. The `ready` expression (not `async {}`) keeps
+    /// `trait_variant`'s `impl Future` rewrite.
+    fn close_sinks(&mut self) -> impl std::future::Future<Output = ()> + Send {
+        std::future::ready(())
     }
 
     /// Register the local source barrier injectors.

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -989,9 +989,13 @@ impl StreamingCoordinator {
             return;
         }
 
-        // Explicit connector checkpoint requests are honored regardless of convergence.
+        // Explicit connector checkpoint requests are honored regardless of convergence —
+        // but NOT during a coordinated restart: sealing an epoch then would advance the
+        // committed state past the recovery target. The fence short-circuits before the
+        // swap so the request stays pending and fires once recovery releases the fence.
         let should_checkpoint = interval_due
             || (callback.is_leader()
+                && !callback.is_recovering()
                 && self
                     .checkpoint_request_flags
                     .iter()

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -989,10 +989,9 @@ impl StreamingCoordinator {
             return;
         }
 
-        // Explicit connector checkpoint requests are honored regardless of convergence —
-        // but NOT during a coordinated restart: sealing an epoch then would advance the
-        // committed state past the recovery target. The fence short-circuits before the
-        // swap so the request stays pending and fires once recovery releases the fence.
+        // Explicit connector checkpoint requests are honored regardless of convergence, but
+        // not during a coordinated restart (sealing an epoch would advance past the recovery
+        // target). The fence short-circuits before the swap, so the request fires afterwards.
         let should_checkpoint = interval_due
             || (callback.is_leader()
                 && !callback.is_recovering()

--- a/crates/laminar-db/src/pipeline/streaming_coordinator.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator.rs
@@ -582,11 +582,9 @@ impl StreamingCoordinator {
                             CycleError::Halt(msg) => {
                                 tracing::warn!(reason = %msg, "[LDB-3022] cycle halted");
                             }
-                            // Exactly-once: continuing would drop the drained rows (EO gap).
-                            CycleError::Fatal(msg)
-                                if self.config.delivery_guarantee
-                                    == DeliveryGuarantee::ExactlyOnce =>
-                            {
+                            // Continuing would drop the drained rows (EO gap), so fault for
+                            // recovery under exactly-once or coordinated recovery.
+                            CycleError::Fatal(msg) if callback.fault_on_cycle_error() => {
                                 tracing::error!(
                                     error = %msg,
                                     "[LDB-3021] fatal SQL cycle error; faulting for recovery"
@@ -744,8 +742,10 @@ impl StreamingCoordinator {
             }
 
             // Run the final checkpoint before dropping source senders so the EpochCommitted
-            // ack reaches the broker (Kafka group offsets, etc.).
-            let checkpoint_enabled = self.config.checkpoint_interval.is_some();
+            // ack reaches the broker (Kafka group offsets, etc.). Skip it during a recovery
+            // stop — committing the open epoch would advance the committed epoch past N.
+            let checkpoint_enabled =
+                self.config.checkpoint_interval.is_some() && !callback.is_recovering();
             if checkpoint_enabled {
                 let source_offsets = self.current_source_offsets();
                 if let Some(epoch) = callback
@@ -781,6 +781,12 @@ impl StreamingCoordinator {
                 }
             }
         }
+
+        // Abort an exactly-once producer's open transaction before a restart re-inits one
+        // (else the new producer races the old → InvalidProducerEpoch). A clean shutdown
+        // already committed via the final checkpoint above; this aborts only an in-flight
+        // (faulted or recovery-rewound) epoch.
+        callback.close_sinks().await;
 
         fault.map_or(ExitReason::Shutdown, ExitReason::Fault)
     }
@@ -976,7 +982,10 @@ impl StreamingCoordinator {
         // a respawned node has adopted the assignment align-waits on its not-yet-flowing
         // shuffle barrier and times out. The verdict is a local borrow, so don't bump
         // `last_checkpoint` — the first post-convergence checkpoint fires immediately.
-        if interval_due && !callback.assignment_ready_for_checkpoint().await {
+        // Also hold during a coordinated restart (injecting would seal an epoch past N).
+        if interval_due
+            && (callback.is_recovering() || !callback.assignment_ready_for_checkpoint().await)
+        {
             return;
         }
 

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1344,8 +1344,7 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     async fn close_sinks(&mut self) {
-        // Concurrently — a stalled sink shouldn't add its 15s timeout to every other one
-        // (recovery downtime would be N×15s with serial closes).
+        // Concurrently, so one stalled sink doesn't add its 15s timeout to every other.
         futures::future::join_all(self.sinks.iter().map(|(_, h, _, _, _)| h.close())).await;
     }
 

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -222,6 +222,7 @@ pub(crate) fn assignment_versions_converged(
     true
 }
 
+#[allow(clippy::struct_excessive_bools)] // config/state flags, not a state machine
 pub(crate) struct ConnectorPipelineCallback {
     pub(crate) graph: crate::operator_graph::OperatorGraph,
     pub(crate) stream_sources: Vec<(String, streaming::Source<crate::catalog::ArrowRecord>)>,
@@ -261,6 +262,9 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) checkpoint_interval: Option<std::time::Duration>,
     pub(crate) pipeline_hash: Option<u64>,
     pub(crate) delivery_guarantee: laminar_connectors::connector::DeliveryGuarantee,
+    /// Fault (rather than drop) on a fatal cycle error even at-least-once, so coordinated
+    /// recovery can drive a global restart and an EO sink's 2PC keeps output exactly-once.
+    pub(crate) coordinated_recovery: bool,
     pub(crate) serialization_timeout: Duration,
     pub(crate) sink_event_rx: laminar_core::streaming::AsyncConsumer<crate::sink_task::SinkEvent>,
     /// Set when a sink write times out; suppresses the next checkpoint to preserve the replay window.
@@ -1197,6 +1201,36 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
         source_batches: &FxHashMap<Arc<str>, Vec<RecordBatch>>,
         watermark: i64,
     ) -> Result<FxHashMap<Arc<str>, Vec<RecordBatch>>, crate::pipeline::CycleError> {
+        // Test-only one-shot fault injector for the recovery soak (inert in release / when
+        // unset): the first cycle after `LAMINAR_FAULT_INJECT_AFTER_MS` faults once.
+        #[cfg(debug_assertions)]
+        {
+            use std::sync::atomic::{AtomicBool, Ordering};
+            use std::sync::OnceLock;
+            use std::time::{Duration, Instant};
+            static AFTER_MS: OnceLock<Option<u64>> = OnceLock::new();
+            static START: OnceLock<Instant> = OnceLock::new();
+            static FIRED: AtomicBool = AtomicBool::new(false);
+            if let Some(after_ms) = *AFTER_MS.get_or_init(|| {
+                std::env::var("LAMINAR_FAULT_INJECT_AFTER_MS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+            }) {
+                let start = START.get_or_init(Instant::now);
+                if !FIRED.load(Ordering::Relaxed)
+                    && start.elapsed() >= Duration::from_millis(after_ms)
+                    && FIRED
+                        .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    return Err(crate::pipeline::CycleError::Fatal(
+                        "injected fault for coordinated-recovery soak \
+                         (LAMINAR_FAULT_INJECT_AFTER_MS)"
+                            .into(),
+                    ));
+                }
+            }
+        }
         self.source_wms_buf.clear();
         if let Some(ref tracker) = self.tracker {
             for (&sid, name_arc) in &self.source_name_arcs {
@@ -1306,6 +1340,12 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             let bytes = store.total_bytes() as u64;
             #[allow(clippy::cast_possible_wrap)]
             self.prom.mv_bytes_stored.set(bytes as i64);
+        }
+    }
+
+    async fn close_sinks(&mut self) {
+        for (_, handle, _, _, _) in &self.sinks {
+            handle.close().await;
         }
     }
 
@@ -1503,6 +1543,21 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             }
         }
         true
+    }
+
+    fn is_recovering(&self) -> bool {
+        #[cfg(feature = "cluster")]
+        {
+            if let Some(ref cc) = self.cluster_controller {
+                return cc.is_recovering();
+            }
+        }
+        false
+    }
+
+    fn fault_on_cycle_error(&self) -> bool {
+        use laminar_connectors::connector::DeliveryGuarantee;
+        self.delivery_guarantee == DeliveryGuarantee::ExactlyOnce || self.coordinated_recovery
     }
 
     #[cfg(feature = "cluster")]

--- a/crates/laminar-db/src/pipeline_callback.rs
+++ b/crates/laminar-db/src/pipeline_callback.rs
@@ -1344,9 +1344,9 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
     }
 
     async fn close_sinks(&mut self) {
-        for (_, handle, _, _, _) in &self.sinks {
-            handle.close().await;
-        }
+        // Concurrently — a stalled sink shouldn't add its 15s timeout to every other one
+        // (recovery downtime would be N×15s with serial closes).
+        futures::future::join_all(self.sinks.iter().map(|(_, h, _, _, _)| h.close())).await;
     }
 
     async fn write_to_sinks(&mut self, results: &FxHashMap<Arc<str>, Vec<RecordBatch>>) {

--- a/crates/laminar-db/src/pipeline_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle.rs
@@ -280,6 +280,29 @@ impl LaminarDB {
         *self.supervisor_self.lock() = Arc::downgrade(self);
     }
 
+    /// Make the next [`Self::start`] restore to `epoch` (the cluster-agreed cut) instead
+    /// of the local latest. Cleared on start.
+    #[cfg(feature = "cluster")]
+    pub fn set_recover_target_epoch(&self, epoch: u64) {
+        *self.recover_target_epoch.lock() = Some(epoch);
+    }
+
+    /// Start the per-node recovery monitor once. No-op when `coordinated_recovery` is off.
+    /// Must be called from a Tokio runtime.
+    #[cfg(feature = "cluster")]
+    pub fn enable_coordinated_recovery(self: &Arc<Self>) {
+        if !self.config.coordinated_recovery {
+            return;
+        }
+        if self
+            .recovery_monitor_started
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return;
+        }
+        crate::coordinated_recovery::spawn_monitor(self);
+    }
+
     /// Start the streaming pipeline. Idempotent if already running. On failure
     /// (or recovering from `Faulted`) it rebuilds from the surviving catalog.
     ///
@@ -1134,7 +1157,18 @@ impl LaminarDB {
         {
             let mut guard = self.coordinator.lock().await;
             if let Some(ref mut coord) = *guard {
-                match coord.recover().await {
+                // Restore to the cluster-agreed epoch if one was armed, else the local
+                // latest. Take it owned first so the guard isn't held across the await.
+                #[cfg(feature = "cluster")]
+                let recover_target = self.recover_target_epoch.lock().take();
+                #[cfg(feature = "cluster")]
+                let recovery = match recover_target {
+                    Some(target) => coord.recover_to_epoch(target).await,
+                    None => coord.recover().await,
+                };
+                #[cfg(not(feature = "cluster"))]
+                let recovery = coord.recover().await;
+                match recovery {
                     Ok(Some(recovered)) => {
                         recovered_source_wms = recovered
                             .manifest
@@ -1820,6 +1854,7 @@ impl LaminarDB {
                 .map(std::time::Duration::from_millis),
             pipeline_hash,
             delivery_guarantee: pipeline_config.delivery_guarantee,
+            coordinated_recovery: self.config.coordinated_recovery,
             serialization_timeout: std::time::Duration::from_secs(120),
             sink_event_rx,
             sink_timed_out: false,
@@ -1958,6 +1993,10 @@ impl LaminarDB {
             let watcher_supervisor = Arc::clone(&self.supervisor_self);
             let watcher_restart_history = Arc::clone(&self.restart_history);
             let watcher_metrics = self.engine_metrics.lock().clone();
+            #[cfg(feature = "cluster")]
+            let watcher_coord_recovery = self.config.coordinated_recovery;
+            #[cfg(feature = "cluster")]
+            let watcher_controller = self.cluster_controller.lock().clone();
             let handle = tokio::spawn(async move {
                 if done_rx.await.is_ok() {
                     // Only finalize for a timed-out stop. A normal stop/shutdown caller is
@@ -1977,6 +2016,16 @@ impl LaminarDB {
                     // Faulted, not Stopped — recoverable via a later start().
                     DbState::Faulted.store(&watcher_state);
                     watcher_shutdown.notify_one();
+                    // Coordinated recovery: report the fault and let the leader drive a global
+                    // restart; the monitor restores this node. A local restart would rewind
+                    // only this node while peers advanced — an inconsistent cut.
+                    #[cfg(feature = "cluster")]
+                    if watcher_coord_recovery {
+                        if let Some(controller) = watcher_controller {
+                            crate::coordinated_recovery::report_local_fault(&controller).await;
+                            return;
+                        }
+                    }
                     // Auto-restart if supervised; otherwise the pipeline stays Faulted.
                     let supervised = watcher_supervisor.lock().upgrade();
                     if let Some(db) = supervised {

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -761,7 +761,16 @@ impl<'a> RecoveryManager<'a> {
             return false;
         }
         match decision_store {
-            Some(ds) => !ds.is_committed(manifest.epoch).await.unwrap_or(false),
+            // A read error can't confirm the commit, so treat as uncommitted (skip) — but
+            // surface it rather than silently rewinding past a maybe-committed checkpoint.
+            Some(ds) => match ds.is_committed(manifest.epoch).await {
+                Ok(committed) => !committed,
+                Err(e) => {
+                    warn!(epoch = manifest.epoch, error = %e,
+                        "[LDB-6040] decision-store read failed; treating epoch as uncommitted");
+                    true
+                }
+            },
             None => true,
         }
     }

--- a/crates/laminar-db/src/recovery_manager.rs
+++ b/crates/laminar-db/src/recovery_manager.rs
@@ -327,100 +327,50 @@ impl<'a> RecoveryManager<'a> {
         sources: &[RegisteredSource],
         sinks: &[RegisteredSink],
         table_sources: &[RegisteredSource],
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
     ) -> Result<Option<RecoveredState>, DbError> {
-        // Fast path: try load_latest() first.
+        // Fast path: the latest checkpoint.
         match self.store.load_latest().await {
             Ok(Some(manifest)) => {
-                if self.is_checkpoint_corrupt(&manifest).await {
-                    warn!(
-                        checkpoint_id = manifest.checkpoint_id,
-                        "[LDB-6010] latest checkpoint corrupt, trying fallback"
-                    );
-                } else if Self::has_pending_sinks(&manifest) {
-                    warn!(
-                        checkpoint_id = manifest.checkpoint_id,
-                        epoch = manifest.epoch,
-                        "[LDB-6015] checkpoint has uncommitted sinks — source offsets \
-                         may be past uncommitted data, falling back to previous checkpoint"
-                    );
-                } else {
-                    let state = self
-                        .restore_from(manifest, sources, sinks, table_sources)
-                        .await;
-                    if let Err(e) = self.check_strict(&state) {
-                        warn!(
-                            checkpoint_id = state.manifest.checkpoint_id,
-                            error = %e,
-                            "latest checkpoint restore had strict errors, trying fallback"
-                        );
-                    } else {
-                        return Ok(Some(state));
-                    }
+                if let Some(state) = self
+                    .try_restore(manifest, sources, sinks, table_sources, decision_store)
+                    .await
+                {
+                    return Ok(Some(state));
                 }
             }
             Ok(None) => {
                 info!("no checkpoint found, starting fresh");
                 return Ok(None);
             }
-            Err(e) => {
-                warn!(error = %e, "latest checkpoint load failed, trying fallback");
-            }
+            Err(e) => warn!(error = %e, "latest checkpoint load failed, trying fallback"),
         }
 
-        // Fallback: iterate through all checkpoints in reverse order.
-        let checkpoints = self.store.list().await.map_err(DbError::from)?;
+        // Fallback: older checkpoints, newest first.
+        let mut checkpoints = self.store.list().await.map_err(DbError::from)?;
+        checkpoints.reverse();
+        self.restore_first(&checkpoints, sources, sinks, table_sources, decision_store)
+            .await
+    }
 
-        if checkpoints.is_empty() {
-            warn!("no checkpoints available for fallback, starting fresh");
-            return Ok(None);
-        }
-
-        for &(checkpoint_id, _epoch) in checkpoints.iter().rev() {
-            match self.store.load_by_id(checkpoint_id).await {
-                Ok(Some(manifest)) => {
-                    if self.is_checkpoint_corrupt(&manifest).await {
-                        warn!(
-                            checkpoint_id,
-                            "[LDB-6010] fallback checkpoint corrupt, skipping"
-                        );
-                        continue;
-                    }
-                    if Self::has_pending_sinks(&manifest) {
-                        warn!(
-                            checkpoint_id,
-                            "[LDB-6015] fallback checkpoint has uncommitted sinks, skipping"
-                        );
-                        continue;
-                    }
-                    info!(checkpoint_id, "recovering from fallback checkpoint");
-                    let state = self
-                        .restore_from(manifest, sources, sinks, table_sources)
-                        .await;
-                    if let Err(e) = self.check_strict(&state) {
-                        warn!(
-                            checkpoint_id,
-                            error = %e,
-                            "fallback checkpoint restore had strict errors, trying next"
-                        );
-                        continue;
-                    }
-                    return Ok(Some(state));
-                }
-                Ok(None) => {
-                    debug!(checkpoint_id, "fallback checkpoint not found, skipping");
-                }
-                Err(e) => {
-                    warn!(
-                        checkpoint_id,
-                        error = %e,
-                        "fallback checkpoint load failed, trying next"
-                    );
-                }
-            }
-        }
-
-        warn!("all checkpoints failed to load, starting fresh");
-        Ok(None)
+    /// Recover from the newest viable checkpoint with `epoch <= target_epoch` — the
+    /// coordinated-restart target, which may be older than this node's local latest.
+    ///
+    /// # Errors
+    /// Returns `DbError::Checkpoint` if the store fails.
+    pub(crate) async fn recover_to_epoch(
+        &self,
+        target_epoch: u64,
+        sources: &[RegisteredSource],
+        sinks: &[RegisteredSink],
+        table_sources: &[RegisteredSource],
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
+    ) -> Result<Option<RecoveredState>, DbError> {
+        let mut checkpoints = self.store.list().await.map_err(DbError::from)?;
+        checkpoints.retain(|&(_, epoch)| epoch <= target_epoch);
+        checkpoints.sort_by_key(|&(_, epoch)| std::cmp::Reverse(epoch)); // newest eligible first
+        self.restore_first(&checkpoints, sources, sinks, table_sources, decision_store)
+            .await
     }
 
     /// Resolve external operator states from the sidecar file into inline entries.
@@ -798,6 +748,86 @@ impl<'a> RecoveryManager<'a> {
             .any(|s| matches!(s, SinkCommitStatus::Pending))
     }
 
+    /// `true` when a checkpoint must be skipped for genuinely-uncommitted sinks: sinks are
+    /// `Pending` AND the decision marker does not confirm the epoch committed. A
+    /// pending-but-marker-committed epoch is NOT skipped — the sink committed but the
+    /// manifest wasn't updated before the fault, and rewinding the source behind it would
+    /// re-emit committed rows (duplicates); `reconcile_prepared_on_init` re-drives the commit.
+    async fn pending_uncommitted(
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
+        manifest: &CheckpointManifest,
+    ) -> bool {
+        if !Self::has_pending_sinks(manifest) {
+            return false;
+        }
+        match decision_store {
+            Some(ds) => !ds.is_committed(manifest.epoch).await.unwrap_or(false),
+            None => true,
+        }
+    }
+
+    /// Restore from `manifest` if it's viable; `None` means try an older checkpoint
+    /// (corrupt, genuinely-uncommitted sinks, or strict-mode restore errors).
+    async fn try_restore(
+        &self,
+        manifest: CheckpointManifest,
+        sources: &[RegisteredSource],
+        sinks: &[RegisteredSink],
+        table_sources: &[RegisteredSource],
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
+    ) -> Option<RecoveredState> {
+        let (checkpoint_id, epoch) = (manifest.checkpoint_id, manifest.epoch);
+        if self.is_checkpoint_corrupt(&manifest).await {
+            warn!(
+                checkpoint_id,
+                epoch, "[LDB-6010] checkpoint corrupt, trying older"
+            );
+            return None;
+        }
+        if Self::pending_uncommitted(decision_store, &manifest).await {
+            warn!(
+                checkpoint_id,
+                epoch, "[LDB-6015] uncommitted sinks, trying older"
+            );
+            return None;
+        }
+        let state = self
+            .restore_from(manifest, sources, sinks, table_sources)
+            .await;
+        if let Err(e) = self.check_strict(&state) {
+            warn!(checkpoint_id, epoch, error = %e, "strict restore errors, trying older");
+            return None;
+        }
+        Some(state)
+    }
+
+    /// Restore from the first viable checkpoint in `candidates` (try-order); `Ok(None)`
+    /// if none restore. `candidates` are `(checkpoint_id, epoch)` pairs.
+    async fn restore_first(
+        &self,
+        candidates: &[(u64, u64)],
+        sources: &[RegisteredSource],
+        sinks: &[RegisteredSink],
+        table_sources: &[RegisteredSource],
+        decision_store: Option<&laminar_core::checkpoint_decision::CheckpointDecisionStore>,
+    ) -> Result<Option<RecoveredState>, DbError> {
+        for &(checkpoint_id, _) in candidates {
+            match self.store.load_by_id(checkpoint_id).await {
+                Ok(Some(manifest)) => {
+                    if let Some(state) = self
+                        .try_restore(manifest, sources, sinks, table_sources, decision_store)
+                        .await
+                    {
+                        return Ok(Some(state));
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => warn!(checkpoint_id, error = %e, "checkpoint load failed, trying older"),
+            }
+        }
+        Ok(None)
+    }
+
     fn check_strict(&self, state: &RecoveredState) -> Result<(), DbError> {
         if !self.strict || !state.has_errors() {
             return Ok(());
@@ -858,7 +888,7 @@ mod tests {
         let store = make_store(dir.path());
         let mgr = RecoveryManager::new(&store);
 
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
         assert!(result.is_none());
     }
 
@@ -872,13 +902,58 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         assert_eq!(result.epoch(), 5);
         assert_eq!(result.sources_restored, 0);
         assert_eq!(result.tables_restored, 0);
         assert_eq!(result.sinks_rolled_back, 0);
         assert!(!result.has_errors());
+    }
+
+    #[tokio::test]
+    async fn recover_to_epoch_picks_newest_at_or_below_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+        for (id, epoch) in [(1u64, 3u64), (2, 5), (3, 7)] {
+            store
+                .save(&CheckpointManifest::new(id, epoch))
+                .await
+                .unwrap();
+        }
+        let mgr = RecoveryManager::new(&store);
+
+        assert_eq!(
+            mgr.recover_to_epoch(7, &[], &[], &[], None)
+                .await
+                .unwrap()
+                .unwrap()
+                .epoch(),
+            7
+        );
+        // A newer local epoch is rewound to the cluster-agreed target.
+        assert_eq!(
+            mgr.recover_to_epoch(6, &[], &[], &[], None)
+                .await
+                .unwrap()
+                .unwrap()
+                .epoch(),
+            5
+        );
+        assert_eq!(
+            mgr.recover_to_epoch(5, &[], &[], &[], None)
+                .await
+                .unwrap()
+                .unwrap()
+                .epoch(),
+            5
+        );
+        // Nothing committed at or below the target → fresh start.
+        assert!(mgr
+            .recover_to_epoch(2, &[], &[], &[], None)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -891,7 +966,7 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         assert_eq!(result.watermark(), Some(42_000));
     }
@@ -911,7 +986,7 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         assert_eq!(result.operator_states().len(), 2);
         let op0 = result.operator_states().get("0").unwrap();
@@ -928,7 +1003,7 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         assert_eq!(
             result.table_store_checkpoint_path(),
@@ -989,7 +1064,7 @@ mod tests {
         // (it already does from the save, but the manifest file is now corrupt)
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
 
         // Should fall back to checkpoint 1
         let recovered = result.expect("should recover from fallback checkpoint");
@@ -1014,7 +1089,7 @@ mod tests {
         std::fs::write(&manifest_path, "corrupt").unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
 
         // All checkpoints corrupt → fresh start
         assert!(result.is_none());
@@ -1029,7 +1104,7 @@ mod tests {
         store.save(&CheckpointManifest::new(2, 20)).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         // Should use the latest (no fallback needed)
         assert_eq!(result.manifest.checkpoint_id, 2);
@@ -1056,7 +1131,7 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         // External state should have been resolved to inline
         let op = result.operator_states().get("big-op").unwrap();
@@ -1087,7 +1162,7 @@ mod tests {
         store.save(&manifest).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         let small = result.operator_states().get("small-op").unwrap();
         assert_eq!(small.decode_inline().unwrap(), b"tiny");
@@ -1112,7 +1187,7 @@ mod tests {
         // sidecar state with empty inline. Strict mode rejects this
         // checkpoint entirely (see test_recover_missing_sidecar_strict).
         let mgr = RecoveryManager::lenient(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap().unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap().unwrap();
 
         // Should still recover (gracefully) — external state replaced with
         // empty inline to avoid dangling offset references
@@ -1166,7 +1241,7 @@ mod tests {
         // and recovery falls back. With only one checkpoint, this means
         // fresh start.
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
         assert!(
             result.is_none(),
             "strict mode should reject checkpoint with missing sidecar"
@@ -1191,7 +1266,7 @@ mod tests {
         store.save(&m2).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
         let state = result.expect("should recover from epoch 1 fallback");
 
         // Must fall back to epoch 1 (the last fully committed checkpoint),
@@ -1215,7 +1290,7 @@ mod tests {
         store.save(&m).await.unwrap();
 
         let mgr = RecoveryManager::new(&store);
-        let result = mgr.recover(&[], &[], &[]).await.unwrap();
+        let result = mgr.recover(&[], &[], &[], None).await.unwrap();
         assert!(
             result.is_none(),
             "should start fresh when all checkpoints have pending sinks"

--- a/crates/laminar-db/src/sink_task.rs
+++ b/crates/laminar-db/src/sink_task.rs
@@ -99,7 +99,7 @@ pub(crate) enum SinkCommand {
     Sync {
         ack: oneshot::TxOneshot<()>,
     },
-    #[cfg(test)]
+    /// Close the connector (abort open transaction, flush) and exit the task.
     Close,
 }
 
@@ -303,12 +303,13 @@ impl SinkTaskHandle {
         ack_rx.await.map_err(|_| self.ack_dropped_err("abandon"))?
     }
 
-    #[cfg(test)]
+    /// Gracefully close the sink: aborts any open transaction (so an exactly-once
+    /// producer doesn't fence the next incarnation on restart) and joins the task.
     pub async fn close(&self) {
         let _ = self.tx.send(SinkCommand::Close).await;
         let handle = self.task.lock().take();
         if let Some(handle) = handle {
-            let _ = tokio::time::timeout(Duration::from_secs(30), handle).await;
+            let _ = tokio::time::timeout(Duration::from_secs(15), handle).await;
         }
     }
 
@@ -457,7 +458,6 @@ async fn handle_sink_command(
         SinkCommand::Sync { ack } => {
             ack.send(());
         }
-        #[cfg(test)]
         SinkCommand::Close => {
             if let Err(e) = inner.sink.flush().await {
                 tracing::warn!(sink = %inner.name, error = %e,

--- a/crates/laminar-server/src/cluster.rs
+++ b/crates/laminar-server/src/cluster.rs
@@ -589,7 +589,8 @@ pub async fn start_cluster(
     builder = builder
         .shuffle_sender(Arc::clone(&shuffle_sender))
         .shuffle_receiver(Arc::clone(&shuffle_receiver))
-        .target_partitions(1);
+        .target_partitions(1)
+        .coordinated_recovery(config.supervision.coordinated_recovery);
 
     let db = builder
         .build()
@@ -644,6 +645,10 @@ pub async fn start_cluster(
             }
             _ => None,
         };
+
+    // No-op unless [supervision] coordinated_recovery is on. Before start() so an early
+    // fault is observed.
+    db.enable_coordinated_recovery();
 
     db.start()
         .await

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -416,6 +416,10 @@ pub struct SupervisionSection {
     pub window_secs: Option<u64>,
     pub initial_backoff_ms: Option<u64>,
     pub max_backoff_secs: Option<u64>,
+    /// Cluster mode: on a fatal fault, rewind every node to the highest cluster-wide
+    /// committed epoch instead of a local-only restart. Default off.
+    #[serde(default)]
+    pub coordinated_recovery: bool,
 }
 
 impl SupervisionSection {

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -44,6 +44,11 @@
 //! - `LAMINAR_SOAK_CHANGELOG_AGG`  any value: add an `EMIT CHANGES` aggregate so
 //!   the changelog `last_emitted` delta path is exercised under kill -9 + rebalance.
 //!   Pair with `LAMINAR_SOAK_DELTA_CHAIN_MAX` (else the agg captures FULL).
+//! - `LAMINAR_SOAK_COORD_RECOVERY`  any value: set `[supervision] coordinated_recovery`.
+//! - `LAMINAR_SOAK_FAULT_INJECT_MS`  arm a one-shot cycle fault on one node this many ms
+//!   in; `LAMINAR_SOAK_FAULT_INJECT_NODE` (default 1 = follower; 0 = leader) picks which.
+//!   The 1A-cluster recovery soak runs these with `LAMINAR_SOAK_COORD_RECOVERY=1`,
+//!   `LAMINAR_SOAK_KILLS=0`, and the Kafka EO sink.
 
 use std::io::{Read, Write as _};
 use std::net::TcpStream;
@@ -68,6 +73,8 @@ struct Node {
     log_path: PathBuf,
     child: Option<Child>,
     http_port: u16,
+    /// `LAMINAR_FAULT_INJECT_AFTER_MS` for this node, when armed (recovery soak).
+    fault_inject_ms: Option<u64>,
 }
 
 impl Node {
@@ -77,18 +84,19 @@ impl Node {
             .append(true)
             .open(&self.log_path)
             .expect("node log file");
-        let child = Command::new(env!("CARGO_BIN_EXE_laminardb"))
-            .arg("--config")
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_laminardb"));
+        cmd.arg("--config")
             .arg(&self.config_path)
             .env(
                 "RUST_LOG",
                 "laminardb=info,laminar_server=info,laminar_db=info,laminar_core=info",
             )
             .stdout(Stdio::from(log.try_clone().expect("clone log handle")))
-            .stderr(Stdio::from(log))
-            .spawn()
-            .expect("spawn laminardb");
-        self.child = Some(child);
+            .stderr(Stdio::from(log));
+        if let Some(ms) = self.fault_inject_ms {
+            cmd.env("LAMINAR_FAULT_INJECT_AFTER_MS", ms.to_string());
+        }
+        self.child = Some(cmd.spawn().expect("spawn laminardb"));
     }
 
     /// `kill -9` equivalent: no shutdown hooks, no final checkpoint.
@@ -359,6 +367,10 @@ format = "json"
         ));
     }
 
+    if std::env::var("LAMINAR_SOAK_COORD_RECOVERY").is_ok() {
+        toml.push_str("\n[supervision]\ncoordinated_recovery = true\n");
+    }
+
     let path = dir.join(format!("node{id}.toml"));
     std::fs::write(&path, toml).unwrap();
     path
@@ -532,6 +544,12 @@ fn three_node_kill9_soak() {
     std::fs::create_dir_all(&log_dir).unwrap();
     eprintln!("soak: node logs in {}", log_dir.display());
 
+    // Recovery soak: arm a one-shot fault on a single node (default 1 = follower, 0 = leader).
+    let fault_inject_ms = std::env::var("LAMINAR_SOAK_FAULT_INJECT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok());
+    let fault_inject_node = env_u64("LAMINAR_SOAK_FAULT_INJECT_NODE", 1) as usize;
+
     let mut nodes: Vec<Node> = (0..NODES)
         .map(|id| Node {
             id,
@@ -539,6 +557,7 @@ fn three_node_kill9_soak() {
             log_path: log_dir.join(format!("node{id}.log")),
             child: None,
             http_port: BASE_PORT + id as u16,
+            fault_inject_ms: fault_inject_ms.filter(|_| id == fault_inject_node),
         })
         .collect();
     for n in &mut nodes {
@@ -981,6 +1000,7 @@ fn graceful_rotation_kafka_soak() {
             log_path: log_dir.join(format!("node{id}.log")),
             child: None,
             http_port: BASE_PORT + id as u16,
+            fault_inject_ms: None,
         })
         .collect();
 

--- a/docs/plans/1a-cluster-recovery-driver.md
+++ b/docs/plans/1a-cluster-recovery-driver.md
@@ -1,0 +1,204 @@
+# 1A-cluster: leader-coordinated recovery driver (global restart-to-epoch)
+
+Make a **fatal cycle error on one cluster node** recover correctly instead of corrupting the
+distributed cut. Single-node 1A (`92fdf9d8`) recovers one node from its last checkpoint; in a
+cluster with cross-node shuffle a local-only restart rewinds the faulted node to committed epoch
+N while peers have produced/consumed shuffle rows for N+1 → lost/dup in-flight rows. This is
+Flink's *global* recovery: drive every node back to one consistent epoch and reprocess.
+
+Status: **NOT built.** A first attempt (reverted) hand-rolled a gossip-KV polling protocol with a
+per-node fence and per-node target computation — it had a real divergence bug and no soak. This
+plan is the correct approach. Build it only with the soak budget below; do not merge before the
+soak is green.
+
+## Semantics
+
+On a fatal fault: all nodes rewind to N = highest epoch committed by **every** participant, and
+reprocess. N is durable/restorable; epochs > N were never committed, so reprocessing is
+exactly-once-safe (committed sinks at N are the truth; the EO 2PC dedups the re-emit). Recovery is
+EO **only for replayable sources** (re-seek to N's offsets; `supports_replay`) and transactional /
+idempotent-keyed sinks; a non-replayable source loses data on rewind and a non-transactional sink
+re-emits duplicates — state these as the semantic boundary.
+
+**Latency tradeoff (be honest about it).** Global recovery is a *full-cluster processing pause* on
+every fault. Flink moved off this to **pipelined-region failover** as the default in 1.9 (only the
+tasks in the failed pipelined region restart). The reason global is an acceptable **v1** here:
+- For a single job with a **cross-node keyed shuffle, the pipelined region spans the whole job**, so
+  region ≈ global anyway (RisingWave and Arroyo both recover the whole job from the last barrier).
+- Regional failover's real win is **multi-query / embarrassingly-parallel** pipelines, where one
+  query's fault must not pause the others — that is exactly the **1B blast-radius** work, which
+  becomes *required* (not "later optional") to avoid a multi-tenant latency regression. Sequence 1B
+  as the near-term follow-up, and adopt Flink's region model: restart the smallest set of
+  pipeline-connected tasks, not the whole cluster.
+
+## Correctness invariants (the attempt got these wrong — get them right)
+
+1. **One target epoch, chosen once, broadcast explicitly.** Every node must rewind to the SAME N.
+   Do NOT have each node read `highest_committed` independently — between the trigger and a node
+   observing it, an in-flight checkpoint commit or a leader change advances `highest_committed`, so
+   nodes diverge to different epochs → inconsistent cut. The leader fixes N at decision time and
+   broadcasts the value.
+2. **Cluster-wide fence before N is read, released only after all nodes restored.** Hold barrier
+   injection from the moment recovery is decided until every live node acks restored-to-N. A
+   per-node-local fence is wrong: leadership can change mid-recovery and the new leader's local flag
+   is unset. Tie the fence to the recovery phase observed cluster-wide, not a local atomic.
+3. **Idempotent + monotonic.** A re-fault during recovery, a node that was down at announce time,
+   and duplicate observes must all converge. Track applied recovery by a monotonic id and the
+   target epoch, both carried in the announcement.
+
+## Design — reuse the existing control plane, don't hand-roll
+
+The codebase already has `BarrierCoordinator` (leader `announce` → follower `observe`/`ack` →
+quorum, over gRPC with gossip-KV fallback) and a per-epoch 2PC decision store. Recovery is
+structurally the same announce/ack/quorum. Reuse it; do not build a parallel KV-polling protocol.
+
+1. **`Phase::Recover` on the existing announcement.** Add `Recover` to `Phase`
+   (`cluster/control/barrier.rs`) — a unit variant, so `Phase` stays `Copy`. Carry the target in
+   the existing `BarrierAnnouncement.epoch`. Leader announces
+   `{ epoch: N, phase: Recover, checkpoint_id }`; followers `observe` it (event-driven via the
+   existing gRPC watch + gossip fallback — no polling).
+2. **Leader decision.** On a fault report, the leader: stops injecting periodic barriers (fence),
+   picks N = `CheckpointDecisionStore::highest_committed()` (re-add — the 2PC marker is written
+   only after full-membership quorum, so its presence = committed cluster-wide), and announces
+   `Recover(N)`. N is the fixed broadcast value.
+3. **Per-node restore.** On observing `Recover(N)`: `set_recover_target_epoch(N)` → stop pipeline →
+   `start()` → `recover_to_epoch(N)` (re-add these two small primitives — they were correct). Then
+   ack restored-to-N via the existing `BarrierAck` path.
+4. **Fence release.** Leader waits for the restored-to-N quorum (reuse `await_*_quorum`), then
+   resumes barrier injection. The existing checkpoint gate stays held while `phase == Recover` is
+   the latest observed announcement.
+5. **Fault report.** A node hitting `ExitReason::Fault` in cluster mode does not locally restart
+   (suppress the supervisor when coordinated recovery is on); it signals the leader via the same
+   control plane (a fault ack / a `BarrierAck { ok: false }`-style signal). On leader fault, the
+   new gossip-elected leader drives recovery.
+6. **Guards.** Cluster-scoped restart budget (reuse `RestartPolicy` semantics) → escalate to a
+   cluster-wide hard-fault surfaced in `/metrics` + status. Bound the restored-to-N wait.
+
+Config: `[coordination] coordinated_recovery` (default off until soak-proven), wired
+builder → server, same staged rollout the delta work used.
+
+## Files
+
+- `crates/laminar-core/src/cluster/control/barrier.rs`: `Phase::Recover`; leader announce + the
+  restored-to-N ack/quorum (extend the existing announce/observe/ack, don't duplicate).
+- `crates/laminar-core/src/checkpoint_decision.rs`: re-add `highest_committed`.
+- `crates/laminar-db/src/recovery_manager.rs` + `checkpoint_coordinator.rs`: re-add
+  `recover_to_epoch`.
+- `crates/laminar-db/src/db.rs` + `pipeline_lifecycle.rs`: `recover_target_epoch` +
+  `set_recover_target_epoch`; consume in `start_inner`; route `ExitReason::Fault` to the
+  report-and-await path in cluster mode (suppress the local supervisor).
+- `crates/laminar-db/src/pipeline_callback.rs`: checkpoint gate also holds while a recovery phase
+  is in flight (reuse the controller's recovery state, derived from the observed phase — not a
+  free-floating local atomic).
+- `crates/laminar-server/...`: `coordinated_recovery` config + flag wiring.
+
+## Soak validation (the acceptance gate — merge only when green)
+
+Tooling (the reverted attempt's harness pieces were right — rebuild them):
+- **Fault injector**: `#[cfg(debug_assertions)]` one-shot in `execute_cycle`, armed by
+  `LAMINAR_FAULT_INJECT_AFTER_MS` (per-process, so the soak arms exactly one node). Inert in release.
+- **Soak knobs** in `cluster_soak.rs`: `LAMINAR_SOAK_COORD_RECOVERY` (sets the config flag),
+  `LAMINAR_SOAK_FAULT_INJECT_MS` (arms node 1). Reuse `three_node_kill9_soak` with
+  `LAMINAR_SOAK_KILLS=0` so the injected fault is the only disruption.
+- The pipeline must be **ExactlyOnce** for the fault to become `ExitReason::Fault`, so run with the
+  Kafka EO sink (`LAMINAR_SOAK_KAFKA_BROKERS=127.0.0.1:29092`); the existing
+  `verify_exactly_once_output` is the gap/dup proof.
+
+Acceptance — all green:
+1. **Follower fault**: node 1 faults mid-stream → cluster coordinates restart-to-N → commits resume
+   AND every node's EO topic stays dense (no gap, no duplicate).
+2. **Leader fault**: arm the fault on the leader (node 0) → new leader drives recovery → same EO
+   assertion.
+3. **Fault during rebalance churn**: combine with a membership change → no deadlock, EO holds.
+4. Repeat each several rounds; epochs never regress; killed/faulted nodes rejoin.
+
+Run the harness via `laminardb-test-harness/docker/compose` (redpanda `127.0.0.1:29092`); recreate
+redpanda (down/up, not restart) if degraded. Build needs the OpenSSL env (rdkafka dev-dep). Build
+one cargo invocation at a time and watch memory — the full server build links a large binary.
+
+## Recovery latency (RTO) — the dimension that matters for "real-time"
+
+The plan above gets *correctness*; this is what makes it *low-latency*. RTO ≈ fault-detect +
+leader-coordinate + state-reload + reprocess-from-N. Attack each:
+
+- **Don't rebuild state — read it from shared storage.** The engine already writes vnode partials
+  and checkpoints to a shared object store, so a coordinated restart should reload epoch N from
+  there (RisingWave's model: recovery reads the last consistent SSTable set from object storage with
+  no upload/rebuild). Flink 2.0's disaggregated state reports **up to 49× faster recovery** precisely
+  because state isn't re-materialized over the network.
+- **Reuse local state when the node still has it.** If a restarting node already holds epoch N's
+  state on local disk/cache, skip the object-store read (Flink *task-local recovery*). Biggest RTO
+  lever; the current `db.stop()`/`db.start()` re-reads from the store unconditionally.
+- **Avoid full graph teardown.** `stop()`/`start()` rebuilds the operator graph and reopens sources.
+  The latency-optimized path resets operators to N and resumes in place (Flink/RisingWave do this).
+  Acceptable to ship the full-restart path first, but track in-place reset as the RTO follow-up.
+- **Small rewind via frequent + cheap checkpoints.** Reprocess time = (now − N). The 100ms floor +
+  delta checkpoints already bound this; keep N close to head.
+- **Leader-election cost.** When the *leader* faults, RTO includes gossip re-election (phi-accrual,
+  ~seconds). Fold this into the budget; the leader-fault soak variant must measure it.
+- **Coordinate processing resumption, not just checkpointing.** The fence holds barrier injection,
+  but `start()` resumes source reads + cross-node shuffle immediately, so a node can shuffle to a
+  peer still restarting. This is already self-healed by the existing **`ShuffleNotReady` deferral +
+  convergence gate (`0bccbe14`)** — the shuffle defers until the peer is ready. Credit that reuse
+  explicitly; it's why staggered restart is safe without a second processing-level fence.
+
+Set an explicit **RTO target** (e.g. p99 < N seconds) and assert it in the soak.
+
+## 2026 state of the art & research roadmap
+
+Techniques to adopt (in roughly priority order), each tied to this engine. These improve checkpoint
+latency, recovery time, and state cost — and several directly shrink the recovery rewind window.
+
+**Checkpoint latency**
+- **Unaligned checkpoints** (Flink FLIP-76): under backpressure/skew, aligned barriers block the
+  fast channels until the slow one's barrier arrives, adding ≥ `t_align` to end-to-end latency and
+  to checkpoint duration. Unaligned lets the barrier overtake records and snapshots in-flight data
+  instead of waiting (EO, one concurrent checkpoint). This engine uses **aligned cross-node
+  barriers**, so it pays exactly this stall — the single biggest checkpoint-latency win available,
+  and it shrinks the rewind window (smaller N→head). Pair with **buffer debloating** (FLIP-183) to
+  cut in-flight bytes so even aligned checkpoints (and unaligned snapshot size) stay small.
+- **Generic log-based incremental checkpoints** (Flink FLIP-158): continuously upload a state
+  changelog and materialize the base infrequently, so each checkpoint's async phase flushes only a
+  small, stable delta → faster, more *stable* checkpoints → more frequent EO 2PC commits → lower
+  end-to-end latency and *less replay on failover*. The engine's **delta checkpoints (Lever 2)** are
+  the same idea; extending them (changelog for all operators, not just agg) is the path.
+
+**Cluster recovery**
+- **Pipelined-region failover** (Flink FLIP-1, default since 1.9): restart only the smallest
+  pipeline-connected region. This *is* the 1B work — promote it from "later" to near-term.
+- **Task-local recovery** (Flink): reuse on-node state to avoid DFS reload (the RTO lever above).
+- **Approximate task-local recovery** (Flink FLIP-135): restart only the failed task, trading
+  consistency for speed — an *at-least-once* fast path for non-EO pipelines; offer as an opt-in mode.
+- **Recovery without state rebuild** (RisingWave Hummock): because state is already in object
+  storage, restart reads the last consistent set rather than re-shuffling/rebuilding — the model the
+  coordinated restart should follow here.
+
+**State management**
+- **Disaggregated state** (Flink 2.0 *ForSt*, VLDB 2025): DFS-primary state with local cache +
+  **async state access** (State V2) to hide remote latency; reported **up to 94% shorter checkpoint
+  duration, up to 49× faster recovery/rescale, ~50% cost**. This is the strategic direction for
+  cloud-native recovery + elastic rescale, and it makes global restart-to-epoch cheap.
+- **Cloud-native LSM state on object store** (RisingWave Hummock): multi-tier (memory/disk/object)
+  LSM, append-only writes, per-barrier snapshot = natural MVCC, horizontal scale **without shuffling
+  state**, sub-100ms latency over S3. The engine's **ADR-005 tiered state** + shared object-store
+  backend are steps toward this; aligning the state layout with an LSM/SSTable + manifest model
+  would unlock no-rebuild recovery and zero-copy rescale.
+- **Async, non-blocking state access**: required to make remote/disaggregated state viable on the
+  hot path (Flink 2.0 redesigned its operators for this). Relevant if state moves off-heap/remote.
+
+Recent production resiliency work to track: *StreamShield* (Fang et al., ByteDance,
+[arXiv:2602.03189](https://arxiv.org/abs/2602.03189), 2026) — production Flink resiliency at scale
+via fine-grained fault-tolerance, a hybrid replication strategy, and HA under external systems;
+maps onto the regional-failover and state-redundancy directions above.
+
+Sequencing recommendation: (1) this driver as correct global v1; (2) unaligned + buffer debloating
+(checkpoint latency, smaller rewind); (3) task-local / no-rebuild recovery (RTO); (4) regional
+failover = 1B (multi-query latency isolation); (5) disaggregated state (cloud-native recovery +
+rescale) as the larger strategic bet.
+
+## Anti-patterns to avoid (from the reverted attempt)
+
+- No parallel gossip-KV polling protocol — reuse `BarrierCoordinator` announce/ack/quorum.
+- No per-node independent `highest_committed` read — broadcast one explicit target N.
+- No per-node-local fence for a cluster-wide decision — tie the fence to the observed phase.
+- No merge before the soak is green — unsoaked distributed recovery is the false-confidence trap.

--- a/docs/plans/1a-cluster-recovery-driver.md
+++ b/docs/plans/1a-cluster-recovery-driver.md
@@ -6,10 +6,93 @@ cluster with cross-node shuffle a local-only restart rewinds the faulted node to
 N while peers have produced/consumed shuffle rows for N+1 → lost/dup in-flight rows. This is
 Flink's *global* recovery: drive every node back to one consistent epoch and reprocess.
 
-Status: **NOT built.** A first attempt (reverted) hand-rolled a gossip-KV polling protocol with a
-per-node fence and per-node target computation — it had a real divergence bug and no soak. This
-plan is the correct approach. Build it only with the soak budget below; do not merge before the
-soak is green.
+Status: **Driver core built, flag-off, soak pending.** A first attempt (reverted) hand-rolled a
+gossip-KV polling protocol with a per-node fence and per-node target computation — it had a real
+divergence bug and no soak. This plan is the correct approach. The driver below is now implemented
+behind `[supervision] coordinated_recovery` (default off, zero behavior change when off); the
+fault-injection EO soak is built but **not yet run** — do not merge before it is green.
+
+### Implemented (this branch, default off)
+
+- Primitives re-added (from the reverted `ba32290a`, unit-tested): `CheckpointDecisionStore::highest_committed`,
+  `RecoveryManager::recover_to_epoch` + `CheckpointCoordinator::recover_to_epoch`, the
+  `recover_target_epoch` plumbing (`db.rs` field + `set_recover_target_epoch` + `start_inner`
+  consumption).
+- `Phase::Recover` on the existing announcement (`barrier.rs`): gossip-only delivery (KV-only,
+  observed by the per-node monitor, no phase-RPC fast path — recovery is mutually exclusive with
+  checkpointing so it never races one).
+- `ClusterController` recovery fence (`is_recovering`/`set_recovering`) + KV helpers
+  (`report_fault`/`read_fault_reports`, `announce_recovered`/`read_recovered`).
+- The driver: `crates/laminar-db/src/coordinated_recovery.rs` — a long-lived per-node monitor.
+  (A) any node restores on observing a new `Recover(N, gen)`; (B) the leader edge-triggers on a
+  changed fault report, fixes `N` from the **DB-level decision store** (works even when its own
+  coordinator is stopped → leader-fault case), announces, restores itself, then waits a
+  restored-to-N quorum before releasing the fence. Restore runs on a dedicated thread (`start()` is
+  `!Send`). Recovery generation is a max-wins KV key, decoupled from the epoch, stable across leader
+  change.
+- Fault routing (`pipeline_lifecycle.rs`): in cluster + coordinated-recovery mode a fault reports to
+  the cluster and suppresses the local supervisor restart (a local-only restart would rewind one
+  node → inconsistent cut).
+- Fence wiring (`streaming_coordinator.rs`): the periodic-checkpoint gate holds while recovering,
+  and the shutdown drain skips its final checkpoint (which would seal an epoch past `N`).
+- Config/build: `LaminarConfig::coordinated_recovery` + builder `.coordinated_recovery(..)` +
+  `LaminarDB::enable_coordinated_recovery` (spawns the monitor once); server `[supervision]
+  coordinated_recovery` wired through cluster startup.
+- Harness: a debug-only one-shot cycle-fault injector (`LAMINAR_FAULT_INJECT_AFTER_MS`) and soak
+  knobs (`LAMINAR_SOAK_COORD_RECOVERY`, `LAMINAR_SOAK_FAULT_INJECT_MS`/`_NODE`) in `cluster_soak.rs`.
+
+Gates green: `laminar-core`/`laminar-db`/`laminar-server` compile `--features cluster` (+ non-cluster),
+clippy clean, `highest_committed` + `recover_to_epoch` unit tests pass.
+
+### Soak run (follower-fault variant) — RED, driver correct, 4th-layer blocker
+
+Ran `three_node_kill9_soak` with `LAMINAR_SOAK_COORD_RECOVERY=1 LAMINAR_SOAK_FAULT_INJECT_MS=45000
+LAMINAR_SOAK_FAULT_INJECT_NODE=1 LAMINAR_SOAK_KILLS=0` + Kafka EO sink (fresh Redpanda). The
+**recovery protocol itself is validated**: the leader detects the fault, fixes `N` = highest
+committed, announces `Recover(N)`, and **all three nodes rewind to `N` and the fence releases**. Three
+real bugs were found and fixed getting there:
+
+1. **Fault never triggered under the server's config.** The server never sets the pipeline
+   `delivery_guarantee` (it configures EO per-sink), so a fatal cycle error drops-and-continues —
+   coordinated recovery would never fire in production. Fixed: `PipelineCallback::fault_on_cycle_error`
+   faults under EO **or** coordinated recovery (the EO sink's 2PC + checkpoint replay give end-to-end
+   EO, the kill-9 model); pipeline stays AtLeastOnce so cluster formation still commits.
+2. **`observe_barrier` epoch-merge shadowed the Recover.** It merges gRPC+gossip by highest epoch, so
+   the lower-epoch recovery target was hidden behind the stale in-flight checkpoint announcement.
+   Fixed with `observe_recover` (reads the leader's gossip slot directly).
+3. **EO Kafka producer went Fatal on the in-process restart.** `SinkTaskHandle::close()` was
+   test-only, so the sink was dropped (not gracefully closed) on stop, leaving the transaction open;
+   the new producer's `init_transactions` raced the old → `InvalidProducerEpoch`. Fixed: close sinks
+   (abort txn + flush) on coordinator shutdown.
+
+A 4th bug then surfaced and was fixed: **the restarted node could not resume the cross-node shuffle**
+(leader stuck on `shuffle stream to peer … closed`). Root cause: the shuffle sender's per-peer driver
+tasks are spawned on the compute-thread runtime, which an in-process restart drops — leaving
+`is_alive() == true` zombie connections the pool reused forever. Fixed: `PeerConn::is_alive` also
+checks `!driver.is_finished()`, so the first post-restart send purges the zombie and reconnects.
+
+With all four fixes, the three variants each passed a clean run (follower / leader / rebalance-churn),
+EO-dense on all topics.
+
+A 5th bug (an intermittent duplicate) was then root-caused and fixed: the marker is written *before*
+sink commit, so a fault can land after Kafka commits epoch `N` but before the manifest records it
+(sinks still `Pending`). Recovery was *skipping* that pending-sink checkpoint and rewinding the source
+to `N-1`, while `reconcile_prepared_on_init` re-drove `N`'s commit separately — so the pipeline
+re-produced `N` and the fresh producer re-committed it (dup). Fix: recovery no longer skips a
+pending-sink checkpoint whose **decision marker says committed** (`RecoveryManager::pending_uncommitted`
+gates the skip on `!is_committed`), keeping source and sink aligned; applied to both `recover()` and
+`recover_to_epoch()` (it also removes a latent dup on the plain kill-9 path).
+
+### Status: 3-variant EO soak GREEN
+
+All three variants run EO-dense (no gap, no dup) and reproduce: follower-fault 6/6, leader-fault 2/2,
+rebalance-churn 2/2 after the fix (the sole failure across the batch was a degraded-broker boot
+timeout, not an EO violation — recreate Redpanda `down -v`/`up`). Each variant restarts/faults nodes
+and EO holds on every topic. Flag-off by default; cluster + non-cluster compile, clippy + fmt clean,
+recovery unit tests pass.
+
+**Remaining before production:** real object store (S3/MinIO) + network-partition + large-state +
+depth>1 validation; a formal RTO assertion; many-round endurance; and a rebase/PR.
 
 ## Semantics
 


### PR DESCRIPTION
## What

Leader-coordinated **global restart-to-epoch** recovery for a fatal cycle fault in cluster mode. On a fault, the leader drives every node back to the highest cluster-wide committed epoch and reprocesses, so a fault on one node can't leave the cross-node shuffle cut inconsistent (Flink-style global recovery, what RisingWave/Arroyo also do for a single keyed-shuffle job).

**Off by default** (`[supervision] coordinated_recovery`); zero behaviour change when off.

## Driver

- `Phase::Recover` on the existing `BarrierCoordinator` announcement (gossip-only; observed via `observe_recover`, which bypasses `observe_barrier`'s higher-epoch merge that would otherwise shadow the lower recovery target).
- Per-node recovery monitor (`coordinated_recovery.rs`): the leader fixes `N` from the DB-level decision store, announces, restores itself, and waits a restored-to-`N` quorum; every node restores on observing `Recover` and acks. A fence (`is_recovering`) holds checkpoint injection over the round.
- A fatal cycle fault reports to the leader and suppresses the local supervisor.

## Bugs found and fixed via the soak

The fault-injection EO soak surfaced five real issues, each fixed here (the last two also fix latent bugs on the plain kill-9 path):

1. **The trigger never fired in the server.** The server configures EO per-sink, never at the pipeline level, so a fatal cycle error dropped-and-continued. `fault_on_cycle_error` now faults for recovery under exactly-once *or* coordinated recovery (recovering EO via the sink's 2PC + checkpoint replay).
2. **`observe_barrier`'s epoch-merge shadowed the `Recover`** (lower target epoch hidden behind the in-flight checkpoint announcement) → `observe_recover`.
3. **EO Kafka producer went `InvalidProducerEpoch` on the in-process restart.** `SinkTaskHandle::close()` was test-only, so the sink was dropped (not closed), leaving the transaction open and racing the new producer's `init_transactions`. Sinks now close (abort txn + flush) on coordinator shutdown.
4. **Shuffle wouldn't reconnect after an in-process restart.** The per-peer driver tasks run on the compute-thread runtime, which a restart drops — leaving `is_alive()==true` zombie connections. `is_alive` now also checks `!driver.is_finished()` (separate commit, standalone fix).
5. **Intermittent duplicate on rewind.** The decision marker is written before sink commit, so a fault could land after Kafka committed epoch `N` but before the manifest recorded it; recovery *skipped* that pending-sink checkpoint and rewound the source behind the sink, re-emitting committed rows. Recovery no longer skips a pending-sink checkpoint whose marker says committed (`pending_uncommitted` gates the skip on `!is_committed`).

## Soak (the merge gate)

3-variant fault-injection EO soak, all EO-dense (no gap, no dup) and reproducible:

| Variant | Result |
|---|---|
| Follower fault | 6/6 |
| Leader fault | 2/2 |
| Fault during a membership change | 2/2 |

Run: build `--no-default-features --features cluster,kafka` (debug, so the injector is live), then `three_node_kill9_soak` with `LAMINAR_SOAK_COORD_RECOVERY=1 LAMINAR_SOAK_FAULT_INJECT_MS=… LAMINAR_SOAK_KILLS=0` + the Kafka EO sink.

## Review notes

- `recover()` and `recover_to_epoch()` now share `try_restore`/`restore_first` (removed ~80 lines of duplicated per-checkpoint logic).
- 24 recovery unit tests pass; cluster + non-cluster compile; clippy + fmt clean.

## Not yet production-ready

Before shipping on: real object store (S3/MinIO) + network-partition + large-state + depth>1 validation, a formal RTO assertion, and many-round endurance. Design and gaps tracked in `docs/plans/1a-cluster-recovery-driver.md`.

Based on `feat/shuffle-barrier-after-kill-recovery` (stacked; rebase to `main` when that lands).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds leader-coordinated global restart-to-epoch recovery in cluster mode to keep the cross-node shuffle consistent after a fatal fault. The leader rewinds all nodes to the highest cluster-wide committed epoch and resumes; off by default, enable with `[supervision].coordinated_recovery` and `db.enable_coordinated_recovery()`.

- New Features
  - `Phase::Recover` on the barrier announcement; observed via `observe_recover` (gossip-only, bypasses epoch-merge).
  - Per-node recovery monitor and fence: leader fixes target from `CheckpointDecisionStore::highest_committed`, assigns a recovery generation, announces, restores itself, waits a restored-to-N quorum, then clears the `Recover` announcement; nodes restore and ack.
  - Recovery primitives: `RecoveryManager::recover_to_epoch` and `CheckpointCoordinator::recover_to_epoch`; `db.set_recover_target_epoch` consumed on start.
  - Config/wiring: builder `.coordinated_recovery(true)`, server `[supervision].coordinated_recovery`, and `LaminarDB::enable_coordinated_recovery()` to spawn the monitor; pipeline lifecycle skips the final checkpoint during recovery stops, restores to the target epoch on start, and closes sinks on shutdown.

- Bug Fixes
  - Recovery correctness: a node only acks after a successful restore; failed restores retry; the leader retries self-restore inline (bounded) and always releases the fence and clears the `Recover` announcement on exit; nodes clear fault reports (`0` = none) to avoid re-triggers.
  - Checkpoint safety: the recovery fence also blocks explicit connector checkpoint requests (not just interval checkpoints); final checkpoint is suppressed during recovery.
  - EO stability: close sinks on shutdown (now concurrently) to avoid Kafka `InvalidProducerEpoch`; recovery no longer rewinds behind committed sinks (skip pending sinks only when the decision marker is not committed); decision-store read errors are logged.
  - Shuffle reconnects after in-process restarts by treating finished drivers as dead in `PeerConn::is_alive` instead of keeping zombies.

<sup>Written for commit 5e5ed97d82f50ba013e95911eb6394f6d0598895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

