### PR TITLE
fix(cluster): refresh assignment publication deadline

### DIFF
--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "cluster")]
 #![allow(clippy::disallowed_types)] // cold path
 
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, atomic::Ordering, Arc};
 use std::time::Duration;
 
 use laminar_connectors::connector::{SourceDrainOutcome, SourceDrainResolution};
@@ -28,7 +28,7 @@ use laminar_core::state::{
 #[cfg(test)]
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
-use tokio::time::MissedTickBehavior;
+use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -416,12 +416,13 @@ impl SnapshotWatcher {
     async fn publish_authority(
         &mut self,
         mut authority_revision: u64,
-        head_deadline: tokio::time::Instant,
+        operation_timeout: Duration,
     ) {
-        let current_authority_revision = self
-            .db
-            .assignment_authority_revision
-            .load(std::sync::atomic::Ordering::Acquire);
+        // The durable-head audit and authority publication are independently bounded phases.
+        let (head_deadline, current_authority_revision) = (
+            Instant::now() + operation_timeout,
+            AtomicU64::load(&self.db.assignment_authority_revision, Ordering::Acquire),
+        );
         if authority_revision != current_authority_revision {
             // The durable head used above predates an authority closure by another adoption.
             // Keep that closure in force and re-read the head on the next tick.
@@ -1060,7 +1061,7 @@ impl SnapshotWatcher {
                                             audited_target.as_ref().expect(
                                                 "stable successor was audited before suspension",
                                             ),
-                                            head_deadline,
+                                            Instant::now() + self.config.checkpoint_timeout,
                                         )
                                         .await
                                     {
@@ -1070,8 +1071,11 @@ impl SnapshotWatcher {
                                     // The transition may have been staged before its predecessor
                                     // transport certificate became active. Repair that exact audited
                                     // authority before waiting for the newer durable head.
-                                    self.publish_authority(authority_revision, head_deadline)
-                                        .await;
+                                    self.publish_authority(
+                                        authority_revision,
+                                        self.config.checkpoint_timeout,
+                                    )
+                                    .await;
                                     continue;
                                 }
                                 Err(error) => {
@@ -1181,7 +1185,7 @@ impl SnapshotWatcher {
                                         audited_target
                                             .as_ref()
                                             .expect("stable successor was audited before adoption"),
-                                        head_deadline,
+                                        Instant::now() + self.config.checkpoint_timeout,
                                     )
                                     .await
                                 {
@@ -1237,7 +1241,7 @@ impl SnapshotWatcher {
                 }
             }
 
-            self.publish_authority(authority_revision, head_deadline)
+            self.publish_authority(authority_revision, self.config.checkpoint_timeout)
                 .await;
         }
     }

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -4,6 +4,28 @@ use std::collections::BTreeMap;
 use object_store::memory::InMemory;
 use object_store::{ObjectStore, ObjectStoreExt};
 
+#[derive(Debug)]
+struct DelayedScanKv {
+    inner: laminar_core::cluster::control::InMemoryKv,
+    scan_delay: Duration,
+}
+
+#[async_trait::async_trait]
+impl laminar_core::cluster::control::ClusterKv for DelayedScanKv {
+    async fn write(&self, key: &str, value: String) {
+        self.inner.write(key, value).await;
+    }
+
+    async fn read_from(&self, who: NodeId, key: &str) -> Option<String> {
+        self.inner.read_from(who, key).await
+    }
+
+    async fn scan(&self, key: &str) -> Vec<(NodeId, String)> {
+        tokio::time::sleep(self.scan_delay).await;
+        self.inner.scan(key).await
+    }
+}
+
 struct PendingListStore {
     inner: Arc<dyn ObjectStore>,
 }
@@ -4305,6 +4327,112 @@ async fn startup_rejects_drain_that_does_not_bind_retained_predecessor() {
         error.contains("does not bind retained predecessor"),
         "{error}"
     );
+}
+
+#[tokio::test]
+async fn watcher_authority_publication_gets_a_fresh_phase_budget() {
+    use laminar_core::cluster::control::{ClusterKv, InMemoryKv};
+    use laminar_core::cluster::discovery::NodeInfo;
+    use laminar_core::shuffle::{ShuffleReceiver, ShuffleSender};
+    use object_store::throttle::{ThrottleConfig, ThrottledStore};
+    use uuid::Uuid;
+
+    let self_id = NodeId(1);
+    let boot = Uuid::from_u128(11);
+    let process = CheckpointParticipant {
+        node_id: self_id.0,
+        boot_incarnation: boot,
+    };
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let seed_store = AssignmentSnapshotStore::new(Arc::clone(&inner));
+    let committed = AssignmentSnapshot::empty()
+        .next_for_participants(BTreeMap::from([(0, self_id)]), vec![process])
+        .unwrap();
+    seed_store.save_if_absent(&committed).await.unwrap();
+
+    let operation_timeout = Duration::from_millis(200);
+    let delayed: Arc<dyn ObjectStore> = Arc::new(ThrottledStore::new(
+        Arc::clone(&inner),
+        ThrottleConfig {
+            wait_list_per_call: Duration::from_millis(160),
+            ..ThrottleConfig::default()
+        },
+    ));
+    let durable = Arc::new(AssignmentSnapshotStore::new(delayed));
+    let kv = Arc::new(DelayedScanKv {
+        inner: InMemoryKv::new(self_id),
+        scan_delay: Duration::from_millis(30),
+    });
+    let control: Arc<dyn ClusterKv> = kv.clone();
+    let recovery: Arc<dyn ClusterKv> = kv;
+    let (_members_tx, members_rx) = tokio::sync::watch::channel(Vec::<NodeInfo>::new());
+    let controller = Arc::new(ClusterController::new_with_recovery_incarnation(
+        self_id,
+        control,
+        recovery,
+        Some(Arc::clone(&durable)),
+        members_rx,
+        boot,
+    ));
+    controller
+        .set_process_lease_deadline(Arc::new(
+            laminar_core::cluster::control::LeaseDeadline::live_for(Duration::from_secs(60)),
+        ))
+        .unwrap();
+    controller.publish_recovery_incarnation().await.unwrap();
+    controller.set_active(true);
+    let _process_authority = install_test_process_authority(&controller, &[process]).await;
+    let _leader_lease = grant_test_leadership(&controller).await;
+
+    let registry = Arc::new(VnodeRegistry::single_owner(1, self_id));
+    let receiver = Arc::new(
+        ShuffleReceiver::bind(self_id.0, "127.0.0.1:0".parse().unwrap(), boot)
+            .await
+            .unwrap(),
+    );
+    let sender = Arc::new(ShuffleSender::new(self_id.0, boot));
+    let db = LaminarDB::builder()
+        .cluster_controller(Arc::clone(&controller))
+        .cluster_checkpoint_object_store(Arc::clone(&inner))
+        .vnode_registry(Arc::clone(&registry))
+        .assignment_snapshot_store(Arc::clone(&durable))
+        .shuffle_sender(sender)
+        .shuffle_receiver(receiver)
+        .build()
+        .await
+        .unwrap();
+    db.set_source_gate(true);
+
+    let shutdown = CancellationToken::new();
+    let config = RebalanceConfig {
+        watcher_poll: Duration::from_secs(5),
+        checkpoint_timeout: operation_timeout,
+        ..RebalanceConfig::test_defaults()
+    };
+    let started = tokio::time::Instant::now();
+    let watcher = spawn_snapshot_watcher(
+        Arc::clone(&db),
+        durable,
+        registry,
+        shutdown.clone(),
+        config,
+        Some(Arc::clone(&controller)),
+    );
+    let publication = tokio::time::timeout(Duration::from_secs(2), async {
+        while controller
+            .checkpoint_assignment_fence(committed.version)
+            .is_none()
+        {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await;
+    shutdown.cancel();
+    watcher.await.unwrap();
+
+    publication.expect("authority publication reused the exhausted durable-head audit deadline");
+    assert!(started.elapsed() > operation_timeout);
+    assert!(!db.cluster_intake_fenced());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- give assignment-authority publication a fresh checkpoint-timeout budget after the durable-head audit
- retain one absolute deadline across the serialized publication phase
- add a deterministic slow-store/slow-control regression for the Azure native-soak failure shape

## Root cause
The snapshot watcher created its deadline before the durable object-store audit and reused the remainder for assignment report/fence publication. Native Azure latency could consume almost the whole budget, causing an unchanged valid assignment to be suspended before recovery.

## Validation
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo clippy -p laminar-db --no-default-features --features cluster --lib --tests -- -D warnings
- cargo test -p laminar-db --lib --no-default-features --features cluster rebalance::tests::watcher_authority_publication_gets_a_fresh_phase_budget -- --exact
- cargo test -p laminar-db --lib --no-default-features --features cluster rebalance::tests::watcher_resumes_exact_authority_after_transient_audit_gaps -- --exact
- RUST_MIN_STACK=33554432 cargo test -p laminar-db --lib --no-default-features --features cluster

Azure native certification remains fail-closed until the protected workflow passes on the exact merged commit. No delivery admission is changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assignment authority publication so it gets a fresh `checkpoint_timeout` budget after the durable-head audit instead of reusing the deadline created before it. Previously native Azure latency could consume almost the whole budget and cause an unchanged valid assignment to be suspended before recovery.

- `publish_authority` now takes a timeout duration and sets its own deadline.
- Adds a deterministic regression test with a delayed control-plane scan and throttled object store.
- No delivery admission behavior changes.

<sup>Written for commit 24320954a65632fc91478cb1fe70ef7a39972a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot authority publication after delayed operations by applying a fresh timeout window.
  * Ensured assignment fences are eventually published correctly without unnecessarily blocking cluster intake.

* **Tests**
  * Added regression coverage for delayed durable-head audits and authority publication timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->