### PR TITLE
chore(ci): add codecov configuration and coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI](https://github.com/laminardb/laminardb/actions/workflows/ci.yml/badge.svg)](https://github.com/laminardb/laminardb/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/laminardb/laminardb/badge.svg)](https://codecov.io/gh/laminardb/laminardb)
 [![Crates.io](https://img.shields.io/crates/v/laminar-db.svg)](https://crates.io/crates/laminar-db)
 [![docs.rs](https://docs.rs/laminar-db/badge.svg)](https://docs.rs/laminar-db)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov configuration — reports are uploaded by .github/workflows/coverage.yml.
+# Public-repo status (2026-09-08): active, ~77% line coverage on main.
+
+coverage:
+  status:
+    project:
+      default:
+        # Track the running average; tolerate small movements from test churn
+        # and feature-gated connector paths so only real regressions flag.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # New code should not drag coverage down; generous threshold keeps
+        # large refactors from failing on incidental diff coverage.
+        target: auto
+        threshold: 10%
+
+# Only crates/ is instrumented (cargo llvm-cov --workspace); everything below
+# is outside the production workspace and never carries coverage.
+ignore:
+  - "examples"
+  - "chatbot"
+  - "site"
+  - "tools"
+  - "vendor"
+  - "tests"
+  - "deploy"
+  - "docs"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary

Codecov is already enabled and receiving reports from the Coverage workflow (`cargo-llvm-cov`, ~77% line coverage on main), and `CODECOV_TOKEN` is now set on the repo. This adds the missing repo-level pieces:

- **`codecov.yml`** — project status check (auto target, 1% threshold) and patch status (auto target, 10% threshold), ignoring paths outside the instrumented workspace (`examples`, `chatbot`, `site`, `tools`, `vendor`, `tests`, `deploy`, `docs`), plus PR comment layout. Codecov honors this config once it lands on the default branch.
- **README badge** — links to https://app.codecov.io/gh/laminardb/laminardb (endpoint verified).

No production code changes; the Coverage workflow itself is untouched.

## Verification

- YAML syntax validated
- Badge endpoint returns 200
- Upload path verified end-to-end against today's main run (report accepted and processed on codecov.io)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing Codecov repo config and README badge so coverage status checks, ignore rules, and PR comments take effect.

- Configures project (1% threshold) and patch (10% threshold) status checks, and ignores paths outside the instrumented workspace.
- Adds a README badge linking to the Codecov dashboard.
- No production code changes; the Coverage workflow is untouched.

<sup>Written for commit 6f66139f96060effc5953aa8f3ef588aee609905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Codecov coverage badge to the README, linking to the project’s coverage report.

- **Chores**
  - Added coverage reporting configuration, including status thresholds, exclusions, and pull request comment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->