### PR TITLE
fix(ci): bound native checkpoint soak oracle

### DIFF
--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -203,6 +203,10 @@ jobs:
           LAMINAR_SOAK_MIN_LIVE_STATE_BYTES: "8388608"
           LAMINAR_SOAK_RPS: "250"
           LAMINAR_SOAK_JOIN_INTERVAL_MS: "15000"
+          # Match the established checkpoint-soak distribution. The default
+          # 4K-key/1.2-Zipf profile exceeds the bounded join oracle at 120s.
+          LAMINAR_SOAK_JOIN_KEYS: "65536"
+          LAMINAR_SOAK_ZIPF_MILLI: "800"
           LAMINAR_SOAK_KAFKA_SOURCE_BROKERS: 127.0.0.1:19092
       - name: Clean interrupted native checkpoint prefix
         id: cleanup


### PR DESCRIPTION
The Azure native retry proved object-store conformance and the deterministic checkpoint fault contract, but the process soak failed because the native workflow omitted the established join distribution and exceeded the 10,000,000-pair bounded oracle. This aligns the native process soak with checkpoint-fault-soak.yml: 65,536 join keys and Zipf milli 800. It preserves four process kills, 120 seconds, 250 RPS, 500 ms checkpoints, the 90-second recovery bound, and the 8 MiB live-state floor. No production admission or storage behavior changes. Failed evidence run: https://github.com/laminardb/laminardb/actions/runs/33678601860. Validation: YAML parse/profile assertions, cargo +nightly fmt --all -- --check, readability checker, git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the native process soak to use 65,536 join keys and a Zipf milli value of 800, replacing the default 4K-key/1.2-Zipf profile that exceeded the 10,000,000-pair bounded oracle. The soak still uses four process kills, 120 seconds, 250 RPS, 500 ms checkpoints, a 90-second recovery bound, and an 8 MiB live-state floor; production admission and storage behavior are unchanged.

<sup>Written for commit 1e8430293f30e46b52901c6c4277c55cedc0dced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated native process-kill soak testing to use a consistent workload of 65,536 keys with an 800-milliunit Zipf distribution.
  - This improves consistency when validating checkpoint behavior under sustained load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->