### PR TITLE
fix(cluster): avoid duplicate recovery decision audit

### DIFF
--- a/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/mod.rs
@@ -5263,49 +5263,6 @@ impl LeaderLeaseStore {
         proof: &LeaderProof,
         decision: AssignmentRecoveryDecision,
     ) -> Result<RecordAssignmentRecoveryDecisionResult, ClusterCheckpointAuthorityError> {
-        decision.validate()?;
-        if &decision.leader_proof != proof || !proof.is_canonical() {
-            return Err(ClusterCheckpointAuthorityError::Fenced);
-        }
-        let current = self
-            .load_record()
-            .await?
-            .ok_or(ClusterCheckpointAuthorityError::Fenced)?;
-        if !current.lease.matches_proof(proof) {
-            return Err(ClusterCheckpointAuthorityError::Fenced);
-        }
-        if let Some(floor) = current.assignment_decision_floor.as_ref() {
-            if decision.target_version() < floor.before_target_version {
-                return Err(DecisionError::Conflict(format!(
-                    "assignment decision version {} is below durable retention floor {}",
-                    decision.target_version(),
-                    floor.before_target_version
-                ))
-                .into());
-            }
-        }
-        if let Some(winner) = self
-            .audited_assignment_decisions_from(&current)
-            .await?
-            .into_iter()
-            .find(|winner| winner.target_version() == decision.target_version())
-        {
-            return match winner {
-                AuthorityAssignmentDecision::Recovery(winner) if winner == decision => {
-                    Ok(RecordAssignmentRecoveryDecisionResult::Unchanged(winner))
-                }
-                AuthorityAssignmentDecision::Recovery(winner) => {
-                    Ok(RecordAssignmentRecoveryDecisionResult::Conflict { winner })
-                }
-                AuthorityAssignmentDecision::Drain(winner) => {
-                    Err(DecisionError::Conflict(format!(
-                        "assignment drain decision already settled target version {}",
-                        winner.target_version()
-                    ))
-                    .into())
-                }
-            };
-        }
         match Box::pin(
             self.record_assignment_decision(proof, AuthorityAssignmentDecision::Recovery(decision)),
         )

--- a/crates/laminar-core/src/cluster/control/leader_lease/tests.rs
+++ b/crates/laminar-core/src/cluster/control/leader_lease/tests.rs
@@ -3654,6 +3654,79 @@ async fn recovery_requires_the_current_cut_and_pins_it_until_the_target_commits(
 }
 
 #[tokio::test]
+async fn recovery_decision_admission_audits_existing_assignment_history_once() {
+    let (raw, store) = blocking_store_at(1_000, OsPath::from("control/never-block"));
+    let incumbent = owner(1, 11, 1);
+    let failed_two = owner(2, 22, 1);
+    let failed_three = owner(3, 33, 1);
+    let replacement_two = owner(2, 222, 2);
+    let replacement_three = owner(3, 333, 2);
+    let LeaseOutcome::Acquired(lease) = store
+        .acquire_or_renew_current_term_for_test(&incumbent, 0)
+        .await
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    let proof = lease.proof();
+    let first = assignment_recovery_decision(
+        &store,
+        1,
+        &[incumbent.clone(), failed_two.clone(), failed_three],
+        &[
+            incumbent.clone(),
+            failed_two.clone(),
+            replacement_three.clone(),
+        ],
+        proof.clone(),
+        1,
+    )
+    .await;
+    assert!(matches!(
+        store
+            .record_assignment_recovery_decision(&proof, first)
+            .await
+            .unwrap(),
+        RecordAssignmentRecoveryDecisionResult::Created(_)
+    ));
+    assert!(matches!(
+        store.materialize_assignment_recovery(2).await.unwrap(),
+        RotateOutcome::Rotated
+    ));
+
+    let second = assignment_recovery_decision(
+        &store,
+        2,
+        &[incumbent.clone(), failed_two, replacement_three.clone()],
+        &[incumbent.clone(), replacement_two, replacement_three],
+        proof.clone(),
+        2,
+    )
+    .await;
+    let prior_decision = store
+        .load_record()
+        .await
+        .unwrap()
+        .unwrap()
+        .assignment_decision_head
+        .unwrap();
+    raw.clear_authority_io_counts();
+
+    assert!(matches!(
+        store
+            .record_assignment_recovery_decision(&proof, second)
+            .await
+            .unwrap(),
+        RecordAssignmentRecoveryDecisionResult::Created(_)
+    ));
+    assert_eq!(
+        raw.get_count(&lease_path(prior_decision.sequence)),
+        2,
+        "recovery admission must read the published decision head and audit its link only once"
+    );
+}
+
+#[tokio::test]
 async fn competing_assignment_recoveries_have_one_same_version_winner() {
     let (raw, store) = blocking_store_at(1_000, lease_path(4));
     let incumbent = owner(1, 11, 1);


### PR DESCRIPTION
## Reproduction

Native Azure diagnostic run https://github.com/laminardb/laminardb/actions/runs/34567859905 completed conformance and the deterministic fault contract with zero skips, but the process soak stopped at 1/2 kills. Its bounded markers show successor authorization, assignment rotation, Prepare publication, and one follower stopped acknowledgement, followed by the 90-second external recovery timeout before Release.

The focused local regression creates two successive recovery decisions over immutable authority history, clears object-store counters before the second admission, and bounds reads of the prior decision record. On merged main it failed with four reads where one admission requires two: one published-head read and one linked-history audit.

The existing three-process follower checkpoint fault regression also exercises the full Prepare -> Start -> Release path without Azure. With this change it completed recovery in 34.251 seconds, reopened intake, retained a live leader, and advanced checkpoints from 50 through 103.

## Root cause

LeaderLeaseStore::record_assignment_recovery_decision loaded and audited the durable assignment-decision chain, then immediately delegated to record_assignment_decision. The delegated CAS path repeats the same decision validation, canonical leader-proof check, live-proof fencing, retention-floor enforcement, winner/conflict resolution, recovery snapshot validation, checkpoint pin validation, and assignment-history audit. The wrapper therefore duplicated remote reads before successor authorization without adding a mutation or safety boundary.

## Minimal fix

Delete only the redundant wrapper validation/audit and preserve the generic fail-closed CAS admission as the single validator. No timeout, retry, API, dependency, feature, linker, build, or delivery behavior changes.

## Validation

- Focused read-budget regression: passed; prior decision record reads reduced from four to two
- Recovery decision tests: passed
- Existing ignored three-process follower fault recovery/Release regression: passed
- cargo +nightly fmt --all -- --check
- readability check
- cargo clippy -p laminar-core --features cluster --all-targets -j 1 -- -D warnings
- cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings
- cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings

## Certification scope

This follows native evidence run https://github.com/laminardb/laminardb/actions/runs/34162984468 and the latest diagnostic above. Azure checkpoint storage is still uncertified until a post-merge 2/2-kill diagnostic and 4/4-kill certification baseline pass on the exact merged SHA.

Delivery admission is unchanged. This does not admit Azure Delta clustered exactly-once, promote Azure Iceberg, infer GCS certification, or change any Delta/Iceberg behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops recovery decision admission from reading the assignment history twice, fixing the read-budget failure and making the delegated CAS path the single validator.

- Removes the duplicated validation and audit in `record_assignment_recovery_decision`; all checks now happen once inside `record_assignment_decision`.
- Adds a regression test asserting the prior decision record is read exactly twice (published head and linked-history audit).

<sup>Written for commit 57db1d6c32ad5a3fcf57b5452eab42e703b7d7f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when recording assignment recovery decisions by applying the same validation and conflict handling used for standard assignment decisions.
  - Enhanced auditing of existing assignment history during recovery decision admission, ensuring prior authority records are checked consistently.

- **Tests**
  - Added coverage verifying assignment history is audited exactly once per recovery decision admission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->