### PR TITLE
test(cloud): make soak failures diagnostic

### DIFF
--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -144,8 +144,11 @@ jobs:
             azure) base="${LAMINAR_AZURE_TEST_URL:?LAMINAR_AZURE_TEST_URL is required}"; location_env=LAMINAR_AZURE_TEST_URL ;;
             gcs) base="${LAMINAR_GCS_TEST_URL:?LAMINAR_GCS_TEST_URL is required}"; location_env=LAMINAR_GCS_TEST_URL ;;
           esac
+          echo "::add-mask::$base"
           base_sha="$(git merge-base HEAD origin/main)"
           root="${base%/}/laminardb-tests/${base_sha}/${GITHUB_RUN_ID}/checkpoint"
+          echo "::add-mask::$root"
+          echo "::add-mask::$root/process-soak"
           metadata="$(cargo metadata --locked --format-version 1)"
           object_store_version="$(jq -er '[.packages[] | select(.name == "object_store") | .version] | unique | if length == 1 then .[0] else error("object_store version is not unique") end' <<<"$metadata")"
           mkdir -p "$LAMINAR_CLOUD_EVIDENCE_DIR"
@@ -230,18 +233,21 @@ jobs:
           if [[ -n "${LAMINAR_SOAK_CHECKPOINT_URL:-}" ]]; then
             scheme="${LAMINAR_SOAK_CHECKPOINT_URL%%:*}"
           fi
-          produced=0
+          requested_kills="$EVIDENCE_PROCESS_KILLS"
+          actual_kills=0
+          produced=null
           output_summary=""
           if [[ -f native-checkpoint-soak.log ]]; then
-            produced="$(sed -n 's/.*producer acknowledged \([0-9][0-9]*\) records.*/\1/p' native-checkpoint-soak.log | tail -1)"
-            produced="${produced:-0}"
+            actual_kills="$(awk '/^soak round [0-9]+: kill -9 delivered / { count++ } END { print count + 0 }' native-checkpoint-soak.log)"
+            produced_value="$(sed -n 's/.*producer acknowledged \([0-9][0-9]*\) records.*/\1/p' native-checkpoint-soak.log | tail -1)"
+            if [[ -n "$produced_value" ]]; then produced="$produced_value"; fi
             output_summary="$(sed -n 's/.*output oracle consumed.*observed all \([0-9][0-9]*\) pairs.*with \([0-9][0-9]*\) at-least-once duplicates.*/\1 \2/p' native-checkpoint-soak.log | tail -1)"
           fi
           recovered=0
           duplicates=0
           if [[ -n "$output_summary" ]]; then read -r recovered duplicates <<< "$output_summary"; fi
           passed=false
-          if [[ "${{ steps.process_soak.outcome }}" == "success" && "${{ steps.cleanup.outcome }}" == "success" && -n "$output_summary" ]]; then passed=true; fi
+          if [[ "${{ steps.process_soak.outcome }}" == "success" && "${{ steps.cleanup.outcome }}" == "success" && "$actual_kills" -eq "$requested_kills" && -n "$output_summary" ]]; then passed=true; fi
           cleanup_result=failed
           if [[ "${{ steps.cleanup.outcome }}" == "success" ]]; then cleanup_result=passed; fi
           if [[ "${{ steps.cleanup.outcome }}" == "skipped" ]]; then cleanup_result="preserved-on-request"; fi
@@ -254,11 +260,11 @@ jobs:
             --arg scheme "$scheme" \
             --arg started "$started" --arg finished "$(date --utc --iso-8601=seconds)" \
             --arg cleanup "$cleanup_result" --argjson passed "$passed" \
-            --argjson kills "$EVIDENCE_PROCESS_KILLS" \
+            --argjson kills "$actual_kills" --argjson requested_kills "$requested_kills" \
             --argjson recovery "$EVIDENCE_RECOVERY_TIMEOUT_MS" \
             --argjson produced "$produced" --argjson recovered "$recovered" \
             --argjson duplicates "$duplicates" --argjson duration "$duration_ms" \
