### PR TITLE
test(cloud): classify recovery assignment stalls

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -209,7 +209,9 @@ const RECOVERY_RETRY_HOLD_LOG: &str = "holding intake shut and requesting a fres
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 15] = [
+const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(feature = "kafka")]
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 22] = [
     (
         "leader_local_deadline_expired",
         "leader lease local deadline expired",
@@ -253,6 +255,25 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 15] = [
         "coordinated recovery: owner-complete assignment audit failed",
     ),
     ("recovery_prepare", RECOVERY_PREPARE_LOG),
+    ("recovery_prepare_handoff", RECOVERY_PREPARE_HANDOFF_LOG),
+    ("recovery_retry_hold", RECOVERY_RETRY_HOLD_LOG),
+    (
+        "recovery_stopped",
+        "stopped for recovery round; awaiting target",
+    ),
+    (
+        "recovery_stop_quorum_timeout",
+        "recovery stop quorum timed out",
+    ),
+    (
+        "recovery_successor_authorized",
+        "authorized successor assignment from the last committed cluster cut",
+    ),
+    ("assignment_rotated", "rotated assignment"),
+    (
+        "rebalance_failed",
+        "rebalance failed; retrying after backoff",
+    ),
     ("recovery_start", "leader announced recovery start"),
     ("recovery_release", RECOVERY_RELEASE_LOG),
 ];
@@ -957,6 +978,29 @@ enum ReadinessDiagnostic {
     TemporarilyUnavailable,
     UnexpectedStatus(u16),
     TransportUnavailable,
+    InvalidResponse,
+}
+
+#[cfg(feature = "kafka")]
+#[derive(Debug, PartialEq, Eq)]
+enum LocalAssignmentDiagnostic {
+    Available {
+        version: u64,
+        vnode_state_ready: bool,
+    },
+    TemporarilyUnavailable,
+    InvalidResponse,
+}
+
+#[cfg(feature = "kafka")]
+#[derive(Debug, PartialEq, Eq)]
+enum DurableAssignmentDiagnostic {
+    Available {
+        version: u64,
+        draining: bool,
+        participant_count: usize,
+    },
+    TemporarilyUnavailable,
     InvalidResponse,
 }
 
@@ -2216,6 +2260,25 @@ impl Node {
     }
 
     #[cfg(feature = "kafka")]
