### PR TITLE
test(cluster): retain diagnostics for every panic

### DIFF
--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -2996,11 +2996,9 @@ impl Node {
         match child.try_wait() {
             Ok(None) => {}
             Ok(Some(status)) => {
-                self.dump_log_tail();
                 panic!("node{} exited before becoming ready: {status}", self.id);
             }
             Err(error) => {
-                self.dump_log_tail();
                 panic!("failed to inspect node{} process: {error}", self.id);
             }
         }
@@ -3009,6 +3007,10 @@ impl Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
+        // DIAGNOSTIC: unwind is the last common path before node processes are terminated.
+        if std::thread::panicking() {
+            self.dump_log_tail();
+        }
         self.terminate_best_effort();
     }
 }
@@ -11277,9 +11279,6 @@ fn wait_for_local_assignment_convergence(
         sleep_until_local_evidence_poll(deadline);
     }
     let diagnostics = durable_progress_diagnostics(nodes, &[]);
-    for node in nodes.iter() {
-        node.dump_log_tail();
-    }
     panic!(
         "soak: {context} did not reach exact local assignment convergence before its existing \
          deadline: {last_pending}; observation=({diagnostics})"
@@ -11928,9 +11927,6 @@ fn assert_progress(
         let observed_ingested = try_cluster_metric(nodes, "laminardb_events_ingested_total");
         let observed_emitted = try_cluster_metric(nodes, "laminardb_events_emitted_total");
         let diagnostics = durable_progress_diagnostics(nodes, commit_oracle.as_slice());
-        for node in nodes.iter() {
-            node.dump_log_tail();
-        }
         panic!(
             "soak: timed out after {advance_window:?} waiting for: {label}: source ingestion and \
              graph output to advance; ingested_target={ingested_target}, \
@@ -11998,9 +11994,6 @@ fn assert_progress(
     });
     if !durability_advanced {
         let diagnostics = durable_progress_diagnostics(nodes, commit_oracle.as_slice());
-        for node in nodes.iter() {
-            node.dump_log_tail();
-        }
         panic!(
             "soak: timed out after {durability_window:?} waiting for: {label}: checkpoints and \
              durable source offsets to advance; checkpoint_target={checkpoint_target}, \
@@ -13686,7 +13679,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
         std::thread::sleep(Duration::from_millis(500));
     }
 
-    // On boot failure dump the node log tails so the cause is visible in test output.
+    // DIAGNOSTIC: resume unwinding through `Node::drop` so every bounded tail is retained.
     let boot = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         wait_for(
             "all nodes to complete startup authority and become ready",
@@ -13701,10 +13694,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
         );
     }));
     if boot.is_err() {
-        for n in &nodes {
-            n.dump_log_tail();
-        }
-        panic!("soak: cluster failed to boot — node log tails above");
+        panic!("soak: cluster failed to boot; bounded node log tails follow during unwind");
     }
     exact_timing_evidence.capture_nodes_unbound(
         &nodes,


### PR DESCRIPTION
## Summary
- emit each node's existing bounded log tail from the common Node panic-unwind cleanup path
- cover every soak assertion failure, including frozen-input and per-node-ingestion gates
- remove duplicated timeout-specific dumps
- preserve all production behavior, recovery bounds, and fail-closed delivery admission

## Evidence
Protected Azure run 34027131603 passed native object-store conformance and all nine deterministic checkpoint fault boundaries on ee06fe940f36a1fe4a97e032e6373c5512d3855d. The process soak then failed before fault injection in assert_final_input_cuts: all three nodes entered Recovering after checkpoint graph-drain failures, but that assertion did not retain node tails. The prior targeted dump sites could not cover this path.

The common Node drop path already owns best-effort process termination. During panic unwinding it now emits that node's bounded 64 KiB / 40-line tail before termination. Normal cleanup remains unchanged.

## Validation
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo clippy -p laminar-server --no-default-features --features "cluster,azure,kafka" --test cluster_soak -- -D warnings
- cargo test -p laminar-server --no-default-features --features "cluster,azure,kafka" --test cluster_soak recovery_log_diagnostics_count_markers_without_copying_log_values -- --exact
- git diff --check

The focused Windows test emitted only the known vendored OpenSSL missing-PDB linker warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves node log-tail dumping into `Node`'s drop path so every panic in the cluster soak retains diagnostics, not just the previously targeted timeout and boot-failure sites.

- Emits each node's bounded 64 KiB / 40-line tail during panic unwinding in `Node::drop`.
- Removes the duplicated timeout-specific dump sites; all other production behavior is unchanged.

<sup>Written for commit 3aa4d24f8616c35a4774e829ac2d547a714ac4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cluster soak-test failure diagnostics by automatically capturing bounded log output when a test panics.
  * Removed redundant log capture calls from individual failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->