### PR TITLE
fix(recovery): retire graph for recovery vnode acquisition

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -28,7 +28,7 @@ use laminar_core::cluster::control::{
 };
 use laminar_core::cluster::discovery::NodeId;
 
-use crate::LaminarDB;
+use crate::{db::DbState, LaminarDB};
 
 /// Healthy-state monitor cadence. Only the leader polls the shared fault inventory; followers use
 /// the replicated recovery intent unless they have a local settlement latch.
@@ -2545,6 +2545,38 @@ async fn stop_and_purge(db: &Arc<LaminarDB>) -> bool {
 async fn stop_for_recovery(db: &Arc<LaminarDB>) -> bool {
     db.fence_coordinated_recovery_lifecycle();
     stop_and_purge(db).await
+}
+
+/// Retire a live graph so an acquired recovery assignment cannot reuse predecessor heap state.
+pub(crate) async fn fault_for_recovery_assignment(db: &Arc<LaminarDB>) -> bool {
+    let lifecycle_timeout = recovery_stop_lifecycle_timeout(db);
+    db.fence_coordinated_recovery_lifecycle();
+    run_lifecycle(db, lifecycle_timeout, |db| async move {
+        db.stop_pipeline_for_coordinated_recovery().await?;
+        db.purge_shuffle_receiver_buffers();
+
+        let mut runtime_shutdown = db.runtime_shutdown.write();
+        let ready = !db.is_closed()
+            && DbState::load(&db.state) == DbState::Created
+            && runtime_shutdown.is_cancelled()
+            && db.cluster_intake_fenced()
+            && db.coordinated_recovery_in_progress()
+            && db.pending_recovery_fault.load(Ordering::Acquire) != 0
+            && db.pending_vnode_transition.lock().is_none()
+            && db.installed_vnode_state.lock().is_none();
+        if !ready {
+            return Err(crate::DbError::Checkpoint(
+                "recovery assignment could not establish a retired local graph boundary".into(),
+            ));
+        }
+
+        // RECOVERY: a naturally faulted generation leaves this token live. Recreate that exact
+        // cold-adoption invariant only after the cancelled runtime has joined and its heap retired.
+        *runtime_shutdown = tokio_util::sync::CancellationToken::new();
+        DbState::Faulted.store(&db.state);
+        Ok(())
+    })
+    .await
 }
 
 fn recovery_driver_proof_is_current(controller: &ClusterController, round: &RecoveryRound) -> bool {

--- a/crates/laminar-db/src/rebalance/recovery_adoption.rs
+++ b/crates/laminar-db/src/rebalance/recovery_adoption.rs
@@ -19,8 +19,8 @@ pub(super) async fn ensure_local_recovery_fault(
         .map(|_| ())
 }
 
-pub(super) fn require_recovery_cold_bootstrap(
-    db: &LaminarDB,
+pub(super) async fn require_recovery_cold_bootstrap(
+    db: &Arc<LaminarDB>,
     controller: &ClusterController,
     registry: &VnodeRegistry,
     snapshot: &AssignmentSnapshot,
@@ -37,11 +37,19 @@ pub(super) fn require_recovery_cold_bootstrap(
     if !acquires_vnodes {
         return Ok(());
     }
-    let state = DbState::load(&db.state);
+    let mut state = DbState::load(&db.state);
     if matches!(state, DbState::Created | DbState::Faulted)
         && db.installed_vnode_state.lock().is_none()
     {
         return Ok(());
+    }
+    if crate::coordinated_recovery::fault_for_recovery_assignment(db).await {
+        state = DbState::load(&db.state);
+        if matches!(state, DbState::Created | DbState::Faulted)
+            && db.installed_vnode_state.lock().is_none()
+        {
+            return Ok(());
+        }
     }
     Err(format!(
         "recovery assignment {} vnode acquisition must wait for a faulted cold bootstrap; local graph is {state:?}",
@@ -116,7 +124,7 @@ pub(super) fn prepare_recovery_assignment_adoption<'a>(
         }
         ensure_local_recovery_fault(db, controller).await?;
         abort_predecessor_checkpoint_for_recovery(store, controller, snapshot, deadline).await?;
-        require_recovery_cold_bootstrap(db, controller, registry, snapshot)
+        require_recovery_cold_bootstrap(db, controller, registry, snapshot).await
     })
 }
 
@@ -138,9 +146,11 @@ pub(super) async fn prepare_watched_recovery_adoption(
                 "snapshot watcher: could not settle predecessor checkpoint for recovery: {error}"
             )
         })?;
-    require_recovery_cold_bootstrap(db, controller, registry, snapshot).map_err(|error| {
-        format!("snapshot watcher: recovery assignment waits for compute retirement: {error}")
-    })?;
+    require_recovery_cold_bootstrap(db, controller, registry, snapshot)
+        .await
+        .map_err(|error| {
+            format!("snapshot watcher: recovery assignment waits for compute retirement: {error}")
+        })?;
     Ok(db.assignment_authority_revision.load(Ordering::Acquire))
 }
 

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -914,6 +914,10 @@ async fn stopped_recovery_successor_fixture(
     ) = dead_predecessor_fixture().await;
     controller.note_unresponsive(&[failed]);
 
