### PR TITLE
test(cloud): classify recovery adoption failures

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -211,7 +211,7 @@ const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 40] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 48] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -302,6 +302,38 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 40] = [
     (
         "recovery_successor_authorized",
         "authorized successor assignment from the last committed cluster cut",
+    ),
+    (
+        "snapshot_recovery_suspend_failed",
+        "snapshot watcher: could not suspend recovery assignment",
+    ),
+    (
+        "snapshot_recovery_fault_failed",
+        "snapshot watcher: could not publish recovery fault",
+    ),
+    (
+        "snapshot_recovery_checkpoint_settlement_failed",
+        "snapshot watcher: could not settle predecessor checkpoint for recovery",
+    ),
+    (
+        "snapshot_recovery_adoption_failed",
+        "snapshot watcher: adoption failed",
+    ),
+    (
+        "recovery_adoption_deadline",
+        "adoption exceeded its end-to-end deadline",
+    ),
+    (
+        "recovery_materialization_deadline",
+        "recovery assignment materialization exceeded its deadline",
+    ),
+    (
+        "recovery_handoff_manifest_missing",
+        "handoff manifest is missing",
+    ),
+    (
+        "recovery_retained_state_missing",
+        "cannot reuse retained vnode memory without its exact predecessor binding",
     ),
     ("assignment_rotated", "rotated assignment"),
     (
@@ -15558,6 +15590,14 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                leader announced recovery prepare\n\
                recovery stop quorum timed out\n\
                authorized successor assignment from the last committed cluster cut\n\
+               snapshot watcher: could not suspend recovery assignment\n\
+               snapshot watcher: could not publish recovery fault\n\
+               snapshot watcher: could not settle predecessor checkpoint for recovery\n\
+               snapshot watcher: adoption failed\n\
+               recovery assignment 2 adoption exceeded its end-to-end deadline\n\
+               recovery assignment materialization exceeded its deadline\n\
+               participant 2 handoff manifest is missing\n\
+               cannot reuse retained vnode memory without its exact predecessor binding\n\
                rebalance failed; retrying after backoff\n\
                coordinated recovery has no live durable leader proof\n\
                Kafka source assign failed: token=secret\n\
@@ -15573,6 +15613,17 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     assert_eq!(counts.get("recovery_prepare"), Some(&1));
     assert_eq!(counts.get("recovery_stop_quorum_timeout"), Some(&1));
     assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
+    assert_eq!(counts.get("snapshot_recovery_suspend_failed"), Some(&1));
+    assert_eq!(counts.get("snapshot_recovery_fault_failed"), Some(&1));
+    assert_eq!(
+        counts.get("snapshot_recovery_checkpoint_settlement_failed"),
+        Some(&1)
+    );
+    assert_eq!(counts.get("snapshot_recovery_adoption_failed"), Some(&1));
+    assert_eq!(counts.get("recovery_adoption_deadline"), Some(&1));
+    assert_eq!(counts.get("recovery_materialization_deadline"), Some(&1));
+    assert_eq!(counts.get("recovery_handoff_manifest_missing"), Some(&1));
+    assert_eq!(counts.get("recovery_retained_state_missing"), Some(&1));
     assert_eq!(counts.get("rebalance_failed"), Some(&1));
     assert_eq!(counts.get("missing_live_leader_proof"), Some(&1));
     assert_eq!(counts.get("kafka_assign_failed"), Some(&1));

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -211,7 +211,7 @@ const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 48] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 52] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -330,6 +330,22 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 48] = [
     (
         "recovery_handoff_manifest_missing",
         "handoff manifest is missing",
+    ),
+    (
+        "recovery_handoff_manifest_read_timeout",
+        "handoff manifest read timed out",
+    ),
+    (
+        "recovery_handoff_manifest_read_failed",
+        "handoff manifest read failed",
+    ),
+    (
+        "recovery_handoff_read_timeout",
+        "vnode handoff read timed out",
+    ),
+    (
+        "recovery_handoff_frame_read_timeout",
+        "vnode handoff frame read timed out",
     ),
     (
         "recovery_retained_state_missing",
@@ -15597,6 +15613,10 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                recovery assignment 2 adoption exceeded its end-to-end deadline\n\
                recovery assignment materialization exceeded its deadline\n\
                participant 2 handoff manifest is missing\n\
+               participant 2 handoff manifest read timed out\n\
+               participant 2 handoff manifest read failed: credential=secret\n\
+               vnode handoff read timed out\n\
+               vnode handoff frame read timed out\n\
                cannot reuse retained vnode memory without its exact predecessor binding\n\
                rebalance failed; retrying after backoff\n\
                coordinated recovery has no live durable leader proof\n\
@@ -15623,6 +15643,16 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     assert_eq!(counts.get("recovery_adoption_deadline"), Some(&1));
     assert_eq!(counts.get("recovery_materialization_deadline"), Some(&1));
     assert_eq!(counts.get("recovery_handoff_manifest_missing"), Some(&1));
+    assert_eq!(
+        counts.get("recovery_handoff_manifest_read_timeout"),
+        Some(&1)
+    );
+    assert_eq!(
+        counts.get("recovery_handoff_manifest_read_failed"),
+        Some(&1)
+    );
+    assert_eq!(counts.get("recovery_handoff_read_timeout"), Some(&1));
+    assert_eq!(counts.get("recovery_handoff_frame_read_timeout"), Some(&1));
     assert_eq!(counts.get("recovery_retained_state_missing"), Some(&1));
     assert_eq!(counts.get("rebalance_failed"), Some(&1));
     assert_eq!(counts.get("missing_live_leader_proof"), Some(&1));


### PR DESCRIPTION
## Summary
- add fixed-category recovery adoption diagnostics to the checkpoint process soak
- keep child log values out of evidence and failure output
- cover each new marker with the existing secret-safety unit test

## Validation
- nightly format check
- focused Azure cluster-soak marker test
- focused Azure cluster-soak clippy
- readability check

Azure delivery admission remains unchanged and fail-closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fixed-category diagnostics for recovery adoption and handoff read failures to the cluster soak test so failures are classified without exposing child log values.

**Test coverage**
- Extends the recovery marker list from 40 to 52 entries with 12 new snapshot watcher, adoption deadline, and handoff read categories.
- Updates the secret-safety unit test to assert each new marker appears without copying log values.
- Azure delivery admission stays unchanged and fail-closed.

<sup>Written for commit 93377953deb7d1c73e958ef0602bec97a7c3ca39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded cluster recovery diagnostics coverage.
  * Added validation for snapshot-watcher failures, recovery deadlines, missing handoff manifests, and missing retained-state predecessor bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->