### PR TITLE
test(cloud): retry bounded diagnostic timeouts

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -875,6 +875,13 @@ enum BoundedHttpError {
 }
 
 #[cfg(feature = "kafka")]
+fn is_retryable_diagnostic_status(status: u16) -> bool {
+    // 429 is the bounded single-flight/rate limit, 503 is unavailable evidence, and 504 is the
+    // diagnostic handler deadline. None contradicts the evidence being sampled.
+    matches!(status, 429 | 503 | 504)
+}
+
+#[cfg(feature = "kafka")]
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct LocalAuthorityEvidenceEnvelope {
@@ -2014,10 +2021,10 @@ impl Node {
                 return LocalAuthorityObservation::Contradiction(error);
             }
         };
-        if response.status == 503 {
+        if is_retryable_diagnostic_status(response.status) {
             return LocalAuthorityObservation::Pending(format!(
-                "node{} local evidence is temporarily unavailable",
-                self.id
+                "node{} local evidence is temporarily unavailable (HTTP {})",
+                self.id, response.status
             ));
         }
         if response.status != 200 {
@@ -2104,10 +2111,10 @@ impl Node {
                 return CheckpointBarrierTimingObservation::Contradiction(error);
             }
         };
-        if response.status == 503 {
+        if is_retryable_diagnostic_status(response.status) {
             return CheckpointBarrierTimingObservation::Pending(format!(
-                "node{} local checkpoint barrier timings are temporarily unavailable",
-                self.id
+                "node{} local checkpoint barrier timings are temporarily unavailable (HTTP {})",
+                self.id, response.status
             ));
         }
         if response.status != 200 {
@@ -14978,6 +14985,23 @@ fn produce_join_inputs(
             broker_acked_at,
         }
     })
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn bounded_diagnostic_statuses_retry_only_transient_responses() {
+    for status in [429, 503, 504] {
+        assert!(
+            is_retryable_diagnostic_status(status),
+            "HTTP {status} must remain pending until the outer evidence deadline"
+        );
+    }
+    for status in [200, 400, 401, 403, 404, 500] {
+        assert!(
+            !is_retryable_diagnostic_status(status),
+            "HTTP {status} must not hide invalid or contradictory evidence"
+        );
+    }
 }
 
 #[cfg(feature = "kafka")]


### PR DESCRIPTION
Native Azure run 33700116867 reached a durable startup checkpoint, then the bounded local-evidence endpoint returned HTTP 504 once. The soak classified that transient middleware deadline as contradictory evidence and failed before fault injection. This change keeps 429, 503, and 504 pending only within the existing convergence deadline, while all other non-200 responses and invalid evidence still fail immediately. It applies the same rule to local checkpoint timing diagnostics and adds a table-driven regression test. Validation: nightly fmt check; readability check; focused regression test; full cluster_soak suite with cluster,kafka,azure (66 passed, 4 ignored); targeted clippy with warnings denied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cluster soak test to treat bounded diagnostic HTTP statuses (429, 503, 504) as pending instead of contradictory evidence, so transient timeouts don't fail the soak before fault injection. Non-200 responses and invalid evidence still fail immediately. Adds a regression test for the retryable statuses.

<sup>Written for commit b605b18c808e82f2a033670504aa0fbdd2e165c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster diagnostics to retry temporarily unavailable Kafka responses, including HTTP 429, 503, and 504 statuses.
  - Pending diagnostics now include the relevant HTTP status, providing clearer visibility while evidence is being collected.
  - Other non-success responses continue to be treated as diagnostic contradictions.

- **Tests**
  - Added coverage distinguishing temporary service unavailability from invalid or contradictory diagnostic responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->