### PR TITLE
state-tier: release-safe resident∩cold overlap guard + cluster group-demotion tests

### DIFF
--- a/crates/laminar-db/src/aggregate_state.rs
+++ b/crates/laminar-db/src/aggregate_state.rs
@@ -1838,19 +1838,13 @@ impl IncrementalAggState {
                 };
                 #[cfg(feature = "state-tier")]
                 let cap = {
+                    // `heal_resident_cold_overlap` (run before capture) keeps the resident and cold
+                    // key sets disjoint, so the re-base and cold groups never share a key.
                     let group_keys: Vec<Vec<u8>> = self
                         .cold_groups
                         .keys()
                         .filter(|k| vnode_of(k) == v)
-                        .map(|k| {
-                            // Resident and cold key sets must stay disjoint — the merge assumes it,
-                            // and an overlap would double-count on recovery (additive merge_groups).
-                            debug_assert!(
-                                !self.groups.contains_key(k),
-                                "cold group is also resident; merge would double-count"
-                            );
-                            k.as_ref().to_vec()
-                        })
+                        .map(|k| k.as_ref().to_vec())
                         .collect();
                     if group_keys.is_empty() {
                         VnodeCapture::Full(full)
@@ -2320,6 +2314,25 @@ impl IncrementalAggState {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn cold_groups(&self) -> &AHashMap<arrow::row::OwnedRow, i64> {
         &self.cold_groups
+    }
+
+    /// Drop any group that is both resident and cold, returning how many. A group in both sets is
+    /// merged twice on recovery (additive `merge_groups`); the resident copy is authoritative. The
+    /// return feeds `state_tier_overlap_total` — must be 0 in a correct run. Runs before capture.
+    pub(crate) fn heal_resident_cold_overlap(&mut self) -> u64 {
+        if self.cold_groups.is_empty() {
+            return 0;
+        }
+        let overlapping: Vec<arrow::row::OwnedRow> = self
+            .cold_groups
+            .keys()
+            .filter(|k| self.groups.contains_key(k))
+            .cloned()
+            .collect();
+        for k in &overlapping {
+            self.cold_groups.remove(k);
+        }
+        overlapping.len() as u64
     }
 
     /// Cold (demoted) group tier keys bucketed by vnode — `vnode -> [group_key_bytes]`, matching the

--- a/crates/laminar-db/src/engine_metrics.rs
+++ b/crates/laminar-db/src/engine_metrics.rs
@@ -51,6 +51,9 @@ pub struct EngineMetrics {
     pub state_tier_fetch_total: IntCounter,
     /// Cold-tier fetch latency (the promotion path's disk read).
     pub state_tier_fetch_duration: Histogram,
+    /// Groups found resident AND cold at capture (the resident∩cold disjoint-set invariant broken).
+    /// Must stay 0; a non-zero value is a demote/promote overlap that double-counts on recovery.
+    pub state_tier_overlap_total: IntCounter,
     /// Global pipeline watermark.
     pub pipeline_watermark: IntGauge,
     /// Per-source watermark (epoch-ms). Label: `source`.
@@ -254,6 +257,11 @@ impl EngineMetrics {
                     "Cold-tier slice fetch latency"
                 )
                 .buckets(prometheus::exponential_buckets(0.0005, 2.0, 18).unwrap()),
+            )
+            .unwrap()),
+            state_tier_overlap_total: reg!(IntCounter::new(
+                "state_tier_overlap_total",
+                "Groups found resident AND cold at capture (disjoint-set invariant broken)"
             )
             .unwrap()),
             pipeline_watermark: reg!(IntGauge::new(

--- a/crates/laminar-db/src/metrics.rs
+++ b/crates/laminar-db/src/metrics.rs
@@ -77,6 +77,8 @@ pub struct TierMetrics {
     pub resident_bytes: i64,
     /// Slices currently resident in the tier.
     pub resident_slices: i64,
+    /// Groups found resident AND cold at capture (disjoint-set invariant broken). Must be 0.
+    pub overlap_total: u64,
 }
 
 /// Metrics for a single registered source.

--- a/crates/laminar-db/src/metrics_api.rs
+++ b/crates/laminar-db/src/metrics_api.rs
@@ -107,6 +107,7 @@ impl LaminarDB {
                     fetch_total: m.state_tier_fetch_total.get(),
                     resident_bytes: m.state_tier_bytes.get(),
                     resident_slices: m.state_tier_slices.get(),
+                    overlap_total: m.state_tier_overlap_total.get(),
                 }
             })
     }

--- a/crates/laminar-db/src/operator/sql_query.rs
+++ b/crates/laminar-db/src/operator/sql_query.rs
@@ -1458,10 +1458,26 @@ impl GraphOperator for SqlQueryOperator {
         // Re-base the delta chain of any vnode acquired since the last capture (its parent epoch is
         // gone), before deciding FULL-vs-DELTA below. Must run before the `agg_state` borrow.
         let newly_acquired = self.take_newly_acquired();
+        // Cloned so the overlap counter can be bumped while `agg_state` is borrowed below.
+        #[cfg(feature = "state-tier")]
+        let prom = self.prom.clone();
         let QueryState::Agg(ref mut agg_state) = self.state else {
             return Ok(None);
         };
         agg_state.reset_acquired_vnodes(&newly_acquired);
+
+        // Keep resident and cold group sets disjoint before capture (both capture paths); an overlap
+        // would double-count on recovery.
+        #[cfg(feature = "state-tier")]
+        {
+            let overlaps = agg_state.heal_resident_cold_overlap();
+            if overlaps > 0 {
+                if let Some(ref p) = prom {
+                    p.state_tier_overlap_total.inc_by(overlaps);
+                }
+                tracing::warn!(overlaps, query = %self.op_name, "healed resident∩cold overlap before capture");
+            }
+        }
 
         // Incremental delta capture: each touched vnode emits a FULL re-base or a DELTA.
         if let Some(chain_max) = self.delta_chain_max {
@@ -2583,6 +2599,71 @@ mod promotion_tests {
             inserts(&out).get("a"),
             Some(&6),
             "rehydrated demoted state: original 1 + new 5"
+        );
+    }
+
+    /// Group demote→promote must not inflate the changelog: feed one row per round for a
+    /// slow-cycling key, checkpoint, demote it, then re-touch it next round to promote it back. The
+    /// emitted `total` must track the number of rows fed, never exceed it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_group_demotion_never_double_counts_changelog() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            crate::state_tier::StateTierStore::open(tmp.path().join("tier"), None).unwrap(),
+        );
+        let tier_tx = crate::state_tier::spawn_worker(
+            &tokio::runtime::Handle::current(),
+            Arc::clone(&store),
+            64,
+        );
+        let mut op = build_op(tier_tx).await;
+        // Cluster group-demotion path: the per-vnode delta chain is the primary checkpoint
+        // (chain_max=2, so re-bases with cold groups happen), plus group dirty-tracking.
+        op.enable_delta_checkpoints(2);
+        op.enable_delta_tracking();
+
+        let rounds: i64 = 8;
+        let mut wm = 0i64;
+        let mut demoted_total = 0u64;
+        let mut max_emitted = 0i64;
+        let record = |out: &[RecordBatch], max: &mut i64| {
+            if let Some(&t) = inserts(out).get("a") {
+                *max = (*max).max(t);
+            }
+        };
+
+        for _ in 1..=rounds {
+            wm += 10;
+            // Feed one row for "a"; if "a" was demoted last round this defers + triggers promotion.
+            let out = op
+                .process(&[vec![events_batch(&["a"], &[1])]], &[wm])
+                .await
+                .unwrap();
+            record(&out, &mut max_emitted);
+            // Drain idle cycles until the promotion (if any) resolves and "a" re-emits.
+            for _ in 0..200 {
+                if op.watermark_hold().is_none() && !op.has_pending_promotion() {
+                    break;
+                }
+                wm += 1;
+                let out = op.process(&[vec![]], &[wm]).await.unwrap();
+                record(&out, &mut max_emitted);
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+            // Mark the group clean (delta baseline), then demote it to the cold tier.
+            op.checkpoint_by_vnode(VNODES).unwrap();
+            let (n, _) = op.demote_cold_groups(usize::MAX, VNODES).await;
+            demoted_total += n as u64;
+        }
+
+        assert!(
+            demoted_total > 0,
+            "group demotion never fired — the test would be vacuous"
+        );
+        assert_eq!(
+            max_emitted, rounds,
+            "cluster group demotion emitted a changelog total ({max_emitted}) different from the \
+             true running count ({rounds}) — a value > {rounds} is the soak's double-count",
         );
     }
 }