-            '{schema_version:1,repository:"laminardb/laminardb",base_sha:$base_sha,tested_sha:$tested_sha,workflow_run_id:$run_id,provider:$provider,native_or_emulator:"native",redacted_endpoint_classification:"native-provider-default",region_or_cloud_location:(env.LAMINAR_CLOUD_LOCATION // null),url_scheme:$scheme,enabled_cargo_features:["cluster","kafka",$provider],object_store_version:(env.LAMINAR_OBJECT_STORE_VERSION // "unknown"),deltalake_version:null,iceberg_version:null,opendal_version:null,auth_source:(env.LAMINAR_NATIVE_AUTH_SOURCE // "unknown"),test_suite:"checkpoint-native-process-soak",test_name:"three_node_alo_join_kill9_soak",started_at:$started,finished_at:$finished,duration_ms:$duration,iterations:$kills,process_kill_count:$kills,recovery_bound_ms:$recovery,capability_results:{real_process_kill:true,fresh_client_recovery:$passed,no_loss_assertion:$passed,duplicates_identified_and_bounded:$passed},conditional_create_result:null,stale_cas_result:null,restart_result:$passed,delivery_contract_tested:"at-least-once",records_produced:$produced,records_committed:(if $passed then $recovered else 0 end),records_recovered:(if $passed then $recovered else 0 end),duplicates:(if $passed then $duplicates else null end),losses:(if $passed then 0 else null end),passed:$passed,skip_count:0,skip_reasons:[],cleanup_result:$cleanup,failure:(if $passed then null else "native checkpoint process soak, output evidence, or cleanup failed" end)}' \
+            '{schema_version:1,repository:"laminardb/laminardb",base_sha:$base_sha,tested_sha:$tested_sha,workflow_run_id:$run_id,provider:$provider,native_or_emulator:"native",redacted_endpoint_classification:"native-provider-default",region_or_cloud_location:(env.LAMINAR_CLOUD_LOCATION // null),url_scheme:$scheme,enabled_cargo_features:["cluster","kafka",$provider],object_store_version:(env.LAMINAR_OBJECT_STORE_VERSION // "unknown"),deltalake_version:null,iceberg_version:null,opendal_version:null,auth_source:(env.LAMINAR_NATIVE_AUTH_SOURCE // "unknown"),test_suite:"checkpoint-native-process-soak",test_name:"three_node_alo_join_kill9_soak",started_at:$started,finished_at:$finished,duration_ms:$duration,iterations:$kills,process_kill_count:$kills,requested_process_kill_count:$requested_kills,recovery_bound_ms:$recovery,capability_results:{real_process_kill:($kills > 0),all_requested_process_kills:($kills == $requested_kills),fresh_client_recovery:$passed,no_loss_assertion:$passed,duplicates_identified_and_bounded:$passed},conditional_create_result:null,stale_cas_result:null,restart_result:$passed,delivery_contract_tested:"at-least-once",records_produced:$produced,records_committed:(if $passed then $recovered else null end),records_recovered:(if $passed then $recovered else null end),duplicates:(if $passed then $duplicates else null end),losses:(if $passed then 0 else null end),passed:$passed,skip_count:0,skip_reasons:[],cleanup_result:$cleanup,failure:(if $passed then null else "native checkpoint process soak, output evidence, or cleanup failed" end)}' \
             > "$LAMINAR_CLOUD_EVIDENCE_DIR/checkpoint-native-process-soak-${{ matrix.provider }}-$GITHUB_RUN_ID.json"
       - name: Validate native evidence eligibility
         id: validate_evidence

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -11287,20 +11287,28 @@ fn assert_progress(
     }
     let ingested_target = cluster_metric(nodes, "laminardb_events_ingested_total") + 1.0;
     let emitted_target = cluster_metric(nodes, "laminardb_events_emitted_total") + 1.0;
