### PR TITLE
test(cloud): bound native checkpoint attempts

### DIFF
--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -240,11 +240,14 @@ jobs:
           requested_kills="$EVIDENCE_PROCESS_KILLS"
           actual_kills=0
           produced=null
+          checkpoint_timeout=null
           output_summary=""
           if [[ -f native-checkpoint-soak.log ]]; then
             actual_kills="$(awk '/^soak round [0-9]+: kill -9 delivered / { count++ } END { print count + 0 }' native-checkpoint-soak.log)"
             produced_value="$(sed -n 's/.*producer acknowledged \([0-9][0-9]*\) records.*/\1/p' native-checkpoint-soak.log | tail -1)"
             if [[ -n "$produced_value" ]]; then produced="$produced_value"; fi
+            checkpoint_timeout_value="$(sed -n 's/^soak: PROFILE mode=cluster .* checkpoint_timeout_ms=\([0-9][0-9]*\) .*/\1/p' native-checkpoint-soak.log | tail -1)"
+            if [[ -n "$checkpoint_timeout_value" ]]; then checkpoint_timeout="$checkpoint_timeout_value"; fi
             output_summary="$(sed -n 's/.*output oracle consumed.*observed all \([0-9][0-9]*\) pairs.*with \([0-9][0-9]*\) at-least-once duplicates.*/\1 \2/p' native-checkpoint-soak.log | tail -1)"
           fi
           recovered=0
@@ -255,6 +258,7 @@ jobs:
           cleanup_result=failed
           if [[ "${{ steps.cleanup.outcome }}" == "success" ]]; then cleanup_result=passed; fi
           if [[ "${{ steps.cleanup.outcome }}" == "skipped" ]]; then cleanup_result="preserved-on-request"; fi
+          if [[ "$checkpoint_timeout" != "$LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS" ]]; then passed=false; fi
           now_ms="$(date +%s%3N)"
           started_ms="${SOAK_STARTED_EPOCH_MS:-$now_ms}"
           duration_ms=$((now_ms - started_ms))
@@ -266,7 +270,7 @@ jobs:
             --arg cleanup "$cleanup_result" --argjson passed "$passed" \
             --argjson kills "$actual_kills" --argjson requested_kills "$requested_kills" \
             --argjson recovery "$EVIDENCE_RECOVERY_TIMEOUT_MS" \
-            --argjson checkpoint_timeout "$LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS" \
+            --argjson checkpoint_timeout "$checkpoint_timeout" \
             --argjson produced "$produced" --argjson recovered "$recovered" \
             --argjson duplicates "$duplicates" --argjson duration "$duration_ms" \
             '{schema_version:1,repository:"laminardb/laminardb",base_sha:$base_sha,tested_sha:$tested_sha,workflow_run_id:$run_id,provider:$provider,native_or_emulator:"native",redacted_endpoint_classification:"native-provider-default",region_or_cloud_location:(env.LAMINAR_CLOUD_LOCATION // null),url_scheme:$scheme,enabled_cargo_features:["cluster","kafka",$provider],object_store_version:(env.LAMINAR_OBJECT_STORE_VERSION // "unknown"),deltalake_version:null,iceberg_version:null,opendal_version:null,auth_source:(env.LAMINAR_NATIVE_AUTH_SOURCE // "unknown"),test_suite:"checkpoint-native-process-soak",test_name:"three_node_alo_join_kill9_soak",started_at:$started,finished_at:$finished,duration_ms:$duration,iterations:$kills,process_kill_count:$kills,requested_process_kill_count:$requested_kills,recovery_bound_ms:$recovery,checkpoint_timeout_ms:$checkpoint_timeout,capability_results:{real_process_kill:($kills > 0),all_requested_process_kills:($kills == $requested_kills),fresh_client_recovery:$passed,no_loss_assertion:$passed,duplicates_identified_and_bounded:$passed},conditional_create_result:null,stale_cas_result:null,restart_result:$passed,delivery_contract_tested:"at-least-once",records_produced:$produced,records_committed:(if $passed then $recovered else null end),records_recovered:(if $passed then $recovered else null end),duplicates:(if $passed then $duplicates else null end),losses:(if $passed then 0 else null end),passed:$passed,skip_count:0,skip_reasons:[],cleanup_result:$cleanup,failure:(if $passed then null else "native checkpoint process soak, output evidence, or cleanup failed" end)}' \

