### PR TITLE
fix(cluster): align cloud recovery control deadlines

### DIFF
--- a/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
@@ -6585,8 +6585,11 @@ pub struct LeaderLeaseConfig {
 impl Default for LeaderLeaseConfig {
     fn default() -> Self {
         Self {
-            ttl: Duration::from_secs(5),
-            renew_interval: Duration::from_secs(2),
+            // Keep one full five-second control-I/O window after the renewal tick. Native cloud
+            // stores can legitimately consume that window while applying their bounded retry
+            // policy; expiring sooner would turn a transport tail into a needless leader term.
+            ttl: Duration::from_secs(15),
+            renew_interval: Duration::from_secs(5),
         }
     }
 }

--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -1707,7 +1707,7 @@ impl RecoveryMonitor {
             db,
             controller,
             &round.assignment_fence,
-            crate::rebalance::RebalanceConfig::default(),
+            checkpoint_bounded_rebalance_config(db),
         )
         .await
         {
@@ -3323,6 +3323,13 @@ async fn read_committed_target_bounded(
         .map_err(|_| {
             format!("decision-store recovery read timed out after {DECISION_IO_TIMEOUT:?}")
         })?
+}
+
+fn checkpoint_bounded_rebalance_config(db: &LaminarDB) -> crate::rebalance::RebalanceConfig {
+    crate::rebalance::RebalanceConfig {
+        checkpoint_timeout: crate::pipeline_lifecycle::configured_checkpoint_timeout(&db.config),
+        ..crate::rebalance::RebalanceConfig::default()
+    }
 }
 
 async fn read_recovery_gen(controller: &ClusterController) -> Result<u64, String> {

--- a/crates/laminar-db/src/pipeline_lifecycle/mod.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle/mod.rs
@@ -62,7 +62,9 @@ fn checked_pipeline_deadline(
 }
 
 #[cfg(feature = "cluster")]
-fn configured_checkpoint_timeout(config: &crate::config::LaminarConfig) -> std::time::Duration {
+pub(crate) fn configured_checkpoint_timeout(
+    config: &crate::config::LaminarConfig,
+) -> std::time::Duration {
     config
         .checkpoint
         .as_ref()

--- a/crates/laminar-db/src/pipeline_lifecycle/startup.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle/startup.rs
@@ -1,7 +1,7 @@
 use super::{
-    panic_message, publish_runtime_fault_state, required_recovery_scope, Arc,
-    CheckpointStorageScope, DbError, DbState, DeliveryGuarantee, FutureExt, HashMap, LaminarDB,
-    PipelineLifecycleAuthority, RuntimeMode, StartupAttempt, StartupDriverGuard,
+    checked_pipeline_deadline, panic_message, publish_runtime_fault_state, required_recovery_scope,
+    Arc, CheckpointStorageScope, DbError, DbState, DeliveryGuarantee, FutureExt, HashMap,
+    LaminarDB, PipelineLifecycleAuthority, RuntimeMode, StartupAttempt, StartupDriverGuard,
 };
 #[cfg(feature = "cluster")]
 use super::{report_cluster_terminal_halt, retire_cluster_compute_generation};
@@ -24,6 +24,28 @@ fn checkpoint_store(
         store
     };
     Ok(Box::new(store))
+}
+
+fn validate_checkpoint_timing(
+    config: &laminar_core::streaming::StreamCheckpointConfig,
+) -> Result<(), DbError> {
+    if config.interval_ms == Some(0) {
+        return Err(DbError::Config(
+            "checkpoint.interval_ms must be greater than zero; use None for manual-only".into(),
+        ));
+    }
+    let Some(timeout_ms) = config.timeout_ms else {
+        return Ok(());
+    };
+    if timeout_ms == 0 {
+        return Err(DbError::Config(
+            "checkpoint.timeout_ms must be greater than zero".into(),
+        ));
+    }
+    checked_pipeline_deadline(std::time::Duration::from_millis(timeout_ms), "checkpoint").map_err(
+        |_| DbError::Config("checkpoint.timeout_ms exceeds the platform clock range".into()),
+    )?;
+    Ok(())
 }
 
 impl LaminarDB {
@@ -628,17 +650,7 @@ impl LaminarDB {
                     "checkpoint.max_node_data_bytes was not resolved at construction".into(),
                 )
             })?;
-            if cp_config.interval_ms == Some(0) {
-                return Err(DbError::Config(
-                    "checkpoint.interval_ms must be greater than zero; use None for manual-only"
-                        .into(),
-                ));
-            }
-            if cp_config.timeout_ms == Some(0) {
-                return Err(DbError::Config(
-                    "checkpoint.timeout_ms must be greater than zero".into(),
-                ));
-            }
+            validate_checkpoint_timing(cp_config)?;
             let key_group_count = self.checkpoint_key_groups();
 
             let data_dir = cp_config

--- a/crates/laminar-server/README.md
+++ b/crates/laminar-server/README.md
@@ -73,7 +73,7 @@ pgwire_bind = "127.0.0.1:5433"  # optional; enables Postgres wire protocol for S
 # file:// until remote writer fencing lands. Startup verifies conditional puts.
 url = "file:///tmp/laminardb/checkpoints"
 interval = "30s"
-timeout = "120s" # one deadline across fence, capture, durable decision, and completion
+timeout = "120s" # checkpoint deadline and per-phase cluster assignment-recovery bound
 
 # Provider features, accepted aliases, ambient identity, and native evidence:
 # ../../docs/cloud-object-store-support.md

--- a/crates/laminar-server/src/cluster/bootstrap.rs
+++ b/crates/laminar-server/src/cluster/bootstrap.rs
@@ -586,6 +586,7 @@ pub(super) async fn install_leader_lease_and_bootstrap_catalog(
         install_lease_gate_and_catalog(config, cluster_cfg, identity, runtime, discovery).await?;
     let rebalance_config = fence_startup_and_prepare_recovery_generation(
         cluster_cfg,
+        config.checkpoint.timeout,
         identity,
         db,
         discovery,
@@ -779,6 +780,7 @@ async fn bootstrap_cluster_catalog(
 /// before assignment certification.
 async fn fence_startup_and_prepare_recovery_generation(
     cluster_cfg: &ClusterConfig,
+    checkpoint_timeout: std::time::Duration,
     identity: &mut AcquiredClusterIdentity,
     db: &Arc<LaminarDB>,
     discovery: &mut DiscoveryImpl,
@@ -813,9 +815,22 @@ async fn fence_startup_and_prepare_recovery_generation(
             ));
         }
     }
-    let rebalance_config = laminar_db::rebalance::RebalanceConfig {
-        placement_isolation_tier: cluster_cfg.discovery.placement_isolation_tier,
-        ..laminar_db::rebalance::RebalanceConfig::default()
-    };
+    let rebalance_config = configured_rebalance(
+        cluster_cfg.discovery.placement_isolation_tier,
+        checkpoint_timeout,
+    );
     Ok(rebalance_config)
+}
+
+pub(super) fn configured_rebalance(
+    placement_isolation_tier: usize,
+    checkpoint_timeout: std::time::Duration,
+) -> laminar_db::rebalance::RebalanceConfig {
+    // Recovery materializes checkpoint-backed state against the same object store. Preserve the
+    // operator's explicit durable-I/O bound instead of silently substituting the library default.
+    laminar_db::rebalance::RebalanceConfig {
+        checkpoint_timeout,
+        placement_isolation_tier,
+        ..laminar_db::rebalance::RebalanceConfig::default()
+    }
 }

--- a/crates/laminar-server/src/cluster/tests.rs
+++ b/crates/laminar-server/src/cluster/tests.rs
@@ -2549,6 +2549,26 @@ fn startup_leader_timeout_covers_manager_and_remote_audit_phases() {
     assert_eq!(timeout, std::time::Duration::from_millis(42_375));
 }
 
+#[test]
+fn control_plane_deadlines_reserve_a_full_leader_renewal_io_window() {
+    let config = laminar_core::cluster::control::LeaderLeaseConfig::default();
+    let renewal_budget = config
+        .ttl
+        .checked_sub(config.renew_interval)
+        .expect("the default renewal interval is below the lease TTL");
+
+    assert!(renewal_budget >= OBJECT_STORE_CONTROL_IO_TIMEOUT);
+}
+
+#[test]
+fn control_plane_deadlines_configure_recovery_from_checkpoint_timeout() {
+    let checkpoint_timeout = std::time::Duration::from_secs(73);
+    let config = bootstrap::configured_rebalance(4, checkpoint_timeout);
+
+    assert_eq!(config.checkpoint_timeout, checkpoint_timeout);
+    assert_eq!(config.placement_isolation_tier, 4);
+}
+
 #[tokio::test]
 async fn startup_leader_authority_requires_a_live_full_owner_and_keeps_intake_fenced() {
     use laminar_core::checkpoint::{CheckpointAssignmentFence, CheckpointParticipant};

--- a/crates/laminar-server/src/config/mod.rs
+++ b/crates/laminar-server/src/config/mod.rs
@@ -349,7 +349,7 @@ pub struct CheckpointSection {
     pub url: String,
     #[serde(default = "default_checkpoint_interval", with = "humantime_serde")]
     pub interval: Duration,
-    /// One end-to-end checkpoint-attempt deadline.
+    /// One checkpoint-attempt deadline; cluster assignment recovery phases use the same bound.
     #[serde(default = "default_checkpoint_timeout", with = "humantime_serde")]
     pub timeout: Duration,
     /// Cloud storage credentials/config (e.g., `aws_access_key_id`).

--- a/crates/laminar-server/src/config/tests.rs
+++ b/crates/laminar-server/src/config/tests.rs
@@ -1323,6 +1323,15 @@ fn test_default_values_applied() {
 }
 
 #[test]
+fn checkpoint_timeout_rejects_unrepresentable_deadline() {
+    let mut config: ServerConfig = toml::from_str("").unwrap();
+    config.checkpoint.timeout = Duration::MAX;
+
+    let error = validate_config(&config).unwrap_err().to_string();
+    assert!(error.contains("checkpoint.timeout exceeds the platform clock range"));
+}
+
+#[test]
 fn event_time_durations_use_engine_millisecond_bounds() {
     let parsed: ServerConfig = toml::from_str(
             "[server]\ntemporal_join_idle_history_retention = \"24h\"\nsource_idle_timeout = \"5s\"\nevent_time_max_future_skew = \"30s\"\n",

--- a/crates/laminar-server/src/config/validation.rs
+++ b/crates/laminar-server/src/config/validation.rs
@@ -344,6 +344,11 @@ fn collect_runtime_limit_errors(config: &ServerConfig, errors: &mut Vec<String>)
     }
     if config.checkpoint.timeout.is_zero() {
         errors.push("checkpoint.timeout must be > 0".to_string());
+    } else if tokio::time::Instant::now()
+        .checked_add(config.checkpoint.timeout)
+        .is_none()
+    {
+        errors.push("checkpoint.timeout exceeds the platform clock range".to_string());
     }
     if config.checkpoint.max_node_data_bytes == Some(0) {
         errors.push("checkpoint.max_node_data_bytes must be > 0".to_string());

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -218,7 +218,7 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 81] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 93] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -303,12 +303,60 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 81] = [
         "stopped for recovery round; awaiting target",
     ),
     (
+        "recovery_leader_quiesce_failed",
+        "leader could not quiesce after publishing recovery Prepare",
+    ),
+    (
+        "recovery_stopped_ack_failed",
+        "could not acknowledge recovery Prepare",
+    ),
+    (
         "recovery_stop_quorum_timeout",
         "recovery stop quorum timed out",
     ),
     (
         "recovery_successor_authorized",
         "authorized successor assignment from the last committed cluster cut",
+    ),
+    (
+        "recovery_transition_still_pending",
+        "waits for a local vnode transition",
+    ),
+    (
+        "recovery_closure_serialization_deadline",
+        "timed out serializing assignment authority closure",
+    ),
+    (
+        "recovery_closure_execution_deadline",
+        "timed out draining assignment execution after closure",
+    ),
+    (
+        "recovery_proposal_load_deadline",
+        "recovery proposal load exceeded the materialization deadline",
+    ),
+    (
+        "recovery_assignment_audit_deadline",
+        "recovery assignment audit exceeded the materialization deadline",
+    ),
+    (
+        "recovery_suspension_serialization_deadline",
+        "timed out serializing recovery assignment suspension",
+    ),
+    (
+        "recovery_suspension_execution_deadline",
+        "timed out draining assignment execution after suspension",
+    ),
+    (
+        "recovery_decision_fenced",
+        "cluster checkpoint decision was fenced by a different durable leader term",
+    ),
+    (
+        "recovery_process_lease_lost",
+        "local process lease authority is not live",
+    ),
+    (
+        "recovery_leader_proof_lost",
+        "assignment recovery lost the current durable leader proof",
     ),
     (
         "snapshot_recovery_suspend_failed",
@@ -15851,8 +15899,20 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                checkpoint state serialization timed out: token=secret\n\
                checkpoint source cut is incomplete: credential=secret\n\
                leader announced recovery prepare\n\
+               leader could not quiesce after publishing recovery Prepare\n\
+               could not acknowledge recovery Prepare\n\
                recovery stop quorum timed out\n\
                authorized successor assignment from the last committed cluster cut\n\
+               recovery assignment 2 waits for a local vnode transition\n\
+               timed out serializing assignment authority closure\n\
+               timed out draining assignment execution after closure\n\
+               recovery proposal load exceeded the materialization deadline\n\
+               recovery assignment audit exceeded the materialization deadline\n\
+               timed out serializing recovery assignment suspension\n\
+               timed out draining assignment execution after suspension\n\
+               cluster checkpoint decision was fenced by a different durable leader term\n\
+               local process lease authority is not live\n\
+               assignment recovery lost the current durable leader proof\n\
                snapshot watcher: could not suspend recovery assignment\n\
                snapshot watcher: could not publish recovery fault\n\
                snapshot watcher: could not settle predecessor checkpoint for recovery\n\
@@ -15907,8 +15967,24 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     );
     assert_eq!(counts.get("checkpoint_source_cut_incomplete"), Some(&1));
     assert_eq!(counts.get("recovery_prepare"), Some(&1));
+    assert_eq!(counts.get("recovery_leader_quiesce_failed"), Some(&1));
+    assert_eq!(counts.get("recovery_stopped_ack_failed"), Some(&1));
     assert_eq!(counts.get("recovery_stop_quorum_timeout"), Some(&1));
     assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
+    for marker in [
+        "recovery_transition_still_pending",
+        "recovery_closure_serialization_deadline",
+        "recovery_closure_execution_deadline",
+        "recovery_proposal_load_deadline",
+        "recovery_assignment_audit_deadline",
+        "recovery_suspension_serialization_deadline",
+        "recovery_suspension_execution_deadline",
+        "recovery_decision_fenced",
+        "recovery_process_lease_lost",
+        "recovery_leader_proof_lost",
+    ] {
+        assert_eq!(counts.get(marker), Some(&1), "missing {marker}");
+    }
     assert_eq!(counts.get("snapshot_recovery_suspend_failed"), Some(&1));
     assert_eq!(counts.get("snapshot_recovery_fault_failed"), Some(&1));
     assert_eq!(


### PR DESCRIPTION
## Summary

- reserve a full bounded object-store I/O window between leader-lease renewal and expiry
- apply the configured checkpoint timeout to startup and coordinated assignment recovery instead of the shorter library default
- extend redacted soak diagnostics with fixed recovery-boundary markers
- document that the checkpoint timeout also bounds each cluster assignment-recovery phase

## Native Azure evidence motivating this change

Workflow run `34116071493`, attempts 1 and 2, tested merged commit `d9aa65a700fdb6f129dd38685a3701a596dc6eb2`.

- native Azure object-store conformance: passed, including single-winner conditional create, stale-CAS rejection, fresh-client restart, and cleanup
- deterministic checkpoint fault contract: passed all required boundaries with zero skips
- native three-node process-kill soak: failed after 1 of 2 requested kills
- attempt 2 progressed through successor authorization and assignment rotation to recovery Prepare, then failed to demonstrate progress within the 90-second recovery bound

The logs showed a leader-lease operation deadline and recovery work using a hard-coded 15-second rebalance timeout even though the server checkpoint timeout was 60 seconds. The previous 5-second lease TTL with a 2-second renewal interval left only about three seconds for a renewal, shorter than the existing five-second bounded control-store I/O window.

This PR does **not** certify Azure and does **not** widen any delivery admission. The protected native checkpoint workflow must pass on the exact merged commit first.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-core --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`
- `cargo test -p laminar-server --bin laminardb control_plane_deadlines -j 1`
- `cargo test -p laminar-server --test cluster_soak recovery_log_diagnostics_count_markers_without_copying_log_values -j 1`

All passed locally. The native Azure rerun is intentionally deferred until merge so evidence is bound to the exact production commit.

## Security and compatibility

- diagnostics match only fixed, non-secret log text and never copy log values into evidence
- no credential, URL, endpoint, or object identifier logging was added
- no dependency, feature, URI, or delivery-admission changes
- the longer default leader lease trades slower failover after an unrecoverable leader loss for enough time to honor the existing bounded cloud-I/O retry window

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud cluster recovery failures where leader leases could expire during bounded object-store I/O and where recovery phases used the library-default 15-second checkpoint timeout instead of the configured one.

- Leader lease defaults change from 5-second TTL with 2-second renewal to 15-second TTL with 5-second renewal, reserving a full I/O window after the renewal tick.
- Startup and coordinated assignment recovery now derive their checkpoint timeout from the server configuration instead of `RebalanceConfig::default()`.
- New startup validation rejects zero and clock-range-exceeding checkpoint timeouts before any recovery work begins.
- Redacted soak diagnostics add 12 fixed recovery-boundary markers so failed recoveries are attributable to a specific phase.
- The longer lease trades slower failover after an unrecoverable leader loss for enough time to honor the existing bounded cloud-I/O retry window.

<sup>Written for commit 64fed68020ddcfb65fef9835fae301a31577072e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Recovery and rebalancing now consistently honor the configured checkpoint timeout.
  - Cluster startup applies the checkpoint deadline during recovery coordination.
  - Leader leases now use a 15-second lifetime with renewal every 5 seconds.

- **Documentation**
  - Clarified that checkpoint timeouts apply to individual checkpoint attempts and cluster assignment-recovery phases.

- **Reliability**
  - Added validation for zero or platform-unrepresentable checkpoint timeouts.
  - Expanded recovery diagnostics and coverage for failure and timeout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->