### PR TITLE
fix(cluster): stop follower tails after leader takeover

### DIFF
--- a/crates/laminar-core/src/cluster/control/leader_lease/attempt_status.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/attempt_status.rs
@@ -1,0 +1,125 @@
+//! Audited checkpoint settlement and commit-authority observation.
+
+use crate::checkpoint::{CheckpointAssignmentFence, CheckpointAttempt, LeaderProof};
+use crate::checkpoint_decision::{CheckpointOutcome, DecisionError};
+
+use super::{ClusterCheckpointAuthorityError, LeaderLeaseStore};
+
+/// Durable settlement state for one exact cluster checkpoint attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClusterAttemptStatus {
+    /// No terminal outcome exists and the admitting leader term can still publish one.
+    Pending,
+    /// An exact or newer terminal outcome durably settles the attempt.
+    Settled(Box<CheckpointOutcome>),
+    /// No terminal outcome exists, but the leader term that admitted the artifacts was superseded.
+    ///
+    /// Takeover and outcome publication serialize through the same authority sequence. Once this
+    /// state is observed, the old term cannot publish a Commit; coordinated recovery still owns
+    /// publication of the authoritative Abort and artifact cleanup.
+    CommitFenced,
+}
+
+fn settlement_from_outcomes(
+    attempt: CheckpointAttempt,
+    outcomes: &[CheckpointOutcome],
+) -> Option<CheckpointOutcome> {
+    if let Ok(index) = outcomes.binary_search_by_key(&attempt.epoch, |outcome| outcome.epoch) {
+        return Some(outcomes[index].clone());
+    }
+    outcomes
+        .last()
+        .filter(|highest| highest.checkpoint_id > attempt.checkpoint_id)
+        .cloned()
+}
+
+impl LeaderLeaseStore {
+    /// Return the exact immutable outcome for `attempt`, or the first audited terminal outcome
+    /// known to close that older checkpoint. Compacted continuity anchors are included in the
+    /// audit.
+    ///
+    /// # Errors
+    /// Returns an error for a noncanonical attempt identity or an unavailable or invalid durable
+    /// authority chain.
+    pub async fn cluster_attempt_settlement(
+        &self,
+        attempt: CheckpointAttempt,
+    ) -> Result<Option<CheckpointOutcome>, ClusterCheckpointAuthorityError> {
+        if !attempt.is_canonical() {
+            return Err(DecisionError::Conflict(
+                "cluster checkpoint settlement requires one nonzero canonical checkpoint ID".into(),
+            )
+            .into());
+        }
+        let outcomes = self.audited_cluster_outcomes().await?.1;
+        Ok(settlement_from_outcomes(attempt, &outcomes))
+    }
+
+    /// Audit the settlement and commit authority of one admitted cluster checkpoint attempt.
+    ///
+    /// Unlike [`Self::cluster_attempt_settlement`], this distinguishes a live pending attempt from
+    /// an attempt whose admitting leader term has been durably superseded. The distinction is
+    /// emitted only when the same audited authority head both retains the exact artifact inventory
+    /// and proves that its admitting leader proof no longer owns the lease.
+    ///
+    /// # Errors
+    /// Returns an error for malformed identities, an unavailable or invalid authority chain, or an
+    /// unsettled attempt that does not exactly match the retained artifact inventory.
+    pub async fn cluster_attempt_status(
+        &self,
+        attempt: CheckpointAttempt,
+        assignment_fence: &CheckpointAssignmentFence,
+        leader_proof: &LeaderProof,
+    ) -> Result<ClusterAttemptStatus, ClusterCheckpointAuthorityError> {
+        if !attempt.is_canonical() {
+            return Err(DecisionError::Conflict(
+                "cluster checkpoint status requires one nonzero canonical checkpoint ID".into(),
+            )
+            .into());
+        }
+        if !assignment_fence.is_canonical() {
+            return Err(DecisionError::Conflict(
+                "cluster checkpoint status requires a canonical assignment fence".into(),
+            )
+            .into());
+        }
+        if !leader_proof.is_canonical() {
+            return Err(ClusterCheckpointAuthorityError::Fenced);
+        }
+        if assignment_fence.participant_incarnation(leader_proof.owner.node_id)
+            != Some(leader_proof.owner.boot_id)
+        {
+            return Err(DecisionError::Conflict(
+                "cluster checkpoint status leader is outside the assignment fence".into(),
+            )
+            .into());
+        }
+
+        let (head, outcomes) = self.audited_cluster_outcomes().await?;
+        if let Some(settlement) = settlement_from_outcomes(attempt, &outcomes) {
+            return Ok(ClusterAttemptStatus::Settled(Box::new(settlement)));
+        }
+        let head = head.ok_or(ClusterCheckpointAuthorityError::Fenced)?;
+        let active = head.active_checkpoint_artifacts.as_ref().ok_or_else(|| {
+            DecisionError::Conflict(format!(
+                "unsettled cluster checkpoint {} has no active artifact inventory",
+                attempt.checkpoint_id
+            ))
+        })?;
+        if active.attempt != attempt
+            || active.assignment_fence.as_ref() != Some(assignment_fence)
+            || head.active_checkpoint_artifact_leader_proof.as_ref() != Some(leader_proof)
+        {
+            return Err(DecisionError::Conflict(format!(
+                "unsettled cluster checkpoint {} does not match its admitted artifact authority",
+                attempt.checkpoint_id
+            ))
+            .into());
+        }
+        if head.lease.matches_proof(leader_proof) {
+            Ok(ClusterAttemptStatus::Pending)
+        } else {
+            Ok(ClusterAttemptStatus::CommitFenced)
+        }
+    }
+}

