### PR TITLE
fix(recovery): reject incomplete adoption before authority audit

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -2835,10 +2835,11 @@ fn assignment_adoptions_match(
 async fn read_assignment_adoptions(
     controller: &ClusterController,
     deadline: tokio::time::Instant,
+    timeout_context: &str,
 ) -> Result<FxHashMap<u64, CheckpointAssignmentAdoption>, String> {
     let reports = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
         .await
-        .map_err(|_| "recovery assignment adoption read timed out".to_string())??;
+        .map_err(|_| format!("recovery {timeout_context} adoption-report read timed out"))??;
     Ok(reports
         .into_iter()
         .map(|(node, adoption)| (node.0, adoption))
@@ -2888,7 +2889,7 @@ async fn current_recovery_assignment_fence(
     if !recovery_fence_participants_present(controller, &candidate_fence) {
         return Ok(None);
     }
-    let adopted = read_assignment_adoptions(controller, deadline).await?;
+    let adopted = read_assignment_adoptions(controller, deadline, "assignment audit").await?;
     if !assignment_adoptions_match(&candidate_fence, &adopted) {
         return Ok(None);
     }
@@ -2990,7 +2991,6 @@ async fn current_recovery_assignment_fence(
         .map(|owner| owner.0)
         .collect();
     let published = controller.checkpoint_assignment_watch().borrow().clone();
-    let confirmed_adopted = read_assignment_adoptions(controller, deadline).await?;
     if confirmed_committed != committed
         || controller
             .checkpoint_drain_transition()
@@ -3001,7 +3001,6 @@ async fn current_recovery_assignment_fence(
         || confirmed_assignment.owners() != local_assignment.owners()
         || !fence.matches_owner_map(&confirmed_owners)
         || !recovery_fence_participants_present(controller, &fence)
-        || !assignment_adoptions_match(&fence, &confirmed_adopted)
         || published
             .as_ref()
             .is_some_and(|published| published != &fence)
@@ -3011,6 +3010,11 @@ async fn current_recovery_assignment_fence(
         || !db.cluster_intake_fenced()
         || !db.coordinated_recovery_fenced.load(Ordering::Acquire)
     {
+        return Ok(None);
+    }
+    let confirmed_adopted =
+        read_assignment_adoptions(controller, deadline, "assignment recheck").await?;
+    if !assignment_adoptions_match(&fence, &confirmed_adopted) {
         return Ok(None);
     }
     Ok(Some(fence))
@@ -3712,7 +3716,7 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
     if live_target_participants != target.participants {
         return Err("materialized assignment target process roster is no longer exact".into());
     }
-    let reported = read_assignment_adoptions(controller, deadline).await?;
+    let reported = read_assignment_adoptions(controller, deadline, "Prepare retirement").await?;
     if !assignment_adoptions_match(&target, &reported) {
         return Ok(None);
     }
@@ -3740,7 +3744,8 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
             "materialized assignment target process roster changed during retirement".into(),
         );
     }
-    let confirmed_reports = read_assignment_adoptions(controller, deadline).await?;
+    let confirmed_reports =
+        read_assignment_adoptions(controller, deadline, "Prepare retirement recheck").await?;
     if !assignment_adoptions_match(&target, &confirmed_reports)
         || !current_stopped_roster_has_adopted_target(
             controller,

--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -2832,6 +2832,19 @@ fn assignment_adoptions_match(
     })
 }
 
+async fn read_assignment_adoptions(
+    controller: &ClusterController,
+    deadline: tokio::time::Instant,
+) -> Result<FxHashMap<u64, CheckpointAssignmentAdoption>, String> {
+    let reports = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
+        .await
+        .map_err(|_| "recovery assignment adoption read timed out".to_string())??;
+    Ok(reports
+        .into_iter()
+        .map(|(node, adoption)| (node.0, adoption))
+        .collect())
+}
+
 /// Reconstruct the withdrawn checkpoint certificate from durable authority, current process
 /// incarnations, and exact adoption while recovery owns the closed data plane. This read-only
 /// fallback neither republishes authority nor requires a faulted owner's stale vnode readiness.
@@ -2875,12 +2888,7 @@ async fn current_recovery_assignment_fence(
     if !recovery_fence_participants_present(controller, &candidate_fence) {
         return Ok(None);
     }
-    let adopted = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
-        .await
-        .map_err(|_| "recovery assignment adoption audit timed out".to_string())??
-        .into_iter()
-        .map(|(node, adoption)| (node.0, adoption))
-        .collect::<FxHashMap<_, _>>();
+    let adopted = read_assignment_adoptions(controller, deadline).await?;
     if !assignment_adoptions_match(&candidate_fence, &adopted) {
         return Ok(None);
     }
@@ -2982,6 +2990,7 @@ async fn current_recovery_assignment_fence(
         .map(|owner| owner.0)
         .collect();
     let published = controller.checkpoint_assignment_watch().borrow().clone();
+    let confirmed_adopted = read_assignment_adoptions(controller, deadline).await?;
     if confirmed_committed != committed
         || controller
             .checkpoint_drain_transition()
@@ -2992,6 +3001,7 @@ async fn current_recovery_assignment_fence(
         || confirmed_assignment.owners() != local_assignment.owners()
         || !fence.matches_owner_map(&confirmed_owners)
         || !recovery_fence_participants_present(controller, &fence)
+        || !assignment_adoptions_match(&fence, &confirmed_adopted)
         || published
             .as_ref()
             .is_some_and(|published| published != &fence)
@@ -3012,7 +3022,7 @@ fn recovery_fence_participants_present(
 ) -> bool {
     // RECOVERY: A quarantined boot remains recoverable behind closed intake and durable audits;
     // Prepare/stop/readiness re-prove it. Require checkpoint membership, not responsiveness.
-    let available = controller.checkpoint_instances();
+    let available: FxHashSet<_> = controller.checkpoint_instances().into_iter().collect();
     fence
         .participants
         .iter()
@@ -3702,13 +3712,7 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
     if live_target_participants != target.participants {
         return Err("materialized assignment target process roster is no longer exact".into());
     }
-    let reports = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
-        .await
-        .map_err(|_| "recovery Prepare retirement adoption-report read timed out".to_string())??;
-    let reported: FxHashMap<u64, _> = reports
-        .into_iter()
-        .map(|(node, adoption)| (node.0, adoption))
-        .collect();
+    let reported = read_assignment_adoptions(controller, deadline).await?;
     if !assignment_adoptions_match(&target, &reported) {
         return Ok(None);
     }
@@ -3736,15 +3740,7 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
             "materialized assignment target process roster changed during retirement".into(),
         );
     }
-    let confirmed_reports =
-        tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
-            .await
-            .map_err(|_| {
-                "recovery Prepare retirement adoption-report recheck timed out".to_string()
-            })??
-            .into_iter()
-            .map(|(node, adoption)| (node.0, adoption))
-            .collect::<FxHashMap<_, _>>();
+    let confirmed_reports = read_assignment_adoptions(controller, deadline).await?;
     if !assignment_adoptions_match(&target, &confirmed_reports)
         || !current_stopped_roster_has_adopted_target(
             controller,

--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -23,8 +23,8 @@ use laminar_core::cluster::control::controller::{
     RecoveryStoppedReport,
 };
 use laminar_core::cluster::control::{
-    ClusterController, RecoverPhase, RecoveryControlError, RecoveryFaultDisposition,
-    RecoveryFaultReportOutcome, ReleaseCommitStatus,
+    AssignmentSnapshot, ClusterController, RecoverPhase, RecoveryControlError,
+    RecoveryFaultDisposition, RecoveryFaultReportOutcome, ReleaseCommitStatus,
 };
 use laminar_core::cluster::discovery::NodeId;
 
@@ -2787,8 +2787,7 @@ where
     }
 }
 
-/// Current owner-complete assignment certificate. Recovery cannot invent a quorum from a
-/// transient membership view; it freezes this already-proven cut instead.
+/// Freeze the current owner-complete certificate rather than inventing a quorum from membership.
 fn current_assignment_fence(
     db: &Arc<LaminarDB>,
     controller: &ClusterController,
@@ -2814,15 +2813,28 @@ fn current_assignment_fence(
         })
 }
 
-/// Recover the exact current assignment cut after fault fencing has deliberately withdrawn the
-/// active checkpoint certificate. This is a read-only recovery proof: it never republishes the
-/// checkpoint fence, reopens intake, or grants shuffle authority.
-///
-/// The normal fast path retains the already-published certificate. The fallback is admitted only
-/// while coordinated recovery owns the closed data plane, and reconstructs the same certificate
-/// from the authority-audited durable head, exact current process incarnations, and durable
-/// assignment-adoption reports. `vnode_state_ready` is deliberately not required: a faulted owner
-/// must be recoverable after publishing a false readiness report.
+fn recovery_head_fence(head: &AssignmentSnapshot) -> Result<CheckpointAssignmentFence, String> {
+    match (head.draining, head.drain_transition.as_ref()) {
+        (true, Some(transition)) => Ok(transition.predecessor.clone()),
+        (true, None) => Err("draining recovery assignment has no transition".into()),
+        (false, _) => head.assignment_fence().map_err(|error| error.to_string()),
+    }
+}
+
+fn assignment_adoptions_match(
+    fence: &CheckpointAssignmentFence,
+    reported: &FxHashMap<u64, CheckpointAssignmentAdoption>,
+) -> bool {
+    fence.participants.iter().all(|participant| {
+        reported.get(&participant.node_id).is_some_and(|adoption| {
+            adoption.participant == *participant && adoption.matches_fence(fence)
+        })
+    })
+}
+
+/// Reconstruct the withdrawn checkpoint certificate from durable authority, current process
+/// incarnations, and exact adoption while recovery owns the closed data plane. This read-only
+/// fallback neither republishes authority nor requires a faulted owner's stale vnode readiness.
 async fn current_recovery_assignment_fence(
     db: &Arc<LaminarDB>,
     controller: &ClusterController,
@@ -2858,6 +2870,20 @@ async fn current_recovery_assignment_fence(
         .map_err(|_| "recovery assignment head read timed out".to_string())?
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "recovery assignment audit has no durable head".to_string())?;
+    // RECOVERY: Missing adoption rejects before remote authority I/O; acceptance still audits.
+    let candidate_fence = recovery_head_fence(&head)?;
+    if !recovery_fence_participants_present(controller, &candidate_fence) {
+        return Ok(None);
+    }
+    let adopted = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
+        .await
+        .map_err(|_| "recovery assignment adoption audit timed out".to_string())??
+        .into_iter()
+        .map(|(node, adoption)| (node.0, adoption))
+        .collect::<FxHashMap<_, _>>();
+    if !assignment_adoptions_match(&candidate_fence, &adopted) {
+        return Ok(None);
+    }
     tokio::time::timeout_at(
         deadline,
         crate::rebalance::audit_assignment_snapshot_authority(&store, Some(controller), &head),
@@ -2920,20 +2946,6 @@ async fn current_recovery_assignment_fence(
     if incarnations != fence.participants {
         return Ok(None);
     }
-    let adopted = tokio::time::timeout_at(deadline, controller.read_adopted_assignments())
-        .await
-        .map_err(|_| "recovery assignment adoption audit timed out".to_string())??
-        .into_iter()
-        .map(|(node, adoption)| (node.0, adoption))
-        .collect::<FxHashMap<_, _>>();
-    if fence.participants.iter().any(|participant| {
-        adopted.get(&participant.node_id).is_none_or(|adoption| {
-            adoption.participant != *participant || !adoption.matches_fence(&fence)
-        })
-    }) {
-        return Ok(None);
-    }
-
     let confirmed = tokio::time::timeout_at(deadline, store.load())
         .await
         .map_err(|_| "recovery assignment head recheck timed out".to_string())?
@@ -2998,21 +3010,13 @@ fn recovery_fence_participants_present(
     controller: &ClusterController,
     fence: &laminar_core::checkpoint::CheckpointAssignmentFence,
 ) -> bool {
-    // A capture-quorum miss quarantines a process from ordinary checkpoint/placement authority,
-    // but it cannot make that exact live boot unrecoverable. This fallback is reachable only with
-    // recovery + intake fenced and separately audits durable incarnations and adoption reports;
-    // the Recovery Prepare/stop/readiness quorums must then re-prove every participant before
-    // Release. Keep requiring current checkpoint-capable membership here, but deliberately do not
-    // apply the ordinary `unresponsive` filter.
-    let available: FxHashSet<u64> = controller
-        .checkpoint_instances()
-        .into_iter()
-        .map(|node| node.0)
-        .collect();
+    // RECOVERY: A quarantined boot remains recoverable behind closed intake and durable audits;
+    // Prepare/stop/readiness re-prove it. Require checkpoint membership, not responsiveness.
+    let available = controller.checkpoint_instances();
     fence
         .participants
         .iter()
-        .all(|participant| available.contains(&participant.node_id))
+        .all(|participant| available.contains(&NodeId(participant.node_id)))
 }
 
 fn clear_stopped_assignment_quarantine(
@@ -3705,12 +3709,7 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
         .into_iter()
         .map(|(node, adoption)| (node.0, adoption))
         .collect();
-    let owner_complete = target.participants.iter().all(|participant| {
-        reported.get(&participant.node_id).is_some_and(|adoption| {
-            adoption.participant == *participant && adoption.matches_fence(&target)
-        })
-    });
-    if !owner_complete {
+    if !assignment_adoptions_match(&target, &reported) {
         return Ok(None);
     }
     if !current_stopped_roster_has_adopted_target(controller, round, &target, &reported, deadline)
@@ -3746,20 +3745,15 @@ pub(crate) async fn recovery_prepare_supersession_fence_after_assignment_settlem
             .into_iter()
             .map(|(node, adoption)| (node.0, adoption))
             .collect::<FxHashMap<_, _>>();
-    if target.participants.iter().any(|participant| {
-        confirmed_reports
-            .get(&participant.node_id)
-            .is_none_or(|adoption| {
-                adoption.participant != *participant || !adoption.matches_fence(&target)
-            })
-    }) || !current_stopped_roster_has_adopted_target(
-        controller,
-        round,
-        &target,
-        &confirmed_reports,
-        deadline,
-    )
-    .await?
+    if !assignment_adoptions_match(&target, &confirmed_reports)
+        || !current_stopped_roster_has_adopted_target(
+            controller,
+            round,
+            &target,
+            &confirmed_reports,
+            deadline,
+        )
+        .await?
     {
         return Ok(None);
     }

--- a/crates/laminar-db/src/coordinated_recovery/tests.rs
+++ b/crates/laminar-db/src/coordinated_recovery/tests.rs
@@ -1563,6 +1563,95 @@ async fn recovery_rejects_an_absent_predecessor_before_durable_incarnation_audit
 }
 
 #[tokio::test]
+async fn recovery_rejects_incomplete_adoption_before_assignment_authority_audit() {
+    use laminar_core::state::{NodeId as StateNodeId, VnodeRegistry};
+
+    let backing: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::memory::InMemory::new());
+    let authority_gate = Arc::new(RecoveryAuthorityReadGateStore::new(backing));
+    let authority_store: Arc<dyn object_store::ObjectStore> = authority_gate.clone();
+    let (controller, _members_tx, _kv) = controller_on(Vec::new(), authority_store.clone()).await;
+    let controller = Arc::new(controller);
+    let participant = CheckpointParticipant {
+        node_id: controller.instance_id().0,
+        boot_incarnation: controller.recovery_incarnation(),
+    };
+    let committed = AssignmentSnapshot::empty()
+        .next_for_participants(
+            AssignmentSnapshot::vnodes_from_vec(&[controller.instance_id()]),
+            vec![participant],
+        )
+        .unwrap();
+    let target = committed
+        .next_for_participants(
+            AssignmentSnapshot::vnodes_from_vec(&[controller.instance_id()]),
+            vec![participant],
+        )
+        .unwrap();
+    let assignments = Arc::new(AssignmentSnapshotStore::new(authority_store));
+    assignments.save_if_absent(&committed).await.unwrap();
+    assignments
+        .save_if_version(&target, committed.version)
+        .await
+        .unwrap();
+    let registry = Arc::new(VnodeRegistry::single_owner(1, StateNodeId(1)));
+    registry.set_assignment_and_version(Arc::from([StateNodeId(1)]), target.version);
+    let db = LaminarDB::builder()
+        .cluster_controller(Arc::clone(&controller))
+        .cluster_checkpoint_object_store(Arc::new(object_store::memory::InMemory::new()))
+        .vnode_registry(Arc::clone(&registry))
+        .assignment_snapshot_store(assignments)
+        .build()
+        .await
+        .unwrap();
+    let fault = report_test_fault(&controller).await;
+    let mut monitor = RecoveryMonitor::default();
+    monitor.hold_for_pending_fault(&db, &controller, &[fault]);
+    controller.publish_checkpoint_assignment_fence(None);
+
+    authority_gate.arm();
+    let observed = tokio::time::timeout(
+        Duration::from_millis(100),
+        current_recovery_assignment_fence(
+            &db,
+            &controller,
+            tokio::time::Instant::now() + Duration::from_secs(1),
+        ),
+    )
+    .await
+    .expect("missing adoption must reject before durable assignment authority I/O")
+    .expect("missing adoption is unavailable, not an assignment audit failure");
+    assert_eq!(observed, None);
+    assert!(
+        authority_gate.armed.load(Ordering::Acquire),
+        "missing adoption must not consume the durable assignment authority read"
+    );
+
+    let adoption = db
+        .publish_local_vnode_state_report(&controller, &registry.versioned_snapshot(), false)
+        .await
+        .unwrap();
+    assert!(adoption.matches_fence(&target.assignment_fence().unwrap()));
+    let auditing_db = Arc::clone(&db);
+    let auditing_controller = Arc::clone(&controller);
+    let authority_audit = tokio::spawn(async move {
+        current_recovery_assignment_fence(
+            &auditing_db,
+            &auditing_controller,
+            tokio::time::Instant::now() + Duration::from_secs(1),
+        )
+        .await
+    });
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        authority_gate.wait_until_blocked(),
+    )
+    .await
+    .expect("complete adoption must still require the durable assignment authority audit");
+    authority_audit.abort();
+}
+
+#[tokio::test]
 async fn recovery_reconstructs_a_suspended_drain_predecessor_fence() {
     use laminar_core::state::{NodeId as StateNodeId, VnodeRegistry};
 


### PR DESCRIPTION
## Reproduction

The existing three-process soak regression `three_node_follower_checkpoint_fault_recovery_release_regression` now deterministically drives a healthy three-node cluster through follower checkpoint-capture failure, Prepare, the exact stopped quorum, Start, Release, reopened intake, a live leader, and later checkpoints under a bounded timeout.

A focused read-gate regression, `recovery_rejects_incomplete_adoption_before_assignment_authority_audit`, reproduces the Azure stall without Azure: a recovery assignment with an incomplete adoption quorum must return unavailable before touching the deliberately blocked durable authority-history read. It also proves that complete adoption still reaches the full authority audit.

## Root cause

After the successor had been authorized and its assignment had rotated, recovery rebuilt the withdrawn checkpoint fence by running the expensive remote assignment-authority history audit before checking whether every target participant had published an exact adoption report. Missing adoption was already independently fail-closed, so Azure spent the monitor poll's I/O budget on an audit only to reject the candidate afterward. Native diagnostic run 34583535780 matched this boundary: rotation completed, but Prepare was never published before the 90-second recovery deadline.

## Minimal fix

Use participant presence and exact adoption as a cheap fail-closed guard before the remote authority-history audit, then re-read exact adoption at the acceptance boundary after the existing authority, incarnation, and durable-head rechecks. No timeout was increased; four identical adoption-report reads are consolidated into one private helper.

## Validation

- focused adoption/read-gate regression: passed
- adjacent suspended-fence reconstruction tests: passed
- existing three-process follower-fault recovery/Release regression: passed; checkpoints advanced 23 -> 28 -> 33
- `cargo +nightly fmt --all -- --check`
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`

This follows the original native evidence from run 34162984468 and the latest post-merge diagnostic evidence from run 34583535780.

Azure checkpoint storage is still uncertified; certification requires successful post-merge native 2-kill diagnostic and 4-kill baseline runs on the exact merge SHA.

Delivery admission is unchanged. This PR does not change Delta or Iceberg admission, dependencies/features, linker configuration, or unrelated infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an Azure checkpoint recovery stall by rejecting incomplete adoption before the durable authority-history audit, and retains a final adoption audit in the acceptance-side recheck.

Previously, recovery ran the remote authority audit first and only then checked whether every target participant had published an exact adoption report, wasting the monitor poll's I/O budget on an audit that would reject the candidate anyway. The participant-presence and exact-adoption guards now run ahead of the authority audit; the acceptance side keeps its final adoption re-read alongside the existing authority, incarnation, durable-head, and fail-closed rechecks. No timeouts or recovery abstractions changed.

**Validation**
- New focused regression proves missing adoption returns unavailable without touching a deliberately blocked authority read, and complete adoption still reaches the full audit.
- Existing three-process follower-fault recovery and Release regressions pass.
- `cargo fmt`, readability check, and clippy for `laminar-db` and `laminar-server` pass.

<sup>Written for commit c54b8fd413fee5b39817e6adb8f57e11b8acd343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordinated recovery validation to reject incomplete or mismatched adoption state earlier in the recovery process.
  - Recovery now consistently verifies that all required participants have matching adoption reports before proceeding.
  - Added safeguards to prevent recovery from continuing when local adoption data is incomplete, improving recovery correctness and reliability.

- **Tests**
  - Added coverage confirming incomplete adoption is rejected before further recovery authority checks are performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