-    wait_for(
-        &format!("{label}: source ingestion and graph output to advance"),
-        remaining_progress_window(deadline, label),
-        || {
-            assert_running_nodes(nodes);
-            if let Some(producer) = producer.as_deref_mut() {
-                producer.assert_running();
-            }
-            try_cluster_metric(nodes, "laminardb_events_ingested_total")
-                .is_some_and(|ingested| ingested >= ingested_target)
-                && try_cluster_metric(nodes, "laminardb_events_emitted_total")
-                    .is_some_and(|emitted| emitted >= emitted_target)
-        },
-    );
+    let advance_window = remaining_progress_window(deadline, label);
+    let graph_advanced = wait_until(advance_window, || {
+        assert_running_nodes(nodes);
+        if let Some(producer) = producer.as_deref_mut() {
+            producer.assert_running();
+        }
+        try_cluster_metric(nodes, "laminardb_events_ingested_total")
+            .is_some_and(|ingested| ingested >= ingested_target)
+            && try_cluster_metric(nodes, "laminardb_events_emitted_total")
+                .is_some_and(|emitted| emitted >= emitted_target)
+    });
+    if !graph_advanced {
+        let observed_ingested = try_cluster_metric(nodes, "laminardb_events_ingested_total");
+        let observed_emitted = try_cluster_metric(nodes, "laminardb_events_emitted_total");
+        let diagnostics = durable_progress_diagnostics(nodes, commit_oracle);
+        panic!(
+            "soak: timed out after {advance_window:?} waiting for: {label}: source ingestion and \
+             graph output to advance; ingested_target={ingested_target}, \
+             observed_ingested={observed_ingested:?}, emitted_target={emitted_target}, \
+             observed_emitted={observed_emitted:?}, observation=({diagnostics})"
+        );
+    }
 
     // Take the durability baselines only after graph output advanced, so checkpoints that happened
     // before this phase cannot satisfy the source-offset proof.
@@ -13342,6 +13350,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
             killed_follower_nodes.insert(victim);
         }
         kills += 1;
+        eprintln!("soak round {round}: kill -9 delivered to {victim_role} node {victim}");
         latest_checkpoint = assert_progress(
             &mut nodes,
             Some(&mut producer),


### PR DESCRIPTION
## Why

Azure native checkpoint run 33706710534 on `23c8417e503cf9cef9867e973b50704650cbb34e` passed object-store conformance and the deterministic checkpoint fault contract, then timed out after the first delivered leader kill because source ingestion and graph output did not advance within 90 seconds. The affected `assert_progress` phase used the generic waiter, so its failure omitted the safe recovery/checkpoint metrics needed to identify the stalled invariant.

The same failed artifact also reported the four requested kills as if all four had executed, although the log proves only one kill was delivered.

## What changed

- preserve the existing recovery deadline while emitting bounded, numeric progress diagnostics on this timeout path;
- emit a post-`kill9()` marker and derive evidence `iterations` / `process_kill_count` from delivered kills;
- record the requested kill count separately and require actual == requested for passing evidence;
- use `null` instead of false zeroes for record counters that are unknown after an incomplete run;
- mask the selected and derived native location before downstream workflow steps.

No production behavior, retry policy, timeout, delivery admission, dependency, or Cargo feature changes.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo test -p laminar-server --no-default-features --features "cluster,kafka,azure" --test cluster_soak` — 66 passed, 4 ignored
- `cargo clippy -p laminar-server --no-default-features --features "cluster,kafka,azure" --test cluster_soak -- -D warnings`
- workflow YAML parse
- delivered-kill parser fixture: two delivered markers counted; pre-kill observation ignored

## Evidence context

- Failed native run: https://github.com/laminardb/laminardb/actions/runs/33706710534
- Uploaded artifact: `native-checkpoint-azure-33706710534`
- Native certification remains closed pending a successful exact-commit rerun with zero skips and successful cleanup/evidence enforcement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes native cloud soak failures diagnostic. The evidence now counts kills actually delivered from the log and requires actual == requested to pass, instead of reporting all requested kills as executed. On progress timeout, the test panics with observed ingestion and emission metrics plus durable progress diagnostics.

- Emits a post-`kill9()` marker and derives `iterations` / `process_kill_count` from delivered kills.
- Uses `null` instead of false zeroes for record counters unknown after an incomplete run.
- Masks the selected and derived native location before downstream workflow steps.
- No production behavior, retry policy, timeout, delivery admission, dependency, or Cargo feature changes.

<sup>Written for commit 35f36c38d009db9ad8e265577883c958b56e524e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cluster soak-test validation by confirming the expected number of kill rounds completed.
  * Added clearer timeout diagnostics for ingestion, emission, metrics, and durability progress.
  * Enhanced soak evidence with separate actual and requested kill counts and clearer unavailable-value handling.

* **Security**
  * Masked derived cloud storage URLs in soak-test logs to reduce sensitive information exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->