### PR TITLE
fix(recovery): bound quorum authority reads

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -3432,6 +3432,21 @@ async fn announce_recover_prepare_bounded(
     })?
 }
 
+async fn observe_recovery_quorum_control_bounded(
+    controller: &ClusterController,
+) -> Result<Option<RecoveryAnnouncement>, RecoveryControlError> {
+    if let Ok(observed) =
+        tokio::time::timeout(DECISION_IO_TIMEOUT, controller.observe_recover_control()).await
+    {
+        observed
+    } else {
+        tracing::warn!("recovery quorum control observation timed out");
+        Err(RecoveryControlError::Uncertain(format!(
+            "recovery quorum control observation exceeded {DECISION_IO_TIMEOUT:?}"
+        )))
+    }
+}
+
 async fn driver_controls_prepare(controller: &ClusterController, round: &RecoveryRound) -> bool {
     if !controller.is_leader()
         || !matches!(
@@ -4045,7 +4060,7 @@ async fn wait_stopped_quorum_until(
                 }
             }
         }
-        match controller.observe_recover_control().await {
+        match observe_recovery_quorum_control_bounded(controller).await {
             Err(RecoveryControlError::Uncertain(_)) => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;
@@ -4200,7 +4215,7 @@ async fn wait_restored_quorum_until(
         ) {
             return RecoveryQuorum::ParticipantsChanged;
         }
-        match controller.observe_recover_control().await {
+        match observe_recovery_quorum_control_bounded(controller).await {
             Err(RecoveryControlError::Uncertain(_)) => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -8,6 +8,114 @@ use laminar_core::cluster::control::{
 use laminar_core::cluster::discovery::{NodeInfo, NodeMetadata, NodeState};
 use tokio::sync::watch;
 
+struct RecoveryAuthorityReadGateStore {
+    inner: Arc<dyn object_store::ObjectStore>,
+    armed: std::sync::atomic::AtomicBool,
+    entered: tokio::sync::Semaphore,
+}
+
+impl RecoveryAuthorityReadGateStore {
+    fn new(inner: Arc<dyn object_store::ObjectStore>) -> Self {
+        Self {
+            inner,
+            armed: std::sync::atomic::AtomicBool::new(false),
+            entered: tokio::sync::Semaphore::new(0),
+        }
+    }
+
+    fn arm(&self) {
+        assert!(
+            !self.armed.swap(true, Ordering::AcqRel),
+            "recovery control read gate is already armed"
+        );
+    }
+
+    async fn wait_until_blocked(&self) {
+        self.entered.acquire().await.unwrap().forget();
+    }
+}
+
+impl std::fmt::Debug for RecoveryAuthorityReadGateStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RecoveryAuthorityReadGateStore")
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Display for RecoveryAuthorityReadGateStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RecoveryAuthorityReadGateStore")
+    }
+}
+
+#[async_trait::async_trait]
+impl object_store::ObjectStore for RecoveryAuthorityReadGateStore {
+    async fn put_opts(
+        &self,
+        location: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        options: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        self.inner.put_opts(location, payload, options).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        if location.as_ref().starts_with("control/leader-lease/")
+            && self.armed.swap(false, Ordering::AcqRel)
+        {
+            self.entered.add_permits(1);
+            return std::future::pending().await;
+        }
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: futures::stream::BoxStream<
+            'static,
+            object_store::Result<object_store::path::Path>,
+        >,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> object_store::Result<object_store::ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+        options: object_store::CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}
+
 #[test]
 fn recovery_timeout_envelope_covers_stop_and_stopped_reporting() {
     let internal_stop = Duration::from_secs(210);
@@ -2434,6 +2542,49 @@ async fn stopped_prepare_leadership_handoff_retains_fault_without_failure_accoun
         inventory_before,
         "the original unhandled inventory must remain the successor's live trigger"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn stalled_quorum_control_read_rechecks_leadership_before_the_quorum_deadline() {
+    let self_id = NodeId(1);
+    let kv = Arc::new(InMemoryKv::new(self_id));
+    let (_members_tx, members_rx) = watch::channel(vec![info(2)]);
+    let controller = ClusterController::new(self_id, kv.clone(), None, members_rx);
+    install_test_process_deadline(&controller);
+    let authority_inner: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::memory::InMemory::new());
+    let authority_gate = Arc::new(RecoveryAuthorityReadGateStore::new(authority_inner));
+    let authority_store: Arc<dyn object_store::ObjectStore> = authority_gate.clone();
+    let (authority, lease_tx, owner) =
+        install_test_leader_authority_with_watch(&controller, authority_store).await;
+    let controller = Arc::new(controller);
+    report_test_fault(&controller).await;
+    let round = round_for_current_faults(&controller, 7, &[1, 2]).await;
+    publish_round_roster(&controller, &kv, &round).await;
+    controller.announce_recover_prepare(&round).await.unwrap();
+    controller.announce_stopped(&round).await.unwrap();
+
+    authority_gate.arm();
+    let waiting = tokio::spawn({
+        let controller = Arc::clone(&controller);
+        let round = round.clone();
+        async move { wait_stopped_quorum_until(&controller, &round).await }
+    });
+    authority_gate.wait_until_blocked().await;
+
+    let LeaseOutcome::Acquired(rotated) = authority.begin_new_term(&owner, 1).await.unwrap() else {
+        panic!("the current owner must rotate its leader term");
+    };
+    assert_ne!(rotated.proof(), round.leader_proof);
+    lease_tx.send_replace(Some(rotated));
+    assert!(!recovery_driver_proof_is_current(&controller, &round));
+
+    tokio::time::advance(DECISION_IO_TIMEOUT + STOP_QUORUM_INITIAL_POLL).await;
+    let outcome = tokio::time::timeout(Duration::from_secs(1), waiting)
+        .await
+        .expect("the bounded observation must yield to the new leader proof")
+        .expect("the quorum task must not panic");
+    assert_eq!(outcome, StoppedQuorum::LeadershipLost);
 }
 
 #[tokio::test]

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -2570,7 +2570,9 @@ async fn stalled_quorum_control_read_rechecks_leadership_before_the_quorum_deadl
         let round = round.clone();
         async move { wait_stopped_quorum_until(&controller, &round).await }
     });
-    authority_gate.wait_until_blocked().await;
+    tokio::time::timeout(Duration::from_secs(1), authority_gate.wait_until_blocked())
+        .await
+        .expect("the gated authority read must be entered");
 
     let LeaseOutcome::Acquired(rotated) = authority.begin_new_term(&owner, 1).await.unwrap() else {
         panic!("the current owner must rotate its leader term");

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -225,7 +225,7 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 99] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 100] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -338,6 +338,10 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 99] = [
     (
         "recovery_stop_quorum_timeout",
         "recovery stop quorum timed out",
+    ),
+    (
+        "recovery_quorum_control_timeout",
+        "recovery quorum control observation timed out",
     ),
     (
         "recovery_successor_authorized",
@@ -16066,6 +16070,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                leader could not quiesce after publishing recovery Prepare\n\
                could not acknowledge recovery Prepare\n\
                recovery stop quorum timed out\n\
+               recovery quorum control observation timed out\n\
                authorized successor assignment from the last committed cluster cut\n\
                coordinated recovery cancelled fenced checkpoint durable tails\n\
                recovery assignment 2 waits for a local vnode transition\n\
@@ -16144,6 +16149,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     assert_eq!(counts.get("recovery_leader_quiesce_failed"), Some(&1));
     assert_eq!(counts.get("recovery_stopped_ack_failed"), Some(&1));
     assert_eq!(counts.get("recovery_stop_quorum_timeout"), Some(&1));
+    assert_eq!(counts.get("recovery_quorum_control_timeout"), Some(&1));
     assert_eq!(counts.get("recovery_successor_authorized"), Some(&1));
     assert_eq!(counts.get("recovery_checkpoint_tails_cancelled"), Some(&1));
     for marker in [


### PR DESCRIPTION
## Deterministic reproduction

The existing `three_node_follower_checkpoint_fault_recovery_release_regression` starts three real processes, waits for several committed checkpoints, injects the existing follower checkpoint fault before any kill, and requires Prepare, the exact stopped quorum, Start, Release, a live leader, reopened source gates, and later committed checkpoints within the recovery ceiling.

A focused paused-time regression now stalls the exact `control/leader-lease/` object-store read made during stopped-quorum observation, rotates the same owner's durable leader term, and requires the old recovery driver to yield `LeadershipLost` before the hard quorum deadline. The test fails by hanging until the outer quorum deadline without the production fix.

## Root cause

`wait_stopped_quorum_until` and `wait_restored_quorum_until` directly awaited `ClusterController::observe_recover_control`. That observation performs durable leader-authority reads, which had no caller-side bound in these two phase loops. A stalled Azure object-store read could therefore pin the recovery driver after Prepare or Start, preventing it from rechecking the local leader proof and handing the fenced round to a successor. This matches the bounded evidence from native run [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468) and the failed post-merge diagnostic [34336591771](https://github.com/laminardb/laminardb/actions/runs/34336591771).

## Minimal fix

Both quorum loops now bound recovery-control observation with the existing 15-second decision-I/O timeout. A timeout is classified as retryable uncertain I/O, leaves recovery and source intake fail-closed, and returns control to the loop so current leader authority is checked again. No timeout was increased. One fixed non-secret marker distinguishes this stall in native summaries.

## Focused validation

- Focused authority-read regression: 1 passed, 0 failed.
- Existing real three-node follower-fault regression: 1 passed, 0 failed; recovery completed in 11.6s and checkpoints advanced from 22 through 28 and beyond 34.
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

Azure checkpoint storage is still uncertified until the post-merge native diagnostic and certification baseline pass. Delivery admission is unchanged. This does not change Delta or Iceberg admission, dependencies, Cargo features, linker/OpenSSL/build configuration, or unrelated infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds durable leader-authority reads during stopped and restored quorum checks. Previously, a stalled object-store read could pin recovery after Prepare or Start; now the existing 15-second decision-I/O timeout returns control to leadership checks so a successor can take over while recovery and source intake remain fail-closed.

**Bug Fixes**

- Treats timed-out quorum-control observations as retryable uncertain I/O and logs `recovery quorum control observation timed out`.
- Adds a paused-time regression that blocks `control/leader-lease/`, rotates the durable leader term, and verifies the old driver returns `LeadershipLost` before the quorum deadline.

<sup>Written for commit 3e5c2cac44aaad805a1467c945232257447c5b0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery quorum waits now remain responsive when control-state reads stall, allowing leadership changes to be detected before the quorum deadline.
  * Timed-out recovery control observations are handled without blocking recovery progress indefinitely.

* **Diagnostics**
  * Added diagnostic tracking for recovery quorum control observation timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->