### PR TITLE
fix(recovery): yield stale stopped rounds

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -1253,15 +1253,8 @@ impl RecoveryMonitor {
         &mut self,
         controller: &ClusterController,
     ) -> Result<Vec<RecoveryFault>, String> {
-        let reported = self.reported_faults(controller).await?;
-        Ok(self.unhandled_faults(&reported))
-    }
-
-    async fn reported_faults(
-        &self,
-        controller: &ClusterController,
-    ) -> Result<Vec<RecoveryFault>, String> {
-        Ok(self.fault_inventory(controller).await?.faults().to_vec())
+        let inventory = self.fault_inventory(controller).await?;
+        Ok(self.unhandled_faults(inventory.faults()))
     }
 
     async fn fault_inventory(
@@ -1274,6 +1267,32 @@ impl RecoveryMonitor {
         )
         .await
         .map_err(|_| "cluster recovery fault inventory read timed out".to_string())?
+    }
+
+    async fn round_faults_are_current(
+        &self,
+        controller: &ClusterController,
+        round: &RecoveryRound,
+    ) -> bool {
+        match self.fault_inventory(controller).await {
+            Ok(inventory)
+                if inventory.revision() == round.fault_revision()
+                    && inventory.faults() == round.faults =>
+            {
+                true
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    gen = round.id.generation,
+                    "recovery fault inventory changed after stopped quorum; yielding stale Prepare"
+                );
+                false
+            }
+            Err(error) => {
+                tracing::error!(%error, "could not read cluster recovery fault reports");
+                false
+            }
+        }
     }
 
     fn unhandled_faults(&self, reported: &[RecoveryFault]) -> Vec<RecoveryFault> {
@@ -1604,6 +1623,9 @@ impl RecoveryMonitor {
 
         if !continue_if_driver_owns_prepare(db, controller, &round, "before target selection").await
         {
+            return;
+        }
+        if !self.round_faults_are_current(controller, &round).await {
             return;
         }
         if round.has_terminal_fault() {

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -2544,6 +2544,121 @@ async fn stopped_prepare_leadership_handoff_retains_fault_without_failure_accoun
     );
 }
 
+#[tokio::test]
+async fn late_fault_after_stopped_quorum_yields_stale_prepare_without_retry_churn() {
+    use laminar_core::state::{NodeId as StateNodeId, VnodeRegistry};
+
+    let (controller, follower, kv) = driver_and_follower().await;
+    let original_fault = report_test_fault(&controller).await;
+    let owner = CheckpointParticipant {
+        node_id: controller.instance_id().0,
+        boot_incarnation: controller.recovery_incarnation(),
+    };
+    let peer = CheckpointParticipant {
+        node_id: follower.instance_id().0,
+        boot_incarnation: follower.recovery_incarnation(),
+    };
+    let assignment_fence = CheckpointAssignmentFence::from_owner_map(
+        1,
+        &[owner.node_id, peer.node_id],
+        vec![owner, peer],
+    )
+    .unwrap();
+    let (assignments, _committed) =
+        initial_assignment_store(&assignment_fence, &[NodeId(1), NodeId(2)]).await;
+    let registry = Arc::new(VnodeRegistry::new_unassigned(2));
+    registry.set_assignment_and_version(
+        Arc::from([StateNodeId(1), StateNodeId(2)]),
+        assignment_fence.assignment_version,
+    );
+    let db = LaminarDB::builder()
+        .cluster_controller(Arc::clone(&controller))
+        .cluster_checkpoint_object_store(Arc::new(object_store::memory::InMemory::new()))
+        .vnode_registry(registry)
+        .assignment_snapshot_store(assignments)
+        .build()
+        .await
+        .unwrap();
+    let metrics = Arc::new(crate::engine_metrics::EngineMetrics::new(
+        &prometheus::Registry::new(),
+    ));
+    *db.engine_metrics.lock() = Some(Arc::clone(&metrics));
+    controller.publish_recovery_incarnation().await.unwrap();
+    kv.seed(
+        follower.instance_id(),
+        "control:recovery-incarnation",
+        follower.recovery_incarnation().to_string(),
+    );
+    controller.publish_checkpoint_assignment_fence(Some(assignment_fence));
+    controller.set_recovering(true);
+    db.set_source_gate(true);
+    db.coordinated_recovery_fenced
+        .store(true, Ordering::Release);
+
+    let initial_inventory = controller.read_recovery_fault_inventory().await.unwrap();
+    let driving = tokio::spawn({
+        let controller = Arc::clone(&controller);
+        let db = Arc::clone(&db);
+        let faults = initial_inventory.faults().to_vec();
+        async move {
+            let mut monitor = RecoveryMonitor::default();
+            monitor
+                .drive_round(&db, &controller, initial_inventory.revision(), faults, None)
+                .await;
+        }
+    });
+    let prepare = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let Some(active) = controller.observe_recover_control().await.unwrap() else {
+                tokio::task::yield_now().await;
+                continue;
+            };
+            if active.phase == RecoverPhase::Prepare
+                && !controller
+                    .read_stopped(&active.round, &[controller.instance_id()])
+                    .await
+                    .unwrap()
+                    .is_empty()
+            {
+                break active;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the driver must publish Prepare and its local stopped report");
+    assert!(!driving.is_finished());
+
+    let late_fault = report_test_fault(&follower).await;
+    let changed_inventory = controller.read_recovery_fault_inventory().await.unwrap();
+    assert_eq!(changed_inventory.faults(), &[original_fault, late_fault]);
+    let peer_stopped = RecoveryStoppedReport::new(&prepare.round, peer).unwrap();
+    kv.seed(
+        follower.instance_id(),
+        "control:recovery-stopped",
+        serde_json::to_string(&peer_stopped).unwrap(),
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), driving)
+        .await
+        .expect("the stale stopped generation must yield promptly")
+        .expect("the recovery driver must not panic");
+    assert_eq!(
+        controller.observe_recover_control().await.unwrap(),
+        Some(prepare),
+        "the stopped Prepare must remain available for direct handoff"
+    );
+    assert_eq!(
+        controller.read_recovery_fault_inventory().await.unwrap(),
+        changed_inventory,
+        "the newer durable fault already drives the successor generation"
+    );
+    assert_eq!(metrics.coordinated_recovery_failures_total.get(), 0);
+    assert_eq!(db.pending_recovery_fault.load(Ordering::Acquire), 0);
+    assert!(controller.is_recovering());
+    assert!(db.cluster_intake_fenced());
+}
+
 #[tokio::test(start_paused = true)]
 async fn stalled_quorum_control_read_rechecks_leadership_before_the_quorum_deadline() {
     let self_id = NodeId(1);

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -225,7 +225,7 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 100] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 101] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -308,6 +308,10 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 100] = [
         "coordinated recovery cancelled fenced checkpoint durable tails",
     ),
     ("recovery_prepare_handoff", RECOVERY_PREPARE_HANDOFF_LOG),