--- a/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
@@ -1,8 +1,10 @@
 //! Durable, append-only leader fencing.
 
 mod artifact_admission;
+mod attempt_status;
 mod subscription_replay;
 
+pub use attempt_status::ClusterAttemptStatus;
 pub use subscription_replay::{
     SubscriptionReplayPin, SubscriptionReplayPinAcquire, SUBSCRIPTION_REPLAY_PIN_RENEW_INTERVAL,
 };
@@ -5919,37 +5921,6 @@ impl LeaderLeaseStore {
         &self,
     ) -> Result<Option<CheckpointOutcome>, ClusterCheckpointAuthorityError> {
         Ok(self.audited_cluster_outcomes().await?.1.last().cloned())
-    }
-
-    /// Return the exact immutable outcome for `attempt`, or the first audited terminal outcome
-    /// known to close that older checkpoint. Compacted continuity anchors are included in the
-    /// audit.
-    ///
-    /// # Errors
-    /// Returns an error for a noncanonical attempt identity or an unavailable or invalid durable
-    /// authority chain.
-    pub async fn cluster_attempt_settlement(
-        &self,
-        attempt: crate::checkpoint::CheckpointAttempt,
-    ) -> Result<Option<CheckpointOutcome>, ClusterCheckpointAuthorityError> {
-        if !attempt.is_canonical() {
-            return Err(DecisionError::Conflict(
-                "cluster checkpoint settlement requires one nonzero canonical checkpoint ID".into(),
-            )
-            .into());
-        }
-        let outcomes = self.audited_cluster_outcomes().await?.1;
-        if let Ok(index) = outcomes.binary_search_by_key(&attempt.epoch, |outcome| outcome.epoch) {
-            return Ok(Some(outcomes[index].clone()));
-        }
-        let Some(highest) = outcomes.last() else {
-            return Ok(None);
-        };
-        if highest.checkpoint_id > attempt.checkpoint_id {
-            Ok(Some(highest.clone()))
-        } else {
-            Ok(None)
-        }
     }
 
     fn cleanup_participant_ids(

--- a/crates/laminar-core/src/cluster/control/leader_lease/tests.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/tests.rs
@@ -4866,6 +4866,87 @@ async fn delayed_artifact_admission_cannot_reopen_a_durable_abort() {
 }
 
 #[tokio::test]
+async fn cluster_attempt_status_fences_commit_after_takeover_without_an_outcome() {
+    let store = store(10);
+    let incumbent = owner(1, 1, 1);
+    let successor = owner(2, 2, 1);
+    let LeaseOutcome::Acquired(first) = store.begin_new_term(&incumbent, 0).await.unwrap() else {
+        unreachable!()
+    };
+    let proof = first.proof();
+    let fence = assignment_fence(&incumbent);
+    let inventory = begin_checkpoint_artifacts(&store, &proof, &fence, 1).await;
+    assert_eq!(
+        store
+            .cluster_attempt_status(inventory.attempt, &fence, &proof)
+            .await
+            .unwrap(),
+        ClusterAttemptStatus::Pending
+    );
+
+    let observation = store.observe_rival(&successor, &first).unwrap();
+    tokio::time::sleep(Duration::from_millis(15)).await;
+    assert!(matches!(
+        store
+            .try_takeover(&successor, &observation, 20)
+            .await
+            .unwrap(),
+        LeaseOutcome::Acquired(_)
+    ));
+    assert_eq!(
+        store
+            .cluster_attempt_status(inventory.attempt, &fence, &proof)
+            .await
+            .unwrap(),
+        ClusterAttemptStatus::CommitFenced
+    );
+    assert!(store
+        .cluster_attempt_settlement(inventory.attempt)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn cluster_attempt_status_retains_commit_when_it_wins_before_takeover() {
+    let store = store(10);
+    let incumbent = owner(1, 1, 1);
+    let successor = owner(2, 2, 1);
+    let LeaseOutcome::Acquired(first) = store.begin_new_term(&incumbent, 0).await.unwrap() else {
+        unreachable!()
+    };
+    let proof = first.proof();
+    let fence = assignment_fence(&incumbent);
+    let committed = match record_commit(&store, &proof, &fence, 1, 1).await {
+        RecordOutcomeResult::Created(outcome) | RecordOutcomeResult::Unchanged(outcome) => outcome,
+        RecordOutcomeResult::Conflict { winner } => {
+            panic!("unexpected checkpoint outcome winner: {winner:?}")
+        }
+    };
+
+    let observation = store.observe_rival(&successor, &first).unwrap();
+    tokio::time::sleep(Duration::from_millis(15)).await;
+    assert!(matches!(
+        store
+            .try_takeover(&successor, &observation, 20)
+            .await
+            .unwrap(),
+        LeaseOutcome::Acquired(_)
+    ));
+    assert_eq!(
+        store
+            .cluster_attempt_status(
+                crate::checkpoint::CheckpointAttempt::canonical(1),
+                &fence,
+                &proof,
+            )
+            .await
+            .unwrap(),
+        ClusterAttemptStatus::Settled(Box::new(committed))
+    );
+}
+
+#[tokio::test]
 async fn takeover_can_only_abort_the_exact_active_checkpoint_inventory() {
     let store = store(10);
     let incumbent = owner(1, 1, 1);

--- a/crates/laminar-core/src/cluster/control/mod.rs
+++ b/crates/laminar-core/src/cluster/control/mod.rs
@@ -41,10 +41,10 @@ pub use leader::leader_of;
 pub use leader_lease::{
     lease_grants_leadership, lease_grants_proof, AssignmentDrainDecision, AssignmentDrainVerdict,
     AssignmentRecoveryDecision, ClusterArtifactCleanupCursor, ClusterArtifactCleanupPhase,
-    ClusterCheckpointAuthorityError, ClusterOutcomeInventory, ClusterOutcomeRetentionBoundary,
-    LeaderCandidacy, LeaderLease, LeaderLeaseConfig, LeaderLeaseManager, LeaderLeaseObservation,
-    LeaderLeaseOwner, LeaderLeaseStore, LeaseError, LeaseOutcome,
-    RecordAssignmentDrainDecisionResult, RecordAssignmentRecoveryDecisionResult,
+    ClusterAttemptStatus, ClusterCheckpointAuthorityError, ClusterOutcomeInventory,
+    ClusterOutcomeRetentionBoundary, LeaderCandidacy, LeaderLease, LeaderLeaseConfig,
+    LeaderLeaseManager, LeaderLeaseObservation, LeaderLeaseOwner, LeaderLeaseStore, LeaseError,
+    LeaseOutcome, RecordAssignmentDrainDecisionResult, RecordAssignmentRecoveryDecisionResult,
     SubscriptionReplayPin, SubscriptionReplayPinAcquire, SUBSCRIPTION_REPLAY_PIN_RENEW_INTERVAL,
 };
 pub use lease_deadline::LeaseDeadline;

--- a/crates/laminar-db/src/checkpoint_coordinator/follower_protocol.rs
+++ b/crates/laminar-db/src/checkpoint_coordinator/follower_protocol.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use laminar_core::checkpoint::{CheckpointAttempt, CheckpointAttemptRelation, LeaderProof};
-use laminar_core::cluster::control::{BarrierAnnouncement, Phase, QuorumOutcome};
+use laminar_core::cluster::control::{
+    BarrierAnnouncement, ClusterAttemptStatus, LeaderLeaseStore, Phase, QuorumOutcome,
+};
 
 use super::{
     require_canonical_attempt, sink_epoch_admission, CheckpointCoordinator, CheckpointRequest,
@@ -210,7 +212,7 @@ impl CheckpointCoordinator {
         let prepare_outcome = self
             .follower_prepare_acked_until(
                 request,
-                proof,
+                proof.clone(),
                 announcement.epoch,
                 announcement.checkpoint_id,
                 deadline,
@@ -267,6 +269,7 @@ impl CheckpointCoordinator {
             announcement.epoch,
             announcement.checkpoint_id,
             &fence,
+            &proof,
             decision_timeout,
         )
         .await
@@ -296,14 +299,79 @@ impl CheckpointCoordinator {
         result
     }
 
+    async fn verify_follower_settlement(
+        controller: &laminar_core::cluster::control::ClusterController,
+        authority: &LeaderLeaseStore,
+        attempt: CheckpointAttempt,
+        assignment_fence: &laminar_core::checkpoint::CheckpointAssignmentFence,
+        settlement: laminar_core::checkpoint_decision::CheckpointOutcome,
+        deadline: tokio::time::Instant,
+    ) -> Result<bool, DbError> {
+        use laminar_core::checkpoint_decision::CheckpointVerdict;
+
+        let settled = CheckpointAttempt::new(settlement.epoch, settlement.checkpoint_id);
+        match settled.relation_to(attempt) {
+            CheckpointAttemptRelation::Exact if settlement.verdict == CheckpointVerdict::Abort => {
+                Ok(false)
+            }
+            CheckpointAttemptRelation::Exact => {
+                let exact = tokio::time::timeout_at(
+                    deadline,
+                    authority.cluster_outcome_with_committed_checkpoint(attempt.epoch),
+                )
+                .await
+                .map_err(|_| DbError::Checkpoint("follower committed-index read timed out".into()))?
+                .map_err(|error| {
+                    DbError::Checkpoint(format!("follower committed-index read failed: {error}"))
+                })?
+                .ok_or_else(|| {
+                    DbError::Checkpoint("Commit outcome has no committed checkpoint index".into())
+                })?;
+                let (outcome, index) = exact;
+                let index = index.ok_or_else(|| {
+                    DbError::Checkpoint("Commit outcome has no committed checkpoint body".into())
+                })?;
+                if outcome != settlement
+                    || outcome.assignment_fence.as_ref() != Some(assignment_fence)
+                    || index.epoch != attempt.epoch
+                    || index.checkpoint_id != attempt.checkpoint_id
+                    || index.assignment_fence.as_ref() != Some(assignment_fence)
+                    || !index
+                        .participants
+                        .iter()
+                        .any(|participant| participant.participant_id == controller.instance_id().0)
+                {
+                    return Err(DbError::Checkpoint(
+                        "follower Commit does not match its prepared participant cut".into(),
+                    ));
+                }
+                index.validate().map_err(DbError::Checkpoint)?;
+                let source_watermarks = index
+                    .effective_source_watermarks()
+                    .map_err(DbError::Checkpoint)?;
+                controller
+                    .publish_committed_checkpoint_progress(
+                        &index.channel_progress,
+                        &source_watermarks,
+                    )
+                    .map_err(DbError::Checkpoint)?;
+                Ok(true)
+            }
+            CheckpointAttemptRelation::Newer => Ok(false),
+            CheckpointAttemptRelation::Older | CheckpointAttemptRelation::Conflict => Err(
+                DbError::Checkpoint("follower observed an incompatible terminal checkpoint".into()),
+            ),
+        }
+    }
+
     pub(crate) async fn await_follower_decision(
         controller: &laminar_core::cluster::control::ClusterController,
         epoch: u64,
         checkpoint_id: u64,
         assignment_fence: &laminar_core::checkpoint::CheckpointAssignmentFence,
+        leader_proof: &LeaderProof,
         decision_timeout: Duration,
     ) -> Result<bool, DbError> {
-        use laminar_core::checkpoint_decision::CheckpointVerdict;
         let attempt = require_canonical_attempt(
             CheckpointAttempt::new(epoch, checkpoint_id),
             "follower decision",
@@ -315,88 +383,53 @@ impl CheckpointCoordinator {
                 "follower decision has an invalid assignment fence".into(),
             ));
         }
+        if !leader_proof.is_canonical()
+            || assignment_fence.participant_incarnation(leader_proof.owner.node_id)
+                != Some(leader_proof.owner.boot_id)
+        {
+            return Err(DbError::Checkpoint(
+                "follower decision has an invalid leader proof".into(),
+            ));
+        }
         let authority = controller.checkpoint_authority().map_err(|error| {
             DbError::Checkpoint(format!("follower checkpoint authority: {error}"))
         })?;
         let deadline = tokio::time::Instant::now() + decision_timeout;
         loop {
-            let settlement =
-                tokio::time::timeout_at(deadline, authority.cluster_attempt_settlement(attempt))
-                    .await
-                    .map_err(|_| {
-                        DbError::Checkpoint(format!(
-                            "follower decision timed out for checkpoint {checkpoint_id}"
-                        ))
-                    })?
-                    .map_err(|error| {
-                        DbError::Checkpoint(format!("follower decision read failed: {error}"))
-                    })?;
-            if let Some(settlement) = settlement {
-                let settled = CheckpointAttempt::new(settlement.epoch, settlement.checkpoint_id);
-                match settled.relation_to(attempt) {
-                    CheckpointAttemptRelation::Exact
-                        if settlement.verdict == CheckpointVerdict::Abort =>
-                    {
-                        return Ok(false);
-                    }
-                    CheckpointAttemptRelation::Exact => {
-                        let exact = tokio::time::timeout_at(
-                            deadline,
-                            authority.cluster_outcome_with_committed_checkpoint(epoch),
-                        )
-                        .await
-                        .map_err(|_| {
-                            DbError::Checkpoint("follower committed-index read timed out".into())
-                        })?
-                        .map_err(|error| {
-                            DbError::Checkpoint(format!(
-                                "follower committed-index read failed: {error}"
-                            ))
-                        })?
-                        .ok_or_else(|| {
-                            DbError::Checkpoint(
-                                "Commit outcome has no committed checkpoint index".into(),
-                            )
-                        })?;
-                        let (outcome, index) = exact;
-                        let index = index.ok_or_else(|| {
-                            DbError::Checkpoint(
-                                "Commit outcome has no committed checkpoint body".into(),
-                            )
-                        })?;
-                        if outcome != settlement
-                            || outcome.assignment_fence.as_ref() != Some(assignment_fence)
-                            || index.epoch != epoch
-                            || index.checkpoint_id != checkpoint_id
-                            || index.assignment_fence.as_ref() != Some(assignment_fence)
-                            || !index.participants.iter().any(|participant| {
-                                participant.participant_id == controller.instance_id().0
-                            })
-                        {
-                            return Err(DbError::Checkpoint(
-                                "follower Commit does not match its prepared participant cut"
-                                    .into(),
-                            ));
-                        }
-                        index.validate().map_err(DbError::Checkpoint)?;
-                        let source_watermarks = index
-                            .effective_source_watermarks()
-                            .map_err(DbError::Checkpoint)?;
-                        controller
-                            .publish_committed_checkpoint_progress(
-                                &index.channel_progress,
-                                &source_watermarks,
-                            )
-                            .map_err(DbError::Checkpoint)?;
-                        return Ok(true);
-                    }
-                    CheckpointAttemptRelation::Newer => return Ok(false),
-                    CheckpointAttemptRelation::Older | CheckpointAttemptRelation::Conflict => {
-                        return Err(DbError::Checkpoint(
-                            "follower observed an incompatible terminal checkpoint".into(),
-                        ));
-                    }
+            let status = tokio::time::timeout_at(
+                deadline,
+                authority.cluster_attempt_status(attempt, assignment_fence, leader_proof),
+            )
+            .await
+            .map_err(|_| {
+                DbError::Checkpoint(format!(
+                    "follower decision timed out for checkpoint {checkpoint_id}"
+                ))
+            })?
+            .map_err(|error| {
+                DbError::Checkpoint(format!("follower decision read failed: {error}"))
+            })?;
+            let settlement = match status {
+                ClusterAttemptStatus::Pending => None,
+                ClusterAttemptStatus::Settled(settlement) => Some(*settlement),
+                ClusterAttemptStatus::CommitFenced => {
+                    return Err(DbError::Checkpoint(format!(
+                        "follower checkpoint {checkpoint_id} leader term was durably superseded \
+                         before a terminal outcome; coordinated recovery must settle the \
+                         in-doubt checkpoint"
+                    )));
                 }
+            };
+            if let Some(settlement) = settlement {
+                return Self::verify_follower_settlement(
+                    controller,
+                    authority.as_ref(),
+                    attempt,
+                    assignment_fence,
+                    settlement,
+                    deadline,
+                )
+                .await;
             }
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {

--- a/crates/laminar-db/src/pipeline_callback/mod.rs
+++ b/crates/laminar-db/src/pipeline_callback/mod.rs
@@ -2307,6 +2307,7 @@ impl ConnectorPipelineCallback {
             attempt.epoch,
             attempt.checkpoint_id,
             &assignment_fence,
+            &tail.identity.leader_proof,
             decision_timeout,
         )
         .await?;
@@ -2716,6 +2717,7 @@ impl ConnectorPipelineCallback {
         prepared_wait_timeout: std::time::Duration,
     ) -> Result<(), String> {
         use laminar_core::cluster::control::Phase;
+        use tokio::time::Instant;
 
         // The gate must outlast the leader's quorum wait: a slow-but-successful alignment that lands
         // `Aligned` AFTER the follower resumes would let epoch-N+1 shuffle rows cross a peer's
@@ -2723,7 +2725,7 @@ impl ConnectorPipelineCallback {
         // the durable-Prepared wait so the gate can never expire first (CL-6).
         let resume_gate_timeout = std::time::Duration::from_secs(10)
             .max(prepared_wait_timeout + std::time::Duration::from_secs(5));
-        let resume_gate_deadline = tokio::time::Instant::now() + resume_gate_timeout;
+        let resume_gate_deadline = Instant::now() + resume_gate_timeout;
 
         if !has_cluster_shuffle {
             return Ok(());
@@ -2757,9 +2759,8 @@ impl ConnectorPipelineCallback {
                             Phase::Prepare => false,
                         },
                         CheckpointAttemptRelation::Exact => match a.phase {
-                            // A successor may durably abort an attempt prepared by the old
-                            // leader. The terminal record is only a wake-up hint; durable outcome
-                            // validation owns its authority and performs the rollback.
+                            // A successor may abort an old leader's attempt. The terminal record
+                            // only wakes the follower; durable outcome validation owns rollback.
                             Phase::Abort => a.flags == identity.flags,
                             Phase::Aligned => {
                                 a.flags == identity.flags
@@ -2798,8 +2799,7 @@ impl ConnectorPipelineCallback {
             && released.checkpoint_id == identity.attempt.checkpoint_id
             && matches!(released.phase, Phase::Commit | Phase::Abort)
         {
-            let remaining =
-                resume_gate_deadline.saturating_duration_since(tokio::time::Instant::now());
+            let remaining = resume_gate_deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(format!(
                     "checkpoint {} epoch {} exhausted its shuffle resume deadline before the \
@@ -2812,6 +2812,7 @@ impl ConnectorPipelineCallback {
                 identity.attempt.epoch,
                 identity.attempt.checkpoint_id,
                 assignment_fence,
+                &identity.leader_proof,
                 remaining,
             )
             .await
@@ -2852,8 +2853,7 @@ impl ConnectorPipelineCallback {
                     released.epoch
                 ));
             }
-            let remaining =
-                resume_gate_deadline.saturating_duration_since(tokio::time::Instant::now());
+            let remaining = resume_gate_deadline.saturating_duration_since(Instant::now());
             let certified = tokio::time::timeout(
                 remaining,
                 controller.checkpoint_assignment_fence_for_leader(

--- a/crates/laminar-db/src/pipeline_callback/tests.rs
+++ b/crates/laminar-db/src/pipeline_callback/tests.rs
@@ -6651,8 +6651,23 @@ async fn terminal_hint_without_an_outcome_does_not_release_the_resume_gate() {
     use laminar_core::cluster::control::{BarrierAnnouncement, Phase, ANNOUNCEMENT_KEY};
 
     for phase in [Phase::Commit, Phase::Abort] {
-        let (kv, controller, leader_id, _members_tx, _decision_store) = gate_controller().await;
+        let (kv, controller, leader_id, _members_tx, decision_store) = gate_controller().await;
         let (prepared_fence, identity) = resume_identity(3, 3);
+        controller
+            .checkpoint_authority()
+            .unwrap()
+            .begin_cluster_checkpoint_artifacts(
+                &identity.leader_proof,
+                laminar_core::checkpoint_decision::CheckpointArtifactInventory {
+                    deployment_id: decision_store.load_or_create_deployment_id().await.unwrap(),
+                    pipeline_identity: laminar_core::checkpoint::PipelineIdentity::empty(),
+                    attempt: identity.attempt,
+                    assignment_fence: Some(prepared_fence.clone()),
+                    sink_artifact_intent_protocol: true,
+                },
+            )
+            .await
+            .unwrap();
         let terminal_fence = if phase == Phase::Commit {
             prepared_fence.clone()
         } else {

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -2578,23 +2578,23 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
         assignment_fence: Some(current.assignment_fence().unwrap()),
         sink_artifact_intent_protocol: true,
     };
+    let predecessor_proof = controller.capture_leader_proof().unwrap();
     authority
-        .begin_cluster_checkpoint_artifacts(
-            &controller.capture_leader_proof().unwrap(),
-            inventory.clone(),
-        )
+        .begin_cluster_checkpoint_artifacts(&predecessor_proof, inventory.clone())
         .await
         .unwrap();
 
     let follower = {
         let controller = Arc::clone(&controller);
         let predecessor = current.assignment_fence().unwrap();
+        let predecessor_proof = predecessor_proof.clone();
         tokio::spawn(Box::pin(async move {
             crate::checkpoint_coordinator::CheckpointCoordinator::await_follower_decision(
                 &controller,
                 attempt.epoch,
                 attempt.checkpoint_id,
                 &predecessor,
+                &predecessor_proof,
                 Duration::from_secs(5),
             )
             .await
@@ -2615,7 +2615,12 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
         error.contains("participant 2 handoff manifest is missing"),
         "{error}"
     );
-    assert!(!follower.await.unwrap().unwrap());
+    match follower.await.unwrap() {
+        Ok(committed) => assert!(!committed),
+        Err(error) => assert!(error
+            .to_string()
+            .contains("leader term was durably superseded")),
+    }
 
     let settlement = authority
         .cluster_attempt_settlement(attempt)
@@ -2645,6 +2650,84 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
     assert_eq!(
         authority.cluster_checkpoint_artifacts().await.unwrap(),
         Some(inventory)
+    );
+}
+
+#[tokio::test]
+async fn follower_stops_waiting_when_checkpoint_commit_authority_is_fenced() {
+    let (
+        _db,
+        controller,
+        _durable,
+        _registry,
+        current,
+        _process_authority,
+        _authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    let authority = controller.checkpoint_authority().unwrap();
+    let committed = authority
+        .highest_cluster_committed_outcome()
+        .await
+        .unwrap()
+        .expect("fixture must publish the predecessor checkpoint");
+    let recovery_index = authority
+        .load_committed_checkpoint(
+            committed
+                .committed_checkpoint
+                .as_ref()
+                .expect("fixture Commit must name its checkpoint index"),
+        )
+        .await
+        .unwrap();
+    let attempt = CheckpointAttempt::canonical(committed.checkpoint_id + 1);
+    let assignment_fence = current.assignment_fence().unwrap();
+    let predecessor_proof = controller.capture_leader_proof().unwrap();
+    authority
+        .begin_cluster_checkpoint_artifacts(
+            &predecessor_proof,
+            CheckpointArtifactInventory {
+                deployment_id: recovery_index.deployment_id,
+                pipeline_identity: recovery_index.pipeline_identity,
+                attempt,
+                assignment_fence: Some(assignment_fence.clone()),
+                sink_artifact_intent_protocol: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    let replacement_owner = laminar_core::cluster::control::LeaderLeaseOwner {
+        node: controller.instance_id(),
+        boot: controller.recovery_incarnation(),
+        process_term: 1,
+    };
+    assert!(matches!(
+        authority
+            .begin_new_term(&replacement_owner, 1)
+            .await
+            .unwrap(),
+        laminar_core::cluster::control::LeaseOutcome::Acquired(_)
+    ));
+    let error = tokio::time::timeout(
+        Duration::from_secs(1),
+        crate::checkpoint_coordinator::CheckpointCoordinator::await_follower_decision(
+            &controller,
+            attempt.epoch,
+            attempt.checkpoint_id,
+            &assignment_fence,
+            &predecessor_proof,
+            Duration::from_secs(5),
+        ),
+    )
+    .await
+    .expect("fenced follower decision must not consume its settlement timeout")
+    .expect_err("a superseded leader cannot commit its in-doubt checkpoint");
+    assert!(
+        error
+            .to_string()
+            .contains("leader term was durably superseded"),
+        "{error}"
     );
 }
 


### PR DESCRIPTION
## Summary

- distinguish a live pending checkpoint from an in-doubt attempt whose admitting leader term has been durably superseded
- stop follower tails promptly after takeover while leaving authoritative Abort publication and cleanup to coordinated recovery
- preserve Commit authority when the old leader wins the append-only authority race before takeover
- keep terminal barrier hints subordinate to durable checkpoint authority

## Why

Azure native fault run 34097871072 showed follower tails waiting through the full checkpoint and cleanup windows after the leader was killed. Recovery waited for those tails to stop before publishing the predecessor Abort, leaving no time to restart inside the configured recovery bound.

Takeover and checkpoint outcome publication already serialize through the same append-only authority head. A single audited head can therefore prove that an old leader term can no longer publish Commit without inventing an Abort or weakening fail-closed recovery.

## Validation

- `cargo test -p laminar-core --features cluster --lib` (946 passed)
- `cargo test -p laminar-db --no-default-features --features cluster --lib` (1,801 passed)
- `cargo clippy -p laminar-core --features cluster --all-targets -- -D warnings`
- `cargo clippy -p laminar-db --no-default-features --features cluster --all-targets -- -D warnings`
- `cargo check -p laminar-core --no-default-features`
- `cargo check -p laminar-db --no-default-features`
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`

## Certification impact

No delivery admission changes. After merge, the Azure native checkpoint workflow must pass against the exact merge commit before its evidence status can change.


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes follower checkpoint decision loops that could keep waiting after a leader takeover, so a superseded leader can no longer act as a commit authority.

**Bug Fixes**
- Follower decision now errors when the admitting leader term is durably superseded before a terminal outcome, leaving the in-doubt checkpoint to coordinated recovery.
- The shuffle resume gate fails fast on a fenced leader instead of waiting out its deadline.
- Rebalance recovery accepts the fenced-leader error when an unresolved predecessor races a takeover.

**Refactors**
- Adds `ClusterAttemptStatus` with `Pending`, `Settled`, and `CommitFenced` states and moves settlement lookup into a new `attempt_status` module without changing `cluster_attempt_settlement` behavior.
- Follower decision and resume gate now validate the leader proof against the assignment fence and pass it to the status query.

<sup>Written for commit 63f008d09edce08096aaaf4f8a2a7679104d2a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint attempt status reporting for pending, completed, and commit-fenced attempts.
  * Added validation to ensure checkpoint decisions are tied to the correct leader and assignment.

* **Bug Fixes**
  * Followers now detect leadership changes while awaiting checkpoint outcomes and stop promptly instead of waiting for the full timeout.
  * Preserved valid committed outcomes across leader takeovers while preventing stale attempts from being accepted.

* **Tests**
  * Added coverage for leader replacement, committed outcomes, and in-doubt checkpoint recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->