### PR TITLE
fix(recovery): reject absent checkpoint rosters early

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -2905,6 +2905,7 @@ async fn current_recovery_assignment_fence(
             .participant_incarnation(local_id)
             .is_some_and(|incarnation| incarnation != controller.recovery_incarnation())
         || (fence.participant_incarnation(local_id).is_none() && local_owners.contains(&local_id))
+        || !recovery_fence_participants_present(controller, &fence)
     {
         return Ok(None);
     }
@@ -2916,9 +2917,7 @@ async fn current_recovery_assignment_fence(
     )
     .await
     .map_err(|_| "recovery assignment incarnation audit timed out".to_string())??;
-    if incarnations != fence.participants
-        || !recovery_fence_participants_present(controller, &fence)
-    {
+    if incarnations != fence.participants {
         return Ok(None);
     }
     let adopted = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -1519,6 +1519,50 @@ async fn recovery_reconstructs_a_suspended_fence_from_exact_durable_adoption() {
 }
 
 #[tokio::test]
+async fn recovery_rejects_an_absent_predecessor_before_durable_incarnation_audit() {
+    use laminar_core::state::{NodeId as StateNodeId, VnodeRegistry};
+
+    let (controller, _members_tx, kv) = controller(Vec::new()).await;
+    let controller = Arc::new(controller);
+    report_test_fault(&controller).await;
+    let round = round_for_current_faults_at_assignment(&controller, 7, 1, &[1, 2]).await;
+    let (assignments, _committed) =
+        initial_assignment_store(&round.assignment_fence, &[NodeId(1), NodeId(2)]).await;
+    let registry = Arc::new(VnodeRegistry::new_unassigned(2));
+    registry.set_assignment_and_version(Arc::from([StateNodeId(1), StateNodeId(2)]), 1);
+    let db = LaminarDB::builder()
+        .cluster_controller(Arc::clone(&controller))
+        .cluster_checkpoint_object_store(Arc::new(object_store::memory::InMemory::new()))
+        .vnode_registry(registry)
+        .assignment_snapshot_store(assignments)
+        .build()
+        .await
+        .unwrap();
+    publish_round_roster(&controller, &kv, &round).await;
+    kv.seed(
+        NodeId(2),
+        "control:recovery-incarnation",
+        "malformed".into(),
+    );
+    controller.set_recovering(true);
+    db.fence_coordinated_recovery_lifecycle();
+    controller.publish_checkpoint_assignment_fence(None);
+
+    let observed = tokio::time::timeout(
+        Duration::from_millis(100),
+        current_recovery_assignment_fence(
+            &db,
+            &controller,
+            tokio::time::Instant::now() + Duration::from_secs(1),
+        ),
+    )
+    .await
+    .expect("absent predecessor detection must not wait on durable incarnation I/O")
+    .expect("an absent predecessor is unavailable, not an assignment audit failure");
+    assert_eq!(observed, None);
+}
+
+#[tokio::test]
 async fn recovery_reconstructs_a_suspended_drain_predecessor_fence() {
     use laminar_core::state::{NodeId as StateNodeId, VnodeRegistry};
 


### PR DESCRIPTION
## Scope

Checkpoint recovery only. This does not change Azure Delta/Iceberg admission, connector dependencies, features, linker settings, or unrelated infrastructure.

## Deterministic reproduction

Adds `recovery_rejects_an_absent_predecessor_before_durable_incarnation_audit` using the existing coordinated-recovery test infrastructure. It retains a two-node committed predecessor while only one checkpoint-capable member is present, then makes the absent node's stale durable incarnation malformed. The test is bounded and requires recovery to return no eligible fence without entering that futile incarnation audit.

## Root cause

`current_recovery_assignment_fence` audited the committed predecessor's durable process-incarnation roster before checking whether every participant was still present. Once a killed predecessor was absent, that roster could not be eligible, but Azure still paid authority-checked control reads before learning that fact. Repeated serialized audits consumed the recovery window.

This matches post-merge native diagnostic [34547996372](https://github.com/laminardb/laminardb/actions/runs/34547996372): conformance and deterministic fault contracts passed with zero skips, but the process soak completed only 1/2 kills; both survivors remained Recovering after successor authorization/assignment rotation and never published Prepare, Start, or Release. Cleanup passed. It is the next bounded finding after native run [34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468).

## Minimal fix

Reject an already-absent predecessor roster in the existing local fence-validation guard before durable incarnation/adoption reads. The existing post-I/O membership recheck remains, and quarantined-but-live participants remain eligible because this deliberately uses checkpoint membership without the ordinary unresponsive filter. Recovery remains fail-closed.

## Local validation

- focused regression: passed
- suspended exact-adoption and drain-predecessor recovery tests: passed
- `cargo +nightly fmt --all -- --check`: passed
- readability check: passed
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`: passed
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`: passed

## Certification status

Azure checkpoint storage is still uncertified until the exact merged SHA passes the post-merge native diagnostic and certification baseline. Delivery admission is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects absent checkpoint recovery rosters before the durable incarnation audit, so recovery no longer consumes the recovery window on futile I/O when a predecessor is gone.

- Adds a regression test proving absent predecessors are detected without waiting on durable incarnation reads.
- Moves the existing presence check ahead of the I/O; the post-I/O membership recheck remains unchanged.
- Azure checkpoint storage stays uncertified until the merged SHA passes the native diagnostic and certification baseline.

<sup>Written for commit 9887b244cd0ea0b594e39a120f0ef1056a57b68a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recovery now correctly treats an unavailable predecessor as absent before performing durable incarnation validation.
  - Prevents recovery checks from waiting unnecessarily when a required participant is unavailable.

- **Tests**
  - Added coverage for recovery rounds with an absent predecessor and malformed incarnation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->