### PR TITLE
fix(recovery): publish fault before graph drain

### DIFF
--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -18,8 +18,8 @@ use laminar_core::cluster::control::{
     AssignmentDrainDecision, AssignmentDrainVerdict, AssignmentRecoveryDecision,
     AssignmentSnapshot, AssignmentSnapshotStore, CheckpointAssignmentAdoption,
     CheckpointAssignmentFence, CheckpointParticipant, ClusterController, LeaderLeaseStore,
-    LeaderProof, RecordAssignmentDrainDecisionResult, RecordAssignmentRecoveryDecisionResult,
-    RotateOutcome, SnapshotError,
+    LeaderProof, ProcessLeaseFence, RecordAssignmentDrainDecisionResult,
+    RecordAssignmentRecoveryDecisionResult, RotateOutcome, SnapshotError,
 };
 use laminar_core::cluster::discovery::NodeState;
 use laminar_core::state::{
@@ -89,8 +89,9 @@ async fn close_local_assignment_authority(
     db: &Arc<LaminarDB>,
     controller: &ClusterController,
     recovery_target: &CheckpointAssignmentFence,
+    removed_processes: &[CheckpointParticipant],
     deadline: tokio::time::Instant,
-) -> Result<(), String> {
+) -> Result<Vec<ProcessLeaseFence>, String> {
     db.set_source_gate(true);
     controller.publish_checkpoint_assignment_fence(None);
     controller.publish_checkpoint_drain_transition(None);
@@ -100,13 +101,26 @@ async fn close_local_assignment_authority(
         .await
         .map_err(|_| "timed out serializing assignment authority closure".to_string())?;
     // A watcher that already owned the adoption lock could have republished and reopened after
-    // the first cancellation. Reassert the full closure while serialized, before draining it.
+    // the first cancellation. Reassert the full closure and retain serialization through process
+    // fencing, fault publication, and the execution drain.
     db.set_source_gate(true);
     controller.publish_checkpoint_assignment_fence(None);
     controller.publish_checkpoint_drain_transition(None);
     db.invalidate_shuffle_assignment_fence();
+    let fence_results = futures::future::join_all(
+        removed_processes
+            .iter()
+            .copied()
+            .map(|participant| controller.fence_process_incarnation(participant, deadline)),
+    )
+    .await;
+    let mut process_fences = Vec::with_capacity(fence_results.len());
+    for result in fence_results {
+        process_fences.push(result?);
+    }
     // RECOVERY: Prepare cancels graph work, so publish its fault before waiting for that work to
-    // release the execution fence. The serialized local authority is already closed above.
+    // release the execution fence. Process fencing above prevents a live predecessor from causing
+    // a spurious fault, and the serialized local authority is already closed.
     if recovery_target.participant_incarnation(controller.instance_id().0)
         == Some(controller.recovery_incarnation())
     {
@@ -118,7 +132,7 @@ async fn close_local_assignment_authority(
     )
     .await
     .map_err(|_| "timed out draining assignment execution after closure".to_string())?;
-    Ok(())
+    Ok(process_fences)
 }
 
 async fn ensure_local_recovery_fault(
@@ -3066,7 +3080,9 @@ fn materialize_recovery_decision<'a>(
 ) -> futures::future::BoxFuture<'a, Result<Option<u64>, String>> {
     Box::pin(async move {
         let deadline = tokio::time::Instant::now() + operation_timeout;
-        close_local_assignment_authority(db, controller, &decision.target, deadline).await?;
+        let _process_fences =
+            close_local_assignment_authority(db, controller, &decision.target, &[], deadline)
+                .await?;
         let proposal =
             tokio::time::timeout_at(deadline, store.load_recovery_proposal(&decision.proposal))
                 .await
@@ -3206,26 +3222,14 @@ fn authorize_recovery_successor<'a>(
             .assignment_fence()
             .map_err(|error| error.to_string())?;
         let deadline = controller.process_fencing_deadline(operation_timeout)?;
-        close_local_assignment_authority(db, controller, &target, deadline).await?;
+        let removed = replaced_predecessor_processes(&predecessor, &target);
+        let process_fences =
+            close_local_assignment_authority(db, controller, &target, &removed, deadline).await?;
         let proposal_ref =
             tokio::time::timeout_at(deadline, store.stage_recovery_proposal(&proposal))
                 .await
                 .map_err(|_| "recovery proposal staging exceeded the fencing deadline".to_string())?
                 .map_err(|error| error.to_string())?;
-
-        let removed = replaced_predecessor_processes(&predecessor, &target);
-        let fence_results = futures::future::join_all(
-            removed
-                .iter()
-                .copied()
-                .map(|participant| controller.fence_process_incarnation(participant, deadline)),
-        )
-        .await;
-        let mut process_fences = Vec::with_capacity(fence_results.len());
-        for result in fence_results {
-            process_fences.push(result?);
-        }
-
         let observed = tokio::time::timeout_at(deadline, store.load())
             .await
             .map_err(|_| "assignment head revalidation exceeded the fencing deadline".to_string())?

--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -87,14 +87,13 @@ impl RebalanceConfig {
 
 async fn close_local_assignment_authority(
     db: &Arc<LaminarDB>,
-    controller: Option<&ClusterController>,
+    controller: &ClusterController,
+    recovery_target: &CheckpointAssignmentFence,
     deadline: tokio::time::Instant,
 ) -> Result<(), String> {
     db.set_source_gate(true);
-    if let Some(controller) = controller {
-        controller.publish_checkpoint_assignment_fence(None);
-        controller.publish_checkpoint_drain_transition(None);
-    }
+    controller.publish_checkpoint_assignment_fence(None);
+    controller.publish_checkpoint_drain_transition(None);
     // Cancel first: a compute-cycle read guard may itself be blocked in shuffle admission.
     db.invalidate_shuffle_assignment_fence();
     let _adoption = tokio::time::timeout_at(deadline, db.assignment_adoption_lock.lock())
@@ -103,11 +102,16 @@ async fn close_local_assignment_authority(
     // A watcher that already owned the adoption lock could have republished and reopened after
     // the first cancellation. Reassert the full closure while serialized, before draining it.
     db.set_source_gate(true);
-    if let Some(controller) = controller {
-        controller.publish_checkpoint_assignment_fence(None);
-        controller.publish_checkpoint_drain_transition(None);
-    }
+    controller.publish_checkpoint_assignment_fence(None);
+    controller.publish_checkpoint_drain_transition(None);
     db.invalidate_shuffle_assignment_fence();
+    // RECOVERY: Prepare cancels graph work, so publish its fault before waiting for that work to
+    // release the execution fence. The serialized local authority is already closed above.
+    if recovery_target.participant_incarnation(controller.instance_id().0)
+        == Some(controller.recovery_incarnation())
+    {
+        ensure_local_recovery_fault(db, controller).await?;
+    }
     let _transition = tokio::time::timeout_at(
         deadline,
         Arc::clone(&db.rotation_execution_fence).write_owned(),
@@ -3062,7 +3066,7 @@ fn materialize_recovery_decision<'a>(
 ) -> futures::future::BoxFuture<'a, Result<Option<u64>, String>> {
     Box::pin(async move {
         let deadline = tokio::time::Instant::now() + operation_timeout;
-        close_local_assignment_authority(db, Some(controller), deadline).await?;
+        close_local_assignment_authority(db, controller, &decision.target, deadline).await?;
         let proposal =
             tokio::time::timeout_at(deadline, store.load_recovery_proposal(&decision.proposal))
                 .await
@@ -3077,11 +3081,7 @@ fn materialize_recovery_decision<'a>(
         {
             return Err("recovery authority winner does not match its staged proposal".into());
         }
-        if local_recovery_assignment_scope(&proposal, controller)?
-            == LocalRecoveryAssignmentScope::Participant
-        {
-            ensure_local_recovery_fault(db, controller).await?;
-        }
+        local_recovery_assignment_scope(&proposal, controller)?;
         let authority = controller
             .checkpoint_authority()
             .map_err(|error| error.to_string())?;
@@ -3206,7 +3206,7 @@ fn authorize_recovery_successor<'a>(
             .assignment_fence()
             .map_err(|error| error.to_string())?;
         let deadline = controller.process_fencing_deadline(operation_timeout)?;
-        close_local_assignment_authority(db, Some(controller), deadline).await?;
+        close_local_assignment_authority(db, controller, &target, deadline).await?;
         let proposal_ref =
             tokio::time::timeout_at(deadline, store.stage_recovery_proposal(&proposal))
                 .await

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -3452,6 +3452,68 @@ async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_a
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_decision_fault_precedes_graph_execution_drain() {
+    let (
+        db,
+        controller,
+        durable,
+        registry,
+        _current,
+        _process_authority,
+        _authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    controller.note_unresponsive(&[NodeId(2)]);
+    db.set_source_gate(false);
+    assert!(!db.cluster_intake_fenced());
+    let execution = Arc::clone(&db.rotation_execution_fence).read_owned().await;
+
+    let rebalancing_db = Arc::clone(&db);
+    let rebalancing_controller = Arc::clone(&controller);
+    let rebalancing_durable = Arc::clone(&durable);
+    let rebalancing_registry = Arc::clone(&registry);
+    let rebalancing = tokio::spawn(async move {
+        let mut config = RebalanceConfig::test_defaults();
+        config.checkpoint_timeout = Duration::from_secs(3);
+        try_rebalance(
+            &rebalancing_db,
+            &rebalancing_controller,
+            &rebalancing_durable,
+            &rebalancing_registry,
+            &[NodeId(1), NodeId(2)],
+            config,
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !db.cluster_intake_fenced() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("recovery assignment authority was not closed");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while controller.read_fault_reports().await.unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("recovery fault publication waited for the graph execution drain");
+
+    drop(execution);
+    let error = tokio::time::timeout(Duration::from_secs(2), rebalancing)
+        .await
+        .expect("recovery assignment materialization did not finish")
+        .unwrap()
+        .expect_err("the test checkpoint intentionally omits the acquired vnode manifest");
+    assert!(
+        error.contains("participant 2 handoff manifest is missing"),
+        "{error}"
+    );
+}
+
 #[tokio::test]
 async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
     let self_id = NodeId(1);
@@ -3839,7 +3901,10 @@ async fn assignment_closure_cancels_shuffle_before_waiting_for_execution_drain()
             boot_incarnation: Uuid::from_u128(22),
         },
     ];
-    let assignment = CheckpointAssignmentFence::from_owner_map(1, &[1, 2], participants).unwrap();
+    let assignment =
+        CheckpointAssignmentFence::from_owner_map(1, &[1, 2], participants.clone()).unwrap();
+    let closure_target =
+        CheckpointAssignmentFence::from_owner_map(2, &[2, 2], vec![participants[1]]).unwrap();
     let controller = test_cluster_controller(NodeId(1), local_boot, None);
     let process_deadline = controller
         .process_lease_deadline()
@@ -3877,7 +3942,7 @@ async fn assignment_closure_cancels_shuffle_before_waiting_for_execution_drain()
 
     let registry = Arc::new(VnodeRegistry::single_owner(1, NodeId(1)));
     let db = LaminarDB::builder()
-        .cluster_controller(controller)
+        .cluster_controller(Arc::clone(&controller))
         .cluster_checkpoint_object_store(test_cluster_checkpoint_store())
         .vnode_registry(registry)
         .shuffle_sender(Arc::clone(&sender))
@@ -3903,7 +3968,9 @@ async fn assignment_closure_cancels_shuffle_before_waiting_for_execution_drain()
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     let closing = {
         let db = Arc::clone(&db);
-        tokio::spawn(async move { close_local_assignment_authority(&db, None, deadline).await })
+        tokio::spawn(async move {
+            close_local_assignment_authority(&db, &controller, &closure_target, deadline).await
+        })
     };
     tokio::time::timeout_at(deadline, async {
         while sender.assignment_version() != 0 {

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -3969,7 +3969,7 @@ async fn assignment_closure_cancels_shuffle_before_waiting_for_execution_drain()
     let closing = {
         let db = Arc::clone(&db);
         tokio::spawn(async move {
-            close_local_assignment_authority(&db, &controller, &closure_target, deadline).await
+            close_local_assignment_authority(&db, &controller, &closure_target, &[], deadline).await
         })
     };
     tokio::time::timeout_at(deadline, async {


### PR DESCRIPTION
## Scope

Azure Blob/ADLS Gen2 checkpoint recovery only. This does not change Delta or Iceberg admission, delivery admission, dependencies, features, linker configuration, or timeouts.

## Deterministic reproduction

The existing `three_node_follower_checkpoint_fault_recovery_release_regression` was run locally against the existing three-process Kafka/MinIO protocol stand-in. It started a healthy three-node cluster, committed checkpoints, injected the existing follower checkpoint fault before any process kill, observed Prepare and the exact stopped quorum, reached Start and Release, reopened intake under a live leader, and completed later checkpoints. Recovery completed in 8.43 seconds; the resumed checkpoint was 35 and later checkpoints 62 and 66 completed. The at-least-once oracle reported no loss and bounded measured duplicates.

The focused unit regression `recovery_decision_fault_precedes_graph_execution_drain` holds the graph execution read fence and requires the existing durable recovery fault to become visible before releasing that fence. The pre-fix ordering fails this bounded assertion; the patched ordering passes.

## Root cause

Successor assignment authorization closed local assignment/shuffle authority and then waited for the graph execution fence. It published the existing coordinated-recovery fault only after that drain completed. A surviving peer could therefore retain its old shuffle scope while the successor waited for graph work involving that peer, delaying successor authorization until the recovery deadline. The bounded native diagnostics showed successor authorization, assignment rotation, and Prepare only at the end of the window, with no stopped/Start/Release markers and zero graph-drain buffered-byte samples.

This is the same recovery liveness family exposed by native run [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468), which reached Start but not Release. Follow-up native run [34403985018](https://github.com/laminardb/laminardb/actions/runs/34403985018) narrowed the earlier successor/Prepare delay.

## Minimal fix

Keep the existing fail-closed local authority closure and removed-process fencing proof. Once that proof succeeds, publish the existing local recovery fault before waiting for the graph execution write fence. Peer recovery monitors can then suspend the old shuffle scope and allow the existing drain to finish. A renewing predecessor still aborts authorization without publishing a fault. Assignment, process-incarnation, restore-quorum, and Release checks otherwise remain unchanged.

## Validation

- `recovery_decision_fault_precedes_graph_execution_drain`: passed
- `renewing_predecessor_cannot_be_removed_by_failure_recovery`: passed
- `assignment_closure_cancels_shuffle_before_waiting_for_execution_drain`: passed
- existing three-node follower-fault recovery/Release regression: passed
- `cargo +nightly fmt --all -- --check`: passed
- readability check: passed
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`: passed
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`: passed

Azure checkpoint storage is still uncertified pending the post-merge diagnostic and certification baseline. Delivery admission is unchanged.