--- a/crates/laminar-db/tests/cluster_integration.rs
+++ b/crates/laminar-db/tests/cluster_integration.rs
@@ -733,6 +733,131 @@ mod failures {
         harness.shutdown().await;
     }
 
+    /// Non-chain group demotion (no delta chain — the whole-node manifest is authoritative and
+    /// demoted groups fold into cold-only partials) must recover EXACT values across a full cluster
+    /// restart. A resident∩cold overlap at capture would double-count here (additive merge).
+    #[cfg(feature = "state-tier")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cluster_group_demotion_nonchain_survives_restart() {
+        use std::collections::HashMap;
+        use std::time::Instant;
+        use tempfile::TempDir;
+
+        let shared = tempfile::tempdir().expect("shared state dir");
+        let cp_dirs: Vec<TempDir> = (0..N_NODES)
+            .map(|_| tempfile::tempdir().expect("cp dir"))
+            .collect();
+        let mut harness = ClusterEngineHarness::spawn_with_dirs(
+            N_NODES,
+            VNODE_COUNT,
+            shared,
+            cp_dirs,
+            None,
+            Some(2048),
+        )
+        .await;
+        for node in &harness.nodes {
+            setup_query(&node.db).await;
+        }
+        harness.start_all().await;
+
+        let owners: Vec<_> = harness
+            .nodes
+            .iter()
+            .map(|n| (n.instance_id, n.owned_vnodes()))
+            .collect();
+        let key_buckets = pick_keys_per_owner(VNODE_COUNT, &owners, 96).expect("pick keys");
+        let all_keys: Vec<i64> = key_buckets
+            .iter()
+            .flat_map(|(_, ks)| ks.iter().copied())
+            .collect();
+        let leader = harness.leader_idx();
+        let demotes = |h: &ClusterEngineHarness| -> u64 {
+            h.nodes
+                .iter()
+                .map(|n| n.db.tier_metrics().demote_total)
+                .sum()
+        };
+
+        for _ in 0..3 {
+            harness.nodes[leader]
+                .db
+                .source_untyped("src")
+                .expect("src")
+                .push_arrow(input_batch(&all_keys))
+                .expect("push");
+            sleep(Duration::from_millis(150)).await;
+        }
+        harness.nodes[leader]
+            .db
+            .checkpoint()
+            .await
+            .expect("checkpoint");
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while demotes(&harness) == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "non-chain group demotion never fired"
+            );
+            sleep(Duration::from_millis(200)).await;
+        }
+        // Checkpoint AGAIN so the demoted groups are captured into durable cold-only partials.
+        harness.nodes[leader]
+            .db
+            .checkpoint()
+            .await
+            .expect("checkpoint2");
+        let expected: HashMap<i64, i64> = all_keys.iter().map(|&k| (k, k * 10 * 3)).collect();
+
+        // Graceful full-cluster restart (tier wiped; recover from the durable manifest + partials).
+        let (shared, cp_dirs) = harness.shutdown_keep_dirs().await;
+        let mut harness = ClusterEngineHarness::spawn_with_dirs(
+            N_NODES,
+            VNODE_COUNT,
+            shared,
+            cp_dirs,
+            None,
+            Some(2048),
+        )
+        .await;
+        for node in &harness.nodes {
+            setup_query(&node.db).await;
+        }
+        harness.start_all().await;
+
+        // No re-feed: the recovered values must equal the pre-restart totals — never doubled.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let got: HashMap<i64, i64> = union_sums(&harness)
+                .await
+                .into_iter()
+                .filter(|(k, _)| expected.contains_key(k))
+                .collect();
+            let bad: Vec<(i64, i64, i64)> = expected
+                .iter()
+                .filter(|(k, &e)| got.get(k).copied() != Some(e))
+                .map(|(k, &e)| (*k, e, got.get(k).copied().unwrap_or(-1)))
+                .take(10)
+                .collect();
+            if bad.is_empty() && got.len() == expected.len() {
+                break;
+            }
+            if Instant::now() > deadline {
+                let overlap: u64 = harness
+                    .nodes
+                    .iter()
+                    .map(|n| n.db.tier_metrics().overlap_total)
+                    .sum();
+                panic!(
+                    "non-chain cluster demotion recovered wrong values (overlap_total={overlap}) \
+                     [(key, expected, got)]: {bad:?}",
+                );
+            }
+            sleep(Duration::from_millis(200)).await;
+        }
+        harness.shutdown().await;
+    }
+
     /// A crashed node's DEMOTED groups must survive failover. With the cold tier on, the follower
     /// demotes idle groups — their durable home is the per-vnode delta chain, NOT the node-local tier
     /// (which dies with the process). When the follower crashes, the survivor acquires its vnodes and

