### PR TITLE
fix(ci): preserve native cloud evidence path

### DIFF
--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -53,7 +53,9 @@ env:
   LAMINAR_NATIVE_CLOUD: "1"
   LAMINAR_NATIVE_CLOUD_REQUIRED: "1"
   LAMINAR_TESTED_SHA: ${{ github.sha }}
-  LAMINAR_CLOUD_EVIDENCE_DIR: target/cloud-evidence
+  # Cargo may execute integration tests from the package directory. Keep Rust
+  # evidence and shell fallbacks anchored to one workspace-absolute location.
+  LAMINAR_CLOUD_EVIDENCE_DIR: ${{ github.workspace }}/target/cloud-evidence
   AZURE_USE_AZURE_CLI: "true"
 
 jobs:

--- a/docs/cloud-object-store-support.md
+++ b/docs/cloud-object-store-support.md
@@ -183,7 +183,11 @@ Protected GitHub environments named `native-cloud-aws`, `native-cloud-azure`, an
 - AWS: OIDC-trusted role, region, and `LAMINAR_AWS_TEST_URL`; grant list/read/create/update/delete
   only for the pre-provisioned test bucket/prefix.
 - Azure: federated client, tenant and subscription identifiers plus `LAMINAR_AZURE_TEST_URL`; grant
-  data-plane list/read/create/update/delete only for the test container. Use a fully qualified
+  the federated service principal the built-in **Storage Blob Data Contributor** role at the test
+  container scope. Management-plane Owner, Contributor, or Storage Account Contributor alone is
+  insufficient. The conformance cleanup uses Blob Batch, whose parent request needs blob write and
+  whose subrequests need blob delete; any role-assignment condition must allow both under the
+  generated `laminardb-tests/` prefix. Use a fully qualified
   `abfss://filesystem@account.dfs.<suffix>` or `wasbs://container@account.blob.<suffix>` URL so the
   account, filesystem/container, and native endpoint are derived without another identifier.
   Generic HTTPS and signed URLs are rejected. Iceberg additionally uses


### PR DESCRIPTION
## Summary
- anchor native-cloud JSON evidence to `github.workspace`, matching the emulator workflow
- prevent shell fallback evidence from replacing Rust evidence written from a package working directory
- document the Azure data-plane role and Blob Batch write/delete requirements

## Evidence
Azure native run 33660626628 reached the native provider and failed closed. Azure returned HTTP 403 for Blob Batch deletion, while the relative evidence path caused detailed test JSON to be replaced by generic setup-failure records.

No capability or delivery-admission check is relaxed.

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- YAML parsed with PyYAML and asserted the workspace-absolute evidence path
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the native cloud soak workflow so generic setup-failure records can no longer overwrite detailed Rust evidence when Cargo runs from a package directory. The evidence path is now anchored to `github.workspace`, matching the emulator workflow, and no capability or delivery-admission check is relaxed. The docs now specify Azure's required Storage Blob Data Contributor role and Blob Batch write/delete permissions for the conformance cleanup.

<sup>Written for commit 6afbc6dffba8f7dba7cb3156e12f4eb26cb07e15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Azure permissions required for native cloud object store testing.
  * Specified the necessary **Storage Blob Data Contributor** role and explained why management-plane roles alone are insufficient.
  * Documented required permissions for cleanup operations under the test prefix.

* **Bug Fixes**
  * Improved cloud object store soak test reliability by ensuring evidence files are accessed consistently regardless of the test’s working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->