### PR TITLE
chore(recovery): distinguish Release publication from gate reopening

### DIFF
--- a/crates/laminar-db/src/coordinated_recovery/mod.rs
+++ b/crates/laminar-db/src/coordinated_recovery/mod.rs
@@ -1875,6 +1875,7 @@ impl RecoveryMonitor {
             hold_intake_and_request_retry(db, controller, gen_id, true).await;
             return;
         }
+        tracing::warn!(gen = gen_id, "leader announced recovery release");
         let release = RecoveryAnnouncement {
             round: round.clone(),
             phase: RecoverPhase::Release { epoch: target },

--- a/crates/laminar-server/tests/cluster_soak.rs
+++ b/crates/laminar-server/tests/cluster_soak.rs
@@ -207,6 +207,8 @@ const RECOVERY_PREPARE_LOG: &str = "leader announced recovery prepare";
 #[cfg(feature = "kafka")]
 const RECOVERY_START_LOG: &str = "leader announced recovery start";
 #[cfg(feature = "kafka")]
+const RECOVERY_RELEASE_PUBLISHED_LOG: &str = "leader announced recovery release";
+#[cfg(feature = "kafka")]
 const RECOVERY_STOPPED_LOG: &str = "stopped for recovery round; awaiting target";
 #[cfg(feature = "kafka")]
 const RECOVERY_DRIVER_HANDOFF_LOG: &str =
@@ -225,7 +227,7 @@ const RECOVERY_DIAGNOSTIC_SEQUENCE_MAX: usize = 32;
 #[cfg(feature = "kafka")]
 const RECOVERY_DIAGNOSTIC_DRAIN_SAMPLES_MAX: usize = 8;
 #[cfg(feature = "kafka")]
-const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 101] = [
+const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 102] = [
     ("checkpoint_failure_metric", CHECKPOINT_FAILURE_METRIC_LOG),
     ("checkpoint_attempt_failed", "checkpoint attempt failed"),
     (
@@ -555,6 +557,7 @@ const RECOVERY_DIAGNOSTIC_MARKERS: [(&str, &str); 101] = [
         "rebalance failed; retrying after backoff",
     ),
     ("recovery_start", RECOVERY_START_LOG),
+    ("recovery_release_published", RECOVERY_RELEASE_PUBLISHED_LOG),
     ("recovery_release", RECOVERY_RELEASE_LOG),
     (
         "kafka_source_started_fenced",
@@ -9686,6 +9689,11 @@ fn assert_explicit_fault_recovery_evidence(nodes: &[Node], evidence: &ExplicitFa
         recovery_starts, prepare_sequence.applied_rounds as usize,
         "explicit fault did not produce one Start per applied recovery generation"
     );
+    assert!(
+        logs.iter()
+            .any(|log| log.contains(RECOVERY_RELEASE_PUBLISHED_LOG)),
+        "explicit fault had no successful recovery Release publication"
+    );
     let stopped_reports = logs
         .iter()
         .map(|log| log.matches(RECOVERY_STOPPED_LOG).count())
@@ -16018,6 +16026,36 @@ fn public_readiness_request_omits_console_authorization() {
         BoundedHttpAuthorization::ConsoleBearer,
     );
     assert!(console_request.contains("Authorization: Bearer "));
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn recovery_log_diagnostics_distinguish_release_publication_from_open_gates() {
+    let published = format!(
+        "{RECOVERY_START_LOG}\n{RECOVERY_RELEASE_PUBLISHED_LOG} gen=1 token=never-copy-this\n"
+    );
+    let diagnostics = recovery_log_diagnostics(&published);
+    assert_eq!(
+        diagnostics.marker_counts.get("recovery_release_published"),
+        Some(&1)
+    );
+    assert!(!diagnostics.marker_counts.contains_key("recovery_release"));
+    assert_eq!(
+        diagnostics.recent_marker_sequence,
+        ["recovery_start", "recovery_release_published"]
+    );
+    assert!(!format!("{diagnostics:?}").contains("never-copy-this"));
+
+    let released = recovery_log_diagnostics(&format!("{published}{RECOVERY_RELEASE_LOG}\n"));
+    assert_eq!(released.marker_counts.get("recovery_release"), Some(&1));
+    assert_eq!(
+        released.recent_marker_sequence,
+        [
+            "recovery_start",
+            "recovery_release_published",
+            "recovery_release"
+        ]
+    );
 }
 
 #[cfg(feature = "kafka")]


### PR DESCRIPTION
## Purpose

Diagnostic-only follow-up for Azure checkpoint recovery. The native root cause is
still unproven; this PR does not claim or implement a recovery behavior fix.

Native diagnostic [34701899831](https://github.com/laminardb/laminardb/actions/runs/34701899831)
tested `e2446aa40b967687e8686fa6fc0ca41e4b30da7b` and failed before its first process
kill (0/2). Conformance, the deterministic fault contract, cleanup, and artifact
upload passed. Bounded summaries show a Prepare handoff, one Start, and no reopened
source gates, without a restore-quorum or Release-publication error. The existing
Release marker only records gate reopening, leaving successful intent publication
unobserved. Original native evidence:
[34162984468](https://github.com/laminardb/laminardb/actions/runs/34162984468).

## Minimal change

- Add one fixed, non-secret log statement after `announce_recover_release` succeeds.
- Count it as `recovery_release_published` in the existing bounded soak summary,
  separately from `recovery_release` (source-gate reopening).
- Test that distinction and require the publication marker in the existing
  three-node follower checkpoint-fault regression. No new harness.

Successful mutable Release-intent publication is not a committed Release or
permission to open intake. All existing restore, authority, readiness, committed
terminal, and source-gate checks remain unchanged and fail closed.

Only the cluster recovery diagnostic path changes. Embedded and non-cluster server
behavior are unchanged. No timeouts, dependencies, Cargo features, linker/build
settings, or infrastructure change.

## Local validation

- `cargo test --profile soak -p laminar-server --no-default-features --features cluster,aws,kafka --test cluster_soak recovery_log_diagnostics_ -j 1 -- --test-threads=1`: 3 passed.
- Existing `three_node_follower_checkpoint_fault_recovery_release_regression`:
  passed with 96 Kafka partitions, 64 key groups, 8 MiB minimum live state,
  250 records/s, a 60-second checkpoint timeout, and a 90-second recovery bound.
  Recovery completed in 11.7 seconds, with one Prepare, one Start, one successful
  Release-publication marker, all three source gates reopened, and later checkpoints.
  All 303,049 bounded-join and 51,961 temporal-load expected output pairs were
  observed; duplicates were measured as 2,701 and 351 against settled broker cuts.
  This is MinIO emulator evidence, not native Azure evidence.
- `cargo +nightly fmt --all -- --check`: passed.
- `cargo run --quiet --manifest-path tools/readability-check/Cargo.toml -- .`: passed.
- `cargo clippy -p laminar-db --features cluster --all-targets -j 1 -- -D warnings`: passed.
- `cargo clippy -p laminar-server --all-features --all-targets -j 1 -- -D warnings`: passed.

## Certification boundary

**Azure checkpoint storage is still uncertified. Delivery admission is unchanged.**
This does not admit Azure Delta clustered exactly-once, promote Azure Iceberg beyond
experimental, infer GCS certification, or promote support documentation.

After required CI is green and this PR merges, run one approved Azure checkpoint-only
2-kill diagnostic on the exact merge SHA (30 seconds, recovery timeout 90,000 ms,
at-least-once, failed-prefix preservation disabled). Verify the workflow head SHA
and inspect its evidence before any certification-baseline or behavior-fix decision.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a diagnostic-only log and soak-summary counter for successful Release publication, so recovery evidence can distinguish it from gate reopening. No recovery behavior changes; the existing `recovery_release` marker still records only source-gate reopening.

- The new `recovery_release_published` marker is counted separately in the bounded summary and required in the three-node follower checkpoint-fault regression.
- Existing restore, authority, readiness, committed terminal, and source-gate checks remain unchanged and fail closed.

<sup>Written for commit 00b2992eb60b914953c8ca1ef501c49765021c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/laminardb/laminardb/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery diagnostics by recording when recovery release announcements are successfully published.
  - Enhanced fault-recovery validation to distinguish between release publication and consumption events, helping identify recovery issues more accurately.

- **Tests**
  - Added coverage to verify recovery event ordering and ensure diagnostic output remains bounded and focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->