+    // Keep this fixture at the materialized-but-not-retired boundary so the tests below can
+    // install an exact stopped Prepare themselves.
+    db.coordinated_lifecycle_active
+        .store(true, Ordering::Release);
     let error = try_rebalance(
         &db,
         &controller,
@@ -924,6 +928,8 @@ async fn stopped_recovery_successor_fixture(
     )
     .await
     .expect_err("vnode acquisition must wait for the running graph to retire");
+    db.coordinated_lifecycle_active
+        .store(false, Ordering::Release);
     assert!(
         error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
@@ -2462,7 +2468,7 @@ async fn missing_source_drain_receipt_requires_stopped_recovery() {
 }
 
 #[tokio::test]
-async fn dead_predecessor_publishes_an_authorized_recovery_generation() {
+async fn dead_predecessor_retires_the_graph_and_publishes_an_authorized_recovery_generation() {
     let self_id = NodeId(1);
     let (
         db,
@@ -2476,21 +2482,22 @@ async fn dead_predecessor_publishes_an_authorized_recovery_generation() {
     ) = dead_predecessor_fixture().await;
     controller.note_unresponsive(&[NodeId(2)]);
 
-    let error = try_rebalance(
-        &db,
-        &controller,
-        &durable,
-        &registry,
-        &[self_id, NodeId(2)],
-        RebalanceConfig::test_defaults(),
+    let adopted = tokio::time::timeout(
+        Duration::from_secs(2),
+        try_rebalance(
+            &db,
+            &controller,
+            &durable,
+            &registry,
+            &[self_id, NodeId(2)],
+            RebalanceConfig::test_defaults(),
+        ),
     )
     .await
-    .expect_err("vnode acquisition must wait for the running graph to retire");
-    assert!(
-        error.contains("must wait for a faulted cold bootstrap"),
-        "{error}"
-    );
+    .expect("recovery successor retirement exceeded the test deadline")
+    .expect("recovery successor must retire the graph before vnode acquisition");
     let successor = durable.load().await.unwrap().unwrap();
+    assert_eq!(adopted, Some(successor.version));
     assert_eq!(successor.version, current.version + 1);
     assert!(!successor.draining);
     assert_eq!(successor.participants.len(), 1);
@@ -2528,7 +2535,11 @@ async fn dead_predecessor_publishes_an_authorized_recovery_generation() {
         )
         .await
         .unwrap());
-    assert_eq!(registry.assignment_version(), current.version);
+    assert_eq!(registry.assignment_version(), successor.version);
+    assert!(db.pending_vnode_transition.lock().is_none());
+    assert!(db.installed_vnode_state.lock().is_none());
+    assert!(!db.runtime_shutdown.read().is_cancelled());
+    assert_eq!(DbState::load(&db.state), DbState::Faulted);
     assert!(db.cluster_intake_fenced());
     assert!(controller.is_recovering());
     assert!(controller
@@ -2601,6 +2612,8 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
         }))
     };
     controller.note_unresponsive(&[NodeId(2)]);
+    db.coordinated_lifecycle_active
+        .store(true, Ordering::Release);
     let error = try_rebalance(
         &db,
         &controller,
@@ -2611,6 +2624,8 @@ async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint()
     )
     .await
     .expect_err("vnode acquisition must wait for the running graph to retire");
+    db.coordinated_lifecycle_active
+        .store(false, Ordering::Release);
     assert!(
         error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
@@ -3362,73 +3377,6 @@ fn takeover_audits_a_recovery_head_while_its_pin_is_propagated_to_the_next_gener
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn materialized_recovery_waits_for_running_graph_retirement() {
-    let self_id = NodeId(1);
-    let (
-        db,
-        controller,
-        durable,
-        registry,
-        current,
-        _process_authority,
-        _authority_store,
-        _checkpoint_dir,
-    ) = dead_predecessor_fixture().await;
-    controller.note_unresponsive(&[NodeId(2)]);
-
-    let error = tokio::time::timeout(
-        Duration::from_secs(2),
-        try_rebalance(
-            &db,
-            &controller,
-            &durable,
-            &registry,
-            &[self_id, NodeId(2)],
-            RebalanceConfig::test_defaults(),
-        ),
-    )
-    .await
-    .expect("recovery successor materialization exceeded the test deadline")
-    .expect_err("a running graph must not live-adopt a recovery checkpoint cut");
-    assert!(
-        error.contains("must wait for a faulted cold bootstrap"),
-        "{error}"
-    );
-
-    let successor = durable.load().await.unwrap().unwrap();
-    assert_eq!(successor.version, current.version + 1);
-    assert_eq!(registry.assignment_version(), current.version);
-    assert!(db.pending_vnode_transition.lock().is_none());
-    assert!(db.installed_vnode_state.lock().is_some());
-    assert_eq!(DbState::load(&db.state), DbState::Running);
-
-    db.fence_coordinated_recovery_lifecycle();
-    let generation = Arc::clone(&db.rotation_execution_fence).write_owned().await;
-    db.installed_vnode_state.lock().take();
-    DbState::Faulted.store(&db.state);
-    drop(generation);
-
-    let adopted = tokio::time::timeout(
-        Duration::from_secs(2),
-        try_rebalance(
-            &db,
-            &controller,
-            &durable,
-            &registry,
-            &[self_id, NodeId(2)],
-            RebalanceConfig::test_defaults(),
-        ),
-    )
-    .await
-    .expect("cold recovery adoption exceeded the test deadline")
-    .expect("the retired graph must cold-adopt the materialized successor");
-    assert_eq!(adopted, Some(successor.version));
-    assert_eq!(registry.assignment_version(), successor.version);
-    assert!(db.pending_vnode_transition.lock().is_none());
-    assert!(db.installed_vnode_state.lock().is_none());
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_audit() {
     let self_id = NodeId(1);
     let (
@@ -3443,6 +3391,8 @@ async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_a
     ) = dead_predecessor_fixture().await;
     controller.note_unresponsive(&[NodeId(2)]);
 
+    db.coordinated_lifecycle_active
+        .store(true, Ordering::Release);
     let error = try_rebalance(
         &db,
         &controller,
@@ -3453,6 +3403,8 @@ async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_a
     )
     .await
     .expect_err("vnode acquisition must wait for the running graph to retire");
+    db.coordinated_lifecycle_active
+        .store(false, Ordering::Release);
     assert!(
         error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
@@ -3529,7 +3481,7 @@ async fn recovery_decision_fault_precedes_graph_execution_drain() {
         controller,
         durable,
         registry,
-        _current,
+        current,
         _process_authority,
         _authority_store,
         _checkpoint_dir,
@@ -3573,15 +3525,14 @@ async fn recovery_decision_fault_precedes_graph_execution_drain() {
     .expect("recovery fault publication waited for the graph execution drain");
 
     drop(execution);
-    let error = tokio::time::timeout(Duration::from_secs(2), rebalancing)
+    let adopted = tokio::time::timeout(Duration::from_secs(2), rebalancing)
         .await
         .expect("recovery assignment materialization did not finish")
         .unwrap()
-        .expect_err("vnode acquisition must wait for the running graph to retire");
-    assert!(
-        error.contains("must wait for a faulted cold bootstrap"),
-        "{error}"
-    );
+        .expect("recovery assignment must retire the graph after the execution fence drains");
+    assert_eq!(adopted, Some(current.version + 1));
+    assert_eq!(registry.assignment_version(), current.version + 1);
+    assert_eq!(DbState::load(&db.state), DbState::Faulted);
 }
 
 #[tokio::test]
@@ -3601,6 +3552,8 @@ async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
 
     // Materialize v2 while Running first; cold-bootstrap admission leaves v1 local until a
     // subsequent retry observes the faulted graph.
+    db.coordinated_lifecycle_active
+        .store(true, Ordering::Release);
     let error = try_rebalance(
         &db,
         &controller,
@@ -3611,6 +3564,10 @@ async fn cold_recovery_adoption_requires_the_coordinated_lifecycle_fence() {
     )
     .await
     .expect_err("vnode acquisition must wait for the running graph to retire");
+    db.coordinated_lifecycle_active
+        .store(false, Ordering::Release);
+    db.coordinated_recovery_fenced
+        .store(false, Ordering::Release);
     assert!(
         error.contains("must wait for a faulted cold bootstrap"),
         "{error}"
@@ -4456,6 +4413,8 @@ async fn successor_adoption_accepts_a_retained_predecessor_after_ancestry_prunin
     ) = dead_predecessor_fixture().await;
     controller.note_unresponsive(&[NodeId(2)]);
 
+    db.coordinated_lifecycle_active
+        .store(true, Ordering::Release);
     let error = try_rebalance(
         &db,
         &controller,
@@ -4466,6 +4425,8 @@ async fn successor_adoption_accepts_a_retained_predecessor_after_ancestry_prunin
     )
     .await
     .expect_err("vnode acquisition must wait for the running graph to retire");
+    db.coordinated_lifecycle_active
+        .store(false, Ordering::Release);
     assert!(
         error.contains("must wait for a faulted cold bootstrap"),
         "{error}"


### PR DESCRIPTION
## Reproduction

The original native Azure evidence is run [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468). After the prior cold-bootstrap guard landed, post-merge native diagnostic [34534820267](https://github.com/laminardb/laminardb/actions/runs/34534820267) completed 1/2 process kills, then timed out with both survivors `Recovering`, no leader, and no Prepare/Start/Release. Its bounded diagnostics recorded an authority-sequenced recovery successor plus repeated `recovery_cold_bootstrap_required` and `assignment_unavailable` markers, with zero graph-drain timeout samples.

The focused regression `dead_predecessor_retires_the_graph_and_publishes_an_authorized_recovery_generation` starts with a running predecessor graph and a committed checkpoint, removes its peer, materializes the recovery successor, and requires bounded cold adoption. Before this fix the call stopped at the cold-bootstrap guard while the graph remained Running and the local registry remained on the predecessor.

## Root cause

Recovery successor materialization correctly refused to acquire checkpoint-bound vnodes into a live predecessor heap. However, publishing the recovery fault did not retire that graph. The durable assignment therefore advanced while the local registry stayed behind, which also prevented the recovery monitor from reconstructing an owner-complete assignment certificate. Neither assignment adoption nor Prepare could make progress.

## Minimal fix

When an authority-audited recovery target gives this process new vnodes, reuse the existing coordinated-recovery lifecycle owner to stop the pipeline and purge shuffle buffers. Only after the old runtime has joined and pending/installed vnode state is empty, publish the same `Faulted` plus live-generation-token invariant produced by a natural compute fault. The existing cold-adoption checks then install the checkpoint-bound successor. Topology-only recovery targets that acquire no local vnodes are unchanged.

No timeout was increased. No dependency, Cargo feature, linker/build setting, cloud infrastructure, Delta/Iceberg behavior, or admission rule changed.

## Validation

- Focused bounded regression: passed
- `rebalance::tests::`: 66 passed
- `coordinated_recovery::tests::`: 59 passed
- Existing three-process follower checkpoint-fault regression: Release completed in 8.44s; durable progress continued through checkpoint 196; final output assertions passed
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

Azure checkpoint storage remains uncertified until the post-merge native diagnostic and certification baseline both pass on the exact merge SHA.

Delivery admission is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery vnode acquisition so an authority-audited recovery target retires the live predecessor graph before adopting checkpoint-bound vnodes. Previously the durable assignment advanced while the local graph stayed Running, so adoption and Prepare made no progress.

**Bug Fixes**
- Reuses the coordinated-recovery lifecycle to stop the pipeline, purge shuffle buffers, and publish the same `Faulted` plus live-generation-token invariant a natural compute fault produces.
- Cold-adoption checks then install the checkpoint-bound successor; topology-only targets that acquire no vnodes are unchanged.

<sup>Written for commit c889d8fa3f5143899e906dfeb61819f68deee39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability Improvements**
  - Recovery assignments now safely fence and reset database lifecycle activity before proceeding.
  - Rebalancing can retire an existing running graph and successfully adopt an authorized recovery successor.
  - Cold-start recovery now verifies that the database is fully stopped and has no remaining partition state before adoption.
  - Recovery operations continue to reject transitions when the required lifecycle boundary cannot be established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->