### PR TITLE
fix(recovery): cold-bootstrap acquired checkpoint vnodes

### DIFF
--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -35,6 +35,13 @@ use tracing::{debug, info, warn};
 use crate::db::{DbState, LaminarDB};
 use crate::engine_metrics::EngineMetrics;
 
+mod recovery_adoption;
+use recovery_adoption::{
+    adopt_materialized_recovery_head, ensure_local_recovery_fault, local_recovery_assignment_scope,
+    prepare_recovery_assignment_adoption, prepare_watched_recovery_adoption,
+    LocalRecoveryAssignmentScope,
+};
+
 /// Tunables for the rebalance control plane.
 #[derive(Debug, Clone, Copy)]
 pub struct RebalanceConfig {
@@ -135,16 +142,6 @@ async fn close_local_assignment_authority(
     Ok(process_fences)
 }
 
-async fn ensure_local_recovery_fault(
-    db: &LaminarDB,
-    controller: &ClusterController,
-) -> Result<(), String> {
-    controller.set_recovering(true);
-    crate::coordinated_recovery::request_local_fault(controller, &db.pending_recovery_fault)
-        .await
-        .map(|_| ())
-}
-
 /// Fail closed for a transient durable snapshot read without forcing a new assignment version.
 /// The exact retained certificate can resume after the same durable head is audited again.
 async fn suspend_local_assignment_authority(
@@ -205,51 +202,6 @@ async fn try_suspend_recovery_assignment_authority(
     }
     suspend_local_assignment_authority_locked(db, Some(controller), deadline).await?;
     Ok(true)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LocalRecoveryAssignmentScope {
-    Participant,
-    Ownerless,
-}
-
-/// Classify this exact process generation against an authority-audited recovery target.
-///
-/// An ownerless process may follow the target topology, but it has no checkpoint or recovery
-/// authority and must not turn the target's recovery provenance into a new cluster-wide fault.
-fn local_recovery_assignment_scope(
-    snapshot: &AssignmentSnapshot,
-    controller: &ClusterController,
-) -> Result<LocalRecoveryAssignmentScope, String> {
-    let fence = snapshot
-        .assignment_fence()
-        .map_err(|error| error.to_string())?;
-    let owners = snapshot
-        .to_vnode_vec(fence.vnode_count)
-        .map_err(|error| error.to_string())?;
-    let owner_ids = owners.iter().map(|owner| owner.0).collect::<Vec<_>>();
-    if !fence.is_canonical() || !fence.matches_owner_map(&owner_ids) {
-        return Err(format!(
-            "recovery assignment {} has no canonical owner-complete target fence",
-            snapshot.version
-        ));
-    }
-
-    let local_id = controller.instance_id().0;
-    match fence.participant_incarnation(local_id) {
-        Some(incarnation) if incarnation == controller.recovery_incarnation() => {
-            Ok(LocalRecoveryAssignmentScope::Participant)
-        }
-        Some(_) => Err(format!(
-            "recovery assignment {} certifies another incarnation of process {local_id}",
-            snapshot.version
-        )),
-        None if owner_ids.contains(&local_id) => Err(format!(
-            "recovery assignment {} gives process {local_id} ownership without checkpoint authority",
-            snapshot.version
-        )),
-        None => Ok(LocalRecoveryAssignmentScope::Ownerless),
-    }
 }
 
 async fn hold_terminal_source_resolution(
@@ -1108,29 +1060,23 @@ impl SnapshotWatcher {
                             self.durable_snapshot = None;
                             self.durable_drain_transition = None;
                             self.installed_fence = None;
-                            if let Err(error) =
-                                ensure_local_recovery_fault(&self.db, controller).await
-                            {
-                                self.assignment_authority_dirty = true;
-                                warn!(%error, version = snap.version, "snapshot watcher: could not publish recovery fault");
-                                continue;
-                            }
-                            if let Err(error) = abort_predecessor_checkpoint_for_recovery(
+                            match prepare_watched_recovery_adoption(
+                                &self.db,
                                 &self.store,
                                 controller,
+                                &self.registry,
                                 &snap,
                                 head_deadline,
                             )
                             .await
                             {
-                                self.assignment_authority_dirty = true;
-                                warn!(%error, version = snap.version, "snapshot watcher: could not settle predecessor checkpoint for recovery");
-                                continue;
+                                Ok(revision) => authority_revision = revision,
+                                Err(error) => {
+                                    self.assignment_authority_dirty = true;
+                                    warn!(%error, version = snap.version, "snapshot watcher: recovery assignment preparation failed");
+                                    continue;
+                                }
                             }
-                            authority_revision = self
-                                .db
-                                .assignment_authority_revision
-                                .load(std::sync::atomic::Ordering::Acquire);
                             self.assignment_authority_dirty = true;
                         } else {
                             debug!(
@@ -2431,30 +2377,6 @@ fn settle_audited_recovery_predecessor_checkpoint<'a>(
     })
 }
 
-fn prepare_recovery_assignment_adoption<'a>(
-    db: &'a Arc<LaminarDB>,
-    store: &'a AssignmentSnapshotStore,
-    controller: &'a ClusterController,
-    snapshot: &'a AssignmentSnapshot,
-    deadline: tokio::time::Instant,
-) -> futures::future::BoxFuture<'a, Result<(), String>> {
-    Box::pin(async move {
-        if !try_suspend_recovery_assignment_authority(db, controller, deadline).await? {
-            return Err(format!(
-                "recovery assignment {} waits for a local vnode transition",
-                snapshot.version
-            ));
-        }
-        if local_recovery_assignment_scope(snapshot, controller)?
-            == LocalRecoveryAssignmentScope::Ownerless
-        {
-            return Ok(());
-        }
-        ensure_local_recovery_fault(db, controller).await?;
-        abort_predecessor_checkpoint_for_recovery(store, controller, snapshot, deadline).await
-    })
-}
-
 async fn audit_materialized_drain_transition(
     store: &AssignmentSnapshotStore,
     authority: Option<&LeaderLeaseStore>,
@@ -3075,6 +2997,7 @@ fn materialize_recovery_decision<'a>(
     db: &'a Arc<LaminarDB>,
     store: &'a Arc<AssignmentSnapshotStore>,
     controller: &'a ClusterController,
+    registry: &'a VnodeRegistry,
     decision: AssignmentRecoveryDecision,
     operation_timeout: Duration,
 ) -> futures::future::BoxFuture<'a, Result<Option<u64>, String>> {
@@ -3126,7 +3049,8 @@ fn materialize_recovery_decision<'a>(
         .map_err(|_| {
             "recovery assignment audit exceeded the materialization deadline".to_string()
         })??;
-        prepare_recovery_assignment_adoption(db, store, controller, &durable, deadline).await?;
+        prepare_recovery_assignment_adoption(db, store, controller, registry, &durable, deadline)
+            .await?;
         let version = durable.version;
         db.adopt_recovery_assignment_snapshot(durable, operation_timeout)
             .await
@@ -3158,6 +3082,7 @@ async fn reconcile_pending_recovery_decision(
     db: &Arc<LaminarDB>,
     store: &Arc<AssignmentSnapshotStore>,
     controller: &ClusterController,
+    registry: &VnodeRegistry,
     current: &AssignmentSnapshot,
     operation_timeout: Duration,
 ) -> Result<Option<u64>, String> {
@@ -3187,7 +3112,8 @@ async fn reconcile_pending_recovery_decision(
             "pending recovery decision for assignment {target_version} has the wrong predecessor"
         ));
     }
