### PR TITLE
test(cluster): retain progress timeout diagnostics

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -76,9 +76,7 @@
 use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
-use std::io::{Read, Write as _};
-#[cfg(feature = "kafka")]
-use std::io::{Seek as _, SeekFrom};
+use std::io::{Read, Seek as _, SeekFrom, Write as _};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -104,6 +102,7 @@ use laminar_core::cluster::control::{
 };
 
 const NODES: usize = 3;
+const NODE_LOG_TAIL_BYTES: u64 = 64 * 1024;
 /// Per-node ports: http = BASE + i, gossip = BASE + 100 + i.
 const BASE_PORT: u16 = 19310;
 const SOAK_CONSOLE_TOKEN: &str = "laminardb-cluster-soak";
@@ -2964,10 +2963,29 @@ impl Node {
 
     fn dump_log_tail(&self) {
         eprintln!("--- node{} log tail:", self.id);
-        if let Ok(log) = std::fs::read_to_string(&self.log_path) {
-            for line in log.lines().rev().take(40).collect::<Vec<_>>().iter().rev() {
-                eprintln!("  {line}");
-            }
+        let Ok(mut log) = std::fs::File::open(&self.log_path) else {
+            return;
+        };
+        let Ok(end) = log.seek(SeekFrom::End(0)) else {
+            return;
+        };
+        let start = end.saturating_sub(NODE_LOG_TAIL_BYTES);
+        if log.seek(SeekFrom::Start(start)).is_err() {
+            return;
+        }
+        let mut bytes = Vec::new();
+        if log.take(end - start).read_to_end(&mut bytes).is_err() {
+            return;
+        }
+        let text = String::from_utf8_lossy(&bytes);
+        let text = if start == 0 {
+            text.as_ref()
+        } else {
+            text.split_once('\n')
+                .map_or(text.as_ref(), |(_, tail)| tail)
+        };
+        for line in text.lines().rev().take(40).collect::<Vec<_>>().iter().rev() {
+            eprintln!("  {line}");
         }
     }
 
@@ -11910,6 +11928,9 @@ fn assert_progress(
         let observed_ingested = try_cluster_metric(nodes, "laminardb_events_ingested_total");
         let observed_emitted = try_cluster_metric(nodes, "laminardb_events_emitted_total");
         let diagnostics = durable_progress_diagnostics(nodes, commit_oracle.as_slice());
+        for node in nodes.iter() {
+            node.dump_log_tail();
+        }
         panic!(
             "soak: timed out after {advance_window:?} waiting for: {label}: source ingestion and \
              graph output to advance; ingested_target={ingested_target}, \
@@ -11977,6 +11998,9 @@ fn assert_progress(
     });
     if !durability_advanced {
         let diagnostics = durable_progress_diagnostics(nodes, commit_oracle.as_slice());
+        for node in nodes.iter() {
+            node.dump_log_tail();
+        }
         panic!(
             "soak: timed out after {durability_window:?} waiting for: {label}: checkpoints and \
              durable source offsets to advance; checkpoint_target={checkpoint_target}, \


### PR DESCRIPTION
## Summary
- dump each node's existing bounded 40-line log tail before graph-progress timeout failures
- dump the same bounded tails before checkpoint/source-offset durability timeout failures
- preserve the existing recovery deadline, assertions, and fail-closed result

## Evidence
Protected Azure run 34021873741 passed native object-store conformance and the nine deterministic checkpoint fault boundaries, then failed after one of two requested process kills. Both surviving nodes stayed Recovering for the 90-second bound, but this assert_progress path did not retain their node logs in the artifact. This change closes that diagnostic gap; it does not change production code or delivery admission.

## Validation
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo clippy -p laminar-server --no-default-features --features "cluster,azure,kafka" --test cluster_soak -- -D warnings
- cargo test -p laminar-server --no-default-features --features "cluster,azure,kafka" --test cluster_soak recovery_log_diagnostics_count_markers_without_copying_log_values -- --exact
- git diff --check

The focused Windows test emitted only the known vendored OpenSSL missing-PDB linker warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains each node's bounded log tail in the soak test artifact whenever a progress or durability timeout fails, so the logs that explain why a node stalled are no longer lost.

Dumps the tail before both the graph-progress and checkpoint/source-offset durability timeout panics. This is test-only; the recovery deadline, assertions, and fail-closed result are unchanged.

<sup>Written for commit 639fe1d9444723eec2cbb542271a0c7570d71590. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for cluster soak test failures by including recent logs from every node when graph progress or durability checkpoints time out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->