### PR TITLE
fix(cluster): avoid duplicate recovery authority audit

### DIFF
--- a/crates/laminar-db/src/rebalance/mod.rs
+++ b/crates/laminar-db/src/rebalance/mod.rs
@@ -3041,14 +3041,6 @@ fn materialize_recovery_decision<'a>(
                 decision.target_version()
             ));
         }
-        tokio::time::timeout_at(
-            deadline,
-            audit_assignment_snapshot_authority(store, Some(controller), &durable),
-        )
-        .await
-        .map_err(|_| {
-            "recovery assignment audit exceeded the materialization deadline".to_string()
-        })??;
         prepare_recovery_assignment_adoption(db, store, controller, registry, &durable, deadline)
             .await?;
         let version = durable.version;

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -29,12 +29,19 @@ impl laminar_core::cluster::control::ClusterKv for DelayedScanKv {
 struct GetBarrier {
     entered: Arc<Notify>,
     release: Arc<Notify>,
+    path_prefix: Option<&'static str>,
     reads_before_wait: std::sync::atomic::AtomicUsize,
     armed: std::sync::atomic::AtomicBool,
 }
 
 impl GetBarrier {
-    async fn wait_once(&self) {
+    async fn wait_once(&self, location: &object_store::path::Path) {
+        if self
+            .path_prefix
+            .is_some_and(|prefix| !location.as_ref().starts_with(prefix))
+        {
+            return;
+        }
         if self
             .reads_before_wait
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
@@ -95,7 +102,7 @@ impl ObjectStore for ReadBarrierStore {
         options: object_store::GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
         if let Some(get) = &self.get {
-            get.wait_once().await;
+            get.wait_once(location).await;
         }
         self.inner.get_opts(location, options).await
     }
@@ -2551,6 +2558,86 @@ async fn dead_predecessor_retires_the_graph_and_publishes_an_authorized_recovery
 }
 
 #[tokio::test]
+async fn recovery_materialization_does_not_repeat_the_settlement_authority_audit() {
+    let self_id = NodeId(1);
+    let (
+        db,
+        controller,
+        durable,
+        registry,
+        current,
+        _process_authority,
+        authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    controller.note_unresponsive(&[NodeId(2)]);
+
+    let local_participant = current
+        .participants
+        .iter()
+        .copied()
+        .find(|participant| participant.node_id == self_id.0)
+        .unwrap();
+    let proposal = current
+        .next_for_participants(
+            AssignmentSnapshot::vnodes_from_vec(&[self_id, self_id]),
+            vec![local_participant],
+        )
+        .unwrap();
+    let decision = authorize_recovery_successor(
+        &db,
+        &durable,
+        &controller,
+        &current,
+        proposal,
+        Duration::from_secs(2),
+        "deterministic recovery audit regression",
+    )
+    .await
+    .expect("the successor must be authorized before materialization");
+
+    let proposal_reads = Arc::new(GetBarrier {
+        entered: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+        path_prefix: Some("control/assignment-recovery-proposals/"),
+        reads_before_wait: std::sync::atomic::AtomicUsize::new(2),
+        armed: std::sync::atomic::AtomicBool::new(true),
+    });
+    let bounded_store: Arc<dyn ObjectStore> = Arc::new(ReadBarrierStore {
+        inner: authority_store,
+        get: Some(Arc::clone(&proposal_reads)),
+        stall_list: false,
+    });
+    let materialization_store = Arc::new(AssignmentSnapshotStore::new(bounded_store));
+
+    let version = tokio::time::timeout(
+        Duration::from_secs(2),
+        materialize_recovery_decision(
+            &db,
+            &materialization_store,
+            &controller,
+            &registry,
+            decision,
+            Duration::from_secs(1),
+        ),
+    )
+    .await
+    .expect("recovery materialization exceeded the bounded test timeout")
+    .expect("one settlement authority audit must fit the materialization budget");
+
+    assert_eq!(version, Some(current.version + 1));
+    assert_eq!(
+        proposal_reads.reads_before_wait.load(Ordering::Acquire),
+        0,
+        "materialization must validate the proposal and perform the settlement authority audit"
+    );
+    assert!(
+        proposal_reads.armed.load(Ordering::Acquire),
+        "a redundant third proposal read exhausted the materialization budget"
+    );
+}
+
+#[tokio::test]
 async fn recovery_materialization_aborts_the_unresolved_predecessor_checkpoint() {
     let self_id = NodeId(1);
     let (
@@ -3422,6 +3509,7 @@ async fn recovery_adoption_waits_for_compute_fault_publication_after_authority_a
     let get = Arc::new(GetBarrier {
         entered: Arc::clone(&entered),
         release: Arc::clone(&release),
+        path_prefix: None,
         // The first read materializes the requested target. Block the audit's independent
         // recovery-materialization read so the generation changes during the authority audit.
         reads_before_wait: std::sync::atomic::AtomicUsize::new(1),


### PR DESCRIPTION
## Summary

- add a deterministic recovery-materialization regression using the existing rebalance fixture and object-store read barrier
- remove one redundant full recovery-authority audit before predecessor settlement
- preserve the settlement audit and the independent pre-publication adoption audit

## Reproduction and root cause

Azure diagnostic run 34557782596 passed checkpoint-store conformance and the deterministic fault contract, then completed only 1/2 process kills. During kill 1, the survivor authorized and materialized the recovery successor near the end of the 90-second recovery ceiling, leaving no time to publish Prepare.

The focused regression authorizes a successor, allows the exact proposal validation and the settlement authority audit, and deterministically stalls a third recovery-proposal read. Before this fix it fails with `assignment 2 recovery authority audit timed out while settling its predecessor checkpoint`. This proves materialization repeated the complete recovery-authority audit immediately before predecessor settlement performs the same audit again. Native Azure latency amplified that duplicate durable read sequence.

## Minimal fix

Delete only the first duplicate `audit_assignment_snapshot_authority` call in `materialize_recovery_decision`. `abort_predecessor_checkpoint_for_recovery` still performs the complete fail-closed recovery-authority audit before settlement, and assignment adoption independently re-audits durable authority before publication. No timeout was increased and no new production abstraction was added.

## Validation

- focused regression failed before the production deletion and passes after it
- related recovery materialization and graph-retirement unit tests pass
- existing three-process follower checkpoint-fault regression passes; Prepare/Start/Release recovery completed in 7.84 seconds and checkpoints advanced afterward
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

Evidence: https://github.com/laminardb/laminardb/actions/runs/34557782596 (follow-up to the original failure in https://github.com/laminardb/laminardb/actions/runs/34162984468).

Azure checkpoint storage is still uncertified until the exact merged SHA passes the post-merge 2-kill diagnostic and 4-kill certification baseline.

Delivery admission is unchanged. This PR does not admit Azure Delta clustered exactly-once, change Iceberg status, infer GCS certification, or alter dependencies, Cargo features, linker/build configuration, or unrelated infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicate full recovery-authority audit during recovery materialization, so the predecessor settlement audit and the adoption audit each run once instead of the settlement audit being repeated.

- Adds a deterministic regression that stalls a third proposal read to prove the redundant audit is gone.
- Existing recovery materialization, graph-retirement, and follower checkpoint-fault tests pass.
- `cargo fmt`, readability check, and `clippy` for `laminar-db` and `laminar-server` pass.
- Azure checkpoint storage remains uncertified until the merged SHA passes the post-merge 2-kill diagnostic and 4-kill certification baseline.

<sup>Written for commit 1ab35a2002b652fcb5ed0d9980e9edcce2b6350d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery processing by ensuring materialized recovery decisions are adopted consistently.
  - Reduced redundant recovery validation steps, helping recovery workflows proceed more predictably.
  - Improved test coverage for recovery behavior involving object-store paths and authority validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->