### PR TITLE
fix(recovery): avoid duplicate assignment authority audit

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -2849,7 +2849,7 @@ async fn read_assignment_adoptions(
 /// Reconstruct the withdrawn checkpoint certificate from durable authority, current process
 /// incarnations, and exact adoption while recovery owns the closed data plane. This read-only
 /// fallback neither republishes authority nor requires a faulted owner's stale vnode readiness.
-async fn current_recovery_assignment_fence(
+pub(crate) async fn current_recovery_assignment_fence(
     db: &Arc<LaminarDB>,
     controller: &ClusterController,
     deadline: tokio::time::Instant,
@@ -2884,7 +2884,7 @@ async fn current_recovery_assignment_fence(
         .map_err(|_| "recovery assignment head read timed out".to_string())?
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "recovery assignment audit has no durable head".to_string())?;
-    // RECOVERY: Missing adoption rejects before remote authority I/O; acceptance still audits.
+    // RECOVERY: Reject cheap local mismatches before the final remote authority audit.
     let candidate_fence = recovery_head_fence(&head)?;
     if !recovery_fence_participants_present(controller, &candidate_fence) {
         return Ok(None);
@@ -2893,12 +2893,6 @@ async fn current_recovery_assignment_fence(
     if !assignment_adoptions_match(&candidate_fence, &adopted) {
         return Ok(None);
     }
-    tokio::time::timeout_at(
-        deadline,
-        crate::rebalance::audit_assignment_snapshot_authority(&store, Some(controller), &head),
-    )
-    .await
-    .map_err(|_| "recovery assignment authority audit timed out".to_string())??;
     let expected_drain_transition = head.drain_transition.clone();
     let committed = if head.draining {
         let Some(expected) = expected_drain_transition.as_ref() else {

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -2558,6 +2558,73 @@ async fn dead_predecessor_retires_the_graph_and_publishes_an_authorized_recovery
 }
 
 #[tokio::test]
+async fn materialized_recovery_fence_audits_authority_once() {
+    let (
+        db,
+        controller,
+        durable,
+        registry,
+        current,
+        _process_authority,
+        authority_store,
+        _checkpoint_dir,
+    ) = dead_predecessor_fixture().await;
+    controller.note_unresponsive(&[NodeId(2)]);
+
+    let adopted = try_rebalance(
+        &db,
+        &controller,
+        &durable,
+        &registry,
+        &[NodeId(1), NodeId(2)],
+        RebalanceConfig::test_defaults(),
+    )
+    .await
+    .expect("recovery successor materialization must succeed");
+    let successor = durable.load().await.unwrap().unwrap();
+    assert_eq!(adopted, Some(current.version + 1));
+    assert_eq!(successor.version, current.version + 1);
+    let successor_fence = successor.assignment_fence().unwrap();
+    let adoption = db
+        .publish_local_vnode_state_report(&controller, &registry.versioned_snapshot(), false)
+        .await
+        .unwrap();
+    assert!(adoption.matches_fence(&successor_fence));
+
+    let proposal_reads = Arc::new(GetBarrier {
+        entered: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+        path_prefix: Some("control/assignment-recovery-proposals/"),
+        reads_before_wait: std::sync::atomic::AtomicUsize::new(1),
+        armed: std::sync::atomic::AtomicBool::new(true),
+    });
+    let bounded_store: Arc<dyn ObjectStore> = Arc::new(ReadBarrierStore {
+        inner: authority_store,
+        get: Some(Arc::clone(&proposal_reads)),
+        stall_list: false,
+    });
+    *db.assignment_snapshot_store.lock() =
+        Some(Arc::new(AssignmentSnapshotStore::new(bounded_store)));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    let observed = tokio::time::timeout(
+        Duration::from_secs(2),
+        crate::coordinated_recovery::current_recovery_assignment_fence(&db, &controller, deadline),
+    )
+    .await
+    .expect("recovery assignment audit exceeded the bounded test timeout")
+    .expect("one assignment-authority audit must fit the recovery decision budget");
+
+    assert_eq!(observed, Some(successor_fence));
+    assert!(
+        proposal_reads.armed.load(Ordering::Acquire),
+        "recovery repeated its full assignment-authority audit"
+    );
+    proposal_reads.armed.store(false, Ordering::Release);
+    proposal_reads.release.notify_waiters();
+    db.close();
+}
+
+#[tokio::test]
 async fn recovery_materialization_does_not_repeat_the_settlement_authority_audit() {
     let self_id = NodeId(1);
     let (

--- a/crates/laminar-db/src/rebalance/tests.rs
+++ b/crates/laminar-db/src/rebalance/tests.rs
@@ -2615,6 +2615,11 @@ async fn materialized_recovery_fence_audits_authority_once() {
     .expect("one assignment-authority audit must fit the recovery decision budget");
 
     assert_eq!(observed, Some(successor_fence));
+    assert_eq!(
+        proposal_reads.reads_before_wait.load(Ordering::Acquire),
+        0,
+        "recovery must perform its final assignment-authority audit"
+    );
     assert!(
         proposal_reads.armed.load(Ordering::Acquire),
         "recovery repeated its full assignment-authority audit"


### PR DESCRIPTION
## Summary

- add a deterministic recovery-fence regression using the existing dead-predecessor fixture and object-store read gate
- remove one duplicate full assignment-authority audit from recovery-fence reconstruction
- retain the final authority audit plus head, incarnation, participant, local assignment, and adoption rechecks

## Reproduction and root cause

Native Azure checkpoint run 34601510229, following the original failed evidence run 34162984468, rotated to the authorized recovery assignment after the first leader kill but never published a new Prepare. Both survivors stayed Recovering until the 90-second bound. The bounded diagnostics reported no false zero-buffer graph-drain timeout.

The deterministic test materializes that same recovery successor, publishes exact local adoption, then permits one recovery-proposal read while blocking a second. With the prior code it fails at the bounded deadline with "recovery assignment authority recheck timed out". Recovery-fence reconstruction performed the same full, read-only authority audit twice inside one decision attempt. The later audit already follows the durable-head and incarnation rechecks and is the admission point, so the earlier audit consumed Azure I/O budget without strengthening acceptance.

## Minimal fix

Delete only the early duplicate audit. Recovery remains fail-closed: the final full authority audit and every subsequent stability/adoption check remain required. No timeout was increased and no abstraction, dependency, feature, linker, or build setting changed.

## Validation

- focused red/green: materialized_recovery_fence_audits_authority_once
- adjacent adoption, suspended-fence, drain-predecessor, dead-predecessor, and settlement-audit tests
- existing three-process follower checkpoint-fault Prepare/Start/Release regression (recovered in 8.37s and committed later checkpoints)
- cargo +nightly fmt --all -- --check
- readability check
- laminar-db cluster all-targets clippy with warnings denied
- laminar-server all-features all-targets clippy with warnings denied

Azure Blob/ADLS Gen2 checkpoint storage is still uncertified pending post-merge native diagnostic and certification soaks. Delivery admission is unchanged; this PR does not alter Delta or Iceberg admission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicate assignment-authority audit from recovery-fence reconstruction that could time out on slow Azure checkpoint storage.

- Only the earlier duplicate audit is removed; the final authority audit and all stability checks remain.
- Adds a regression test verifying exactly one authority audit and the correct successor fence.

<sup>Written for commit 0ef7767374f288bd6d189f55920c494221342b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery coordination by checking assignment authority at the appropriate stage, helping prevent inconsistent recovery-fence decisions.
  - Recovery fence handling now avoids redundant authority checks while retaining the later verification step.

- **Tests**
  - Added coverage for recovery fencing to verify authority validation occurs as expected and the correct successor fence is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->