-    materialize_recovery_decision(db, store, controller, decision, operation_timeout).await
+    materialize_recovery_decision(db, store, controller, registry, decision, operation_timeout)
+        .await
 }
 
 fn replaced_predecessor_processes(
@@ -3700,7 +3626,15 @@ fn execute_graceful_rotation_owned(
             }
             RotateOutcome::Conflict(winner) => {
                 let v = winner.version;
-                adopt_any(&db, &store, &controller, *winner, config.checkpoint_timeout).await?;
+                adopt_any(
+                    &db,
+                    &store,
+                    &controller,
+                    &registry,
+                    *winner,
+                    config.checkpoint_timeout,
+                )
+                .await?;
                 Ok(Some(v))
             }
         }
@@ -3743,21 +3677,12 @@ fn try_rebalance_owned(
             .map_err(|error| error.to_string())?;
 
         let local_assignment = registry.versioned_snapshot();
-        if current.version < local_assignment.version() {
-            return Err(format!(
-                "durable assignment head {} regressed behind local assignment {}",
-                current.version,
-                local_assignment.version()
-            ));
-        }
-        if current.version == local_assignment.version()
-            && current_owners.as_slice() != local_assignment.owners()
-        {
-            return Err(format!(
-                "durable and local assignment {} have different owner maps",
-                current.version
-            ));
-        }
+        validate_local_assignment_head(
+            &current,
+            &current_owners,
+            local_assignment.version(),
+            local_assignment.owners(),
+        )?;
 
         // A propagated pin means D(current + 1) is already durable while `current` remains the
         // materialized assignment head. A faulted graph may cold-bootstrap directly from the
@@ -3775,6 +3700,7 @@ fn try_rebalance_owned(
                 Arc::clone(&db),
                 Arc::clone(&store),
                 Arc::clone(&controller),
+                Arc::clone(&registry),
                 current.clone(),
                 config.checkpoint_timeout,
             )
@@ -3892,19 +3818,17 @@ fn try_rebalance_owned(
             && current_authority.is_recovery()
             && assignment_binds_local_process(&current, &controller)?
         {
-            prepare_recovery_assignment_adoption(&db, &store, &controller, &current, head_deadline)
-                .await?;
-            db.adopt_recovery_assignment_snapshot(current.clone(), config.checkpoint_timeout)
-                .await
-                .map_err(|error| error.to_string())?;
-            let reconciled_version = registry.assignment_version();
-            if reconciled_version < current.version {
-                return Err(format!(
-                    "durable recovery assignment {} was not adopted; local assignment remains {}",
-                    current.version, reconciled_version
-                ));
-            }
-            return Ok(Some(reconciled_version));
+            return adopt_materialized_recovery_head(
+                &db,
+                &store,
+                &controller,
+                &registry,
+                &current,
+                head_deadline,
+                config.checkpoint_timeout,
+            )
+            .await
+            .map(Some);
         }
         if current.version > local_assignment.version() && current_roster_is_live {
             // A writer can fail after its durable CAS succeeds but before local adoption. Adopt
@@ -3930,6 +3854,7 @@ fn try_rebalance_owned(
             Arc::clone(&db),
             Arc::clone(&store),
             Arc::clone(&controller),
+            Arc::clone(&registry),
             current.clone(),
             config.checkpoint_timeout,
         )
@@ -3970,6 +3895,7 @@ fn try_rebalance_owned(
                 Arc::clone(&db),
                 Arc::clone(&store),
                 Arc::clone(&controller),
+                Arc::clone(&registry),
                 current.clone(),
                 proposal,
                 config.checkpoint_timeout,
@@ -3990,6 +3916,27 @@ fn try_rebalance_owned(
         )
         .await
     })
+}
+
+fn validate_local_assignment_head(
+    current: &AssignmentSnapshot,
+    current_owners: &[NodeId],
+    local_version: u64,
+    local_owners: &[NodeId],
+) -> Result<(), String> {
+    if current.version < local_version {
+        return Err(format!(
+            "durable assignment head {} regressed behind local assignment {local_version}",
+            current.version
+        ));
+    }
+    if current.version == local_version && current_owners != local_owners {
+        return Err(format!(
+            "durable and local assignment {} have different owner maps",
+            current.version
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -4036,12 +3983,20 @@ fn reconcile_pending_recovery_decision_owned(
     db: Arc<LaminarDB>,
     store: Arc<AssignmentSnapshotStore>,
     controller: Arc<ClusterController>,
+    registry: Arc<VnodeRegistry>,
     current: AssignmentSnapshot,
     operation_timeout: Duration,
 ) -> futures::future::BoxFuture<'static, Result<Option<u64>, String>> {
     Box::pin(async move {
-        reconcile_pending_recovery_decision(&db, &store, &controller, &current, operation_timeout)
-            .await
+        reconcile_pending_recovery_decision(
+            &db,
+            &store,
+            &controller,
+            &registry,
+            &current,
+            operation_timeout,
+        )
+        .await
     })
 }
 
@@ -4049,6 +4004,7 @@ fn authorize_recovery_successor_owned(
     db: Arc<LaminarDB>,
     store: Arc<AssignmentSnapshotStore>,
     controller: Arc<ClusterController>,
+    registry: Arc<VnodeRegistry>,
     current: AssignmentSnapshot,
     proposal: AssignmentSnapshot,
     operation_timeout: Duration,
@@ -4065,7 +4021,15 @@ fn authorize_recovery_successor_owned(
             &reason,
         )
         .await?;
-        materialize_recovery_decision(&db, &store, &controller, decision, operation_timeout).await
+        materialize_recovery_decision(
+            &db,
+            &store,
+            &controller,
+            &registry,
+            decision,
+            operation_timeout,
+        )
+        .await
     })
 }
 
@@ -4897,6 +4861,7 @@ async fn adopt_any(
     db: &Arc<LaminarDB>,
     store: &AssignmentSnapshotStore,
     controller: &ClusterController,
+    registry: &VnodeRegistry,
     snap: AssignmentSnapshot,
     operation_timeout: Duration,
 ) -> Result<(), String> {
@@ -4911,7 +4876,8 @@ async fn adopt_any(
         db.validate_source_drain_snapshot(&snap)
             .map_err(|error| error.to_string())?;
     } else if audited.is_recovery() {
-        prepare_recovery_assignment_adoption(db, store, controller, &snap, deadline).await?;
+        prepare_recovery_assignment_adoption(db, store, controller, registry, &snap, deadline)
+            .await?;
         db.adopt_recovery_assignment_snapshot(snap, operation_timeout)
             .await
             .map_err(|error| error.to_string())?;

--- a/crates/laminar-db/src/rebalance/recovery_adoption.rs
+++ b/crates/laminar-db/src/rebalance/recovery_adoption.rs
@@ -1,0 +1,169 @@
+use std::sync::{atomic::Ordering, Arc};
+use std::time::Duration;
+
+use laminar_core::cluster::control::{
+    AssignmentSnapshot, AssignmentSnapshotStore, ClusterController,
+};
+use laminar_core::state::VnodeRegistry;
+
+use super::{abort_predecessor_checkpoint_for_recovery, try_suspend_recovery_assignment_authority};
+use crate::db::{DbState, LaminarDB};
+
+pub(super) async fn ensure_local_recovery_fault(
+    db: &LaminarDB,
+    controller: &ClusterController,
+) -> Result<(), String> {
+    controller.set_recovering(true);
+    crate::coordinated_recovery::request_local_fault(controller, &db.pending_recovery_fault)
+        .await
+        .map(|_| ())
+}
+
+pub(super) fn require_recovery_cold_bootstrap(
+    db: &LaminarDB,
+    controller: &ClusterController,
+    registry: &VnodeRegistry,
+    snapshot: &AssignmentSnapshot,
+) -> Result<(), String> {
+    let target_owners = snapshot
+        .to_vnode_vec(registry.vnode_count())
+        .map_err(|error| error.to_string())?;
+    let current_owners = registry.snapshot();
+    let local = controller.instance_id();
+    let acquires_vnodes = target_owners
+        .iter()
+        .zip(current_owners.iter())
+        .any(|(target, current)| *target == local && *current != local);
+    if !acquires_vnodes {
+        return Ok(());
+    }
+    let state = DbState::load(&db.state);
+    if matches!(state, DbState::Created | DbState::Faulted)
+        && db.installed_vnode_state.lock().is_none()
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "recovery assignment {} vnode acquisition must wait for a faulted cold bootstrap; local graph is {state:?}",
+        snapshot.version
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalRecoveryAssignmentScope {
+    Participant,
+    Ownerless,
+}
+
+/// Classify this exact process generation against an authority-audited recovery target.
+///
+/// An ownerless process may follow the target topology, but it has no checkpoint or recovery
+/// authority and must not turn the target's recovery provenance into a new cluster-wide fault.
+pub(super) fn local_recovery_assignment_scope(
+    snapshot: &AssignmentSnapshot,
+    controller: &ClusterController,
+) -> Result<LocalRecoveryAssignmentScope, String> {
+    let fence = snapshot
+        .assignment_fence()
+        .map_err(|error| error.to_string())?;
+    let owners = snapshot
+        .to_vnode_vec(fence.vnode_count)
+        .map_err(|error| error.to_string())?;
+    let owner_ids = owners.iter().map(|owner| owner.0).collect::<Vec<_>>();
+    if !fence.is_canonical() || !fence.matches_owner_map(&owner_ids) {
+        return Err(format!(
+            "recovery assignment {} has no canonical owner-complete target fence",
+            snapshot.version
+        ));
+    }
+
+    let local_id = controller.instance_id().0;
+    match fence.participant_incarnation(local_id) {
+        Some(incarnation) if incarnation == controller.recovery_incarnation() => {
+            Ok(LocalRecoveryAssignmentScope::Participant)
+        }
+        Some(_) => Err(format!(
+            "recovery assignment {} certifies another incarnation of process {local_id}",
+            snapshot.version
+        )),
+        None if owner_ids.contains(&local_id) => Err(format!(
+            "recovery assignment {} gives process {local_id} ownership without checkpoint authority",
+            snapshot.version
+        )),
+        None => Ok(LocalRecoveryAssignmentScope::Ownerless),
+    }
+}
+
+pub(super) fn prepare_recovery_assignment_adoption<'a>(
+    db: &'a Arc<LaminarDB>,
+    store: &'a AssignmentSnapshotStore,
+    controller: &'a ClusterController,
+    registry: &'a VnodeRegistry,
+    snapshot: &'a AssignmentSnapshot,
+    deadline: tokio::time::Instant,
+) -> futures::future::BoxFuture<'a, Result<(), String>> {
+    Box::pin(async move {
+        if !try_suspend_recovery_assignment_authority(db, controller, deadline).await? {
+            return Err(format!(
+                "recovery assignment {} waits for a local vnode transition",
+                snapshot.version
+            ));
+        }
+        if local_recovery_assignment_scope(snapshot, controller)?
+            == LocalRecoveryAssignmentScope::Ownerless
+        {
+            return Ok(());
+        }
+        ensure_local_recovery_fault(db, controller).await?;
+        abort_predecessor_checkpoint_for_recovery(store, controller, snapshot, deadline).await?;
+        require_recovery_cold_bootstrap(db, controller, registry, snapshot)
+    })
+}
+
+pub(super) async fn prepare_watched_recovery_adoption(
+    db: &Arc<LaminarDB>,
+    store: &AssignmentSnapshotStore,
+    controller: &ClusterController,
+    registry: &VnodeRegistry,
+    snapshot: &AssignmentSnapshot,
+    deadline: tokio::time::Instant,
+) -> Result<u64, String> {
+    ensure_local_recovery_fault(db, controller)
+        .await
+        .map_err(|error| format!("snapshot watcher: could not publish recovery fault: {error}"))?;
+    abort_predecessor_checkpoint_for_recovery(store, controller, snapshot, deadline)
+        .await
+        .map_err(|error| {
+            format!(
+                "snapshot watcher: could not settle predecessor checkpoint for recovery: {error}"
+            )
+        })?;
+    require_recovery_cold_bootstrap(db, controller, registry, snapshot).map_err(|error| {
+        format!("snapshot watcher: recovery assignment waits for compute retirement: {error}")
+    })?;
+    Ok(db.assignment_authority_revision.load(Ordering::Acquire))
+}
+
+pub(super) async fn adopt_materialized_recovery_head(
+    db: &Arc<LaminarDB>,
+    store: &AssignmentSnapshotStore,
+    controller: &ClusterController,
+    registry: &VnodeRegistry,
+    snapshot: &AssignmentSnapshot,
+    deadline: tokio::time::Instant,
+    operation_timeout: Duration,
+) -> Result<u64, String> {
+    prepare_recovery_assignment_adoption(db, store, controller, registry, snapshot, deadline)
+        .await?;
+    db.adopt_recovery_assignment_snapshot(snapshot.clone(), operation_timeout)
+        .await
+        .map_err(|error| error.to_string())?;
+    let reconciled_version = registry.assignment_version();
+    if reconciled_version < snapshot.version {
+        return Err(format!(
+            "durable recovery assignment {} was not adopted; local assignment remains {reconciled_version}",
+            snapshot.version
+        ));
+    }
+    Ok(reconciled_version)
+}

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -923,9 +923,9 @@ async fn stopped_recovery_successor_fixture(
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("the live predecessor intentionally lacks the removed owner's handoff manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     let target = durable
@@ -2485,9 +2485,9 @@ async fn dead_predecessor_publishes_an_authorized_recovery_generation() {
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("the test checkpoint intentionally omits the acquired vnode manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     let successor = durable.load().await.unwrap().unwrap();
@@ -2610,9 +2610,9 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("live adoption still requires the failed owner's handoff manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     match follower.await.unwrap() {
@@ -2761,7 +2761,7 @@ async fn recovery_adoption_fault_scope_excludes_an_ownerless_process() {
     let ownerless_db = LaminarDB::builder()
         .cluster_controller(Arc::clone(&ownerless_controller))
         .cluster_checkpoint_object_store(test_cluster_checkpoint_store())
-        .vnode_registry(ownerless_registry)
+        .vnode_registry(Arc::clone(&ownerless_registry))
         .assignment_snapshot_store(Arc::clone(&durable))
         .build()
         .await
@@ -2775,6 +2775,7 @@ async fn recovery_adoption_fault_scope_excludes_an_ownerless_process() {
         &ownerless_db,
         &durable,
         &ownerless_controller,
+        &ownerless_registry,
         &target,
         tokio::time::Instant::now() + Duration::from_secs(1),
     )
@@ -2806,10 +2807,11 @@ async fn recovery_adoption_fault_scope_excludes_an_ownerless_process() {
     // shared authority for the report audit but withdraw this controller's local leader proof.
     participant_leadership.send(None).unwrap();
     participant_controller.set_active(true);
+    let participant_registry = Arc::new(VnodeRegistry::single_owner(1, NodeId(1)));
     let participant_db = LaminarDB::builder()
         .cluster_controller(Arc::clone(&participant_controller))
         .cluster_checkpoint_object_store(test_cluster_checkpoint_store())
-        .vnode_registry(Arc::new(VnodeRegistry::single_owner(1, NodeId(1))))
+        .vnode_registry(Arc::clone(&participant_registry))
         .assignment_snapshot_store(Arc::clone(&durable))
         .build()
         .await
@@ -2823,6 +2825,7 @@ async fn recovery_adoption_fault_scope_excludes_an_ownerless_process() {
         &participant_db,
         &durable,
         &participant_controller,
+        &participant_registry,
         &target,
         tokio::time::Instant::now() + Duration::from_secs(1),
     )
@@ -3359,6 +3362,73 @@ fn takeover_audits_a_recovery_head_while_its_pin_is_propagated_to_the_next_gener
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn materialized_recovery_waits_for_running_graph_retirement() {
+    let self_id = NodeId(1);
+    let (
+        db,
+        controller,
+        durable,
+        registry,
+        current,
+        _process_authority,
+        _authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    controller.note_unresponsive(&[NodeId(2)]);
+
+    let error = tokio::time::timeout(
+        Duration::from_secs(2),
+        try_rebalance(
+            &db,
+            &controller,
+            &durable,
+            &registry,
+            &[self_id, NodeId(2)],
+            RebalanceConfig::test_defaults(),
+        ),
+    )
+    .await
+    .expect("recovery successor materialization exceeded the test deadline")
+    .expect_err("a running graph must not live-adopt a recovery checkpoint cut");
+    assert!(
+        error.contains("must wait for a faulted cold bootstrap"),
+        "{error}"
+    );
+
+    let successor = durable.load().await.unwrap().unwrap();
+    assert_eq!(successor.version, current.version + 1);
+    assert_eq!(registry.assignment_version(), current.version);
+    assert!(db.pending_vnode_transition.lock().is_none());
+    assert!(db.installed_vnode_state.lock().is_some());
+    assert_eq!(DbState::load(&db.state), DbState::Running);
+
+    db.fence_coordinated_recovery_lifecycle();
+    let generation = Arc::clone(&db.rotation_execution_fence).write_owned().await;
+    db.installed_vnode_state.lock().take();
+    DbState::Faulted.store(&db.state);
+    drop(generation);
+
+    let adopted = tokio::time::timeout(
+        Duration::from_secs(2),
+        try_rebalance(
+            &db,
+            &controller,
+            &durable,
+            &registry,
+            &[self_id, NodeId(2)],
+            RebalanceConfig::test_defaults(),
+        ),
+    )
+    .await
+    .expect("cold recovery adoption exceeded the test deadline")
+    .expect("the retired graph must cold-adopt the materialized successor");
+    assert_eq!(adopted, Some(successor.version));
+    assert_eq!(registry.assignment_version(), successor.version);
+    assert!(db.pending_vnode_transition.lock().is_none());
+    assert!(db.installed_vnode_state.lock().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_audit() {
     let self_id = NodeId(1);
     let (
@@ -3382,9 +3452,9 @@ async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_a
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("live adoption intentionally lacks the failed owner's handoff manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     let successor = durable.load().await.unwrap().unwrap();
@@ -3507,9 +3577,9 @@ async fn recovery_decision_fault_precedes_graph_execution_drain() {
         .await
         .expect("recovery assignment materialization did not finish")
         .unwrap()
-        .expect_err("the test checkpoint intentionally omits the acquired vnode manifest");
+        .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
 }
@@ -3529,8 +3599,8 @@ async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
     ) = dead_predecessor_fixture().await;
     controller.note_unresponsive(&[NodeId(2)]);
 
-    // Materialize v2 through the normal Running path first; the missing handoff manifest leaves
-    // v1 local, exactly as it does before a subsequent retry observes the faulted graph.
+    // Materialize v2 while Running first; cold-bootstrap admission leaves v1 local until a
+    // subsequent retry observes the faulted graph.
     let error = try_rebalance(
         &db,
         &controller,
@@ -3540,9 +3610,9 @@ async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("live adoption intentionally lacks the acquired vnode manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     let successor = durable.load().await.unwrap().unwrap();
@@ -4395,9 +4465,9 @@ async fn successor_adoption_accepts_a_retained_predecessor_after_ancestry_prunin
         RebalanceConfig::test_defaults(),
     )
     .await
-    .expect_err("the test checkpoint intentionally omits the acquired vnode manifest");
+    .expect_err("vnode acquisition must wait for the running graph to retire");
     assert!(
-        error.contains("participant 2 handoff manifest is missing"),
+        error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
     );
     let recovery = durable.load().await.unwrap().unwrap();


### PR DESCRIPTION
## Reproduction

Native Azure diagnostic run [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468) established the original Start-without-Release failure. The later post-merge diagnostic [34501894268](https://github.com/laminardb/laminardb/actions/runs/34501894268) narrowed the next failure to recovery-successor adoption after the leader process was killed: both survivors rejected acquired interval-join vnodes because their in-memory state no longer matched the pinned checkpoint handoff cut.

A deterministic rebalance regression now materializes the recovery successor while the local graph is deliberately Running. Before the fix it entered live vnode restore and failed on the intentionally absent participant handoff manifest. The test then retires the graph through the existing coordinated-recovery lifecycle fence and proves the same durable successor cold-adopts within a bounded timeout.

## Root cause

Recovery successor materialization could race ahead of local graph retirement. A surviving process that acquired vnodes therefore tried to apply the checkpoint-bound recovery assignment as a live transition against in-memory state that had advanced beyond the pinned checkpoint cut. Azure latency made this race observable; the faster local object-store path usually retired the graph first.

## Minimal fix

Require a recovery target that gives the local process new vnodes to wait until the graph is Created or Faulted and installed vnode state has been retired. The guard runs after recovery-fault publication and predecessor-checkpoint settlement, and is shared by leader/materialization and follower snapshot-watcher adoption. Unchanged local ownership still permits the existing topology-only live adoption path.

No timeout was increased. No dependency, Cargo feature, linker/build setting, cloud infrastructure, Delta/Iceberg behavior, or admission rule changed.

## Validation

- New focused red/green regression: `materialized_recovery_waits_for_running_graph_retirement`
- Full `rebalance::tests::`: 67 passed
- Existing three-process follower checkpoint-fault/Prepare/Start/Release regression: passed; recovery completed in 8.7s and checkpoints continued through 82+
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

Azure checkpoint storage remains uncertified until the post-merge native diagnostic and certification baseline both pass on the exact merge SHA.

Delivery admission is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a recovery-adoption race in `laminar-db` that made survivors reject acquired vnodes after a leader process was killed.

- Recovery assignments that give the local process new vnodes now wait for the graph to be `Created` or `Faulted` with installed vnode state retired before cold-adopting.
- Previously a surviving process applied the checkpoint-bound recovery assignment as a live transition against in-memory state ahead of the pinned checkpoint cut.
- The cold-bootstrap guard is shared by leader materialization and follower snapshot-watcher adoption.
- Unchanged local ownership keeps the existing topology-only live adoption path.
- Adds a deterministic regression test; all 67 `rebalance::tests::` pass unchanged.
- No timeouts, dependencies, or admission rules changed.

<sup>Written for commit dcfb5b932f7727c4a05f35b6af7530f9093f4a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery and rebalance handling when a node is faulted or recovering.
  - Recovery now waits for the running graph to retire before acquiring virtual nodes when a cold bootstrap is required.
  - Improved adoption of recovered assignments and materialized recovery state.
  - Added safeguards to prevent local assignment heads from moving backward during recovery.
- **Tests**
  - Expanded coverage for recovery adoption, ownerless processes, cold bootstrap requirements, and graph retirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->