### PR TITLE
test(cloud): diagnose per-node ingest stalls

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -211,7 +211,7 @@ const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 32] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 40] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -310,6 +310,32 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 32] = [
     ),
     ("recovery_start", "leader announced recovery start"),
     ("recovery_release", RECOVERY_RELEASE_LOG),
+    (
+        "kafka_source_started_fenced",
+        "Kafka source started fenced with no partitions until durable vnode adoption",
+    ),
+    (
+        "kafka_assigned_partitions",
+        "Kafka source assigned vnode-owned partitions (engine-controlled)",
+    ),
+    (
+        "kafka_assignment_inspection_failed",
+        "Kafka source could not inspect its current assignment; rotation will retry",
+    ),
+    ("kafka_assign_failed", "Kafka source assign failed"),
+    ("kafka_consumer_error", "Kafka consumer error"),
+    (
+        "source_intake_opened",
+        "Cluster assignment certified; source intake opened",
+    ),
+    (
+        "source_intake_recovery_fenced",
+        "Cluster source intake remains fenced for coordinated recovery",
+    ),
+    (
+        "worker_no_vnodes",
+        "Cluster worker owns no vnodes; data plane remains fenced pending assignment",
+    ),
 ];
 const RECOVERY_LIVENESS_WINDOW: Duration = Duration::from_secs(90);
 const DEFAULT_MAX_RECOVERY_MS: u64 = 90_000;
@@ -1476,6 +1502,20 @@ fn prometheus_histogram_bucket_value(body: &str, metric: &str, upper_bound: f64)
     found.then_some(sum)
 }
 