+    (
+        "recovery_fault_inventory_changed_after_stop",
+        "recovery fault inventory changed after stopped quorum; yielding stale Prepare",
+    ),
     ("recovery_retry_hold", RECOVERY_RETRY_HOLD_LOG),
     ("recovery_stopped", RECOVERY_STOPPED_LOG),
     ("recovery_driver_lost", RECOVERY_DRIVER_HANDOFF_LOG),
@@ -16062,6 +16066,7 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
                checkpoint state serialization timed out: token=secret\n\
                checkpoint source cut is incomplete: credential=secret\n\
                leader announced recovery prepare\n\
+               recovery fault inventory changed after stopped quorum; yielding stale Prepare\n\
                recovery driver lost leadership; retaining current control and fence for successor generation\n\
                leader self-restore failed; retrying\n\
                recovery pipeline restart failed\n\
@@ -16137,6 +16142,10 @@ fn recovery_log_diagnostics_count_markers_without_copying_log_values() {
     );
     assert_eq!(counts.get("checkpoint_source_cut_incomplete"), Some(&1));
     assert_eq!(counts.get("recovery_prepare"), Some(&1));
+    assert_eq!(
+        counts.get("recovery_fault_inventory_changed_after_stop"),
+        Some(&1)
+    );
     for marker in [
         "recovery_driver_lost",
         "recovery_leader_self_restore_failed",


### PR DESCRIPTION
## Reproduction

- Reuses the existing coordinated-recovery and cluster-soak infrastructure; no new harness was added.
- Adds a deterministic two-participant regression that blocks the driver at stopped quorum, publishes a later follower fault, completes the exact quorum, and requires the stale generation to yield promptly while retaining Prepare and closed intake.
- Before the fix, the regression changed the durable inventory from revision 3 to a synthetic revision 4 driver fault and incremented recovery-failure state.
- The existing three-node follower checkpoint-fault regression passed with the native-failure load shape against MinIO: 65,536 keys, 8 MiB minimum live state, 500 ms checkpoint cadence, 60 s checkpoint timeout, and 90 s recovery ceiling.

## Root cause

A recovery round freezes its fault inventory before Prepare, but another legitimate fault can arrive while participants are reaching stopped quorum. The driver did not re-audit that inventory after quorum. On a slow native Azure path it therefore performed object-store artifact settlement for an already-stale generation. Start admission eventually rejected the changed fault set, and the generic failed-boundary path published a redundant retry fault, causing generation churn and consuming the soak recovery window.

This explains the process-soak failure after the earlier graph-drain repair: native run 34472453520 reached a second Start but not Release before the outer bound. The original native evidence is run 34162984468: https://github.com/laminardb/laminardb/actions/runs/34162984468

## Fix

Immediately after exact stopped quorum and Prepare ownership validation, re-read the bounded durable fault inventory. If it differs from the round, retain the stopped Prepare and intake fence and let the existing direct Prepare-to-Prepare handoff drive the newer inventory. Do not count an expected handoff as a recovery failure and do not manufacture another fault. An unavailable audit also remains fail-closed.

Adds one fixed, non-secret diagnostic marker for this boundary.

## Validation

- Focused late-fault regression: passed
- Adjacent stopped-Prepare, leadership-handoff, and post-ready-fault tests: passed
- Existing three-node follower checkpoint-fault regression: passed; recovery completed in 15.5 s, checkpoints advanced from 32 through 163, no expected records were lost, and ALO duplicates were measured
- cargo +nightly fmt --all -- --check
- cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .
- cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings
- cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings

## Certification scope

Azure checkpoint storage is still uncertified until the post-merge native diagnostic and certification baseline both pass on the exact merged SHA. Delivery admission is unchanged. This PR does not change Delta or Iceberg admission, dependencies, Cargo features, linker configuration, OpenSSL, or build settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery rounds that could settle a stale fault inventory after stopped quorum, which caused generation churn and soak recovery failures.

A recovery round freezes its fault inventory before Prepare; if another legitimate fault arrives while participants are reaching stopped quorum, the driver now re-reads the inventory immediately after quorum and Prepare ownership validation. If it changed, the stale generation keeps the stopped Prepare and intake fence and yields to the existing Prepare-to-Prepare handoff. It no longer counts the handoff as a recovery failure or manufactures another fault, and a failed audit still fails closed.

- Adds a deterministic two-participant regression for a late follower fault after stopped quorum.
- Adds one fixed, non-secret diagnostic marker for this boundary.
- Existing three-node follower checkpoint-fault soak regression passes.
- Azure checkpoint storage remains uncertified until the post-merge diagnostic and certification baseline pass on the merged SHA.

<sup>Written for commit 6cca2f4c5e9faba8c5e33c7f3f981c31e346800a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

