### PR TITLE
fix(db): retain new aggregate groups in release builds

### DIFF
--- a/crates/laminar-db/src/aggregate_state/mod.rs
+++ b/crates/laminar-db/src/aggregate_state/mod.rs
@@ -1722,13 +1722,9 @@ impl IncrementalAggState {
                 entry.last_updated_ms = watermark_ms;
                 entry.refresh_accumulator_usage();
 
-                let usage = AggregateVnodeState::group_usage(&owned_key, &entry);
                 let emit_key = emit_changelog.then(|| owned_key.clone());
                 let vnode_state = self.vnode_states.get_or_insert(vnode);
-                let previous_spare = vnode_state.collection_spare_usage();
-                debug_assert!(vnode_state.groups.insert(owned_key, entry).is_none());
-                vnode_state.add_usage(usage);
-                vnode_state.reconcile_collection_spare_usage(previous_spare);
+                vnode_state.insert_new_group(owned_key, entry);
                 if let Some(emit_key) = emit_key {
                     vnode_state.insert_emit_dirty_key(emit_key);
                 }
@@ -1815,15 +1811,8 @@ impl IncrementalAggState {
             entry.last_updated_ms = watermark_ms;
             entry.refresh_accumulator_usage();
 
-            let usage = AggregateVnodeState::group_usage(&empty_key, &entry);
             let vnode_state = self.vnode_states.get_or_insert(0);
-            let previous_spare = vnode_state.collection_spare_usage();
-            debug_assert!(vnode_state
-                .groups
-                .insert(empty_key.clone(), entry)
-                .is_none());
-            vnode_state.add_usage(usage);
-            vnode_state.reconcile_collection_spare_usage(previous_spare);
+            vnode_state.insert_new_group(empty_key.clone(), entry);
             if self.emit_changelog {
                 vnode_state.insert_emit_dirty_key(empty_key);
             }

--- a/crates/laminar-db/src/aggregate_state/tests.rs
+++ b/crates/laminar-db/src/aggregate_state/tests.rs
@@ -448,6 +448,50 @@ fn sum_pre_agg_batch(names: &[&str], values: &[f64]) -> RecordBatch {
     .unwrap()
 }
 
+#[tokio::test]
+async fn new_aggregate_state_is_retained_for_grouped_batches() {
+    let sql = "SELECT name, SUM(value) AS total FROM events GROUP BY name";
+    let (_, mut state) = setup_agg_state(sql).await;
+    state
+        .process_batch(&sum_pre_agg_batch(&["a"], &[3.0]), 10)
+        .unwrap();
+
+    let output = state.emit().expect("new grouped state must emit");
+    assert_eq!(output.len(), 1);
+    assert_eq!(output[0].num_rows(), 1);
+    let totals = output[0]
+        .column(1)
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .unwrap();
+    assert_eq!(totals.value(0), 3.0);
+}
+
+#[tokio::test]
+async fn new_aggregate_state_is_retained_for_global_batches() {
+    let (_, mut state) = setup_agg_state("SELECT SUM(value) AS total FROM events").await;
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "__agg_input_0",
+            DataType::Float64,
+            true,
+        )])),
+        vec![Arc::new(arrow::array::Float64Array::from(vec![1.0, 2.0]))],
+    )
+    .unwrap();
+    state.process_batch(&batch, 10).unwrap();
+
+    let output = state.emit().expect("new global state must emit");
+    assert_eq!(output.len(), 1);
+    assert_eq!(output[0].num_rows(), 1);
+    let totals = output[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::Float64Array>()
+        .unwrap();
+    assert_eq!(totals.value(0), 3.0);
+}
+
 fn capture_all_vnodes(
     state: &mut IncrementalAggState,
 ) -> Result<Vec<(u32, AggStateCheckpoint)>, DbError> {

--- a/crates/laminar-db/src/aggregate_state/vnode_state.rs
+++ b/crates/laminar-db/src/aggregate_state/vnode_state.rs
@@ -116,6 +116,15 @@ impl AggregateVnodeState {
         self.usage = self.usage.saturating_add(usage);
     }
 
+    pub(super) fn insert_new_group(&mut self, key: arrow::row::OwnedRow, entry: GroupEntry) {
+        let previous_spare = self.collection_spare_usage();
+        let usage = Self::group_usage(&key, &entry);
+        let previous = self.groups.insert(key, entry);
+        debug_assert!(previous.is_none());
+        self.add_usage(usage);
+        self.reconcile_collection_spare_usage(previous_spare);
+    }
+
     pub(super) fn reconcile_accumulator_usage(&mut self, previous: usize, current: usize) {
         let usage = |bytes| AggregateStateUsage::from_parts(0, 0, 0, 0, bytes);
         self.usage = self


### PR DESCRIPTION
## What

Retain newly created grouped and global aggregate state in optimized builds, and add regressions for both paths.

## Why

The insertion previously happened inside `debug_assert!`. Rust removes that expression in release builds, so the first aggregate group was never stored and could not be emitted.

## How

Move insertion and memory-accounting into `AggregateVnodeState::insert_new_group`; keep only the duplicate-key invariant in `debug_assert!`.

Applies to embedded, single-node server, and cluster execution wherever incremental aggregate state uses this path.

## Testing

- [x] Unit regressions added for grouped and global aggregates
- [x] `cargo test --workspace --lib -- --test-threads=1`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- [ ] Targeted release test is blocked before execution by the existing `external_sink_tests.rs:123` initializer for the absent `SinkTaskConfig::process_authority` field (outside this diff)
- [ ] Root clippy gates are blocked by the existing unsupported `clippy::unused_async_trait_impl` lint on the installed toolchain

## Ring 0

- [x] No new heap allocation, lock, trait-object dispatch, or async boundary
- [ ] Benchmarks not run

## Checklist

- [x] No public API changes
- [x] No breaking changes