### PR TITLE
fix(recovery): yield stale driver during local stop

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -198,6 +198,13 @@ enum StoppedQuorum {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DriverStopOutcome {
+    Stopped,
+    Failed,
+    LeadershipLost,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RoundDriverAuthority {
     Current,
     Superseded,
@@ -1553,12 +1560,7 @@ impl RecoveryMonitor {
             return;
         }
         tracing::warn!(gen = gen_id, "leader announced recovery prepare");
-        if !stop_for_recovery(db).await {
-            tracing::error!(
-                gen = gen_id,
-                "leader could not quiesce after publishing recovery Prepare; retaining the fence"
-            );
-            retain_stopped_prepare_and_request_retry(db, controller, &round).await;
+        if !quiesce_recovery_driver(db, controller, &round).await {
             return;
         }
         if let Err(error) = announce_stopped_bounded(controller, &round).await {
@@ -2156,10 +2158,7 @@ impl RecoveryMonitor {
             }
 
             if pending.round.id.driver == controller.instance_id() {
-                if !controller.is_leader()
-                    || controller.capture_leader_proof().as_ref()
-                        != Some(&pending.round.leader_proof)
-                {
+                if !recovery_driver_proof_is_current(controller, &pending.round) {
                     return None;
                 }
                 match tokio::time::timeout_at(
@@ -2524,6 +2523,57 @@ async fn stop_and_purge(db: &Arc<LaminarDB>) -> bool {
 async fn stop_for_recovery(db: &Arc<LaminarDB>) -> bool {
     db.fence_coordinated_recovery_lifecycle();
     stop_and_purge(db).await
+}
+
+fn recovery_driver_proof_is_current(controller: &ClusterController, round: &RecoveryRound) -> bool {
+    round.id.driver == controller.instance_id() && controller.proof_is_live(&round.leader_proof)
+}
+
+/// Wait for local quiescence only while this exact driver term remains authoritative. The
+/// lifecycle owner thread outlives a dropped await, so yielding here cannot cancel or overlap it.
+async fn await_recovery_driver_stop(
+    controller: &ClusterController,
+    round: &RecoveryRound,
+    stop: impl std::future::Future<Output = bool>,
+) -> DriverStopOutcome {
+    tokio::pin!(stop);
+    loop {
+        if !recovery_driver_proof_is_current(controller, round) {
+            return DriverStopOutcome::LeadershipLost;
+        }
+        if let Ok(stopped) = tokio::time::timeout(STOP_QUORUM_INITIAL_POLL, stop.as_mut()).await {
+            if !recovery_driver_proof_is_current(controller, round) {
+                return DriverStopOutcome::LeadershipLost;
+            }
+            return if stopped {
+                DriverStopOutcome::Stopped
+            } else {
+                DriverStopOutcome::Failed
+            };
+        }
+    }
+}
+
+async fn quiesce_recovery_driver(
+    db: &Arc<LaminarDB>,
+    controller: &ClusterController,
+    round: &RecoveryRound,
+) -> bool {
+    match await_recovery_driver_stop(controller, round, stop_for_recovery(db)).await {
+        DriverStopOutcome::Stopped => true,
+        DriverStopOutcome::LeadershipLost => {
+            retain_recovery_control_after_leadership_loss(db, controller, round);
+            false
+        }
+        DriverStopOutcome::Failed => {
+            tracing::error!(
+                gen = round.id.generation,
+                "leader could not quiesce after publishing recovery Prepare; retaining the fence"
+            );
+            retain_stopped_prepare_and_request_retry(db, controller, round).await;
+            false
+        }
+    }
 }
 
 async fn install_recovery_start_assignment(
@@ -3964,9 +4014,7 @@ async fn wait_stopped_quorum_until(
     let mut poll = STOP_QUORUM_INITIAL_POLL;
     let mut next_roster_audit = tokio::time::Instant::now();
     loop {
-        if round.id.driver != controller.instance_id()
-            || controller.capture_leader_proof().as_ref() != Some(&round.leader_proof)
-        {
+        if !recovery_driver_proof_is_current(controller, round) {
             return StoppedQuorum::LeadershipLost;
         }
         let local_assignment_is_exact = controller
@@ -4132,9 +4180,7 @@ async fn wait_restored_quorum_until(
 ) -> RecoveryQuorum {
     let round = &start.round;
     loop {
-        if round.id.driver != controller.instance_id()
-            || controller.capture_leader_proof().as_ref() != Some(&round.leader_proof)
-        {
+        if !recovery_driver_proof_is_current(controller, round) {
             return RecoveryQuorum::LeadershipLost;
         }
         let local_assignment_is_exact = controller
@@ -4190,7 +4236,7 @@ async fn wait_restored_quorum_until(
         let owners = round.owners();
         let pending = frozen_pending(&owners, reports, |ack| ack == start);
         if pending.is_empty() {
-            if controller.capture_leader_proof().as_ref() != Some(&round.leader_proof) {
+            if !recovery_driver_proof_is_current(controller, round) {
                 return RecoveryQuorum::LeadershipLost;
             }
             return RecoveryQuorum::Reached;

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -2147,12 +2147,24 @@ async fn leader_stop_wait_yields_on_same_node_leader_term_rotation() {
     controller.announce_recover_prepare(&round).await.unwrap();
     let retained_prepare = kv.read_from(self_id, "control:recover").await.unwrap();
 
+    let (stop_started_tx, stop_started_rx) = tokio::sync::oneshot::channel();
     let waiting = tokio::spawn({
         let controller = Arc::clone(&controller);
         let round = round.clone();
-        async move { await_recovery_driver_stop(&controller, &round, std::future::pending()).await }
+        async move {
+            let stop = async move {
+                stop_started_tx
+                    .send(())
+                    .expect("the driver stop wait must remain live");
+                std::future::pending().await
+            };
+            await_recovery_driver_stop(&controller, &round, stop).await
+        }
     });
-    tokio::task::yield_now().await;
+    tokio::time::timeout(Duration::from_secs(1), stop_started_rx)
+        .await
+        .expect("the driver must begin awaiting its local stop")
+        .expect("the driver stop wait must remain live");
     assert!(
         !waiting.is_finished(),
         "the unfinished local stop must keep the original driver waiting"

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -2130,6 +2130,55 @@ async fn post_start_same_node_leader_term_rotation_retains_control_for_a_success
 }
 
 #[tokio::test]
+async fn leader_stop_wait_yields_on_same_node_leader_term_rotation() {
+    let self_id = NodeId(1);
+    let kv = Arc::new(InMemoryKv::new(self_id));
+    let (_members_tx, members_rx) = watch::channel(Vec::new());
+    let controller = ClusterController::new(self_id, kv.clone(), None, members_rx);
+    install_test_process_deadline(&controller);
+    let backing: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::memory::InMemory::new());
+    let (authority, lease_tx, owner) =
+        install_test_leader_authority_with_watch(&controller, backing).await;
+    let controller = Arc::new(controller);
+    report_test_fault(&controller).await;
+    let round = round_for_current_faults(&controller, 7, &[1]).await;
+    publish_round_roster(&controller, &kv, &round).await;
+    controller.announce_recover_prepare(&round).await.unwrap();
+    let retained_prepare = kv.read_from(self_id, "control:recover").await.unwrap();
+
+    let waiting = tokio::spawn({
+        let controller = Arc::clone(&controller);
+        let round = round.clone();
+        async move { await_recovery_driver_stop(&controller, &round, std::future::pending()).await }
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !waiting.is_finished(),
+        "the unfinished local stop must keep the original driver waiting"
+    );
+
+    let LeaseOutcome::Acquired(rotated) = authority.begin_new_term(&owner, 1).await.unwrap() else {
+        panic!("the current owner must rotate its leader term");
+    };
+    assert_ne!(rotated.proof(), round.leader_proof);
+    lease_tx.send_replace(Some(rotated));
+    assert!(controller.is_leader());
+    assert!(!recovery_driver_proof_is_current(&controller, &round));
+
+    let outcome = tokio::time::timeout(Duration::from_secs(1), waiting)
+        .await
+        .expect("proof rotation must release the old driver's stop wait")
+        .expect("the stop wait task must not panic");
+    assert_eq!(outcome, DriverStopOutcome::LeadershipLost);
+    assert_eq!(
+        kv.read_from(self_id, "control:recover").await.as_deref(),
+        Some(retained_prepare.as_str()),
+        "the successor must inherit the published Prepare"
+    );
+}
+
+#[tokio::test]
 async fn restore_quorum_accepts_an_intentionally_suspended_assignment_certificate() {
     let (controller, _members_tx, kv) = controller(Vec::new()).await;
     report_test_fault(&controller).await;


### PR DESCRIPTION
## What changed

- add a deterministic regression that keeps the recovery driver's local stop pending, rotates the same node to a new durable leader term after Prepare, and requires the old driver to yield within one second while Prepare remains intact
- recheck the exact generation-bound leader proof while local quiescence is in flight
- retain the existing fail-closed Prepare and intake fence for the successor generation when that proof is lost

## Root cause

Native Azure diagnostic run [34221990737](https://github.com/laminardb/laminardb/actions/runs/34221990737) completed the first process kill, then stalled after a successor published Prepare: the peer stopped, but the driver published neither its stopped acknowledgement nor Start before the 90-second recovery bound. The local pipeline stop runs on an independent owner thread and can outlive a leader-term rotation. `drive_round` awaited that stop without observing exact leader-proof loss, so a stale same-node driver could hold the sole recovery monitor and prevent its successor term from driving a fresh generation.

This is the post-kill continuation of #503 and the original native evidence in [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468).

## Fix

The driver now polls the existing exact proof while awaiting the already-bounded local stop. If authority changes, it yields immediately through the existing leadership-loss path. The lifecycle owner thread remains independently fenced until it finishes, so no stop is cancelled or overlapped. No timeout was increased and no diagnostic marker was added.

## Validation

- `cargo test -p laminar-db --features cluster --lib -j 1 leader_term_rotation` (2 passed)
- unchanged three-node ALO process soak against local MinIO/Redpanda: exactly 2/2 kills, final checkpoint 104 plus later checkpoint 107/138, zero record loss, duplicates measured, exit 0
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

The MinIO run is protocol validation only and is not native Azure evidence. Azure checkpoint storage remains uncertified until the post-merge native diagnostic and certification baseline pass.

Delivery admission is unchanged: this PR does not alter Delta or Iceberg admission, connector guarantees, dependencies, Cargo features, linker configuration, or build settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a recovery driver stall where a stale same-node driver could hold the recovery monitor during local stop after a leader-term rotation, preventing the successor from driving a fresh generation. The driver now rechecks the exact leader proof while the local stop is in flight and yields immediately on leadership loss, without changing timeouts or diagnostics.

- Adds a deterministic regression test that holds the driver's local stop wait pending, rotates the same node to a new leader term after Prepare, and requires the old driver to yield within one second.
- Reuses the existing leadership-loss path for the yield; the lifecycle owner thread remains independently fenced.

<sup>Written for commit 9d68ca830f290e29f835533e25358bfdd6817ecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinated recovery when leadership changes during recovery operations.
  * Recovery now exits incomplete stop waits cleanly when the leader term rotates.
  * Preserves recovery control and previously published preparation state for the successor leader.

* **Tests**
  * Added regression coverage for leadership rotation during an unfinished recovery stop wait.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->