--- a/crates/laminar-server/src/config.rs
+++ b/crates/laminar-server/src/config.rs
@@ -244,6 +244,17 @@ fn validate_config(config: &ServerConfig) -> Result<(), ConfigError> {
 
 /// Validate the `state_tier_dir` contract once, shared by embedded and cluster startup.
 fn validate_state_tier(config: &ServerConfig, errors: &mut Vec<String>) {
+    // Group demotion needs the cold tier; enabling it without a tier dir demotes nothing.
+    if config.server.state_tier_group_demotion == Some(true)
+        && config.server.state_tier_dir.is_none()
+    {
+        errors.push(
+            "state_tier_group_demotion is set but state_tier_dir is not — group demotion needs a \
+             cold tier to shed groups to, so without state_tier_dir it does nothing; set \
+             state_tier_dir (with state_memory_budget_bytes) or remove state_tier_group_demotion"
+                .to_string(),
+        );
+    }
     if config.server.state_tier_dir.is_none() {
         return;
     }

--- a/docs/plans/state-tier-hardening-followups.md
+++ b/docs/plans/state-tier-hardening-followups.md
@@ -1,0 +1,40 @@
+# State-Tier Hardening Followups (cluster group-demotion path)
+
+Open items gating the flip of **cluster** group demotion from default-OFF
+(`laminar-server/src/cluster.rs`) to default-ON. Referenced by ADR-005. Embedded single-node
+group demotion is default-ON and kill-9-soaked; cluster stays vnode-granular until these close.
+
+## The reported "2× double-count" was a soak-harness artifact
+
+The Kafka state-tier soak reported a 3-node cluster emitting exactly 2× the correct COUNT for
+every group. Root cause: the harness recreated the Kafka topics each run but reused the durable
+checkpoint backend, so a fresh run recovered the previous run's committed state and reprocessed
+the recreated input → every group counted twice (uniform 2× = whole input processed twice, not a
+per-group demote/promote overlap). With an isolated checkpoint backend the same scenario passes
+with exact per-group values and demotion/promotion heavily exercised. Fixed harness-side by
+run-id-scoping the checkpoint backend. The engine already refuses to start (`LDB-6029`/`LDB-6030`)
+when a recovered checkpoint is inconsistent with local state.
+
+## Items
+
+- **B1 — resident∩cold disjoint guard (DONE).** `IncrementalAggState::heal_resident_cold_overlap`
+  runs before every per-vnode capture (both the `FullWithColdGroups` and `ColdGroups` paths), drops
+  any group found in both, and reports the count via `laminardb_state_tier_overlap_total`. Replaces
+  the release-compiled-out `debug_assert`.
+- **B2 — fail-loud on misconfig (DONE).** `validate_state_tier` rejects `state_tier_group_demotion`
+  without `state_tier_dir`. (Group demotion does not need `delta_chain_max`: it auto-enables agg
+  delta tracking and `checkpoint_groups_by_vnode` sets `delta_vnode_count`.)
+- **A2 — demotion suppressed under failover (accepted).** Rebalance rehydration marks vnodes dirty
+  and refuses demotion until the next clean capture, so demotion and node-kills can't co-occur on
+  cluster (the reference soak uses `kills=0`). Correctness-preserving; kept as a limitation.
+- **D2 — Linux-NVMe p99 gate (open).** The formal cold-read p99 ≤ 1 ms gate (ADR-005) is still owed.
+
+## Flip criteria (separate, reviewed step)
+
+1. Cluster soak green on a clean/isolated backend: `demote_total>0`, `fetch_total>0`,
+   `mismatches=0`, `missing_groups=0`, `source_lag=0`, `state_tier_overlap_total=0`. **Met.**
+2. In-repo suite green (`cargo test -p laminar-db group_demotion`, cluster `group_demotion` tests)
+   and embedded regressions. **Met.**
+3. Kill-9 cluster soak: demoted groups survive a mid-soak node kill/restart with exact values
+   (bounded by A2 — interleave quiet demotion windows with kill windows).
+4. D2 perf gate (perf, not correctness).


### PR DESCRIPTION
## Summary

A cluster group-demotion soak reported a uniform **2× per-group double-count**. Investigation shows this is **not a bug in the demotion state machine** — it's cross-run checkpoint contamination in the soak harness: a fresh run recovered the previous run's committed aggregate state, then reprocessed the recreated input topic, so every group was counted twice. (Uniform exactly-2× is the fingerprint of the whole input processed twice, not a per-group demote/promote overlap, which would double only demoted groups by varying amounts.) With an isolated checkpoint backend the same scenario passes with exact per-group values.

This PR is the engine-side hardening so the resident∩cold overlap class is caught in release rather than shipped silently, plus focused tests and the plan doc ADR-005 references. The harness fix (run-id-scoped checkpoint backend, budget tuning, idempotent producer) is a companion change in the test-harness repo.

## Changes
- **Overlap guard** — `IncrementalAggState::heal_resident_cold_overlap` replaces the release-compiled-out resident∩cold `debug_assert`. It runs before every per-vnode capture (covers both the `FullWithColdGroups` and `ColdGroups` paths), drops any group found in both (the resident copy is authoritative → recovery stays correct), and reports the count via the new `laminardb_state_tier_overlap_total` counter (must stay 0 in a correct run).
- **Config validation** — reject `state_tier_group_demotion` set without `state_tier_dir` (was a silent no-op).
- **Tests** — operator-level changelog no-double-count under demote→promote; non-chain cluster demote→restart exact recovery.
- **Docs** — `docs/plans/state-tier-hardening-followups.md` (referenced by ADR-005): cluster group-path items + the default-flip criteria.

## Verification
- Cluster state-tier soak (clean/isolated backend): PASS — demote/fetch heavily exercised, 0 mismatches, 0 missing, source lag 0, `state_tier_overlap_total = 0`.
- `cargo test -p laminar-db group_demotion` (lib + single-node oracle + cluster) and the embedded regression soak: green.
- `cargo clippy --features state-tier -D warnings` (laminar-db tests + laminar-server bins): clean.

## Not in scope
Flipping the cluster `group_demotion` default → ON is left as a separate reviewed step, gated on the kill-9 cluster dimension (bounded by A2 in the plan doc) and the ADR-005 Linux-NVMe p99 gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents resident∩cold overlap during state-tier capture by healing overlaps and counting them to avoid double-counting on recovery. Also validates state-tier config and adds operator/cluster tests for demote→promote and restart correctness.

- **New Features**
  - Added `IncrementalAggState::heal_resident_cold_overlap` before every per-vnode capture; drops overlapping groups, warns, and increments `state_tier_overlap_total` (must stay 0).
  - Exposed overlap metric via API as `TierMetrics.overlap_total`.
  - Config validation: reject `state_tier_group_demotion=true` without `state_tier_dir`.
  - Tests: no double-count in operator changelog under demote→promote; exact recovery after non-chain cluster demote→restart.

- **Migration**
  - If you enable `state_tier_group_demotion`, set `state_tier_dir`.

<sup>Written for commit 51e83daf0257b281dca961267b2adbb56f392c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger state-tier safeguards for group demotion and checkpointing, helping prevent duplicate counts and inconsistent reads during tier transitions.
  * Added validation to catch misconfiguration when demotion is enabled without a cold-tier directory.

* **Bug Fixes**
  * Fixed rare overlap cases between resident and cold data so recovered results stay accurate after restarts and demotions.
  * Improved metrics to surface overlap occurrences when they happen.

* **Documentation**
  * Updated the state-tier hardening notes with completed work, known limitations, and remaining rollout criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->