### PR TITLE
fix(cloud): align native evidence read deadlines

### DIFF
--- a/crates/laminar-server/src/cluster/control_kv.rs
+++ b/crates/laminar-server/src/cluster/control_kv.rs
@@ -57,7 +57,7 @@ impl laminar_core::cluster::control::ClusterKv for StaticClusterKv {
     }
 }
 
-pub(super) const OBJECT_STORE_CONTROL_IO_TIMEOUT: std::time::Duration =
+pub(crate) const OBJECT_STORE_CONTROL_IO_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(5);
 const OBJECT_STORE_CONTROL_MAX_VALUE_BYTES: u64 = 1024 * 1024;
 const OBJECT_STORE_CONTROL_MAX_KEY_BYTES: usize = 1024;

--- a/crates/laminar-server/src/cluster/mod.rs
+++ b/crates/laminar-server/src/cluster/mod.rs
@@ -24,6 +24,8 @@ mod serving;
 mod shutdown;
 mod startup;
 
+pub(crate) use control_kv::OBJECT_STORE_CONTROL_IO_TIMEOUT;
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/laminar-server/src/http/auth.rs
+++ b/crates/laminar-server/src/http/auth.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 #[cfg(feature = "cluster")]
 use std::time::Instant;
 
+#[cfg(feature = "cluster")]
+use crate::cluster::OBJECT_STORE_CONTROL_IO_TIMEOUT;
+
 use axum::extract::State;
 use axum::http::StatusCode;
 #[cfg(feature = "cluster")]
@@ -92,7 +95,10 @@ pub(super) const DIAGNOSTIC_READ_MAX_STARTS_PER_WINDOW: usize = 8;
 pub(super) const DIAGNOSTIC_READ_RATE_WINDOW: std::time::Duration =
     std::time::Duration::from_secs(1);
 #[cfg(feature = "cluster")]
