### PR TITLE
chore(ci): scope workflow permissions and exclude vendored code from CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,9 +95,10 @@ jobs:
           # WHY: vendor/ holds third-party pgwire forks. Their SCRAM/MD5
           # protocol constants and RFC test vectors trip the crypto queries,
           # and security fixes belong upstream — not patched in place where
-          # the next vendor update would clobber them.
+          # the next vendor update would clobber them. The config keys follow
+          # the custom-config-file format: the exclusion key is paths-ignore.
           config: |
-            ignore:
+            paths-ignore:
               - vendor
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -92,6 +92,13 @@ jobs:
         with:
           languages: rust
           build-mode: none
+          # WHY: vendor/ holds third-party pgwire forks. Their SCRAM/MD5
+          # protocol constants and RFC test vectors trip the crypto queries,
+          # and security fixes belong upstream — not patched in place where
+          # the next vendor update would clobber them.
+          config: |
+            ignore:
+              - vendor
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  # Codecov's OIDC fallback for tokenless public-repo uploads.
+  id-token: write
+
 jobs:
   coverage:
     name: Code Coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,13 +12,16 @@ concurrency:
 
 permissions:
   contents: read
-  # Codecov's OIDC fallback for tokenless public-repo uploads.
-  id-token: write
 
 jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    # Job-scoped least privilege: only this job needs the OIDC scope for
+    # Codecov's tokenless upload fallback.
+    permissions:
+      contents: read
+      id-token: write
     env:
       CARGO_INCREMENTAL: 0
       # Coverage instrumentation grows the same large async recovery test frames exercised by CI.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,8 @@ jobs:
   prepare:
     name: Prepare metadata
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       tags: ${{ steps.meta.outputs.tags }}
@@ -79,6 +81,8 @@ jobs:
     needs: prepare
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Addresses the 36 open code-scanning alerts. Review of every alert showed 3 real findings and 33 noise (vendored protocol code, test fixtures, stale taint paths). This PR fixes the real ones and stops the noise at the source:

- **`coverage.yml`** — explicit `permissions: contents: read, id-token: write` (`id-token` backs Codecov's OIDC upload fallback).
- **`docker.yml`** — `contents: read` on the `prepare` and `validate` jobs; `build`/`merge`/`scan` already declared theirs.
- **`codeql.yml`** — `config: ignore: [vendor]`: the vendored pgwire forks contribute 18 alerts (SCRAM RFC 5802 test vectors, PostgreSQL MD5 wire-protocol constants) that are third-party by definition.

The remaining 15 first-party alerts are being dismissed with documented reasons: 10 `used in tests` (fixtures/guards inside `#[cfg(test)]` modules), 4 `false positive` (taint paths referencing symbols that no longer exist in the code), 1 `won't fix` (`load_config` path — operator-trusted input).

## Verification

- All three files pass YAML parsing
- No job loses a scope it uses: build/merge keep `packages: write`, scan keeps `security-events: write`, CodeQL job permissions untouched

## Notes

- If the CodeQL path exclusion does not auto-close the 18 vendor alerts on the next analysis of main, they will be dismissed manually with the same rationale.
- Also improves OpenSSF Scorecard's Token-Permissions check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes GitHub Actions workflow permissions to least-privilege and stops CodeQL from scanning vendored code, clearing out 36 open code-scanning alerts (3 real, 33 noise).

- `coverage.yml` declares workflow-level `contents: read` plus job-scoped `id-token: write` for Codecov's OIDC fallback.
- `docker.yml` adds `contents: read` to the `prepare` and `validate` jobs.
- `codeql.yml` ignores the `vendor` directory via the `paths-ignore` key (the custom-config-file format; the earlier `ignore:` key was silently ineffective), since third-party pgwire forks trigger crypto queries.

<sup>Written for commit b6a97eb5357add56a41b683ba61a1c7427592e1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

