### PR TITLE
test(cluster): retain convergence failure diagnostics

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -11259,6 +11259,9 @@ fn wait_for_local_assignment_convergence(
         sleep_until_local_evidence_poll(deadline);
     }
     let diagnostics = durable_progress_diagnostics(nodes, &[]);
+    for node in nodes.iter() {
+        node.dump_log_tail();
+    }
     panic!(
         "soak: {context} did not reach exact local assignment convergence before its existing \
          deadline: {last_pending}; observation=({diagnostics})"


### PR DESCRIPTION
## Summary
- dump each node's existing bounded log tail when exact local-assignment convergence exhausts its deadline
- retain the causal server error in the already-uploaded native checkpoint soak log
- keep native evidence fail-closed; no timeout or delivery-admission change

## Evidence motivating this change
Azure native checkpoint run 34016379571 passed object-store conformance and all deterministic storage fault cases, then failed before the first process kill during stable startup. The structured evidence identified a checkpoint/pipeline fault but the node log containing the causal error was not retained in the artifact.

Azure remains uncertified. A protected rerun against the merge commit is required.

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo test -p laminar-server --no-default-features --features cluster,kafka --test cluster_soak recovery_log_diagnostics_count_markers_without_copying_log_values -- --exact --nocapture`
- `cargo clippy -p laminar-server --no-default-features --features cluster,kafka --test cluster_soak -- -D warnings`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains node log tails when the native checkpoint soak test fails to reach exact local-assignment convergence, so the causal server error is now available in the uploaded artifact. Test-only change; no timeout or delivery-admission behavior changes. Azure remains uncertified and requires a protected rerun.

<sup>Written for commit 293862a9cf7ecdbaff8ff738d84852e092dba50f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for local-assignment convergence timeouts by including each node’s recent log output when a test fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->