--- a/.github/workflows/native-cloud-object-store-soak.yml
+++ b/.github/workflows/native-cloud-object-store-soak.yml
@@ -103,6 +103,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Native control-plane and checkpoint I/O share one semantic attempt deadline. Keep the
+      # provider-latency allowance bounded below the 90-second recovery liveness ceiling.
+      LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS: "60000"
     strategy:
       fail-fast: false
       matrix:
@@ -262,9 +266,10 @@ jobs:
             --arg cleanup "$cleanup_result" --argjson passed "$passed" \
             --argjson kills "$actual_kills" --argjson requested_kills "$requested_kills" \
             --argjson recovery "$EVIDENCE_RECOVERY_TIMEOUT_MS" \
+            --argjson checkpoint_timeout "$LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS" \
             --argjson produced "$produced" --argjson recovered "$recovered" \
             --argjson duplicates "$duplicates" --argjson duration "$duration_ms" \
-            '{schema_version:1,repository:"laminardb/laminardb",base_sha:$base_sha,tested_sha:$tested_sha,workflow_run_id:$run_id,provider:$provider,native_or_emulator:"native",redacted_endpoint_classification:"native-provider-default",region_or_cloud_location:(env.LAMINAR_CLOUD_LOCATION // null),url_scheme:$scheme,enabled_cargo_features:["cluster","kafka",$provider],object_store_version:(env.LAMINAR_OBJECT_STORE_VERSION // "unknown"),deltalake_version:null,iceberg_version:null,opendal_version:null,auth_source:(env.LAMINAR_NATIVE_AUTH_SOURCE // "unknown"),test_suite:"checkpoint-native-process-soak",test_name:"three_node_alo_join_kill9_soak",started_at:$started,finished_at:$finished,duration_ms:$duration,iterations:$kills,process_kill_count:$kills,requested_process_kill_count:$requested_kills,recovery_bound_ms:$recovery,capability_results:{real_process_kill:($kills > 0),all_requested_process_kills:($kills == $requested_kills),fresh_client_recovery:$passed,no_loss_assertion:$passed,duplicates_identified_and_bounded:$passed},conditional_create_result:null,stale_cas_result:null,restart_result:$passed,delivery_contract_tested:"at-least-once",records_produced:$produced,records_committed:(if $passed then $recovered else null end),records_recovered:(if $passed then $recovered else null end),duplicates:(if $passed then $duplicates else null end),losses:(if $passed then 0 else null end),passed:$passed,skip_count:0,skip_reasons:[],cleanup_result:$cleanup,failure:(if $passed then null else "native checkpoint process soak, output evidence, or cleanup failed" end)}' \
+            '{schema_version:1,repository:"laminardb/laminardb",base_sha:$base_sha,tested_sha:$tested_sha,workflow_run_id:$run_id,provider:$provider,native_or_emulator:"native",redacted_endpoint_classification:"native-provider-default",region_or_cloud_location:(env.LAMINAR_CLOUD_LOCATION // null),url_scheme:$scheme,enabled_cargo_features:["cluster","kafka",$provider],object_store_version:(env.LAMINAR_OBJECT_STORE_VERSION // "unknown"),deltalake_version:null,iceberg_version:null,opendal_version:null,auth_source:(env.LAMINAR_NATIVE_AUTH_SOURCE // "unknown"),test_suite:"checkpoint-native-process-soak",test_name:"three_node_alo_join_kill9_soak",started_at:$started,finished_at:$finished,duration_ms:$duration,iterations:$kills,process_kill_count:$kills,requested_process_kill_count:$requested_kills,recovery_bound_ms:$recovery,checkpoint_timeout_ms:$checkpoint_timeout,capability_results:{real_process_kill:($kills > 0),all_requested_process_kills:($kills == $requested_kills),fresh_client_recovery:$passed,no_loss_assertion:$passed,duplicates_identified_and_bounded:$passed},conditional_create_result:null,stale_cas_result:null,restart_result:$passed,delivery_contract_tested:"at-least-once",records_produced:$produced,records_committed:(if $passed then $recovered else null end),records_recovered:(if $passed then $recovered else null end),duplicates:(if $passed then $duplicates else null end),losses:(if $passed then 0 else null end),passed:$passed,skip_count:0,skip_reasons:[],cleanup_result:$cleanup,failure:(if $passed then null else "native checkpoint process soak, output evidence, or cleanup failed" end)}' \
             > "$LAMINAR_CLOUD_EVIDENCE_DIR/checkpoint-native-process-soak-${{ matrix.provider }}-$GITHUB_RUN_ID.json"
       - name: Validate native evidence eligibility
         id: validate_evidence
