### PR TITLE
fix(cluster): cancel fenced checkpoint tails during recovery

### DIFF
--- a/crates/laminar-db/src/pipeline/callback.rs
+++ b/crates/laminar-db/src/pipeline/callback.rs
@@ -641,6 +641,12 @@ pub trait PipelineCallback: Send + 'static {
         None
     }
 
+    /// Cancel checkpoint tails only after coordinated recovery owns the lifecycle fence.
+    /// Returns whether that fence was observed, so shutdown need not repeat cancellation.
+    fn cancel_checkpoint_tails_for_recovery(&mut self) -> bool {
+        false
+    }
+
     /// Record a checkpoint failure observed by the coordinator. Exactly-once implementations
     /// fault for recovery; weaker guarantees may retain retry-on-next-interval behaviour.
     fn record_checkpoint_failure(&mut self, _checkpoint_id: u64, _reason: &str) {}

--- a/crates/laminar-db/src/pipeline/streaming_coordinator/checkpoint_lifecycle.rs
+++ b/crates/laminar-db/src/pipeline/streaming_coordinator/checkpoint_lifecycle.rs
@@ -345,15 +345,21 @@ impl StreamingCoordinator {
     /// completion before dropping the claim, so waiting for zero and then draining the channel
     /// preserves exact source acknowledgements, public barriers, and manual replies. The tick
     /// handles tails that legitimately terminate without a completion (cluster followers) and
-    /// avoids relying on a channel event after the atomic reaches zero.
+    /// avoids relying on a channel event after the atomic reaches zero. A coordinated recovery
+    /// lifecycle may cancel predecessor tails only after their durable authority is fenced.
     pub(super) async fn settle_checkpoint_tails(
         &mut self,
         callback: &mut impl PipelineCallback,
     ) -> Option<String> {
         let mut continuation_fault = None;
+        let mut recovery_tails_cancelled = false;
         loop {
             self.drain_manual_requests();
             self.fail_waiting_manual("pipeline is stopping; no new checkpoint can be admitted");
+
+            if !recovery_tails_cancelled {
+                recovery_tails_cancelled = callback.cancel_checkpoint_tails_for_recovery();
+            }
 
             while let Some(completion) = self
                 .checkpoint_complete_rx

--- a/crates/laminar-db/src/pipeline_callback/checkpoint_tail.rs
+++ b/crates/laminar-db/src/pipeline_callback/checkpoint_tail.rs
@@ -4,6 +4,71 @@ use super::{
 };
 
 impl ConnectorPipelineCallback {
+    pub(super) fn reap_checkpoint_tail_tasks(&mut self) {
+        while let Some(result) = self.checkpoint_tail_tasks.try_join_next() {
+            if let Err(error) = result {
+                set_checkpoint_fault(
+                    &self.checkpoint_fault,
+                    format!("checkpoint durable tail terminated unexpectedly: {error}"),
+                );
+            }
+        }
+    }
+
+    pub(super) fn spawn_checkpoint_tail(
+        &mut self,
+        tail: impl std::future::Future<Output = ()> + Send + 'static,
+    ) {
+        self.reap_checkpoint_tail_tasks();
+        self.checkpoint_tail_tasks
+            .spawn_on(tail, &self.checkpoint_tail_runtime);
+    }
+
+    pub(super) fn cancel_fenced_checkpoint_tail_tasks(&mut self) -> bool {
+        #[cfg(feature = "cluster")]
+        {
+            use std::sync::atomic::Ordering;
+
+            if !self.coordinated_lifecycle_active.load(Ordering::Acquire) {
+                return false;
+            }
+            self.reap_checkpoint_tail_tasks();
+            let tail_count = self.checkpoint_tail_tasks.len();
+            if tail_count != 0 {
+                tracing::warn!(
+                    tail_count,
+                    "coordinated recovery cancelled fenced checkpoint durable tails"
+                );
+                self.checkpoint_tail_tasks.abort_all();
+            }
+        }
+        true
+    }
+
+    pub(super) async fn settle_spawned_checkpoint_tail_tasks(&mut self) -> Result<(), String> {
+        let mut failures = Vec::new();
+        while let Some(result) = self.checkpoint_tail_tasks.join_next().await {
+            match result {
+                Ok(()) => {}
+                #[cfg(feature = "cluster")]
+                Err(error)
+                    if error.is_cancelled()
+                        && self
+                            .coordinated_lifecycle_active
+                            .load(std::sync::atomic::Ordering::Acquire) => {}
+                Err(error) => failures.push(error.to_string()),
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "checkpoint durable tail task failure: {}",
+                failures.join("; ")
+            ))
+        }
+    }
+
     pub(super) async fn complete_successful_leader_tail(
         tail: &mut LeaderTail,
         result: crate::checkpoint_coordinator::CheckpointResult,

--- a/crates/laminar-db/src/pipeline_callback/mod.rs
+++ b/crates/laminar-db/src/pipeline_callback/mod.rs
@@ -1253,6 +1253,10 @@ pub(crate) struct ConnectorPipelineCallback {
     pub(crate) shutdown_signal: Arc<tokio::sync::Notify>,
     #[cfg(feature = "cluster")]
     pub(crate) cluster_controller: Option<Arc<laminar_core::cluster::control::ClusterController>>,
+    /// Set only while the recovery monitor owns a lifecycle operation under a published round.
+    /// At that point predecessor checkpoint authority is fenced and its pending tails are stale.
+    #[cfg(feature = "cluster")]
+    pub(crate) coordinated_lifecycle_active: Arc<std::sync::atomic::AtomicBool>,
     /// Shared assignment/checkpoint admission boundary. The coordinator carries an owned guard
     /// from its exact assignment audit through durable Prepare and source-barrier installation.
     #[cfg(feature = "cluster")]
@@ -1411,26 +1415,6 @@ impl ConnectorPipelineCallback {
             assignment_version: assignment_fence.assignment_version,
             assignment_digest: assignment_fence.digest(),
         })
-    }
-
-    fn reap_checkpoint_tail_tasks(&mut self) {
-        while let Some(result) = self.checkpoint_tail_tasks.try_join_next() {
-            if let Err(error) = result {
-                set_checkpoint_fault(
-                    &self.checkpoint_fault,
-                    format!("checkpoint durable tail terminated unexpectedly: {error}"),
-                );
-            }
-        }
-    }
-
-    fn spawn_checkpoint_tail(
-        &mut self,
-        tail: impl std::future::Future<Output = ()> + Send + 'static,
-    ) {
-        self.reap_checkpoint_tail_tasks();
-        self.checkpoint_tail_tasks
-            .spawn_on(tail, &self.checkpoint_tail_runtime);
     }
 
     #[cfg(feature = "cluster")]
@@ -6158,22 +6142,12 @@ impl crate::pipeline::PipelineCallback for ConnectorPipelineCallback {
             .or_else(|| self.graph.execution_poison_reason().map(str::to_owned))
     }
 
+    fn cancel_checkpoint_tails_for_recovery(&mut self) -> bool {
+        self.cancel_fenced_checkpoint_tail_tasks()
+    }
+
     async fn settle_checkpoint_tail_tasks(&mut self) -> Result<(), String> {
-        let mut failures = Vec::new();
-        while let Some(result) = self.checkpoint_tail_tasks.join_next().await {
-            match result {
-                Ok(()) => {}
-                Err(error) => failures.push(error.to_string()),
-            }
-        }
-        if failures.is_empty() {
-            Ok(())
-        } else {
-            Err(format!(
-                "checkpoint durable tail task failure: {}",
-                failures.join("; ")
-            ))
-        }
+        self.settle_spawned_checkpoint_tail_tasks().await
     }
 
     fn record_checkpoint_failure(&mut self, checkpoint_id: u64, reason: &str) {

--- a/crates/laminar-db/src/pipeline_callback/tests.rs
+++ b/crates/laminar-db/src/pipeline_callback/tests.rs
@@ -532,6 +532,8 @@ fn empty_callback_fixture() -> ConnectorPipelineCallback {
         #[cfg(feature = "cluster")]
         cluster_controller: None,
         #[cfg(feature = "cluster")]
+        coordinated_lifecycle_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        #[cfg(feature = "cluster")]
         assignment_adoption_lock: Arc::new(tokio::sync::Mutex::new(())),
         #[cfg(feature = "cluster")]
         shuffle_delivery_loss_incidents: None,
@@ -1105,6 +1107,42 @@ async fn checkpoint_tail_settlement_waits_for_terminal_task() {
         settlement.await.unwrap();
     }
 
+    assert!(callback.checkpoint_tail_tasks.is_empty());
+}
+
+#[cfg(feature = "cluster")]
+#[tokio::test]
+async fn coordinated_recovery_cancels_a_fenced_checkpoint_tail() {
+    let mut callback = empty_callback_fixture();
+    let in_flight = Arc::clone(&callback.checkpoint_in_flight);
+    let guard = EpochInFlightGuard::claim(
+        &in_flight,
+        &callback.checkpoint_fault,
+        CheckpointAttempt::canonical(1),
+        std::iter::empty(),
+    )
+    .unwrap();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    callback.spawn_checkpoint_tail(async move {
+        let _guard = guard;
+        started_tx.send(()).unwrap();
+        std::future::pending::<()>().await;
+    });
+    started_rx.await.unwrap();
+
+    callback
+        .coordinated_lifecycle_active
+        .store(true, std::sync::atomic::Ordering::Release);
+    assert!(crate::pipeline::PipelineCallback::cancel_checkpoint_tails_for_recovery(&mut callback));
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        crate::pipeline::PipelineCallback::settle_checkpoint_tail_tasks(&mut callback),
+    )
+    .await
+    .expect("a recovery-fenced tail must not hold shutdown")
+    .unwrap();
+
+    assert_eq!(in_flight.load(std::sync::atomic::Ordering::Acquire), 0);
     assert!(callback.checkpoint_tail_tasks.is_empty());
 }
 
@@ -3468,6 +3506,7 @@ fn cluster_callback_fixture(
             checkpoint_admission_recovering: false,
             shutdown_signal: Arc::new(tokio::sync::Notify::new()),
             cluster_controller: Some(controller),
+            coordinated_lifecycle_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             assignment_adoption_lock: Arc::new(tokio::sync::Mutex::new(())),
             shuffle_delivery_loss_incidents: None,
             shuffle_recovered_delivery_loss_incidents: None,

--- a/crates/laminar-db/src/pipeline_lifecycle/runtime_preparation.rs
+++ b/crates/laminar-db/src/pipeline_lifecycle/runtime_preparation.rs
@@ -2,6 +2,7 @@ use super::{
     Arc, DbError, LaminarDB, PipelineRuntimeSetup, PipelineSinkSetup, PipelineWatermarks,
     PreparedPipelineRuntime, RuntimeMode, TrackedSourceRegistration,
 };
+use std::sync::atomic::AtomicBool;
 
 struct CallbackCollections {
     source_name_arcs: rustc_hash::FxHashMap<usize, Arc<str>>,
@@ -230,6 +231,8 @@ impl LaminarDB {
             #[cfg(feature = "cluster")]
             cluster_controller: callback_controller,
             #[cfg(feature = "cluster")]
+            coordinated_lifecycle_active: Arc::clone(&self.coordinated_lifecycle_active),
+            #[cfg(feature = "cluster")]
             assignment_adoption_lock: Arc::clone(&self.assignment_adoption_lock),
             #[cfg(feature = "cluster")]
             follower_tail: Arc::default(),
@@ -253,9 +256,7 @@ impl LaminarDB {
             checkpoint_tail_runtime: self.control_runtime.handle()?,
             checkpoint_tail_tasks: tokio::task::JoinSet::new(),
             checkpoint_in_flight: Arc::clone(&checkpoint_in_flight),
-            full_vnode_capture_needed: Arc::new(std::sync::atomic::AtomicBool::new(
-                full_vnode_capture_needed,
-            )),
+            full_vnode_capture_needed: Arc::new(AtomicBool::new(full_vnode_capture_needed)),
             epoch_allocator,
             #[cfg(feature = "cluster")]
             quorum_timeout,

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -225,7 +225,7 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 98] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 99] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -303,6 +303,10 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 98] = [
         "coordinated recovery: owner-complete assignment audit failed",
     ),
     ("recovery_prepare", RECOVERY_PREPARE_LOG),
+    (
+        "recovery_checkpoint_tails_cancelled",
+        "coordinated recovery cancelled fenced checkpoint durable tails",
+    ),
     ("recovery_prepare_handoff", RECOVERY_PREPARE_HANDOFF_LOG),
     ("recovery_retry_hold", RECOVERY_RETRY_HOLD_LOG),
     ("recovery_stopped", RECOVERY_STOPPED_LOG),
@@ -16063,6 +16067,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                could not acknowledge recovery Prepare\n\
                recovery stop quorum timed out\n\
                authorized successor assignment from the last committed cluster cut\n\
+               coordinated recovery cancelled fenced checkpoint durable tails\n\
                recovery assignment 2 waits for a local vnode transition\n\
                timed out serializing assignment authority closure\n\
                timed out draining assignment execution after closure\n\
@@ -16140,6 +16145,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     assert_eq!(counts.get("recovery_stopped_ack_failed"), Some(&1));
     assert_eq!(counts.get("recovery_stop_quorum_timeout"), Some(&1));
     assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
+    assert_eq!(counts.get("recovery_checkpoint_tails_cancelled"), Some(&1));
     for marker in [
         "recovery_transition_still_pending",
         "recovery_closure_serialization_deadline",


### PR DESCRIPTION
## Reproduction

The existing ignored `three_node_follower_checkpoint_fault_recovery_release_regression` reproduces the recovery sequence without Azure: it starts three nodes, commits checkpoints, injects the existing follower checkpoint fault, and requires Prepare, the exact stopped quorum, Start, Release, reopened intake, a live leader, and later checkpoints under the bounded recovery ceiling.

This is the local regression for the native Azure failure in run 34286016773, following the original failed evidence in run 34162984468.

## Root cause

During pipeline stop, `StreamingCoordinator::settle_checkpoint_tails` waited for the in-flight checkpoint counter to reach zero before joining durable tail tasks. A tail blocked in cloud object-store I/O could retain its in-flight guard after the successor had already published recovery Prepare. The successor therefore never published its own Stopped acknowledgement, leaving Start and Release unreachable.

## Fix

Once the existing coordinated-lifecycle fence is active, cancel predecessor checkpoint tails before waiting for the in-flight counter. Normal shutdown still settles tails naturally. Cancelled tasks are accepted only while that recovery fence remains active; all other tail failures remain fail-closed. One fixed non-secret marker records this state.

## Validation

- `three_node_follower_checkpoint_fault_recovery_release_regression`: passed; recovery completed in 11.6s and progressed from checkpoint 39 through later durable checkpoints
- focused recovery-tail cancellation test: passed
- normal checkpoint-tail settlement test: passed
- `cargo +nightly fmt --all -- --check`
- readability check
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

Azure checkpoint storage is still uncertified until the post-merge native diagnostic and certification baseline pass. Delivery admission is unchanged. Delta/Iceberg admission, dependencies, Cargo features, linker/build configuration, and unrelated infrastructure are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cluster recovery hang where a checkpoint tail blocked in cloud I/O held the in-flight counter at zero after the successor had published recovery Prepare, leaving Start and Release unreachable.

- Now, once the coordinated lifecycle fence is active, `StreamingCoordinator` cancels predecessor checkpoint tails before waiting for the in-flight counter.
- Cancelled tails are accepted only while the fence remains active; other tail failures still fail closed.
- Adds a non-secret diagnostic marker when recovery cancels fenced tails.
- Adds a regression test verifying a fenced tail can't block shutdown.
- Existing normal shutdown settlement and non-cluster paths are unchanged.

<sup>Written for commit 213acb03185fe54f2ea64e913bf672862bdc8cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinated recovery by cancelling fenced checkpoint operations promptly, helping shutdown and recovery complete reliably.
  * Prevented checkpoint activity from remaining in flight indefinitely during recovery.
  * Avoided repeating cancellation work during the same recovery sequence.

* **Tests**
  * Added coverage verifying checkpoint operations settle correctly after coordinated recovery cancellation.
  * Expanded recovery diagnostics to recognize and validate checkpoint-tail cancellation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->