+    fn local_assignment_diagnostic(&self) -> LocalAssignmentDiagnostic {
+        let deadline = Instant::now() + RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT;
+        match self.local_authority_observation(deadline) {
+            LocalAuthorityObservation::Available(evidence) => {
+                LocalAssignmentDiagnostic::Available {
+                    version: evidence.adopted_assignment.assignment_version,
+                    vnode_state_ready: evidence.adopted_assignment.vnode_state_ready,
+                }
+            }
+            LocalAuthorityObservation::Pending(_) => {
+                LocalAssignmentDiagnostic::TemporarilyUnavailable
+            }
+            LocalAuthorityObservation::Contradiction(_) => {
+                LocalAssignmentDiagnostic::InvalidResponse
+            }
+        }
+    }
+
+    #[cfg(feature = "kafka")]
     fn checkpoint_barrier_timing_observation(
         &self,
         expected_process: Option<LocalProcessAuthorityIdentity>,
@@ -2322,7 +2385,7 @@ impl Node {
             Err(BoundedHttpError::Unavailable(_)) => return Ok(None),
             Err(BoundedHttpError::Invalid(error)) => return Err(error),
         };
-        if response.status == 503 {
+        if is_retryable_diagnostic_status(response.status) {
             return Ok(None);
         }
         if response.status != 200 {
@@ -2350,6 +2413,20 @@ impl Node {
             return Ok(None);
         }
         Ok(Some(snapshot))
+    }
+
+    #[cfg(feature = "kafka")]
+    fn durable_assignment_diagnostic(&self) -> DurableAssignmentDiagnostic {
+        let deadline = Instant::now() + RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT;
+        match self.durable_assignment_observation(deadline) {
+            Ok(Some(snapshot)) => DurableAssignmentDiagnostic::Available {
+                version: snapshot.version,
+                draining: snapshot.draining,
+                participant_count: snapshot.participants.len(),
+            },
+            Ok(None) => DurableAssignmentDiagnostic::TemporarilyUnavailable,
+            Err(_) => DurableAssignmentDiagnostic::InvalidResponse,
+        }
     }
 
     #[cfg(feature = "kafka")]
@@ -11404,6 +11481,14 @@ fn durable_progress_diagnostics(
         .iter()
         .map(|node| (node.id, node.readiness_diagnostic()))
         .collect();
+    let local_assignment_by_node: Vec<_> = live_nodes
+        .iter()
+        .map(|node| (node.id, node.local_assignment_diagnostic()))
+        .collect();
+    let durable_assignment_by_node: Vec<_> = live_nodes
+        .iter()
+        .map(|node| (node.id, node.durable_assignment_diagnostic()))
+        .collect();
     let recovery_log_markers_by_node: Vec<_> = live_nodes
         .iter()
         .map(|node| (node.id, node.recovery_log_marker_counts()))
@@ -11448,6 +11533,8 @@ fn durable_progress_diagnostics(
     format!(
         "live_node_ids={live_node_ids:?}, leader_by_node={leader_by_node:?}, \
          readiness_by_node={readiness_by_node:?}, \
+         local_assignment_by_node={local_assignment_by_node:?}, \
+         durable_assignment_by_node={durable_assignment_by_node:?}, \
          completed_checkpoints={completed:?}, failed_checkpoints={failed:?}, \
          recovery_metrics={recovery_metrics:?}, \
          recovery_log_markers_by_node={recovery_log_markers_by_node:?}, \
@@ -15266,10 +15353,16 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     let log = "leader lease operation failed: signed_url=?sig=secret\n\
                leader lease operation failed: account=secret\n\
                leader announced recovery prepare\n\
+               recovery stop quorum timed out\n\
+               authorized successor assignment from the last committed cluster cut\n\
+               rebalance failed; retrying after backoff\n\
                coordinated recovery has no live durable leader proof\n";
     let counts = count_recovery_diagnostic_markers(log);
     assert_eq!(counts.get("leader_operation_failed"), Some(&2));
     assert_eq!(counts.get("recovery_prepare"), Some(&1));
+    assert_eq!(counts.get("recovery_stop_quorum_timeout"), Some(&1));
+    assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
+    assert_eq!(counts.get("rebalance_failed"), Some(&1));
     assert_eq!(counts.get("missing_live_leader_proof"), Some(&1));
     let diagnostic = format!("{counts:?}");
     assert!(!diagnostic.contains("secret"));


### PR DESCRIPTION
## Summary
- classify local and durable assignment state in process-soak timeout diagnostics
- count recovery handoff, quorum timeout, successor authorization, rotation, and rebalance markers
- retain bounded, fixed-category diagnostics without copying response bodies or storage errors

## Evidence motivating the change
Native Azure run 33969524648 passed object-store conformance and checkpoint CAS/fault-boundary tests, but its process-kill soak stalled after the first kill with both survivors in Recovering. Existing output did not reveal whether stop quorum, successor authorization, or assignment rotation failed to advance.

Azure remains **not certified**. This PR changes neither production behavior nor delivery admission.

## Local validation
- cargo test -p laminar-server --no-default-features --features cluster,kafka,azure --test cluster_soak (69 passed, 4 ignored process tests)
- cargo clippy -p laminar-server --no-default-features --features cluster,kafka,azure --test cluster_soak -- -D warnings
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves soak test diagnostics for recovery assignment stalls by classifying local and durable assignment state and adding new recovery-stage markers.

This is a test-only change; production behavior and delivery admission are unaffected. It adds bounded, fixed-category diagnostics without copying response bodies or storage errors, and broadens retryable-status handling beyond `503` when reading durable assignment snapshots. The expanded marker set covers recovery handoff, quorum timeout, successor authorization, rotation, and rebalance failure, so a stalled recovery now shows which stage failed to advance.

<sup>Written for commit dad957804b4da12d1a6dbd63115cf55a565f4ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded recovery diagnostics to cover additional handoff, retry, stop, authorization, rotation, and rebalance outcomes.
  * Added assignment availability and validity checks to improve diagnostic reporting during recovery.
  * Extended soak-test assertions to verify the new recovery markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->