### PR TITLE
fix(cluster): refresh recovery adoption mode after audit

### DIFF
--- a/crates/laminar-db/src/db/assignment_authority.rs
+++ b/crates/laminar-db/src/db/assignment_authority.rs
@@ -1,8 +1,24 @@
-use super::{AssignmentAuthorityActivation, DbError, LaminarDB};
+use super::{AssignmentAdoptionMode, AssignmentAuthorityActivation, DbError, DbState, LaminarDB};
 use laminar_core::checkpoint::{CheckpointAssignmentFence, CheckpointParticipant, LeaderProof};
 use laminar_core::cluster::control::{
     ClusterController, RecoverPhase, RecoveryAnnouncement, RecoveryControlError, RecoveryRound,
 };
+
+impl AssignmentAdoptionMode {
+    pub(super) fn after_authority_audit(
+        self,
+        audited_recovery: bool,
+        terminal_drain: bool,
+        state: DbState,
+    ) -> (Self, bool) {
+        let faulted = state == DbState::Faulted;
+        let faulted_terminal_drain = faulted && terminal_drain;
+        let use_cold =
+            self == Self::LiveTransition && faulted && (audited_recovery || terminal_drain);
+        let selected = if use_cold { Self::ColdRecovery } else { self };
+        (selected, faulted_terminal_drain)
+    }
+}
 
 async fn observe_stopped_round(
     controller: &ClusterController,

--- a/crates/laminar-db/src/db/mod.rs
+++ b/crates/laminar-db/src/db/mod.rs
@@ -2889,7 +2889,6 @@ impl LaminarDB {
         mode: AssignmentAdoptionMode,
     ) -> futures::future::BoxFuture<'_, Result<SnapshotAdoption, DbError>> {
         Box::pin(async move {
-            let mut mode = mode;
             if snapshot.draining {
                 return Err(DbError::Checkpoint(format!(
                     "assignment {} is a draining generation and cannot publish ownership",
@@ -3003,11 +3002,14 @@ impl LaminarDB {
             // still needs topology publication before a pristine graph can restore that older cut.
             // Reuse the cold-publication path only when the immutable drain audit and exact faulted
             // lifecycle below both hold; neither outcome reuses predecessor heap memory.
-            let faulted_terminal_drain_cold =
-                terminal_drain_authority && DbState::load(&self.state) == DbState::Faulted;
-            if mode == AssignmentAdoptionMode::LiveTransition && faulted_terminal_drain_cold {
-                mode = AssignmentAdoptionMode::ColdRecovery;
-            }
+            // The durable audit above can outlive the compute generation on a remote store. Select
+            // the recovery mode again after that I/O so a graph that faulted meanwhile does not
+            // pay for a known-invalid live transition and a second complete authority audit.
+            let (mut mode, faulted_terminal_drain_cold) = mode.after_authority_audit(
+                audited_recovery,
+                terminal_drain_authority,
+                DbState::load(&self.state),
+            );
             let target_fence = snapshot
                 .assignment_fence()
                 .map_err(|error| DbError::Checkpoint(error.to_string()))?;

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -26,24 +26,52 @@ impl laminar_core::cluster::control::ClusterKv for DelayedScanKv {
     }
 }
 
-struct PendingListStore {
-    inner: Arc<dyn ObjectStore>,
+struct GetBarrier {
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+    reads_before_wait: std::sync::atomic::AtomicUsize,
+    armed: std::sync::atomic::AtomicBool,
 }
 
-impl std::fmt::Debug for PendingListStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PendingListStore").finish_non_exhaustive()
+impl GetBarrier {
+    async fn wait_once(&self) {
+        if self
+            .reads_before_wait
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return;
+        }
+        if !self.armed.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        self.entered.notify_one();
+        self.release.notified().await;
     }
 }
 
-impl std::fmt::Display for PendingListStore {
+struct ReadBarrierStore {
+    inner: Arc<dyn ObjectStore>,
+    get: Option<Arc<GetBarrier>>,
+    stall_list: bool,
+}
+
+impl std::fmt::Debug for ReadBarrierStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("PendingListStore")
+        f.debug_struct("ReadBarrierStore").finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for ReadBarrierStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ReadBarrierStore")
     }
 }
 
 #[async_trait::async_trait]
-impl ObjectStore for PendingListStore {
+impl ObjectStore for ReadBarrierStore {
     async fn put_opts(
         &self,
         location: &object_store::path::Path,
@@ -66,6 +94,9 @@ impl ObjectStore for PendingListStore {
         location: &object_store::path::Path,
         options: object_store::GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
+        if let Some(get) = &self.get {
+            get.wait_once().await;
+        }
         self.inner.get_opts(location, options).await
     }
 
@@ -81,9 +112,13 @@ impl ObjectStore for PendingListStore {
 
     fn list(
         &self,
-        _prefix: Option<&object_store::path::Path>,
+        prefix: Option<&object_store::path::Path>,
     ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
-        Box::pin(futures::stream::pending())
+        if self.stall_list {
+            Box::pin(futures::stream::pending())
+        } else {
+            self.inner.list(prefix)
+        }
     }
 
     async fn list_with_delimiter(
@@ -1764,6 +1799,29 @@ async fn faulted_owner_cold_publishes_the_next_committed_drain_topology() {
 }
 
 #[tokio::test]
+async fn already_faulted_recovery_adoption_preserves_terminal_drain_authority() {
+    let (db, controller, registry, _current, target, _checkpoint_dir) =
+        stopped_recovery_topology_fixture(true, true, AssignmentDrainVerdict::Commit).await;
+    *db.runtime_shutdown.write() = tokio_util::sync::CancellationToken::new();
+    controller.set_recovering(true);
+    DbState::Faulted.store(&db.state);
+
+    let adoption = db
+        .adopt_recovery_assignment_snapshot(target.clone(), Duration::from_secs(1))
+        .await
+        .expect("an already-cold adoption must retain audited terminal-drain authority");
+
+    assert!(adoption.adopted);
+    assert_eq!(registry.assignment_version(), target.version);
+    assert_eq!(registry.owner(0), NodeId(2));
+    assert!(db.pending_vnode_transition.lock().is_none());
+    assert!(db.installed_vnode_state.lock().is_none());
+    assert!(db.cluster_intake_fenced());
+    assert!(db.coordinated_recovery_in_progress());
+    assert_eq!(DbState::load(&db.state), DbState::Faulted);
+}
+
+#[tokio::test]
 async fn faulted_owner_cold_publishes_an_aborted_drain_rollback_topology() {
     let (db, controller, registry, current, target, _checkpoint_dir) =
         stopped_recovery_topology_fixture(true, true, AssignmentDrainVerdict::Abort).await;
@@ -3217,6 +3275,93 @@ fn takeover_audits_a_recovery_head_while_its_pin_is_propagated_to_the_next_gener
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_adoption_observes_a_compute_fault_during_authority_audit() {
+    let self_id = NodeId(1);
+    let (
+        db,
+        controller,
+        durable,
+        registry,
+        current,
+        _process_authority,
+        authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    controller.note_unresponsive(&[NodeId(2)]);
+
+    let error = try_rebalance(
+        &db,
+        &controller,
+        &durable,
+        &registry,
+        &[self_id, NodeId(2)],
+        RebalanceConfig::test_defaults(),
+    )
+    .await
+    .expect_err("live adoption intentionally lacks the failed owner's handoff manifest");
+    assert!(
+        error.contains("participant 2 handoff manifest is missing"),
+        "{error}"
+    );
+    let successor = durable.load().await.unwrap().unwrap();
+    assert_eq!(
+        crate::db::DbState::load(&db.state),
+        crate::db::DbState::Running
+    );
+    assert!(db.installed_vnode_state.lock().is_some());
+    assert!(db.pending_recovery_fault.load(Ordering::Acquire) != 0);
+
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let get = Arc::new(GetBarrier {
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+        // The first read materializes the requested target. Block the audit's independent
+        // recovery-materialization read so the generation changes during the authority audit.
+        reads_before_wait: std::sync::atomic::AtomicUsize::new(1),
+        armed: std::sync::atomic::AtomicBool::new(true),
+    });
+    let delayed_store: Arc<dyn ObjectStore> = Arc::new(ReadBarrierStore {
+        inner: authority_store,
+        get: Some(get),
+        stall_list: false,
+    });
+    *db.assignment_snapshot_store.lock() =
+        Some(Arc::new(AssignmentSnapshotStore::new(delayed_store)));
+
+    let adopting_db = Arc::clone(&db);
+    let adoption = tokio::spawn(async move {
+        adopting_db
+            .adopt_recovery_assignment_snapshot(successor, Duration::from_secs(2))
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), entered.notified())
+        .await
+        .expect("recovery adoption did not enter its durable authority audit");
+
+    db.fence_coordinated_recovery_lifecycle();
+    let generation = Arc::clone(&db.rotation_execution_fence).write_owned().await;
+    db.installed_vnode_state.lock().take();
+    crate::db::DbState::Faulted.store(&db.state);
+    drop(generation);
+    release.notify_one();
+
+    let adoption = tokio::time::timeout(Duration::from_secs(3), adoption)
+        .await
+        .expect("recovery adoption remained blocked after the authority audit resumed")
+        .unwrap()
+        .expect("the faulted generation must use cold recovery in the same adoption attempt");
+    assert!(adoption.adopted);
+    assert_eq!(registry.assignment_version(), current.version + 1);
+    assert!(db.pending_vnode_transition.lock().is_none());
+    assert!(db.installed_vnode_state.lock().is_none());
+    assert_eq!(
+        crate::db::DbState::load(&db.state),
+        crate::db::DbState::Faulted
+    );
+}
+
 #[tokio::test]
 async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
     let self_id = NodeId(1);
@@ -3564,7 +3709,11 @@ async fn wait_until_drained_fails_closed_when_no_snapshot() {
 #[tokio::test]
 async fn wait_until_drained_bounds_a_stalled_snapshot_read() {
     let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-    let blocked: Arc<dyn ObjectStore> = Arc::new(PendingListStore { inner });
+    let blocked: Arc<dyn ObjectStore> = Arc::new(ReadBarrierStore {
+        inner,
+        get: None,
+        stall_list: true,
+    });
     let store = AssignmentSnapshotStore::new(blocked);
 
     let drained = tokio::time::timeout(


### PR DESCRIPTION
## What

Refresh recovery assignment mode after the durable authority audit, so a compute generation that faults during remote object-store I/O uses the existing fenced cold-recovery path in the same adoption attempt.

Add a deterministic object-store read barrier regression covering the Running-to-Faulted transition during that audit. Reuse the barrier store for the existing stalled-list deadline test.

## Why

Azure native checkpoint run 34058338489 passed object-store conformance and the deterministic fault contract, but the process-kill soak missed its 90-second recovery bound. Redacted diagnostics showed each survivor first rejected stale live adoption because its exact predecessor binding had already been retired, then retried recovery. On a native remote store that repeats a complete authority audit and delays owner-complete topology needed by coordinated recovery.

This remains fail-closed. Cold publication still requires an authority-sequenced recovery target, closed intake, active recovery fault, coordinated lifecycle fence, live process lease, and empty retained vnode state. No delivery admission changes are included.

## How

- Re-evaluate the already-selected adoption mode after durable authority I/O.
- Select ColdRecovery only when the graph is now exactly Faulted and the audited target is a recovery successor or terminal drain.
- Keep all existing cold-publication eligibility and authority rechecks unchanged.

## Testing

- [x] Unit regression added and passed
- [x] Recovery-adoption test group passed (5 tests)
- [x] Faulted-owner cold/terminal adoption group passed (5 tests)
- [x] Existing stalled-read deadline test passed
- [x] Minimal cluster clippy passed with warnings denied
- [x] Nightly formatting check passed
- [x] Readability check passed
- [ ] Linux CI full suite pending

Attempting the complete 1,796-test minimal-cluster lib suite locally on Windows reached the pre-existing evidence_only_worker_consumes_tombstoned_release_after_stopped_quorum stack overflow, including when isolated; this change does not touch that test. Linux CI is the authoritative full-suite gate.

## Ring 0

Not applicable: assignment/recovery control-plane code, outside the record hot path.

## Checklist

- [x] No public API changes
- [x] No dependency changes
- [x] No delivery-admission changes
- [x] No secrets or storage locations logged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-evaluates recovery adoption mode after the durable authority audit so a compute generation that faults during remote object-store I/O uses the existing fenced cold-recovery path in the same adoption attempt, instead of rejecting stale live adoption and retrying.

- Selects `ColdRecovery` only when the graph is exactly `Faulted` and the audited target is a recovery successor or terminal drain.
- Adds a deterministic object-store read barrier regression for the Running-to-Faulted transition during the audit; the existing stalled-list deadline test now reuses that barrier store.
- Remains fail-closed with no delivery-admission changes; cold publication still requires the same authority-sequenced recovery target, closed intake, active recovery fault, coordinated lifecycle fence, live process lease, and empty retained vnode state.

<sup>Written for commit 6e79a9b2ab55146f2809c7a591d046d6ea3e20f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery adoption when a compute fault occurs during an authority audit.
  * The system now correctly switches to cold recovery when a live transition encounters a faulted state during audited recovery or terminal draining.
  * Recovery decisions now reflect the latest audited authority and database state, helping ensure interrupted or faulted recovery operations complete safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->