@@ -278,6 +283,9 @@ jobs:
             jq -e --arg sha "$GITHUB_SHA" '.tested_sha == $sha and .native_or_emulator == "native" and .skip_count == 0 and .passed == true and .cleanup_result == "passed"' "$evidence" >/dev/null
             count=$((count + 1))
           done
+          jq -e --argjson timeout "$LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS" \
+            '.checkpoint_timeout_ms == $timeout' \
+            "$LAMINAR_CLOUD_EVIDENCE_DIR/checkpoint-native-process-soak-${{ matrix.provider }}-$GITHUB_RUN_ID.json" >/dev/null
           test "$count" -eq 3
       - name: Upload native checkpoint evidence
         id: upload_evidence

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -39,6 +39,8 @@
 //! Environment knobs:
 //! - `LAMINAR_SOAK_SECONDS`      steady-soak duration after fault rounds (default 90)
 //! - `LAMINAR_SOAK_INTERVAL_MS`  checkpoint cadence (default 500; minimum 100)
+//! - `LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS`  optional bounded end-to-end checkpoint-attempt timeout;
+//!   it must remain below the configured recovery ceiling
 //! - `LAMINAR_SOAK_CHECKPOINT_SLO_MODE`  `certify` (default) enforces the checkpoint latency
 //!   sample-size and percentile SLOs; `observe` retains exact timing evidence and diagnostics for
 //!   functional smoke runs without claiming performance certification
@@ -50,7 +52,7 @@
 //! - `LAMINAR_SOAK_DELTA_BUCKET`  existing bucket for unique EO output tables
 //! - `LAMINAR_SOAK_ALLOW_S3_EMULATOR=1`  debug/soak-only MinIO protocol validation; this does not
 //!   certify an emulator or custom endpoint for production; EO emulator runs use a bounded 60s
-//!   checkpoint-operation timeout while the real-store soak profile retains 30s
+//!   checkpoint-operation timeout
 //! - `LAMINAR_SOAK_ALO_VISIBILITY_MS`  maximum Kafka output visibility latency (default 10000)
 //! - `LAMINAR_SOAK_EO_VISIBILITY_MS`  maximum frozen-input-to-Delta visibility latency (default 10000)
 //! - `LAMINAR_SOAK_KAFKA_SOURCE_BROKERS`  required shared Kafka/Redpanda source broker
@@ -74,6 +76,8 @@
 
 #[cfg(all(feature = "kafka", feature = "delta-lake-s3"))]
 use std::collections::HashMap;
+#[cfg(feature = "kafka")]
+use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{OsStr, OsString};
 use std::io::{Read, Seek as _, SeekFrom, Write as _};
@@ -207,6 +211,10 @@ const RECOVERY_PREPARE_HANDOFF_LOG: &str =
 const RECOVERY_RETRY_HOLD_LOG: &str = "holding intake shut and requesting a fresh recovery round";
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES: u64 = 4 * 1024 * 1024;
+#[cfg(feature = "kafka")]
+const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
+#[cfg(feature = "kafka")]
+const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "kafka")]
@@ -2907,7 +2915,7 @@ impl Node {
     }
 
     #[cfg(feature = "kafka")]
