### PR TITLE
fix(cluster): await recovery fault publication

### DIFF
--- a/crates/laminar-db/src/db/assignment_authority.rs
+++ b/crates/laminar-db/src/db/assignment_authority.rs
@@ -5,18 +5,64 @@ use laminar_core::cluster::control::{
 };
 
 impl AssignmentAdoptionMode {
-    pub(super) fn after_authority_audit(
+    pub(super) async fn after_authority_audit(
         self,
+        db: &LaminarDB,
         audited_recovery: bool,
         terminal_drain: bool,
-        state: DbState,
-    ) -> (Self, bool) {
+        deadline: tokio::time::Instant,
+    ) -> Result<(Self, bool), DbError> {
+        let state = self
+            .state_after_retired_generation(db, audited_recovery, deadline)
+            .await?;
         let faulted = state == DbState::Faulted;
         let faulted_terminal_drain = faulted && terminal_drain;
         let use_cold =
             self == Self::LiveTransition && faulted && (audited_recovery || terminal_drain);
         let selected = if use_cold { Self::ColdRecovery } else { self };
-        (selected, faulted_terminal_drain)
+        Ok((selected, faulted_terminal_drain))
+    }
+
+    async fn state_after_retired_generation(
+        self,
+        db: &LaminarDB,
+        audited_recovery: bool,
+        deadline: tokio::time::Instant,
+    ) -> Result<DbState, DbError> {
+        let state = DbState::load(&db.state);
+        let retired_during_fault = self == Self::LiveTransition
+            && audited_recovery
+            && matches!(state, DbState::Running | DbState::ShuttingDown)
+            && db
+                .pending_recovery_fault
+                .load(std::sync::atomic::Ordering::Acquire)
+                != 0
+            && db.installed_vnode_state.lock().is_none();
+        if !retired_during_fault {
+            return Ok(state);
+        }
+
+        // RECOVERY: graph poison retires its state binding before the compute runtime finishes
+        // draining non-abortable storage work and publishes Faulted. Reusing that heap is unsafe;
+        // wait under the adoption deadline for the lifecycle owner to expose the stable boundary.
+        loop {
+            tokio::select! {
+                biased;
+                () = db.assignment_restore_shutdown.cancelled() => {
+                    return Err(DbError::Shutdown);
+                }
+                () = tokio::time::sleep_until(deadline) => {
+                    return Err(DbError::Checkpoint(
+                        "[LDB-6053] recovery assignment adoption timed out waiting for the retired compute generation lifecycle boundary".into(),
+                    ));
+                }
+                () = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+            }
+            let state = DbState::load(&db.state);
+            if !matches!(state, DbState::Running | DbState::ShuttingDown) {
+                return Ok(state);
+            }
+        }
     }
 }
 

--- a/crates/laminar-db/src/db/mod.rs
+++ b/crates/laminar-db/src/db/mod.rs
@@ -3005,11 +3005,9 @@ impl LaminarDB {
             // The durable audit above can outlive the compute generation on a remote store. Select
             // the recovery mode again after that I/O so a graph that faulted meanwhile does not
             // pay for a known-invalid live transition and a second complete authority audit.
-            let (mut mode, faulted_terminal_drain_cold) = mode.after_authority_audit(
-                audited_recovery,
-                terminal_drain_authority,
-                DbState::load(&self.state),
-            );
+            let (mut mode, faulted_terminal_drain_cold) = mode
+                .after_authority_audit(self, audited_recovery, terminal_drain_authority, deadline)
+                .await?;
             let target_fence = snapshot
                 .assignment_fence()
                 .map_err(|error| DbError::Checkpoint(error.to_string()))?;

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -3276,7 +3276,7 @@ fn takeover_audits_a_recovery_head_while_its_pin_is_propagated_to_the_next_gener
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn recovery_adoption_observes_a_compute_fault_during_authority_audit() {
+async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_audit() {
     let self_id = NodeId(1);
     let (
         db,
@@ -3331,7 +3331,7 @@ async fn recovery_adoption_observes_a_compute_fault_during_authority_audit() {
         Some(Arc::new(AssignmentSnapshotStore::new(delayed_store)));
 
     let adopting_db = Arc::clone(&db);
-    let adoption = tokio::spawn(async move {
+    let mut adoption = tokio::spawn(async move {
         adopting_db
             .adopt_recovery_assignment_snapshot(successor, Duration::from_secs(2))
             .await
@@ -3343,9 +3343,16 @@ async fn recovery_adoption_observes_a_compute_fault_during_authority_audit() {
     db.fence_coordinated_recovery_lifecycle();
     let generation = Arc::clone(&db.rotation_execution_fence).write_owned().await;
     db.installed_vnode_state.lock().take();
-    crate::db::DbState::Faulted.store(&db.state);
     drop(generation);
     release.notify_one();
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut adoption)
+            .await
+            .is_err(),
+        "recovery adoption reused retired state before the compute fault was published"
+    );
+    crate::db::DbState::Faulted.store(&db.state);
 
     let adoption = tokio::time::timeout(Duration::from_secs(3), adoption)
         .await


### PR DESCRIPTION
## Summary

- wait for an already-poisoned compute generation to publish its stable lifecycle state before selecting live versus cold recovery adoption
- bound the wait by the existing end-to-end adoption deadline and shutdown token
- strengthen the authority-audit race regression so retired vnode state cannot be reused while `DbState` still reports `Running`

## Root cause

Azure native run [34067126416](https://github.com/laminardb/laminardb/actions/runs/34067126416) moved past graph progress after #497, but recovery then failed with LDB-6053. Operator-graph poison intentionally retires the installed vnode-state certificate immediately. The compute thread publishes `Faulted` only after its private Tokio runtime drains non-abortable storage work, which is materially slower against native object storage. An authority audit could finish inside that interval and incorrectly continue in live-adoption mode.

This change does not reuse unbound state. It waits only when all of these are true: the target is an audited recovery, a local recovery fault is pending, the lifecycle is `Running` or `ShuttingDown`, and the installed state binding is already absent. Timeout and shutdown remain fail-closed.

## Validation

- pre-fix regression: failed with `recovery adoption reused retired state before the compute fault was published`
- `cargo test -p laminar-db --no-default-features --features cluster recovery_adoption -- --nocapture`
- `set RUST_MIN_STACK=33554432&& cargo test -p laminar-db --no-default-features --features cluster rebalance::tests -- --nocapture` (64 passed)
- `set RUST_MIN_STACK=33554432&& cargo test -p laminar-db --no-default-features --features cluster pipeline_lifecycle::cluster_fault_watcher_tests -- --nocapture` (21 passed)
- `cargo clippy -p laminar-db --no-default-features --features cluster --lib --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `git diff --check`

The default Windows test-thread stack overflows in an existing deep recovery test; the exact test and complete rebalance module pass with `RUST_MIN_STACK=33554432`. Linux CI is authoritative for the normal gate.

## Certification and delivery admission

This PR is a candidate fix for the Azure checkpoint process-kill soak failure. It is not certification evidence by itself. The protected Azure workflow must execute successfully against the exact merged commit before evidence can be promoted. No Azure/GCS clustered exact-delivery admission is changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where recovery adoption could reuse retired vnode state before the compute generation publishes its `Faulted` lifecycle state.

- Waits for the retired compute generation's stable lifecycle state before selecting live vs. cold recovery adoption, bounded by the existing adoption deadline and shutdown token.
- The wait applies only when the target is an audited recovery, a local recovery fault is pending, the lifecycle is `Running` or `ShuttingDown`, and the installed state binding is already absent.
- Timeout and shutdown remain fail-closed.
- Strengthens the authority-audit regression test to assert the adoption stays blocked until the compute fault is published.

**Migration**

- No migration steps required; behavior is fail-closed and bounded by the existing adoption deadline.

<sup>Written for commit 6eb0a09d5ee63e0d8e30d3bb8df9e95d7ab74012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery adoption during authority audits to wait for a stable database lifecycle state before proceeding.
  - Correctly handles compute faults that are published during the audit process, preventing premature recovery decisions.
  - Added safeguards for shutdown cancellation and checkpoint deadlines during recovery transitions.

- **Tests**
  - Expanded recovery coverage to verify adoption remains pending until fault publication is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->