### PR TITLE
fix(cluster): preserve stopped recovery successor adoption

### DIFF
--- a/crates/laminar-core/src/cluster/control/controller/recovery_protocol.rs
+++ b/crates/laminar-core/src/cluster/control/controller/recovery_protocol.rs
@@ -370,18 +370,12 @@ impl ClusterController {
         }
     }
 
-    /// Active recovery announcement with semantic failures separated from uncertain I/O.
-    ///
-    /// # Errors
-    /// Classifies malformed state, superseded authority, and retryable durable I/O separately.
-    pub async fn observe_recover_control(
+    async fn recovery_announcement_for_driver(
         &self,
+        driver: NodeId,
     ) -> Result<Option<RecoveryAnnouncement>, RecoveryControlError> {
-        let Some(current_driver) = self.current_leader() else {
-            return Ok(None);
-        };
         let Some(raw) = self
-            .read_recovery_value(current_driver, "control:recover")
+            .read_recovery_value(driver, "control:recover")
             .await
             .map_err(RecoveryControlError::Uncertain)?
         else {
@@ -397,43 +391,104 @@ impl ClusterController {
                 "committed recovery release appeared in the mutable intent slot".into(),
             ));
         }
-        if announcement.round.id.driver != current_driver {
+        if announcement.round.id.driver != driver {
             return Err(RecoveryControlError::Conflict(format!(
-                "recovery publisher {current_driver} is not declared driver {}",
+                "recovery publisher {driver} is not declared driver {}",
                 announcement.round.id.driver
             )));
         }
+        Ok(Some(announcement))
+    }
+
+    async fn recovery_authority_matches_for_observation(
+        &self,
+        proof: &LeaderProof,
+    ) -> Result<bool, RecoveryControlError> {
         let authority = self
             .checkpoint_authority()
             .map_err(|error| RecoveryControlError::Conflict(error.to_string()))?;
-        let Some(authority_before) = authority.load().await.map_err(|error| match error {
-            super::super::LeaseError::Io(reason) => RecoveryControlError::Uncertain(reason),
-            error => RecoveryControlError::Conflict(error.to_string()),
-        })?
-        else {
-            return Err(RecoveryControlError::Superseded(
-                "durable recovery authority has no leader".into(),
-            ));
+        authority
+            .load()
+            .await
+            .map_err(|error| match error {
+                super::super::LeaseError::Io(reason) => RecoveryControlError::Uncertain(reason),
+                error => RecoveryControlError::Conflict(error.to_string()),
+            })
+            .map(|lease| lease.is_some_and(|lease| lease.matches_proof(proof)))
+    }
+
+    /// Active recovery announcement with semantic failures separated from uncertain I/O.
+    ///
+    /// # Errors
+    /// Classifies malformed state, superseded authority, and retryable durable I/O separately.
+    pub async fn observe_recover_control(
+        &self,
+    ) -> Result<Option<RecoveryAnnouncement>, RecoveryControlError> {
+        let Some(current_driver) = self.current_leader() else {
+            return Ok(None);
         };
-        if !authority_before.matches_proof(&announcement.round.leader_proof) {
+        let Some(announcement) = self
+            .recovery_announcement_for_driver(current_driver)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if !self
+            .recovery_authority_matches_for_observation(&announcement.round.leader_proof)
+            .await?
+        {
             return Err(RecoveryControlError::Superseded(format!(
                 "recovery phase from {current_driver} does not match durable leader authority"
             )));
         }
-        let Some(authority_after) = authority.load().await.map_err(|error| match error {
-            super::super::LeaseError::Io(reason) => RecoveryControlError::Uncertain(reason),
-            error => RecoveryControlError::Conflict(error.to_string()),
-        })?
-        else {
-            return Err(RecoveryControlError::Superseded(
-                "durable recovery authority vanished during observation".into(),
-            ));
-        };
         if self.current_leader() != Some(current_driver)
-            || !authority_after.matches_proof(&announcement.round.leader_proof)
+            || !self
+                .recovery_authority_matches_for_observation(&announcement.round.leader_proof)
+                .await?
         {
             return Err(RecoveryControlError::Superseded(format!(
                 "recovery authority changed while observing {current_driver}"
+            )));
+        }
+        Ok(Some(announcement))
+    }
+
+    /// Observe a nonterminal recovery announcement through an exact durable leader proof.
+    ///
+    /// This is intentionally independent of the local gossip candidacy view. It permits a stopped
+    /// process to finish publishing an already-audited recovery topology after its driver loses
+    /// candidacy, while the durable fencing term remains unchanged.
+    ///
+    /// # Errors
+    /// Classifies malformed state, superseded authority, and retryable durable I/O separately.
+    pub async fn observe_recover_control_for_durable_proof(
+        &self,
+        proof: &LeaderProof,
+    ) -> Result<Option<RecoveryAnnouncement>, RecoveryControlError> {
+        if !proof.is_canonical() {
+            return Err(RecoveryControlError::Conflict(
+                "recovery observation requires a canonical durable leader proof".into(),
+            ));
+        }
+        if !self
+            .recovery_authority_matches_for_observation(proof)
+            .await?
+        {
+            return Err(RecoveryControlError::Superseded(
+                "durable recovery authority does not match the audited proof".into(),
+            ));
+        }
+        let driver = NodeId(proof.owner.node_id);
+        let Some(announcement) = self.recovery_announcement_for_driver(driver).await? else {
+            return Ok(None);
+        };
+        if announcement.round.leader_proof != *proof
+            || !self
+                .recovery_authority_matches_for_observation(proof)
+                .await?
+        {
+            return Err(RecoveryControlError::Superseded(format!(
+                "recovery authority changed while observing {driver} through its durable proof"
             )));
         }
         Ok(Some(announcement))

--- a/crates/laminar-core/src/cluster/control/controller/tests.rs
+++ b/crates/laminar-core/src/cluster/control/controller/tests.rs
@@ -3933,6 +3933,40 @@ async fn stale_noncurrent_recovery_slot_does_not_mask_the_current_driver() {
 }
 
 #[tokio::test]
+async fn durable_proof_observation_survives_local_driver_candidacy_loss() {
+    let controller = ctl(1, vec![]);
+    controller.publish_recovery_incarnation().await.unwrap();
+    let (_authority, proof) = install_recovery_authority(&controller, 1_000).await;
+    report_new_local_fault(&controller).await;
+    let round = recovery_round_from_current_faults(&controller, 18, &proof, &[1]).await;
+    controller.publish_checkpoint_assignment_fence(Some(round.assignment_fence.clone()));
+    controller.announce_recover_prepare(&round).await.unwrap();
+    let prepare = RecoveryAnnouncement {
+        round,
+        phase: RecoverPhase::Prepare,
+    };
+
+    controller.set_active(false);
+    assert_eq!(controller.observe_recover_control().await.unwrap(), None);
+    assert_eq!(
+        controller
+            .observe_recover_control_for_durable_proof(&proof)
+            .await
+            .unwrap(),
+        Some(prepare)
+    );
+
+    let mut wrong_proof = proof;
+    wrong_proof.fencing_token += 1;
+    assert!(matches!(
+        controller
+            .observe_recover_control_for_durable_proof(&wrong_proof)
+            .await,
+        Err(RecoveryControlError::Superseded(_))
+    ));
+}
+
+#[tokio::test]
 async fn malformed_current_driver_recovery_slot_fails_closed() {
     let self_id = NodeId(2);
     let kv = Arc::new(InMemoryKv::new(self_id));

--- a/crates/laminar-db/src/db/assignment_authority.rs
+++ b/crates/laminar-db/src/db/assignment_authority.rs
@@ -1,4 +1,116 @@
 use super::{AssignmentAuthorityActivation, DbError, LaminarDB};
+use laminar_core::checkpoint::{CheckpointAssignmentFence, CheckpointParticipant, LeaderProof};
+use laminar_core::cluster::control::{
+    ClusterController, RecoverPhase, RecoveryAnnouncement, RecoveryControlError, RecoveryRound,
+};
+
+async fn observe_stopped_round(
+    controller: &ClusterController,
+    durable_proof: Option<&LeaderProof>,
+) -> Result<Option<RecoveryAnnouncement>, RecoveryControlError> {
+    match durable_proof {
+        Some(proof) => {
+            controller
+                .observe_recover_control_for_durable_proof(proof)
+                .await
+        }
+        None => controller.observe_recover_control().await,
+    }
+}
+
+pub(crate) async fn audited_stopped_terminal_round(
+    controller: &ClusterController,
+    predecessor: &CheckpointAssignmentFence,
+    deadline: tokio::time::Instant,
+) -> Result<Option<RecoveryRound>, DbError> {
+    audited_stopped_round(controller, predecessor, None, deadline).await
+}
+
+pub(crate) async fn audited_stopped_recovery_successor_round(
+    controller: &ClusterController,
+    predecessor: &CheckpointAssignmentFence,
+    leader_proof: &LeaderProof,
+    deadline: tokio::time::Instant,
+) -> Result<Option<RecoveryRound>, DbError> {
+    audited_stopped_round(controller, predecessor, Some(leader_proof), deadline).await
+}
+
+async fn audited_stopped_round(
+    controller: &ClusterController,
+    predecessor: &CheckpointAssignmentFence,
+    durable_proof: Option<&LeaderProof>,
+    deadline: tokio::time::Instant,
+) -> Result<Option<RecoveryRound>, DbError> {
+    let active =
+        tokio::time::timeout_at(deadline, observe_stopped_round(controller, durable_proof))
+            .await
+            .map_err(|_| {
+                DbError::Checkpoint(
+                    "stopped-recovery Prepare authority observation timed out".into(),
+                )
+            })?
+            .map_err(|error| {
+                DbError::Checkpoint(format!(
+                    "stopped-recovery Prepare authority observation failed: {error}"
+                ))
+            })?;
+    let Some(RecoveryAnnouncement {
+        round,
+        phase: RecoverPhase::Prepare,
+    }) = active
+    else {
+        return Ok(None);
+    };
+    let local = controller.instance_id();
+    if round.assignment_fence != *predecessor
+        || (durable_proof.is_none() && !controller.recovery_driver_is_current(&round))
+        || !controller.recovery_round_requires_current_process_stop(&round)
+        || !controller.process_lease_is_live()
+    {
+        return Ok(None);
+    }
+    let reports = tokio::time::timeout_at(deadline, controller.read_stopped(&round, &[local]))
+        .await
+        .map_err(|_| {
+            DbError::Checkpoint("stopped-recovery local stopped-report read timed out".into())
+        })?
+        .map_err(|error| {
+            DbError::Checkpoint(format!(
+                "stopped-recovery local stopped-report read failed: {error}"
+            ))
+        })?;
+    let expected = CheckpointParticipant {
+        node_id: local.0,
+        boot_incarnation: controller.recovery_incarnation(),
+    };
+    if reports.len() != 1
+        || reports[0].publisher() != expected
+        || reports[0].validate(&round).is_err()
+    {
+        return Ok(None);
+    }
+    let confirmed =
+        tokio::time::timeout_at(deadline, observe_stopped_round(controller, durable_proof))
+            .await
+            .map_err(|_| {
+                DbError::Checkpoint("stopped-recovery Prepare authority recheck timed out".into())
+            })?
+            .map_err(|error| {
+                DbError::Checkpoint(format!(
+                    "stopped-recovery Prepare authority recheck failed: {error}"
+                ))
+            })?;
+    if confirmed
+        != Some(RecoveryAnnouncement {
+            round: round.clone(),
+            phase: RecoverPhase::Prepare,
+        })
+        || !controller.process_lease_is_live()
+    {
+        return Ok(None);
+    }
+    Ok(Some(round))
+}
 
 #[cfg(feature = "cluster")]
 impl LaminarDB {

--- a/crates/laminar-db/src/db/mod.rs
+++ b/crates/laminar-db/src/db/mod.rs
@@ -5,6 +5,10 @@
 mod assignment_authority;
 #[cfg(feature = "cluster")]
 mod cluster_subscription;
+#[cfg(feature = "cluster")]
+pub(crate) use assignment_authority::{
+    audited_stopped_recovery_successor_round, audited_stopped_terminal_round,
+};
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -1428,81 +1432,6 @@ enum AssignmentAdoptionMode {
     /// process, or an exact recovery successor whose pinned cut still belongs to the stopped
     /// predecessor. The successor graph restores the durable cut at startup.
     StoppedRecoveryTopology,
-}
-
-#[cfg(feature = "cluster")]
-pub(crate) async fn audited_stopped_terminal_round(
-    controller: &laminar_core::cluster::control::ClusterController,
-    predecessor: &laminar_core::checkpoint::CheckpointAssignmentFence,
-    deadline: tokio::time::Instant,
-) -> Result<Option<laminar_core::cluster::control::RecoveryRound>, DbError> {
-    use laminar_core::cluster::control::{RecoverPhase, RecoveryAnnouncement};
-
-    let active = tokio::time::timeout_at(deadline, controller.observe_recover_control())
-        .await
-        .map_err(|_| {
-            DbError::Checkpoint("stopped-recovery Prepare authority observation timed out".into())
-        })?
-        .map_err(|error| {
-            DbError::Checkpoint(format!(
-                "stopped-recovery Prepare authority observation failed: {error}"
-            ))
-        })?;
-    let Some(RecoveryAnnouncement {
-        round,
-        phase: RecoverPhase::Prepare,
-    }) = active
-    else {
-        return Ok(None);
-    };
-    let local = controller.instance_id();
-    if round.assignment_fence != *predecessor
-        || !controller.recovery_driver_is_current(&round)
-        || !controller.recovery_round_requires_current_process_stop(&round)
-        || !controller.process_lease_is_live()
-    {
-        return Ok(None);
-    }
-    let reports = tokio::time::timeout_at(deadline, controller.read_stopped(&round, &[local]))
-        .await
-        .map_err(|_| {
-            DbError::Checkpoint("stopped-recovery local stopped-report read timed out".into())
-        })?
-        .map_err(|error| {
-            DbError::Checkpoint(format!(
-                "stopped-recovery local stopped-report read failed: {error}"
-            ))
-        })?;
-    let expected = laminar_core::checkpoint::CheckpointParticipant {
-        node_id: local.0,
-        boot_incarnation: controller.recovery_incarnation(),
-    };
-    if reports.len() != 1
-        || reports[0].publisher() != expected
-        || reports[0].validate(&round).is_err()
-    {
-        return Ok(None);
-    }
-    let confirmed = tokio::time::timeout_at(deadline, controller.observe_recover_control())
-        .await
-        .map_err(|_| {
-            DbError::Checkpoint("stopped-recovery Prepare authority recheck timed out".into())
-        })?
-        .map_err(|error| {
-            DbError::Checkpoint(format!(
-                "stopped-recovery Prepare authority recheck failed: {error}"
-            ))
-        })?;
-    if confirmed
-        != Some(RecoveryAnnouncement {
-            round: round.clone(),
-            phase: RecoverPhase::Prepare,
-        })
-        || !controller.process_lease_is_live()
-    {
-        return Ok(None);
-    }
-    Ok(Some(round))
 }
 
 /// Result of certifying a clustered process at startup.
@@ -3042,9 +2971,8 @@ impl LaminarDB {
             let audited_predecessor = audited_target.predecessor().cloned();
             let committed_handoff_checkpoint = audited_target.handoff_checkpoint().cloned();
             let recovery_origin = audited_target.recovery_origin().cloned();
-            let recovery_pin_is_active = audited_target.recovery_pin_is_active();
-            let recovery_checkpoint_was_consumed =
-                audited_target.recovery_checkpoint_was_consumed();
+            let recovery_proof = audited_target.active_recovery_leader_proof().cloned();
+            let recovery_was_consumed = audited_target.recovery_checkpoint_was_consumed();
             let audited_drain = audited_target.into_terminal();
             let terminal_drain_authority = !audited_recovery && audited_drain.is_some();
             let aborted_drain_authority = !audited_recovery
@@ -3073,7 +3001,7 @@ impl LaminarDB {
                 .assignment_fence()
                 .map_err(|error| DbError::Checkpoint(error.to_string()))?;
             let recovery_requires_cold = audited_recovery
-                && (recovery_checkpoint_was_consumed
+                && (recovery_was_consumed
                     || recovery_origin.as_ref().is_some_and(|origin| {
                         audited_predecessor.as_ref().is_some_and(|predecessor| {
                             origin.assignment_version < predecessor.assignment_version
@@ -3099,7 +3027,7 @@ impl LaminarDB {
                             snapshot.version
                         ))
                     })?;
-                    if recovery_pin_is_active {
+                    if recovery_proof.is_some() {
                         let pinned = tokio::time::timeout_at(
                             deadline,
                             authority.assignment_handoff_checkpoint(&target_fence),
@@ -3123,7 +3051,7 @@ impl LaminarDB {
                                 snapshot.version
                             )));
                         }
-                    } else if recovery_checkpoint_was_consumed {
+                    } else if recovery_was_consumed {
                         let head = tokio::time::timeout_at(
                             deadline,
                             authority.highest_cluster_committed_outcome(),
@@ -3475,8 +3403,7 @@ impl LaminarDB {
                 && target_fence.participant_incarnation(self_id.0).is_none();
             let stopped_aborted_topology_shape =
                 stopped_aborted_owner_topology_shape || stopped_aborted_ownerless_topology_shape;
-            let stopped_recovery_successor_topology_shape = audited_recovery
-                && recovery_pin_is_active
+            let stopped_recovery_successor_topology_shape = recovery_proof.is_some()
                 && committed_handoff_checkpoint.is_some()
                 && predecessor_fence.is_some();
             let prepared_recovery_fault_is_active = if stopped_recovery_topology_common
@@ -3537,11 +3464,12 @@ impl LaminarDB {
                 };
             let stopped_recovery_successor_round =
                 if stopped_recovery_topology_common && stopped_recovery_successor_topology_shape {
-                    audited_stopped_terminal_round(
+                    audited_stopped_recovery_successor_round(
                         controller.as_ref(),
                         predecessor_fence
                             .as_ref()
                             .expect("recovery successor shape has predecessor"),
+                        recovery_proof.as_ref().expect("audited active proof"),
                         deadline,
                     )
                     .await?
@@ -3867,11 +3795,12 @@ impl LaminarDB {
                 == AssignmentAdoptionMode::StoppedRecoveryTopology
                 && stopped_recovery_successor_topology_shape
             {
-                audited_stopped_terminal_round(
+                audited_stopped_recovery_successor_round(
                     controller.as_ref(),
                     predecessor_fence
                         .as_ref()
                         .expect("recovery successor shape has predecessor"),
+                    recovery_proof.as_ref().expect("audited active proof"),
                     deadline,
                 )
                 .await?

--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -18,8 +18,8 @@ use laminar_core::cluster::control::{
     AssignmentDrainDecision, AssignmentDrainVerdict, AssignmentRecoveryDecision,
     AssignmentSnapshot, AssignmentSnapshotStore, CheckpointAssignmentAdoption,
     CheckpointAssignmentFence, CheckpointParticipant, ClusterController, LeaderLeaseStore,
-    RecordAssignmentDrainDecisionResult, RecordAssignmentRecoveryDecisionResult, RotateOutcome,
-    SnapshotError,
+    LeaderProof, RecordAssignmentDrainDecisionResult, RecordAssignmentRecoveryDecisionResult,
+    RotateOutcome, SnapshotError,
 };
 use laminar_core::cluster::discovery::NodeState;
 use laminar_core::state::{
@@ -1425,6 +1425,7 @@ pub(crate) struct AuditedAssignmentAuthority {
     predecessor: Option<CheckpointAssignmentFence>,
     handoff_checkpoint: Option<CommittedCheckpointRef>,
     recovery_checkpoint: Option<AuditedRecoveryCheckpoint>,
+    recovery_leader_proof: Option<LeaderProof>,
     terminal: Option<AuditedDrainOutcome>,
 }
 
@@ -1494,6 +1495,7 @@ impl AuditedAssignmentAuthority {
             predecessor: None,
             handoff_checkpoint: None,
             recovery_checkpoint: None,
+            recovery_leader_proof: None,
             terminal: None,
         }
     }
@@ -1502,6 +1504,7 @@ impl AuditedAssignmentAuthority {
         target_version: u64,
         predecessor: CheckpointAssignmentFence,
         recovery_checkpoint: AuditedRecoveryCheckpoint,
+        recovery_leader_proof: LeaderProof,
     ) -> Self {
         let handoff_checkpoint = recovery_checkpoint.checkpoint().clone();
         Self {
@@ -1509,6 +1512,7 @@ impl AuditedAssignmentAuthority {
             predecessor: Some(predecessor),
             handoff_checkpoint: Some(handoff_checkpoint),
             recovery_checkpoint: Some(recovery_checkpoint),
+            recovery_leader_proof: Some(recovery_leader_proof),
             terminal: None,
         }
     }
@@ -1520,6 +1524,7 @@ impl AuditedAssignmentAuthority {
             predecessor: Some(terminal.transition.predecessor.clone()),
             handoff_checkpoint,
             recovery_checkpoint: None,
+            recovery_leader_proof: None,
             terminal: Some(terminal),
         }
     }
@@ -1550,6 +1555,13 @@ impl AuditedAssignmentAuthority {
         self.recovery_checkpoint
             .as_ref()
             .is_some_and(AuditedRecoveryCheckpoint::pin_is_active)
+    }
+
+    pub(crate) fn active_recovery_leader_proof(&self) -> Option<&LeaderProof> {
+        self.recovery_checkpoint
+            .as_ref()
+            .filter(|checkpoint| checkpoint.pin_is_active())
+            .and(self.recovery_leader_proof.as_ref())
     }
 
     pub(crate) fn recovery_checkpoint_was_consumed(&self) -> bool {
@@ -1779,13 +1791,14 @@ pub(crate) fn audit_assignment_snapshot_authority_outcome<'a>(
             .await
             .map_err(|error| error.to_string())?
         else {
-            let (predecessor, handoff_checkpoint) =
+            let (predecessor, handoff_checkpoint, leader_proof) =
                 audit_materialized_recovery_with_authority(store, authority.as_deref(), snapshot)
                     .await?;
             return Ok(AuditedAssignmentAuthority::recovery(
                 snapshot.version,
                 predecessor,
                 handoff_checkpoint,
+                leader_proof,
             ));
         };
         audit_materialized_drain_transition(store, authority.as_deref(), snapshot, transition)
@@ -1865,29 +1878,29 @@ fn validate_portable_recovery_cut(
     Ok(origin.clone())
 }
 
+type AuditedRecoveryAuthority = (
+    CheckpointAssignmentFence,
+    AuditedRecoveryCheckpoint,
+    LeaderProof,
+);
+
 fn audit_materialized_recovery_with_authority<'a>(
     store: &'a AssignmentSnapshotStore,
     authority: Option<&'a LeaderLeaseStore>,
     snapshot: &'a AssignmentSnapshot,
-) -> futures::future::BoxFuture<
-    'a,
-    Result<(CheckpointAssignmentFence, AuditedRecoveryCheckpoint), String>,
-> {
+) -> futures::future::BoxFuture<'a, Result<AuditedRecoveryAuthority, String>> {
     Box::pin(async move {
+        let version = snapshot.version;
         let authority = authority.ok_or_else(|| {
-            format!(
-                "materialized assignment recovery {} has no cluster authority",
-                snapshot.version
-            )
+            format!("materialized assignment recovery {version} has no cluster authority")
         })?;
         let decision = authority
-            .assignment_recovery_decision(snapshot.version)
+            .assignment_recovery_decision(version)
             .await
             .map_err(|error| error.to_string())?
             .ok_or_else(|| {
                 format!(
-                    "assignment {} has no drain transition or recovery authority decision",
-                    snapshot.version
+                    "assignment {version} has no drain transition or recovery authority decision"
                 )
             })?;
         let proposal = store
@@ -1905,8 +1918,7 @@ fn audit_materialized_recovery_with_authority<'a>(
                 snapshot.version
             ));
         }
-        let predecessor_version = snapshot
-            .version
+        let predecessor_version = version
             .checked_sub(1)
             .ok_or_else(|| "recovery assignment has no predecessor generation".to_string())?;
         let predecessor = store
@@ -1914,10 +1926,7 @@ fn audit_materialized_recovery_with_authority<'a>(
             .await
             .map_err(|error| error.to_string())?
             .ok_or_else(|| {
-                format!(
-                    "recovery assignment {} lost predecessor {predecessor_version}",
-                    snapshot.version
-                )
+                format!("recovery assignment {version} lost predecessor {predecessor_version}")
             })?;
         if predecessor.draining
             || predecessor
@@ -2101,7 +2110,11 @@ fn audit_materialized_recovery_with_authority<'a>(
                 successor: successor.target,
             }
         };
-        Ok((decision.predecessor, recovery_checkpoint))
+        Ok((
+            decision.predecessor,
+            recovery_checkpoint,
+            decision.leader_proof,
+        ))
     })
 }
 
@@ -2139,7 +2152,7 @@ fn abort_predecessor_checkpoint_for_recovery<'a>(
         let authority = controller
             .checkpoint_authority()
             .map_err(|error| error.to_string())?;
-        let (predecessor, audited_recovery) = tokio::time::timeout_at(
+        let (predecessor, audited_recovery, _) = tokio::time::timeout_at(
             deadline,
             audit_materialized_recovery_with_authority(store, Some(authority.as_ref()), snapshot),
         )

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -1208,7 +1208,7 @@ async fn stopped_recovery_topology_requires_the_exact_durable_fault_sequence() {
 }
 
 #[tokio::test]
-async fn stopped_recovery_owner_topology_publishes_an_audited_recovery_successor() {
+async fn stopped_recovery_owner_publishes_successor_after_driver_candidacy_loss() {
     let (db, controller, registry, _current, target, round, process_authority, _checkpoint_dir) =
         stopped_recovery_successor_fixture(true).await;
     assert!(controller.recovery_round_requires_current_process_stop(&round));
@@ -1223,6 +1223,8 @@ async fn stopped_recovery_owner_topology_publishes_an_audited_recovery_successor
         .is_none(),
         "Prepare is the only quiescence witness until the exact target roster adopts"
     );
+    controller.set_active(false);
+    assert!(!controller.recovery_driver_is_current(&round));
 
     let adoption = db
         .adopt_recovery_assignment_snapshot(


### PR DESCRIPTION
## Summary

- observe a recovery intent through the immutable assignment decision's exact durable leader proof when local gossip candidacy has already been withdrawn
- retain the decision proof in the audited recovery authority capability and use it only for stopped recovery-successor topology publication
- keep ordinary recovery observation tied to the current elected driver and fail closed on proof, stopped-report, process-lease, or handoff-pin changes

## Native Azure reproduction

Native run 33998498173 passed Azure authentication, object-store conformance, atomic create/CAS, deterministic fault-contract, cleanup, evidence validation, and artifact upload. Its process soak then stalled after the first leader kill because the stopped owner could not publish the already-audited successor once local driver candidacy disappeared.

This PR addresses that recovery boundary only. It does not widen Azure delivery admission or claim native certification; the native workflow must pass again on the exact merged commit.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo test --workspace --lib` (all passed; one pre-existing ignored test)
- `cargo test -p laminar-core --lib --features cluster` (944 passed)
- `cargo test -p laminar-db --lib --no-default-features --features cluster` (1,792 passed)
- `cargo test -p laminar-db --lib --no-default-features --features cluster stopped_recovery_ -- --nocapture` (15 passed on final form)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo clippy --workspace --no-default-features -- -D warnings`
- focused final-form LaminarDB cluster clippy with `-D warnings`

The Windows all-feature build used incremental compilation and debug symbols disabled after generated artifacts exhausted local disk; lint scope and warning policy were unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stopped recovery-successor adoption stalling after a leader kill. The stopped owner previously required its own local gossip candidacy to publish the audited successor; once the driver lost candidacy the soak stalled. The process now publishes through the exact durable leader proof, while ordinary recovery observation stays tied to the current elected driver and fails closed on proof, stopped-report, process-lease, or handoff-pin changes.

**Validation**
- Added a controller test covering durable-proof observation surviving local candidacy loss and rejecting an altered fencing token.
- Workspace lib tests, `laminar-core` and `laminar-db` cluster-feature suites, and clippy with `-D warnings` pass.

<sup>Written for commit b06d18c34034e7f042f8ab14a26f7303030707ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery handling when the current recovery driver loses candidacy.
  * Recovery announcements and leadership proofs are now checked more consistently to prevent accepting stale or conflicting recovery decisions.
  * Recovery successor handling is now distinguished from terminal recovery completion, improving checkpoint adoption and validation.

* **Tests**
  * Added coverage for preserving valid recovery successors during driver candidacy changes and rejecting outdated proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->