-    fn recovery_log_marker_counts(&self) -> Option<BTreeMap<&'static str, usize>> {
+    fn recovery_log_diagnostics(&self) -> Option<RecoveryLogDiagnostics> {
         let mut log = std::fs::File::open(&self.log_path).ok()?;
         let log_len = log.metadata().ok()?.len();
         let start = log_len.saturating_sub(RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES);
@@ -2916,9 +2924,7 @@ impl Node {
         log.take(RECOVERY_DIAGNOSTIC_LOG_TAIL_MAX_BYTES)
             .read_to_end(&mut tail)
             .ok()?;
-        Some(count_recovery_diagnostic_markers(&String::from_utf8_lossy(
-            &tail,
-        )))
+        Some(recovery_log_diagnostics(&String::from_utf8_lossy(&tail)))
     }
 
     #[cfg(feature = "kafka")]
@@ -9730,12 +9736,36 @@ impl JoinDelivery {
 }
 
 #[cfg(feature = "kafka")]
-fn cluster_checkpoint_timeout(delivery: JoinDelivery, s3_emulator: bool) -> Duration {
+fn cluster_checkpoint_timeout(
+    delivery: JoinDelivery,
+    s3_emulator: bool,
+    configured: Option<Duration>,
+) -> Duration {
+    if let Some(configured) = configured {
+        assert!(
+            !configured.is_zero(),
+            "LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS must be greater than zero"
+        );
+        return configured;
+    }
     if delivery == JoinDelivery::ExactlyOnce && s3_emulator {
         CLUSTER_EMULATOR_EO_CHECKPOINT_TIMEOUT
     } else {
         CLUSTER_CHECKPOINT_TIMEOUT
     }
+}
+
+#[cfg(feature = "kafka")]
+fn configured_cluster_checkpoint_timeout(delivery: JoinDelivery, s3_emulator: bool) -> Duration {
+    let configured = std::env::var("LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS")
+        .ok()
+        .map(|value| {
+            let milliseconds = value.parse::<u64>().unwrap_or_else(|_| {
+                panic!("LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS must be an unsigned integer")
+            });
+            Duration::from_millis(milliseconds)
+        });
+    cluster_checkpoint_timeout(delivery, s3_emulator, configured)
 }
 
 #[cfg(feature = "kafka")]
@@ -10803,6 +10833,7 @@ fn write_config(
     dir: &Path,
     id: usize,
     interval_ms: u64,
+    checkpoint_timeout: Duration,
     key_groups: u32,
     checkpoint_url: &str,
     brokers: &str,
@@ -10838,8 +10869,11 @@ fn write_config(
     if storage.contains("endpoint") {
         storage.push_str("allow_http = \"true\"\n");
     }
-    let checkpoint_timeout_secs =
-        cluster_checkpoint_timeout(delivery, s3_emulator_enabled()).as_secs();
+    let checkpoint_timeout = if checkpoint_timeout.subsec_millis() == 0 {
+        format!("{}s", checkpoint_timeout.as_secs())
+    } else {
+        format!("{}ms", checkpoint_timeout.as_millis())
+    };
 
     // Discovery: gossip (phi-accrual failure detection) by default;
     // `LAMINAR_SOAK_DISCOVERY=static` for the seed-list heartbeat path.
@@ -10871,7 +10905,7 @@ advertise_host = "127.0.0.1"
 [checkpoint]
 url = "{url}"
 interval = "{interval_ms}ms"
-timeout = "{checkpoint_timeout_secs}s"
+timeout = "{checkpoint_timeout}"
 
 [checkpoint.storage]
 {storage}
@@ -11797,6 +11831,52 @@ fn assert_checkpoint_progress(
 }
 
 #[cfg(feature = "kafka")]
+#[derive(Debug, PartialEq, Eq)]
+struct RecoveryLogDiagnostics {
+    marker_counts: BTreeMap<&'static str, usize>,
+    recent_marker_sequence: Vec<&'static str>,
+    graph_drain_buffered_bytes: Vec<u64>,
+}
+
+#[cfg(feature = "kafka")]
+fn recovery_log_diagnostics(log: &str) -> RecoveryLogDiagnostics {
+    let mut recent_marker_sequence = VecDeque::with_capacity(RECOVERY_DIAGNOSTIC_SEQUENCE_MAX);
+    let mut graph_drain_buffered_bytes =
+        VecDeque::with_capacity(RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX);
+    for line in log.lines() {
+        for (name, marker) in RECOVERY_DIAGNOSTIC_MARKERS {
+            if line.contains(marker) {
+                if recent_marker_sequence.len() == RECOVERY_DIAGNOSTIC_SEQUENCE_MAX {
+                    recent_marker_sequence.pop_front();
+                }
+                recent_marker_sequence.push_back(name);
+            }
+        }
+        let Some((_, detail)) =
+            line.split_once("checkpoint graph drain exhausted its end-to-end deadline with ")
+        else {
+            continue;
+        };
+        let Some(bytes) = detail
+            .split_ascii_whitespace()
+            .next()
+            .and_then(|value| value.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if graph_drain_buffered_bytes.len() == RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX {
+            graph_drain_buffered_bytes.pop_front();
+        }
+        graph_drain_buffered_bytes.push_back(bytes);
+    }
+    RecoveryLogDiagnostics {
+        marker_counts: count_recovery_diagnostic_markers(log),
+        recent_marker_sequence: recent_marker_sequence.into_iter().collect(),
+        graph_drain_buffered_bytes: graph_drain_buffered_bytes.into_iter().collect(),
+    }
+}
+
+#[cfg(feature = "kafka")]
 fn count_recovery_diagnostic_markers(log: &str) -> BTreeMap<&'static str, usize> {
     RECOVERY_DIAGNOSTIC_MARKERS
         .iter()
@@ -11832,9 +11912,9 @@ fn durable_progress_diagnostics(
         .iter()
         .map(|node| (node.id, node.durable_assignment_diagnostic()))
         .collect();
-    let recovery_log_markers_by_node: Vec<_> = live_nodes
+    let recovery_log_diagnostics_by_node: Vec<_> = live_nodes
         .iter()
-        .map(|node| (node.id, node.recovery_log_marker_counts()))
+        .map(|node| (node.id, node.recovery_log_diagnostics()))
         .collect();
     let ingestion_metrics_by_node: Vec<_> = live_nodes
         .iter()
@@ -11888,7 +11968,7 @@ fn durable_progress_diagnostics(
          durable_assignment_by_node={durable_assignment_by_node:?}, \
          completed_checkpoints={completed:?}, failed_checkpoints={failed:?}, \
          recovery_metrics={recovery_metrics:?}, \
-         recovery_log_markers_by_node={recovery_log_markers_by_node:?}, \
+         recovery_log_diagnostics_by_node={recovery_log_diagnostics_by_node:?}, \
          ingestion_metrics_by_node={ingestion_metrics_by_node:?}, \
          checkpoint_size_bytes_by_node={checkpoint_size_bytes_by_node:?}, \
          durable_checkpoint_by_node={durable_checkpoint_by_node:?}, \
@@ -13415,7 +13495,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
     );
     validate_retained_state_profile(soak_secs, retained_interval_ms, minimum_live_state_bytes);
     let recovery_ceiling = recovery_ceiling();
-    let checkpoint_timeout = cluster_checkpoint_timeout(delivery, s3_emulator_enabled());
+    let checkpoint_timeout = configured_cluster_checkpoint_timeout(delivery, s3_emulator_enabled());
     validate_checkpoint_liveness(interval_ms, checkpoint_timeout, recovery_ceiling);
     let durable_output_window = recovery_aware_durable_progress_window(
         interval_ms,
@@ -13600,8 +13680,9 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
     let join_keys = env_u64("LAMINAR_SOAK_JOIN_KEYS", DEFAULT_JOIN_KEYS);
     let zipf_milli = env_u64("LAMINAR_SOAK_ZIPF_MILLI", DEFAULT_ZIPF_MILLI);
     eprintln!(
-        "soak: PROFILE mode=cluster delivery={} seconds={soak_secs} checkpoint_ms={interval_ms} checkpoint_slo_mode={} hot_path_slo_mode={} join_interval_ms={retained_interval_ms} rps={source_rps} keys={join_keys} zipf_milli={zipf_milli} kills={max_kills} min_live_state_bytes={minimum_live_state_bytes} kafka_sink_linger_ms={SOAK_KAFKA_SINK_LINGER_MS}",
+        "soak: PROFILE mode=cluster delivery={} seconds={soak_secs} checkpoint_ms={interval_ms} checkpoint_timeout_ms={} checkpoint_slo_mode={} hot_path_slo_mode={} join_interval_ms={retained_interval_ms} rps={source_rps} keys={join_keys} zipf_milli={zipf_milli} kills={max_kills} min_live_state_bytes={minimum_live_state_bytes} kafka_sink_linger_ms={SOAK_KAFKA_SINK_LINGER_MS}",
         delivery.label(),
+        checkpoint_timeout.as_millis(),
         checkpoint_slo_mode.label(),
         hot_path_slo_mode.label(),
     );
@@ -13639,6 +13720,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
                 dir.path(),
                 id,
                 interval_ms,
+                checkpoint_timeout,
                 key_group_count,
                 &checkpoint_url,
                 &brokers,
@@ -15721,6 +15803,44 @@ fn public_readiness_request_omits_console_authorization() {
         BoundedHttpAuthorization::ConsoleBearer,
     );
     assert!(console_request.contains("Authorization: Bearer "));
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn recovery_log_diagnostics_are_bounded_and_do_not_copy_log_values() {
+    let drain_count = RECOVERY_DIAGNOSTIC_SEQUENCE_MAX + 2;
+    let mut log = String::new();
+    for buffered_bytes in 0..drain_count {
+        log.push_str(&format!(
+            "checkpoint graph drain exhausted its end-to-end deadline with {buffered_bytes} \
+             buffered bytes token=never-copy-this\n"
+        ));
+    }
+    log.push_str("leader announced recovery prepare account=never-copy-this\n");
+
+    let diagnostics = recovery_log_diagnostics(&log);
+    assert_eq!(
+        diagnostics
+            .marker_counts
+            .get("checkpoint_graph_drain_timeout"),
+        Some(&drain_count)
+    );
+    assert_eq!(
+        diagnostics.recent_marker_sequence.len(),
+        RECOVERY_DIAGNOSTIC_SEQUENCE_MAX
+    );
+    assert_eq!(
+        diagnostics.recent_marker_sequence.last(),
+        Some(&"recovery_prepare")
+    );
+    let first_retained_sample = drain_count - RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX;
+    assert_eq!(
+        diagnostics.graph_drain_buffered_bytes,
+        (first_retained_sample..drain_count)
+            .map(|value| u64::try_from(value).unwrap())
+            .collect::<Vec<_>>()
+    );
+    assert!(!format!("{diagnostics:?}").contains("never-copy-this"));
 }
 
 #[cfg(feature = "kafka")]
@@ -18284,16 +18404,24 @@ fn bounded_join_oracle_matches_one_sided_sql_contract() {
 fn cluster_soak_config_bounds_checkpoint_timeout_within_liveness_window() {
     assert_eq!(CLUSTER_CHECKPOINT_TIMEOUT, Duration::from_secs(30));
     assert_eq!(
-        cluster_checkpoint_timeout(JoinDelivery::AtLeastOnce, true),
+        cluster_checkpoint_timeout(JoinDelivery::AtLeastOnce, true, None),
         CLUSTER_CHECKPOINT_TIMEOUT
     );
     assert_eq!(
-        cluster_checkpoint_timeout(JoinDelivery::ExactlyOnce, false),
+        cluster_checkpoint_timeout(JoinDelivery::ExactlyOnce, false, None),
         CLUSTER_CHECKPOINT_TIMEOUT
     );
     assert_eq!(
-        cluster_checkpoint_timeout(JoinDelivery::ExactlyOnce, true),
+        cluster_checkpoint_timeout(JoinDelivery::ExactlyOnce, true, None),
         CLUSTER_EMULATOR_EO_CHECKPOINT_TIMEOUT
+    );
+    assert_eq!(
+        cluster_checkpoint_timeout(
+            JoinDelivery::AtLeastOnce,
+            false,
+            Some(Duration::from_secs(60)),
+        ),
+        Duration::from_secs(60)
     );
     assert!(CLUSTER_CHECKPOINT_TIMEOUT < RECOVERY_LIVENESS_WINDOW);
     assert!(CLUSTER_EMULATOR_EO_CHECKPOINT_TIMEOUT < RECOVERY_LIVENESS_WINDOW);
@@ -18303,6 +18431,7 @@ fn cluster_soak_config_bounds_checkpoint_timeout_within_liveness_window() {
         directory.path(),
         0,
         250,
+        CLUSTER_CHECKPOINT_TIMEOUT,
         DEFAULT_CLUSTER_KEY_GROUPS,
         "s3://soak/checkpoints",
         "broker:9092",

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -14424,7 +14424,7 @@ fn run_three_node_join_kill9_soak(delivery: JoinDelivery, subscription_soak: boo
         .collect::<Vec<_>>();
     let observation_budget = checkpoint_observation_budget(
         interval_ms,
-        CLUSTER_CHECKPOINT_TIMEOUT,
+        checkpoint_timeout,
         recovery_ceiling,
         &live_observation_budget,
     )


### PR DESCRIPTION
## Summary

- let protected native checkpoint soaks opt into a bounded end-to-end checkpoint-attempt timeout
- run native provider jobs with a 60-second attempt timeout below the existing 90-second recovery ceiling
- record and validate that timeout in machine-readable process-soak evidence
- add bounded, normalized recovery marker sequencing and graph-drain byte samples without copying raw log values

## Why

Azure run 34050909580 passed native object-store conformance and deterministic checkpoint fault contracts on the exact merge commit, then failed before its first injected process kill. The three-node process soak exhausted the existing 30-second checkpoint deadline while draining a roughly 9 MiB native checkpoint. This patch changes only the protected soak profile; production defaults and delivery admission are unchanged.

## Validation

- `cargo test --profile soak -p laminar-server --no-default-features --features cluster,kafka --test cluster_soak` (71 passed, 4 real-process tests ignored)
- `cargo clippy -p laminar-server --no-default-features --features cluster,kafka --test cluster_soak -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- workflow YAML parse check

## Certification status

This PR is not Azure certification evidence. After merge, the protected Azure workflow must run all required native tests without skips and upload passing evidence tied to the exact merge commit. No clustered exact-delivery admission changes are made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the native checkpoint attempt timeout so the protected Azure soak stops exhausting the 30-second deadline while draining ~9 MiB checkpoints. Production defaults and delivery admission are unchanged.

**Changes**
- Adds optional `LAMINAR_SOAK_CHECKPOINT_TIMEOUT_MS`; existing 30s and 60s emulator defaults apply when unset.
- Sets the native soak checkpoint attempt timeout to 60s, below the 90-second recovery ceiling, and fails the soak if evidence doesn't record that effective timeout.
- Caps recovery-log marker sequence at 32 and drain byte samples at 8 without copying raw log values.
- Writes checkpoint timeouts with millisecond precision in config when they aren't whole seconds.

<sup>Written for commit cf959d417d8b29bc2a8d30e5716644b68c6b9ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added configurable checkpoint timeouts for native and cluster soak testing.
  * Improved validation to confirm configured timeout values are recorded consistently.
  * Expanded recovery diagnostics with recent event sequences and buffered-data samples.
  * Added coverage for bounded diagnostic collection and timeout configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->