### PR TITLE
fix(ci): repair Azure native certification

### DIFF
--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Install process-soak dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake pkg-config libsasl2-dev libudev-dev mold protobuf-compiler jq
+          sudo apt-get install -y libelf-dev zlib1g-dev libcurl4-openssl-dev cmake pkg-config libsasl2-dev libudev-dev mold protobuf-compiler jq
       - name: Select isolated native locations
         shell: bash
         env:
@@ -224,9 +224,13 @@ jobs:
           if [[ -n "${LAMINAR_SOAK_CHECKPOINT_URL:-}" ]]; then
             scheme="${LAMINAR_SOAK_CHECKPOINT_URL%%:*}"
           fi
-          produced="$(sed -n 's/.*producer acknowledged \([0-9][0-9]*\) records.*/\1/p' native-checkpoint-soak.log 2>/dev/null | tail -1)"
-          produced="${produced:-0}"
-          output_summary="$(sed -n 's/.*output oracle consumed.*observed all \([0-9][0-9]*\) pairs.*with \([0-9][0-9]*\) at-least-once duplicates.*/\1 \2/p' native-checkpoint-soak.log 2>/dev/null | tail -1)"
+          produced=0
+          output_summary=""
+          if [[ -f native-checkpoint-soak.log ]]; then
+            produced="$(sed -n 's/.*producer acknowledged \([0-9][0-9]*\) records.*/\1/p' native-checkpoint-soak.log | tail -1)"
+            produced="${produced:-0}"
+            output_summary="$(sed -n 's/.*output oracle consumed.*observed all \([0-9][0-9]*\) pairs.*with \([0-9][0-9]*\) at-least-once duplicates.*/\1 \2/p' native-checkpoint-soak.log | tail -1)"
+          fi
           recovered=0
           duplicates=0
           if [[ -n "$output_summary" ]]; then read -r recovered duplicates <<< "$output_summary"; fi

--- a/docs/cloud-object-store-support.md
+++ b/docs/cloud-object-store-support.md
@@ -183,9 +183,11 @@ Protected GitHub environments named `native-cloud-aws`, `native-cloud-azure`, an
 - AWS: OIDC-trusted role, region, and `LAMINAR_AWS_TEST_URL`; grant list/read/create/update/delete
   only for the pre-provisioned test bucket/prefix.
 - Azure: federated client, tenant and subscription identifiers plus `LAMINAR_AZURE_TEST_URL`; grant
-  data-plane list/read/create/update/delete only for the test container. Iceberg additionally uses
-  `LAMINAR_AZURE_ICEBERG_TEST_URL` in the fully qualified `abfs[s]://` or `wasb[s]://` form because
-  its OpenDAL adapter derives account, filesystem/container, and service from the URL.
+  data-plane list/read/create/update/delete only for the test container. Use a fully qualified
+  `abfss://filesystem@account.dfs.<suffix>` or `wasbs://container@account.blob.<suffix>` URL so the
+  account, filesystem/container, and native endpoint are derived without another identifier.
+  Generic HTTPS and signed URLs are rejected. Iceberg additionally uses
+  `LAMINAR_AZURE_ICEBERG_TEST_URL` in the same fully qualified form.
 - GCP: Workload Identity Provider, service account, project, and `LAMINAR_GCS_TEST_URL`; grant
   object list/read/create/update/delete only for the test bucket/prefix.
 - Iceberg jobs additionally require the provider-specific


### PR DESCRIPTION
## Summary

- install the native dependencies already used by the checkpoint soak, including the libcurl headers required by rdkafka-sys
- emit fail-closed process evidence when setup ends before the soak log exists
- document the fully qualified Azure URI required by the OIDC native workflow

## Evidence

The Azure attempt at https://github.com/laminardb/laminardb/actions/runs/33645186422 confirmed OIDC login succeeds, then exposed two fail-closed setup issues: the prior generic HTTPS location was rejected by the shared provider parser and the process-soak build lacked curl/curl.h. The protected GitHub environment location has been normalized separately without committing account or container identifiers.

## Validation

- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo test -p laminar-core --no-default-features --features azure storage_location::tests
- cargo test -p laminar-core --no-default-features --features azure --test object_store_conformance
- YAML parse check
- missing-log evidence-path shell check

Native Azure certification remains unclaimed until the protected workflow passes against the merged commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the Azure native certification workflow so OIDC login and process-soak setup pass on the protected runner.

- Installs `libcurl4-openssl-dev` (plus `libelf-dev` and `zlib1g-dev`) for the `rdkafka-sys` build.
- Emits fail-closed process evidence when the soak log is missing instead of defaulting to zero counts.
- Documents that Azure test URLs must be fully qualified `abfss://` or `wasbs://` URIs; generic HTTPS and signed URLs are rejected.

<sup>Written for commit 24341f69e5c5241aa1bded9d4ec4bb0f2bc1b9f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native cloud object store soak testing by supporting required system libraries and handling missing evidence logs without failing during result collection.

* **Documentation**
  * Clarified Azure test configuration requirements: storage URLs must use fully qualified `abfss://` or `wasbs://` formats.
  * Updated Iceberg test URL guidance and clarified that generic HTTPS and signed URLs are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->