-pub(super) const DIAGNOSTIC_READ_DEADLINE: std::time::Duration = std::time::Duration::from_secs(2);
+// INVARIANT: a durable local-evidence read may consume the full control-I/O bound. The outer
+// deadline must still leave time for the handler to return its typed unavailable response.
+pub(super) const DIAGNOSTIC_READ_DEADLINE: std::time::Duration =
+    OBJECT_STORE_CONTROL_IO_TIMEOUT.saturating_add(std::time::Duration::from_secs(1));
 
 #[cfg(feature = "cluster")]
 pub(crate) struct DiagnosticRateWindow {

--- a/crates/laminar-server/src/http/tests.rs
+++ b/crates/laminar-server/src/http/tests.rs
@@ -117,6 +117,12 @@ fn diagnostic_read_gate_is_single_flight_and_rate_bounded() {
 }
 
 #[cfg(feature = "cluster")]
+#[test]
+fn diagnostic_read_deadline_outlives_object_store_control_io() {
+    assert!(DIAGNOSTIC_READ_DEADLINE > crate::cluster::OBJECT_STORE_CONTROL_IO_TIMEOUT);
+}
+
+#[cfg(feature = "cluster")]
 #[tokio::test]
 async fn diagnostic_read_deadline_releases_the_single_flight_permit() {
     let (state, diagnostic) = diagnostic_middleware_state();

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -113,6 +113,8 @@ const SOAK_CONSOLE_TOKEN: &str = "laminardb-cluster-soak";
 #[cfg(feature = "kafka")]
 const SOAK_HTTP_HEADER_MAX_BYTES: usize = 16 * 1_024;
 #[cfg(feature = "kafka")]
+const SOAK_HTTP_OPERATION_TIMEOUT: Duration = Duration::from_secs(7);
+#[cfg(feature = "kafka")]
 const READINESS_DIAGNOSTIC_MAX_BYTES: usize = 4 * 1_024;
 #[cfg(feature = "kafka")]
 const LOCAL_AUTHORITY_EVIDENCE_MAX_BYTES: usize = 4 * 1_024;
@@ -2318,7 +2320,7 @@ impl Node {
     ) -> Result<BoundedHttpResponse, BoundedHttpError> {
         let remaining = || {
             remaining_at(deadline, Instant::now())
-                .map(|duration| duration.min(Duration::from_secs(6)))
+                .map(|duration| duration.min(SOAK_HTTP_OPERATION_TIMEOUT))
                 .ok_or_else(|| {
                     BoundedHttpError::Unavailable(format!(
                         "node{} HTTP evidence deadline was exhausted",

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -218,8 +218,6 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT: Duration = Duration::from_secs(2);
-#[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 81] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
@@ -2658,7 +2656,7 @@ impl Node {
 
     #[cfg(feature = "kafka")]
     fn durable_assignment_diagnostic(&self) -> DurableAssignmentDiagnostic {
-        let deadline = Instant::now() + RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT;
+        let deadline = Instant::now() + SOAK_HTTP_OPERATION_TIMEOUT;
         match self.durable_assignment_observation(deadline) {
             Ok(Some(snapshot)) => DurableAssignmentDiagnostic::Available {
                 version: snapshot.version,

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -2502,7 +2502,7 @@ impl Node {
 
     #[cfg(feature = "kafka")]
     fn local_assignment_diagnostic(&self) -> LocalAssignmentDiagnostic {
-        let deadline = Instant::now() + RECOVERY_DIAGNOSTIC_HTTP_TIMEOUT;
+        let deadline = Instant::now() + SOAK_HTTP_OPERATION_TIMEOUT;
         match self.local_authority_observation(deadline) {
             LocalAuthorityObservation::Available(evidence) => {
                 LocalAssignmentDiagnostic::Available {


### PR DESCRIPTION
## Summary

- derive the protected diagnostic-read deadline from the object-store control-I/O bound
- leave a bounded response-completion margin so durable local evidence can return 200/503 instead of being masked by HTTP 504
- give the process-soak HTTP client a separate bounded margin beyond the server deadline
- retain single-flight/rate limiting and exact local-assignment convergence checks

## Native evidence motivating this change

Azure run 34073944392 passed native object-store conformance and the deterministic checkpoint fault contract, then stopped before its first process kill. All 14 captured local-evidence requests returned 504 in 2000-2002 ms, while the checked object-store control read is bounded at 5 seconds. The run remains failed and is not certification evidence.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p laminar-server --bin laminardb --no-default-features --features cluster diagnostic_read_` (4 passed)
- `cargo test -p laminar-server --test cluster_soak --no-default-features --features cluster,kafka bounded_` (6 passed)
- `cargo clippy -p laminar-server --all-targets --no-default-features --features cluster,kafka,azure -- -D warnings`
- `cargo test -p laminar-server --no-default-features --features cluster,kafka,azure --bin laminardb --test cluster_soak` (327 server tests passed; 71 soak tests passed, 4 process tests ignored)
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `git diff --check`

## Delivery admission

No change. Azure clustered delivery remains at-least-once. A protected native process-kill run against the exact merged commit is still required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns native evidence read deadlines with the object-store control I/O bound so durable local evidence can return 200/503 instead of being masked by HTTP 504.

- Derives the diagnostic read deadline from the control I/O timeout plus a one-second response margin.
- Gives the soak test a named 7-second HTTP operation timeout, used for evidence reads, local assignment diagnostics, and durable assignment failure snapshots.
- Exposes the control I/O timeout constant and adds a test asserting the deadline outlives it.

<sup>Written for commit efae456e271a73ffe748010cd358750f933e2bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Diagnostic read requests now use a timeout aligned with control operations, allowing sufficient time for typed responses and reducing premature timeout results.

- **Reliability**
  - Cluster soak testing now permits slightly longer HTTP operations, improving coverage for slower responses and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->