### PR TITLE
fix(cluster): preserve recovery adoption budget

### DIFF
--- a/crates/laminar-db/src/db/mod.rs
+++ b/crates/laminar-db/src/db/mod.rs
@@ -2845,23 +2845,34 @@ impl LaminarDB {
     /// Install an authority-sequenced failure-recovery successor. A still-running graph uses the
     /// ordinary live transition. Only an exactly faulted, terminally observed and recovery-fenced
     /// graph selects cold publication without reusing predecessor heap memory.
+    ///
+    /// Waiting for another assignment operation and executing this adoption are independently
+    /// bounded. A competing observer must not consume the durable re-audit and publication budget
+    /// after this caller acquires serialization.
     #[cfg(feature = "cluster")]
     pub(crate) async fn adopt_recovery_assignment_snapshot(
         &self,
         snapshot: laminar_core::cluster::control::AssignmentSnapshot,
-        deadline: tokio::time::Instant,
+        operation_timeout: Duration,
     ) -> Result<SnapshotAdoption, DbError> {
         let version = snapshot.version;
-        tokio::time::timeout_at(deadline, async {
-            let _adoption = self.assignment_adoption_lock.lock().await;
-            let mode = if DbState::load(&self.state) == DbState::Faulted {
-                AssignmentAdoptionMode::ColdRecovery
-            } else {
-                AssignmentAdoptionMode::LiveTransition
-            };
-            self.adopt_assignment_snapshot_locked(snapshot, deadline, mode)
-                .await
-        })
+        let _adoption = tokio::time::timeout(operation_timeout, self.assignment_adoption_lock.lock())
+            .await
+            .map_err(|_| {
+                DbError::Checkpoint(format!(
+                    "recovery assignment {version} adoption timed out waiting for assignment serialization"
+                ))
+            })?;
+        let deadline = tokio::time::Instant::now() + operation_timeout;
+        let mode = if DbState::load(&self.state) == DbState::Faulted {
+            AssignmentAdoptionMode::ColdRecovery
+        } else {
+            AssignmentAdoptionMode::LiveTransition
+        };
+        tokio::time::timeout_at(
+            deadline,
+            self.adopt_assignment_snapshot_locked(snapshot, deadline, mode),
+        )
         .await
         .unwrap_or_else(|_| {
             Err(DbError::Checkpoint(format!(

--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -42,7 +42,8 @@ pub struct RebalanceConfig {
     pub watcher_poll: Duration,
     /// Quiet period before a membership change triggers rotation.
     pub rebalance_debounce: Duration,
-    /// Upper bound on the pre-rotation forced checkpoint.
+    /// Upper bound used for the pre-rotation checkpoint and each serialized recovery-adoption
+    /// phase.
     pub checkpoint_timeout: Duration,
     /// Delay before retrying a failed rotation.
     pub retry_delay: Duration,
@@ -1116,16 +1117,12 @@ impl SnapshotWatcher {
                             );
                         }
                     }
-                    let resolved_local = self.registry.assignment_version();
-                    if snap.version > resolved_local {
-                        debug!(
-                            local = resolved_local,
-                            remote = snap.version,
-                            "adopting newer assignment"
-                        );
+                    if snap.version > self.registry.assignment_version() {
+                        debug!(remote = snap.version, "adopting newer assignment");
+                        let recovery_timeout = self.config.checkpoint_timeout;
                         let adoption = if audited_recovery {
                             self.db
-                                .adopt_recovery_assignment_snapshot(snap.clone(), head_deadline)
+                                .adopt_recovery_assignment_snapshot(snap.clone(), recovery_timeout)
                                 .await
                         } else {
                             self.db
@@ -3111,7 +3108,7 @@ fn materialize_recovery_decision<'a>(
         })??;
         prepare_recovery_assignment_adoption(db, store, controller, &durable, deadline).await?;
         let version = durable.version;
-        db.adopt_recovery_assignment_snapshot(durable, deadline)
+        db.adopt_recovery_assignment_snapshot(durable, operation_timeout)
             .await
             .map_err(|error| error.to_string())?;
         let oldest_retained = version.saturating_sub(1);
@@ -3695,14 +3692,7 @@ fn execute_graceful_rotation_owned(
             }
             RotateOutcome::Conflict(winner) => {
                 let v = winner.version;
-                adopt_any(
-                    &db,
-                    &store,
-                    &controller,
-                    *winner,
-                    tokio::time::Instant::now() + config.checkpoint_timeout,
-                )
-                .await?;
+                adopt_any(&db, &store, &controller, *winner, config.checkpoint_timeout).await?;
                 Ok(Some(v))
             }
         }
@@ -3896,7 +3886,7 @@ fn try_rebalance_owned(
         {
             prepare_recovery_assignment_adoption(&db, &store, &controller, &current, head_deadline)
                 .await?;
-            db.adopt_recovery_assignment_snapshot(current.clone(), head_deadline)
+            db.adopt_recovery_assignment_snapshot(current.clone(), config.checkpoint_timeout)
                 .await
                 .map_err(|error| error.to_string())?;
             let reconciled_version = registry.assignment_version();
@@ -4900,8 +4890,9 @@ async fn adopt_any(
     store: &AssignmentSnapshotStore,
     controller: &ClusterController,
     snap: AssignmentSnapshot,
-    deadline: tokio::time::Instant,
+    operation_timeout: Duration,
 ) -> Result<(), String> {
+    let deadline = tokio::time::Instant::now() + operation_timeout;
     let audited = tokio::time::timeout_at(
         deadline,
         audit_assignment_snapshot_authority_outcome(store, Some(controller), &snap),
@@ -4913,7 +4904,7 @@ async fn adopt_any(
             .map_err(|error| error.to_string())?;
     } else if audited.is_recovery() {
         prepare_recovery_assignment_adoption(db, store, controller, &snap, deadline).await?;
-        db.adopt_recovery_assignment_snapshot(snap, deadline)
+        db.adopt_recovery_assignment_snapshot(snap, operation_timeout)
             .await
             .map_err(|error| error.to_string())?;
     } else {

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -1227,10 +1227,7 @@ async fn stopped_recovery_owner_publishes_successor_after_driver_candidacy_loss(
     assert!(!controller.recovery_driver_is_current(&round));
 
     let adoption = db
-        .adopt_recovery_assignment_snapshot(
-            target.clone(),
-            tokio::time::Instant::now() + Duration::from_secs(1),
-        )
+        .adopt_recovery_assignment_snapshot(target.clone(), Duration::from_secs(1))
         .await
         .expect("an exact stopped owner must topology-publish its audited recovery successor");
 
@@ -1323,16 +1320,67 @@ async fn stopped_recovery_owner_publishes_successor_after_driver_candidacy_loss(
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_adoption_execution_budget_starts_after_serialization() {
+    let (db, controller, registry, current, target, _round, _process_authority, _checkpoint_dir) =
+        stopped_recovery_successor_fixture(true).await;
+    controller.set_active(false);
+
+    let operation_timeout = Duration::from_millis(500);
+    let serialization = Arc::clone(&db.assignment_adoption_lock).lock_owned().await;
+    let execution = Arc::clone(&db.rotation_execution_fence).read_owned().await;
+    let adopting_db = Arc::clone(&db);
+    let started = tokio::time::Instant::now();
+    let adoption = tokio::spawn(async move {
+        adopting_db
+            .adopt_recovery_assignment_snapshot(target, operation_timeout)
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(350)).await;
+    drop(serialization);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    drop(execution);
+
+    let adoption = tokio::time::timeout(Duration::from_secs(2), adoption)
+        .await
+        .expect("recovery adoption remained blocked after both bounded phases")
+        .unwrap()
+        .expect("serialized recovery adoption must retain its full execution budget");
+    assert!(started.elapsed() > operation_timeout);
+    assert!(adoption.adopted);
+    assert_eq!(registry.assignment_version(), current.version + 1);
+}
+
+#[tokio::test]
+async fn recovery_adoption_serialization_timeout_is_fail_closed() {
+    let (db, controller, registry, current, target, _round, _process_authority, _checkpoint_dir) =
+        stopped_recovery_successor_fixture(true).await;
+    controller.set_active(false);
+    let _serialization = Arc::clone(&db.assignment_adoption_lock).lock_owned().await;
+
+    let error = db
+        .adopt_recovery_assignment_snapshot(target, Duration::from_millis(50))
+        .await
+        .expect_err("recovery adoption must not wait indefinitely for assignment serialization");
+
+    assert!(
+        error
+            .to_string()
+            .contains("timed out waiting for assignment serialization"),
+        "{error}"
+    );
+    assert_eq!(registry.assignment_version(), current.version);
+    assert!(db.pending_vnode_transition.lock().is_none());
+}
+
 #[tokio::test]
 async fn stopped_recovery_successor_requires_the_exact_local_stopped_report() {
     let (db, _controller, registry, current, target, _round, _process_authority, _checkpoint_dir) =
         stopped_recovery_successor_fixture(false).await;
 
     let error = db
-        .adopt_recovery_assignment_snapshot(
-            target,
-            tokio::time::Instant::now() + Duration::from_secs(1),
-        )
+        .adopt_recovery_assignment_snapshot(target, Duration::from_secs(1))
         .await
         .expect_err(
             "Prepare without this boot's Stopped report must not publish recovery topology",
@@ -3184,10 +3232,7 @@ async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
     crate::db::DbState::Faulted.store(&db.state);
 
     let error = db
-        .adopt_recovery_assignment_snapshot(
-            successor,
-            tokio::time::Instant::now() + Duration::from_secs(1),
-        )
+        .adopt_recovery_assignment_snapshot(successor, Duration::from_secs(1))
         .await
         .expect_err("cold publication requires coordinated recovery lifecycle ownership");
     assert!(error.to_string().contains("recovery lifecycle fence"));

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -211,7 +211,7 @@ const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 80] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 81] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -424,6 +424,10 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 80] = [
     (
         "recovery_history_missing",
         "cannot be adopted without durable assignment history",
+    ),
+    (
+        "recovery_adoption_serialization_deadline",
+        "adoption timed out waiting for assignment serialization",
     ),
     (
         "recovery_adoption_deadline",
@@ -15744,6 +15748,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                is absent from durable history\n\
                has no live local process identity\n\
                cannot be adopted without durable assignment history\n\
+               recovery assignment 2 adoption timed out waiting for assignment serialization\n\
                recovery assignment 2 adoption exceeded its end-to-end deadline\n\
                recovery assignment materialization exceeded its deadline\n\
                participant 2 handoff manifest is missing\n\
@@ -15806,6 +15811,10 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     ] {
         assert_eq!(counts.get(marker), Some(&1), "missing {marker}");
     }
+    assert_eq!(
+        counts.get("recovery_adoption_serialization_deadline"),
+        Some(&1)
+    );
     assert_eq!(counts.get("recovery_adoption_deadline"), Some(&1));
     assert_eq!(counts.get("recovery_materialization_deadline"), Some(&1));
     assert_eq!(counts.get("recovery_handoff_manifest_missing"), Some(&1));


### PR DESCRIPTION
## Summary
- give recovery assignment serialization and audited publication separate bounded timeout budgets
- make recovery callers pass a duration so earlier native-store preparation cannot hand adoption an expired deadline
- add deterministic success and fail-closed timeout regressions
- expose a value-free serialization-timeout marker in process-soak diagnostics

## Native evidence motivating this fix
Azure run 34008785959 passed native object-store conformance and the deterministic checkpoint fault contract, then timed out after process kill while the rebalancer and snapshot watcher contended for recovery adoption. The prior retained-state gate was cleared, but adoption reused a deadline already consumed by Azure authority reads and lock wait.

Azure remains uncertified. This PR does not change clustered delivery admission. A protected native Azure checkpoint rerun against the merge commit is the next gate.

## Local validation
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo clippy -p laminar-db --no-default-features --features cluster --all-targets -- -D warnings
- cargo clippy -p laminar-server --no-default-features --features cluster,kafka --all-targets -- -D warnings
- cargo test -p laminar-db --no-default-features --features cluster --lib (1794 passed)
- targeted recovery adoption and soak diagnostic tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery adoption timeouts by separating serialization wait and execution into independent bounded budgets, so earlier lock contention no longer consumes the publication deadline. Clustered delivery admission is unchanged.

**Bug Fixes**
- Recovery adoption now takes a `Duration` and computes a fresh deadline after acquiring serialization.
- Added deterministic tests for serialization timeout and execution budget preservation.
- Adds a diagnostic marker for serialization timeout in soak logs.

<sup>Written for commit 7bc14204b00a005e0cc79d2acd1db35a31f6cab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery and rebalancing timeout handling by separately bounding assignment serialization waits and recovery execution.
  - Recovery operations now fail promptly when they cannot acquire the required serialization lock within the configured timeout.
  - Timeout behavior is applied consistently across recovery adoption and graceful transition workflows.

- **Tests**
  - Added coverage for execution budgets and serialization-wait timeouts.
  - Expanded recovery diagnostics validation for serialization deadline events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->