### PR TITLE
fix(ci): pull pinned MinIO images from Quay

### DIFF
--- a/tests/docker/iceberg-compose.yml
+++ b/tests/docker/iceberg-compose.yml
@@ -10,7 +10,7 @@
 
 services:
   minio:
-    image: minio/minio:RELEASE.2024-10-13T13-34-11Z
+    image: quay.io/minio/minio:RELEASE.2024-10-13T13-34-11Z
     command: server /data --console-address :9001
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -25,7 +25,7 @@ services:
       retries: 30
 
   minio-init:
-    image: minio/mc:RELEASE.2024-10-08T09-37-26Z
+    image: quay.io/minio/mc:RELEASE.2024-10-08T09-37-26Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## What

Fetch the two pinned MinIO images in the Iceberg integration Compose file from `quay.io/minio`. Both release tags stay unchanged.

## Why

The required CI job fails before running tests because Docker Hub denies pulls for `minio/minio` and `minio/mc`. The failure reproduced on a fresh runner in [CI run 34687504375, attempt 2](https://github.com/laminardb/laminardb/actions/runs/34687504375/attempts/2) and locally, blocking recovery PR #518.

## How

Add the `quay.io/` registry prefix to the two image references. This affects integration-test service startup only; runtime modes, release versions, dependencies, and delivery admission are unchanged. Azure checkpoint storage remains uncertified.

## Testing

- Compose configuration validation passed.
- Both pinned images pulled from Quay and reported the expected release versions.
- The existing Compose stack started successfully: MinIO became healthy, bucket initialization exited successfully, and the Iceberg REST catalog became healthy.
- MinIO health and Iceberg REST configuration endpoints both returned HTTP 200.
- The temporary verification stack was removed after validation.
- `git diff --check` passed. PR CI will run the existing integration tests and workspace checks.

## Ring 0 / API changes

Not applicable: this is a two-line integration-test image registry change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pulls the pinned MinIO images in the Iceberg integration Compose file from `quay.io` instead of Docker Hub. The CI job previously failed before running tests because Docker Hub denies pulls for `minio/minio` and `minio/mc`; the release tags remain unchanged.

<sup>Written for commit 0423b693568ddb5fe4a57980daddc207db859c61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Iceberg integration-test services to use MinIO images from Quay.io while retaining the existing release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->