+fn prometheus_metric_sum(body: &str, name: &str) -> Option<f64> {
+    let mut found = false;
+    let sum = body
+        .lines()
+        .filter(|line| {
+            line.strip_prefix(name)
+                .is_some_and(|rest| rest.starts_with(' ') || rest.starts_with('{'))
+        })
+        .filter_map(|line| line.split_whitespace().last()?.parse::<f64>().ok())
+        .inspect(|_| found = true)
+        .sum();
+    found.then_some(sum)
+}
+
 #[cfg(feature = "kafka")]
 #[derive(Clone, Copy, Debug)]
 struct HotPathLatencySnapshot {
@@ -2482,17 +2522,39 @@ impl Node {
     /// Scrape one gauge/counter from `/metrics`; `None` while the node is down or booting.
     fn metric(&self, name: &str) -> Option<f64> {
         let body = self.http_get("/metrics")?;
-        let mut found = false;
-        let sum = body
-            .lines()
-            .filter(|line| {
-                line.strip_prefix(name)
-                    .is_some_and(|rest| rest.starts_with(' ') || rest.starts_with('{'))
-            })
-            .filter_map(|line| line.split_whitespace().last()?.parse::<f64>().ok())
-            .inspect(|_| found = true)
-            .sum();
-        found.then_some(sum)
+        prometheus_metric_sum(&body, name)
+    }
+
+    #[cfg(feature = "kafka")]
+    fn ingestion_diagnostic_metrics(&self) -> [(&'static str, Option<f64>); 6] {
+        const METRICS: [(&str, &str); 6] = [
+            ("events_ingested", "laminardb_events_ingested_total"),
+            (
+                "kafka_records_polled",
+                "laminardb_kafka_source_records_polled_total",
+            ),
+            (
+                "kafka_batches_polled",
+                "laminardb_kafka_source_batches_polled_total",
+            ),
+            ("kafka_source_errors", "laminardb_kafka_source_errors_total"),
+            (
+                "kafka_source_rebalances",
+                "laminardb_kafka_source_rebalances_total",
+            ),
+            (
+                "kafka_source_commits",
+                "laminardb_kafka_source_commits_total",
+            ),
+        ];
+        let body = self.http_get("/metrics");
+        METRICS.map(|(label, name)| {
+            (
+                label,
+                body.as_deref()
+                    .and_then(|metrics| prometheus_metric_sum(metrics, name)),
+            )
+        })
     }
 
     #[cfg(feature = "kafka")]
@@ -11447,14 +11509,32 @@ fn assert_every_node_ingests(nodes: &mut [Node], producer: &mut ProducerGuard, w
                 .expect("node did not expose events_ingested_total")
         })
         .collect();
-    wait_for("every node to ingest assigned Kafka work", window, || {
+    if wait_until(window, || {
         assert_running_nodes(nodes);
         producer.assert_running();
         nodes.iter().zip(&baselines).all(|(node, baseline)| {
             node.metric("laminardb_events_ingested_total")
                 .is_some_and(|ingested| ingested > *baseline)
         })
-    });
+    }) {
+        return;
+    }
+    let ingestion_progress_by_node = nodes
+        .iter()
+        .zip(&baselines)
+        .map(|(node, baseline)| {
+            (
+                node.id,
+                *baseline,
+                node.metric("laminardb_events_ingested_total"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let diagnostics = durable_progress_diagnostics(nodes, &[]);
+    panic!(
+        "soak: timed out after {window:?} waiting for: every node to ingest assigned Kafka work; \
+         ingestion_progress_by_node={ingestion_progress_by_node:?}; observation=({diagnostics})"
+    );
 }
 
 #[cfg(feature = "kafka")]
@@ -11578,6 +11658,10 @@ fn durable_progress_diagnostics(
         .iter()
         .map(|node| (node.id, node.recovery_log_marker_counts()))
         .collect();
+    let ingestion_metrics_by_node: Vec<_> = live_nodes
+        .iter()
+        .map(|node| (node.id, node.ingestion_diagnostic_metrics()))
+        .collect();
     let checkpoint_size_bytes_by_node: Vec<_> = live_nodes
         .iter()
         .map(|node| (node.id, node.metric("laminardb_checkpoint_size_bytes")))
@@ -11627,6 +11711,7 @@ fn durable_progress_diagnostics(
          completed_checkpoints={completed:?}, failed_checkpoints={failed:?}, \
          recovery_metrics={recovery_metrics:?}, \
          recovery_log_markers_by_node={recovery_log_markers_by_node:?}, \
+         ingestion_metrics_by_node={ingestion_metrics_by_node:?}, \
          checkpoint_size_bytes_by_node={checkpoint_size_bytes_by_node:?}, \
          durable_checkpoint_by_node={durable_checkpoint_by_node:?}, \
          committed_source_offsets={offsets:?}"
@@ -15474,7 +15559,10 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                recovery stop quorum timed out\n\
                authorized successor assignment from the last committed cluster cut\n\
                rebalance failed; retrying after backoff\n\
-               coordinated recovery has no live durable leader proof\n";
+               coordinated recovery has no live durable leader proof\n\
+               Kafka source assign failed: token=secret\n\
+               Kafka consumer error: credential=secret\n\
+               Cluster source intake remains fenced for coordinated recovery\n";
     let counts = count_recovery_diagnostic_markers(log);
     assert_eq!(counts.get("leader_operation_failed"), Some(&2));
     assert_eq!(
@@ -15487,6 +15575,9 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
     assert_eq!(counts.get("rebalance_failed"), Some(&1));
     assert_eq!(counts.get("missing_live_leader_proof"), Some(&1));
+    assert_eq!(counts.get("kafka_assign_failed"), Some(&1));
+    assert_eq!(counts.get("kafka_consumer_error"), Some(&1));
+    assert_eq!(counts.get("source_intake_recovery_fenced"), Some(&1));
     let diagnostic = format!("{counts:?}");
     assert!(!diagnostic.contains("secret"));
     assert!(!diagnostic.contains("sig="));


### PR DESCRIPTION
## What

Add bounded, secret-safe diagnostics when the three-node cloud checkpoint soak cannot prove that every node is ingesting its assigned Kafka work.

## Why

Azure native run 33980074272 passed object-store conformance and the checkpoint CAS/fault-boundary contract, then failed before its first process kill because at least one node's ingestion counter did not advance within the existing 60-second gate. That gate reported no per-node state and the child-process logs were not uploaded, so the failure could not be distinguished between assignment, source polling, pipeline fencing, or checkpoint/recovery state.

## How

- preserve the existing 60-second fail-closed assertion;
- report per-node baseline/current ingestion and one bounded scrape of Kafka source counters;
- reuse existing redacted readiness, assignment, checkpoint, and recovery diagnostics;
- count only fixed Kafka/intake log marker categories, never raw log content;
- retain the same production behavior and delivery admission.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests pass (`cargo test --all`) — full workspace CI is delegated to the PR gate; targeted test passed
- [x] No clippy warnings for the changed Azure-featured target
- [x] Code is formatted (`cargo +nightly fmt --all -- --check`)

Commands run:

- `cargo test -p laminar-server --no-default-features --features "cluster,kafka,azure" --test cluster_soak` (70 passed, 4 real-process tests ignored)
- `cargo clippy -p laminar-server --no-default-features --features "cluster,kafka,azure" --test cluster_soak -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `git diff --check`

## Ring 0 (if applicable)

Not applicable: test harness only; no coordinator or operator hot-path changes.

- [x] No heap allocations on production hot path
- [x] No locks on production hot path
- [ ] Benchmarks run before and after — not applicable

## Checklist

- [x] Public APIs are unchanged
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-node ingestion diagnostics to the three-node cloud checkpoint soak so a stalled node reports why instead of failing with no state.

- Keeps the existing 60-second fail-closed assertion; only the failure output changes.
- On timeout, the panic now includes each node's baseline/current ingestion count, a bounded scrape of Kafka source counters, and the existing redacted readiness, assignment, checkpoint, and recovery diagnostics.
- New recovery log markers cover Kafka source fencing, assignment, consumer errors, and intake state, but only fixed marker counts are recorded, never raw log content.
- Test harness only: no production hot-path, delivery admission, or public API changes.

<sup>Written for commit 0d196620ed3ac58f8fd7214b60340a9c6d87f78e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded recovery and ingestion soak-test coverage for Kafka source startup, vnode assignment, consumer errors, source intake, and worker ownership scenarios.
  * Added per-node ingestion metric reporting and more detailed progress diagnostics.
  * Improved timeout failures with actionable per-node ingestion and durable-progress information.
  * Added validation for newly tracked recovery and source-intake diagnostic markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->